### PR TITLE
Add usage bar on dashboard showing runs consumed

### DIFF
--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -371,5 +371,8 @@
   "connections.topics": "المواضيع (مفصولة بفواصل)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "معرف مجموعة المستهلكين",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "استخدام الخطة",
+  "dashboard.usage_runs": "عمليات تشغيل النماذج هذا الشهر",
+  "dashboard.usage_upgrade": "ترقية للمزيد"
 }

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -371,5 +371,8 @@
   "connections.topics": "Topics (kommagetrennt)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "Konsumentengruppen-ID",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "Plannutzung",
+  "dashboard.usage_runs": "Modellausführungen diesen Monat",
+  "dashboard.usage_upgrade": "Upgrade für mehr"
 }

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -371,5 +371,8 @@
   "connections.topics": "Topics (χωρισμένα με κόμμα)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "ID ομάδας καταναλωτών",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "Χρήση πλάνου",
+  "dashboard.usage_runs": "εκτελέσεις μοντέλων αυτόν τον μήνα",
+  "dashboard.usage_upgrade": "Αναβάθμιση για περισσότερα"
 }

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -371,5 +371,8 @@
   "audit.resource_type": "Resource Type",
   "audit.resource_id": "Resource ID",
   "audit.ip_address": "IP Address",
-  "audit.no_logs": "No audit log entries found."
+  "audit.no_logs": "No audit log entries found.",
+  "dashboard.usage_title": "Plan Usage",
+  "dashboard.usage_runs": "model runs this month",
+  "dashboard.usage_upgrade": "Upgrade for more"
 }

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -371,5 +371,8 @@
   "connections.topics": "Topics (separados por comas)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "ID del grupo de consumidores",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "Uso del plan",
+  "dashboard.usage_runs": "ejecuciones de modelos este mes",
+  "dashboard.usage_upgrade": "Mejorar para más"
 }

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -371,5 +371,8 @@
   "connections.topics": "Topics (séparés par des virgules)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "ID du groupe de consommateurs",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "Utilisation du plan",
+  "dashboard.usage_runs": "exécutions de modèles ce mois",
+  "dashboard.usage_upgrade": "Passer au niveau supérieur"
 }

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -371,5 +371,8 @@
   "connections.topics": "Топики (через запятую)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "ID группы потребителей",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "Использование тарифа",
+  "dashboard.usage_runs": "запусков моделей в этом месяце",
+  "dashboard.usage_upgrade": "Улучшить для большего"
 }

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -371,5 +371,8 @@
   "connections.topics": "Теме (раздвојене зарезом)",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "ID групе потрошача",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "Коришћење плана",
+  "dashboard.usage_runs": "покретања модела овог месеца",
+  "dashboard.usage_upgrade": "Надогради за више"
 }

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -371,5 +371,8 @@
   "connections.topics": "主题（逗号分隔）",
   "connections.ph_topics": "events, orders",
   "connections.group_id": "消费者组 ID",
-  "connections.ph_group_id": "datanika-consumer"
+  "connections.ph_group_id": "datanika-consumer",
+  "dashboard.usage_title": "计划使用情况",
+  "dashboard.usage_runs": "本月模型运行次数",
+  "dashboard.usage_upgrade": "升级获取更多"
 }

--- a/datanika/ui/pages/dashboard.py
+++ b/datanika/ui/pages/dashboard.py
@@ -75,6 +75,75 @@ def _guide_step(title: rx.Var[str], desc: rx.Var[str]) -> rx.Component:
     )
 
 
