### PR TITLE
Add health check endpoints and structured JSON logging

### DIFF
--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -1,5 +1,7 @@
 import reflex as rx
 
+from datanika.config import settings as _settings
+from datanika.logging_config import setup_logging
 from datanika.scheduler import scheduler_integration
 from datanika.ui.pages.audit_logs import audit_logs_page
 from datanika.ui.pages.auth_complete import auth_complete_page
@@ -33,6 +35,8 @@ from datanika.ui.state.settings_state import SettingsState
 from datanika.ui.state.transformation_state import TransformationState
 from datanika.ui.state.upload_state import UploadState
 
+setup_logging(debug=_settings.debug)
+
 app = rx.App(
     head_components=[
         rx.el.link(rel="icon", href="/favicon.ico", type="image/x-icon"),
@@ -40,8 +44,6 @@ app = rx.App(
 )
 
 # Load cloud plugin if running in cloud edition
-from datanika.config import settings as _settings  # noqa: E402
-
 if _settings.datanika_edition == "cloud":
     from datanika_cloud.plugin import init_cloud  # noqa: E402
 
@@ -169,4 +171,10 @@ for _route in email_routes:
 from datanika.services.sso_routes import sso_routes  # noqa: E402
 
 for _route in sso_routes:
+    app._api.routes.append(_route)
+
+# Mount health check routes
+from datanika.services.health_routes import health_routes  # noqa: E402
+
+for _route in health_routes:
     app._api.routes.append(_route)

--- a/datanika/logging_config.py
+++ b/datanika/logging_config.py
@@ -1,0 +1,55 @@
+"""Structured JSON logging configuration.
+
+Import and call ``setup_logging()`` early in the application lifecycle
+(before any logger is used). In production, logs are emitted as JSON
+for easy aggregation in Grafana/Loki. In debug mode, human-readable
+format is used instead.
+"""
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+
+
+class JSONFormatter(logging.Formatter):
+    """Emit each log record as a single JSON line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        entry = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info and record.exc_info[1]:
+            entry["exception"] = self.formatException(record.exc_info)
+        if hasattr(record, "org_id"):
+            entry["org_id"] = record.org_id
+        if hasattr(record, "run_id"):
+            entry["run_id"] = record.run_id
+        return json.dumps(entry, default=str)
+
+
+def setup_logging(*, debug: bool = False) -> None:
+    """Configure root logger with JSON (prod) or text (dev) output."""
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    # Remove any existing handlers
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(sys.stdout)
+
+    if debug:
+        fmt = "%(asctime)s %(levelname)-8s %(name)s — %(message)s"
+        handler.setFormatter(logging.Formatter(fmt, datefmt="%H:%M:%S"))
+    else:
+        handler.setFormatter(JSONFormatter())
+
+    root.addHandler(handler)
+
+    # Quiet noisy third-party loggers
+    for name in ("httpx", "httpcore", "urllib3", "sqlalchemy.engine"):
+        logging.getLogger(name).setLevel(logging.WARNING)

--- a/datanika/services/health_routes.py
+++ b/datanika/services/health_routes.py
@@ -1,0 +1,54 @@
+"""Health check endpoints — /healthz (liveness) and /readyz (readiness)."""
+
+import logging
+
+from sqlalchemy import create_engine, text
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from datanika.config import settings
+
+logger = logging.getLogger(__name__)
+
+_engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
+
+
+async def healthz(request: Request) -> JSONResponse:
+    """Liveness probe — always returns 200 if the process is alive."""
+    return JSONResponse({"status": "ok"})
+
+
+async def readyz(request: Request) -> JSONResponse:
+    """Readiness probe — checks database and Redis connectivity."""
+    checks = {}
+
+    # Database
+    try:
+        with _engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        checks["database"] = "ok"
+    except Exception as exc:
+        logger.warning("Readiness: database check failed: %s", exc)
+        checks["database"] = "error"
+
+    # Redis
+    try:
+        import redis
+
+        r = redis.from_url(settings.redis_url, socket_timeout=2)
+        r.ping()
+        checks["redis"] = "ok"
+    except Exception as exc:
+        logger.warning("Readiness: redis check failed: %s", exc)
+        checks["redis"] = "error"
+
+    all_ok = all(v == "ok" for v in checks.values())
+    status_code = 200 if all_ok else 503
+    return JSONResponse({"status": "ok" if all_ok else "degraded", "checks": checks}, status_code)
+
+
+health_routes = [
+    Route("/healthz", healthz, methods=["GET"]),
+    Route("/readyz", readyz, methods=["GET"]),
+]

--- a/datanika/tasks/celery_app.py
+++ b/datanika/tasks/celery_app.py
@@ -1,6 +1,9 @@
 from celery import Celery
 
 from datanika.config import settings
+from datanika.logging_config import setup_logging
+
+setup_logging(debug=settings.debug)
 
 celery_app = Celery(
     "datanika",

--- a/tests/test_services/test_health_routes.py
+++ b/tests/test_services/test_health_routes.py
@@ -1,0 +1,60 @@
+"""Tests for health check endpoints."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from datanika.services.health_routes import health_routes
+
+
+@pytest.fixture
+def client():
+    app = Starlette(routes=health_routes)
+    return TestClient(app)
+
+
+class TestHealthz:
+    def test_liveness_returns_200(self, client):
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+
+class TestReadyz:
+    @patch("datanika.services.health_routes._engine")
+    def test_readiness_all_ok(self, mock_engine, client):
+        # Mock database check
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = lambda s: mock_conn
+        mock_engine.connect.return_value.__exit__ = lambda s, *a: None
+
+        # Mock redis
+        with patch("redis.from_url") as mock_redis:
+            mock_r = MagicMock()
+            mock_redis.return_value = mock_r
+            mock_r.ping.return_value = True
+
+            resp = client.get("/readyz")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "ok"
+            assert data["checks"]["database"] == "ok"
+            assert data["checks"]["redis"] == "ok"
+
+    @patch("datanika.services.health_routes._engine")
+    def test_readiness_db_down(self, mock_engine, client):
+        mock_engine.connect.side_effect = Exception("DB down")
+
+        with patch("redis.from_url") as mock_redis:
+            mock_r = MagicMock()
+            mock_redis.return_value = mock_r
+            mock_r.ping.return_value = True
+
+            resp = client.get("/readyz")
+            assert resp.status_code == 503
+            data = resp.json()
+            assert data["status"] == "degraded"
+            assert data["checks"]["database"] == "error"
+            assert data["checks"]["redis"] == "ok"

--- a/tests/test_services/test_logging_config.py
+++ b/tests/test_services/test_logging_config.py
@@ -1,0 +1,61 @@
+"""Tests for structured JSON logging configuration."""
+
+import json
+import logging
+
+from datanika.logging_config import JSONFormatter, setup_logging
+
+
+class TestJSONFormatter:
+    def test_formats_as_json(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert data["level"] == "INFO"
+        assert data["logger"] == "test.logger"
+        assert data["message"] == "hello world"
+        assert "timestamp" in data
+
+    def test_includes_exception(self):
+        formatter = JSONFormatter()
+        try:
+            raise ValueError("test error")
+        except ValueError:
+            import sys
+
+            record = logging.LogRecord(
+                name="test",
+                level=logging.ERROR,
+                pathname="test.py",
+                lineno=1,
+                msg="oops",
+                args=(),
+                exc_info=sys.exc_info(),
+            )
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert "exception" in data
+        assert "ValueError" in data["exception"]
+
+
+class TestSetupLogging:
+    def test_debug_mode_uses_text_formatter(self):
+        setup_logging(debug=True)
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert not isinstance(root.handlers[0].formatter, JSONFormatter)
+
+    def test_prod_mode_uses_json_formatter(self):
+        setup_logging(debug=False)
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0].formatter, JSONFormatter)


### PR DESCRIPTION
## Summary
- `/healthz` liveness probe — always returns 200 if process is alive
- `/readyz` readiness probe — checks DB + Redis, returns 503 if degraded
- `JSONFormatter` for structured log aggregation (Grafana/Loki)
- Human-readable format in debug mode
- Wired into app startup and Celery worker

Closes #10

## Test plan
- [x] 3 health check tests (liveness, readiness ok, readiness degraded)
- [x] 4 logging tests (JSON format, exception inclusion, debug vs prod mode)
- [x] All 1271 existing tests still pass