### PR TITLE
Standardize Celery retry policies

### DIFF
--- a/datanika/tasks/email_tasks.py
+++ b/datanika/tasks/email_tasks.py
@@ -3,7 +3,13 @@
 from datanika.tasks.celery_app import celery_app
 
 
-@celery_app.task(name="datanika.send_email")
+@celery_app.task(
+    name="datanika.send_email",
+    autoretry_for=(OSError, ConnectionError, TimeoutError),
+    retry_backoff=30,
+    retry_backoff_max=300,
+    max_retries=3,
+)
 def send_email_task(to: str, subject: str, html_body: str) -> bool:
     from datanika.config import settings
     from datanika.services.email_service import EmailService
@@ -21,7 +27,13 @@ def send_email_task(to: str, subject: str, html_body: str) -> bool:
     return svc.send(to, subject, html_body)
 
 
-@celery_app.task(name="datanika.send_verification_email")
+@celery_app.task(
+    name="datanika.send_verification_email",
+    autoretry_for=(OSError, ConnectionError, TimeoutError),
+    retry_backoff=30,
+    retry_backoff_max=300,
+    max_retries=3,
+)
 def send_verification_email_task(to: str, token: str) -> bool:
     from datanika.config import settings
     from datanika.services.email_service import EmailService
@@ -39,7 +51,13 @@ def send_verification_email_task(to: str, token: str) -> bool:
     return svc.send_verification_email(to, token)
 
 
-@celery_app.task(name="datanika.send_invitation_email")
+@celery_app.task(
+    name="datanika.send_invitation_email",
+    autoretry_for=(OSError, ConnectionError, TimeoutError),
+    retry_backoff=30,
+    retry_backoff_max=300,
+    max_retries=3,
+)
 def send_invitation_email_task(
     to: str, org_name: str, inviter_name: str, token: str
 ) -> bool:

--- a/datanika/tasks/pipeline_tasks.py
+++ b/datanika/tasks/pipeline_tasks.py
@@ -288,7 +288,7 @@ def run_pipeline(
             session.close()
 
 
-@celery_app.task(bind=True, name="datanika.run_pipeline")
+@celery_app.task(bind=True, name="datanika.run_pipeline", max_retries=60)
 def run_pipeline_task(self, run_id: int, org_id: int, scheduled: bool = False):
     """Celery entry point for dbt pipeline execution."""
     if scheduled:

--- a/datanika/tasks/transformation_tasks.py
+++ b/datanika/tasks/transformation_tasks.py
@@ -199,7 +199,7 @@ def run_transformation(
             session.close()
 
 
-@celery_app.task(bind=True, name="datanika.run_transformation")
+@celery_app.task(bind=True, name="datanika.run_transformation", max_retries=60)
 def run_transformation_task(self, run_id: int, org_id: int, scheduled: bool = False):
     """Celery entry point for transformation execution."""
     if scheduled:

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -231,7 +231,7 @@ def run_upload(
             session.close()
 
 
-@celery_app.task(bind=True, name="datanika.run_upload")
+@celery_app.task(bind=True, name="datanika.run_upload", max_retries=60)
 def run_upload_task(self, run_id: int, org_id: int, scheduled: bool = False):
     """Celery entry point for upload execution."""
     if scheduled:


### PR DESCRIPTION
## Summary
- **Email tasks**: autoretry on transient SMTP errors (OSError, ConnectionError, TimeoutError) with exponential backoff (30s-300s), max 3 retries
- **Run tasks**: explicit `max_retries=60` for concurrency slot acquisition; execution failures are NOT retried (they are legitimate errors)
- **Maintenance task**: unchanged — periodic, no retry needed

Closes #18

## Test plan
- [x] All 37 task tests pass
- [x] Ruff clean