+def usage_bar() -> rx.Component:
+    return rx.cond(
+        DashboardState.has_usage_data,
+        rx.card(
+            rx.vstack(
+                rx.hstack(
+                    rx.text(_t["dashboard.usage_title"], weight="bold", size="3"),
+                    rx.badge(DashboardState.plan_name, color_scheme="violet", size="1"),
+                    align="center",
+                    spacing="2",
+                ),
+                rx.hstack(
+                    rx.text(
+                        DashboardState.runs_used,
+                        " / ",
+                        DashboardState.runs_limit,
+                        " ",
+                        _t["dashboard.usage_runs"],
+                        size="2",
+                    ),
+                    rx.text(
+                        DashboardState.runs_percent,
+                        "%",
+                        size="2",
+                        weight="bold",
+                        color=rx.cond(
+                            DashboardState.runs_percent >= 80,
+                            "var(--red-11)",
+                            rx.cond(
+                                DashboardState.runs_percent >= 60,
+                                "var(--amber-11)",
+                                "var(--green-11)",
+                            ),
+                        ),
+                    ),
+                    justify="between",
+                    width="100%",
+                ),
+                rx.progress(
+                    value=DashboardState.runs_percent,
+                    max=100,
+                    color_scheme=DashboardState.runs_color,
+                    width="100%",
+                ),
+                rx.cond(
+                    DashboardState.runs_percent >= 80,
+                    rx.hstack(
+                        rx.icon("alert-triangle", size=14, color="var(--red-11)"),
+                        rx.link(
+                            rx.text(
+                                _t["dashboard.usage_upgrade"],
+                                size="2",
+                                color="var(--red-11)",
+                                weight="medium",
+                            ),
+                            href="/settings?tab=billing",
+                        ),
+                        align="center",
+                        spacing="1",
+                    ),
+                ),
+                spacing="2",
+                width="100%",
+            ),
+            width="100%",
+        ),
+    )
+
+
 def getting_started_card() -> rx.Component:
     return rx.accordion.root(
         rx.accordion.item(
@@ -161,6 +230,7 @@ def dashboard_page() -> rx.Component:
                 spacing="4",
                 wrap="wrap",
             ),
+            usage_bar(),
             recent_runs_table(),
             spacing="6",
             width="100%",

--- a/datanika/ui/state/dashboard_state.py
+++ b/datanika/ui/state/dashboard_state.py
@@ -1,8 +1,10 @@
 """Dashboard state — stats and recent runs."""
 
+import reflex as rx
 from pydantic import BaseModel
 
 from datanika.config import settings
+from datanika.hooks import emit
 from datanika.models.run import RunStatus
 from datanika.services.connection_service import ConnectionService
 from datanika.services.encryption import EncryptionService
@@ -28,6 +30,30 @@ class DashboardStats(BaseModel):
 class DashboardState(BaseState):
     stats: DashboardStats = DashboardStats()
     recent_runs: list[RunItem] = []
+
+    # Usage bar (populated via hook — zero when cloud plugin not active)
+    runs_used: int = 0
+    runs_limit: int = 0
+    plan_name: str = ""
+
+    @rx.var
+    def runs_percent(self) -> int:
+        if self.runs_limit <= 0:
+            return 0
+        return min(int(self.runs_used / self.runs_limit * 100), 100)
+
+    @rx.var
+    def runs_color(self) -> str:
+        pct = self.runs_percent
+        if pct >= 80:
+            return "red"
+        if pct >= 60:
+            return "yellow"
+        return "green"
+
+    @rx.var
+    def has_usage_data(self) -> bool:
+        return self.runs_limit > 0
 
     async def load_dashboard(self):
         org_id = await self._get_org_id()
@@ -82,6 +108,19 @@ class DashboardState(BaseState):
                 )
                 for r in recent
             ]
+
+        # Load usage data via hook (cloud plugin fills this in)
+        usage_ctx = {
+            "org_id": org_id,
+            "runs_used": 0,
+            "runs_limit": 0,
+            "plan_name": "",
+        }
+        emit("usage.get_summary", context=usage_ctx)
+        self.runs_used = usage_ctx["runs_used"]
+        self.runs_limit = usage_ctx["runs_limit"]
+        self.plan_name = usage_ctx["plan_name"]
+
         self.error_message = ""
 
     @staticmethod

--- a/tests/test_ui/test_usage_bar.py
+++ b/tests/test_ui/test_usage_bar.py
@@ -1,0 +1,84 @@
+"""Tests for usage bar on dashboard."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from datanika.hooks import clear, emit, on
+
+
+class TestUsageHook:
+    """Test that usage.get_summary hook populates context."""
+
+    def setup_method(self):
+        clear()
+
+    def teardown_method(self):
+        clear()
+
+    def test_no_handler_returns_empty_context(self):
+        ctx = {"org_id": 1, "runs_used": 0, "runs_limit": 0, "plan_name": ""}
+        emit("usage.get_summary", context=ctx)
+        assert ctx["runs_used"] == 0
+        assert ctx["runs_limit"] == 0
+        assert ctx["plan_name"] == ""
+
+    def test_handler_populates_context(self):
+        def fake_handler(*, context, **_kw):
+            context["runs_used"] = 380
+            context["runs_limit"] = 500
+            context["plan_name"] = "Free"
+
+        on("usage.get_summary", fake_handler)
+
+        ctx = {"org_id": 1, "runs_used": 0, "runs_limit": 0, "plan_name": ""}
+        emit("usage.get_summary", context=ctx)
+        assert ctx["runs_used"] == 380
+        assert ctx["runs_limit"] == 500
+        assert ctx["plan_name"] == "Free"
+
+    def test_percentage_calculation(self):
+        used, limit = 400, 500
+        pct = int(used / limit * 100) if limit > 0 else 0
+        assert pct == 80
+
+    def test_percentage_zero_limit(self):
+        used, limit = 0, 0
+        pct = int(used / limit * 100) if limit > 0 else 0
+        assert pct == 0
+
+    def test_color_thresholds(self):
+        def color_for(pct):
+            if pct >= 80:
+                return "red"
+            if pct >= 60:
+                return "yellow"
+            return "green"
+
+        assert color_for(50) == "green"
+        assert color_for(60) == "yellow"
+        assert color_for(79) == "yellow"
+        assert color_for(80) == "red"
+        assert color_for(100) == "red"
+
+
+class TestUsageI18nKeys:
+    """Verify usage bar i18n keys exist in all locale files."""
+
+    def test_usage_keys_in_all_locales(self):
+        i18n_dir = Path(__file__).resolve().parent.parent.parent / "datanika" / "i18n"
+        required_keys = [
+            "dashboard.usage_title",
+            "dashboard.usage_runs",
+            "dashboard.usage_upgrade",
+        ]
+        locales = ["en", "ru", "el", "de", "fr", "es", "zh", "ar", "sr"]
+
+        for locale in locales:
+            path = i18n_dir / f"{locale}.json"
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            for key in required_keys:
+                assert key in data, f"Missing key '{key}' in {locale}.json"
+                assert data[key], f"Empty value for '{key}' in {locale}.json"


### PR DESCRIPTION
## Summary

- New `usage.get_summary` hook — core emits, cloud plugin fills in runs_used/runs_limit/plan_name
- `DashboardState` gets `runs_used`, `runs_limit`, `plan_name` fields + computed `runs_percent`, `runs_color`, `has_usage_data`
- Progress bar on dashboard: green (<60%), yellow (60-80%), red (>80%) with "Upgrade for more" link
- Hidden on self-hosted (no hook handler = `runs_limit` stays 0)
- i18n: 3 keys in all 9 locales
- 6 tests (hook behavior, percentage math, color thresholds, i18n parity)

## Test plan

- [x] Hook with no handler returns zeros (self-hosted case)
- [x] Hook with handler populates context correctly
- [x] Color thresholds: green/yellow/red at correct boundaries
- [x] i18n keys present in all 9 locales
- [x] i18n parity test (15 tests) still passes

Requires: datanika-io/datanika-cloud#3 (cloud-side hook handler)

Closes #4