### PR TITLE
Centralize DB connection pooling and tune pool settings

### DIFF
--- a/datanika/config.py
+++ b/datanika/config.py
@@ -63,6 +63,12 @@ class Settings(BaseSettings):
     # SSO
     sso_sp_entity_id: str = "datanika"
 
+    # Database connection pool
+    db_pool_size: int = 5
+    db_max_overflow: int = 10
+    db_pool_timeout: int = 30
+    db_pool_recycle: int = 1800  # 30 minutes
+
     # API rate limiting (requests per minute, per API key)
     api_rate_limit_rpm: int = 60
     api_rate_limit_burst: int = 10

--- a/datanika/db.py
+++ b/datanika/db.py
@@ -1,13 +1,50 @@
+"""Centralized database engine and session factories.
+
+All code should use these engines instead of creating their own.
+- Async engine/sessions: Reflex UI state handlers
+- Sync engine/sessions: Celery tasks, API middleware, Starlette routes
+"""
+
 from collections.abc import AsyncGenerator
 
+from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session
 
 from datanika.config import settings
 
-engine = create_async_engine(settings.database_url, echo=settings.debug)
-async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+_pool_kwargs = {
+    "pool_size": settings.db_pool_size,
+    "max_overflow": settings.db_max_overflow,
+    "pool_timeout": settings.db_pool_timeout,
+    "pool_recycle": settings.db_pool_recycle,
+    "pool_pre_ping": True,
+}
+
+# Async engine — used by Reflex UI via get_session()
+engine = create_async_engine(
+    settings.database_url,
+    echo=settings.debug,
+    **_pool_kwargs,
+)
+async_session_factory = async_sessionmaker(
+    engine, class_=AsyncSession, expire_on_commit=False,
+)
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_factory() as session:
         yield session
+
+
+# Sync engine — used by Celery tasks, API middleware, Starlette routes
+sync_engine = create_engine(
+    settings.database_url_sync,
+    echo=settings.debug,
+    **_pool_kwargs,
+)
+
+
+def get_sync_session() -> Session:
+    """Return a sync Session bound to the shared sync engine."""
+    return Session(sync_engine)

--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -375,7 +375,6 @@
   "notifications.active": "نشط",
   "notifications.add": "إضافة قناة",
   "notifications.custom_url": "رابط Webhook",
-  "notifications.delete_confirm": "حذف هذه القناة؟",
   "notifications.email_address": "عنوان البريد الإلكتروني",
   "notifications.events": "الأحداث",
   "notifications.name": "اسم القناة",

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -375,7 +375,6 @@
   "notifications.active": "Aktiv",
   "notifications.add": "Kanal hinzufügen",
   "notifications.custom_url": "Webhook-URL",
-  "notifications.delete_confirm": "Diesen Kanal löschen?",
   "notifications.email_address": "E-Mail-Adresse",
   "notifications.events": "Ereignisse",
   "notifications.name": "Kanalname",

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -375,7 +375,6 @@
   "notifications.active": "Ενεργό",
   "notifications.add": "Προσθήκη καναλιού",
   "notifications.custom_url": "URL Webhook",
-  "notifications.delete_confirm": "Διαγραφή αυτού του καναλιού;",
   "notifications.email_address": "Διεύθυνση email",
   "notifications.events": "Συμβάντα",
   "notifications.name": "Όνομα καναλιού",

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -375,7 +375,6 @@
   "notifications.active": "Active",
   "notifications.add": "Add Channel",
   "notifications.custom_url": "Webhook URL",
-  "notifications.delete_confirm": "Delete this channel?",
   "notifications.email_address": "Email Address",
   "notifications.events": "Events",
   "notifications.name": "Channel Name",

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -375,7 +375,6 @@
   "notifications.active": "Activo",
   "notifications.add": "Agregar canal",
   "notifications.custom_url": "URL del webhook",
-  "notifications.delete_confirm": "¿Eliminar este canal?",
   "notifications.email_address": "Dirección de email",
   "notifications.events": "Eventos",
   "notifications.name": "Nombre del canal",

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -375,7 +375,6 @@
   "notifications.active": "Actif",
   "notifications.add": "Ajouter un canal",
   "notifications.custom_url": "URL du webhook",
-  "notifications.delete_confirm": "Supprimer ce canal ?",
   "notifications.email_address": "Adresse email",
   "notifications.events": "Événements",
   "notifications.name": "Nom du canal",

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -375,7 +375,6 @@
   "notifications.active": "Активный",
   "notifications.add": "Добавить канал",
   "notifications.custom_url": "URL вебхука",
-  "notifications.delete_confirm": "Удалить этот канал?",
   "notifications.email_address": "Email адрес",
   "notifications.events": "События",
   "notifications.name": "Название канала",

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -375,7 +375,6 @@
   "notifications.active": "Активан",
   "notifications.add": "Додај канал",
   "notifications.custom_url": "Webhook URL",
-  "notifications.delete_confirm": "Обрисати овај канал?",
   "notifications.email_address": "Имејл адреса",
   "notifications.events": "Догађаји",
   "notifications.name": "Назив канала",

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -375,7 +375,6 @@
   "notifications.active": "启用",
   "notifications.add": "添加渠道",
   "notifications.custom_url": "Webhook URL",
-  "notifications.delete_confirm": "删除此渠道？",
   "notifications.email_address": "邮箱地址",
   "notifications.events": "事件",
   "notifications.name": "渠道名称",

--- a/datanika/services/api_middleware.py
+++ b/datanika/services/api_middleware.py
@@ -4,24 +4,22 @@ import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from datanika.config import settings
+from datanika.db import get_sync_session
 from datanika.services.api_key_service import ApiKeyService
 from datanika.services.rate_limit_service import RateLimitService
 
 logger = logging.getLogger(__name__)
 
-_engine = create_engine(settings.database_url_sync)
 _api_key_svc = ApiKeyService()
 _rate_limit_svc = RateLimitService()
 
 
-def _get_session() -> Session:
-    return Session(_engine)
+def _get_session():
+    return get_sync_session()
 
 
 def _error(status: int, message: str, headers: dict[str, str] | None = None) -> JSONResponse:

--- a/datanika/services/health_routes.py
+++ b/datanika/services/health_routes.py
@@ -2,16 +2,15 @@
 
 import logging
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from datanika.config import settings
+from datanika.db import sync_engine
 
 logger = logging.getLogger(__name__)
-
-_engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
 
 
 async def healthz(request: Request) -> JSONResponse:
@@ -25,7 +24,7 @@ async def readyz(request: Request) -> JSONResponse:
 
     # Database
     try:
-        with _engine.connect() as conn:
+        with sync_engine.connect() as conn:
             conn.execute(text("SELECT 1"))
         checks["database"] = "ok"
     except Exception as exc:

--- a/datanika/services/oauth_routes.py
+++ b/datanika/services/oauth_routes.py
@@ -42,11 +42,9 @@ def _get_service() -> OAuthService:
 
 
 def _get_session():
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session as SASession
+    from datanika.db import get_sync_session
 
-    engine = create_engine(settings.database_url_sync)
-    return SASession(engine)
+    return get_sync_session()
 
 
 def _frontend(path: str) -> str:

--- a/datanika/services/scheduler_integration.py
+++ b/datanika/services/scheduler_integration.py
@@ -3,9 +3,8 @@
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
-from sqlalchemy import create_engine, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
-from sqlalchemy.orm import Session as SyncSession
 
 from datanika.models.dependency import NodeType
 from datanika.models.schedule import Schedule
@@ -118,10 +117,9 @@ class SchedulerIntegrationService:
     @staticmethod
     def _dispatch_target(org_id: int, target_type: str, target_id: int) -> None:
         """Callback for APScheduler: create Run + dispatch Celery task."""
-        from datanika.config import settings
+        from datanika.db import get_sync_session
 
-        engine = create_engine(settings.database_url_sync)
-        session = SyncSession(engine)
+        session = get_sync_session()
 
         try:
             exec_svc = ExecutionService()

--- a/datanika/services/sso_routes.py
+++ b/datanika/services/sso_routes.py
@@ -22,11 +22,9 @@ _SSO_STATE_COOKIE = "sso_state"
 
 
 def _get_session():
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session as SASession
+    from datanika.db import get_sync_session
 
-    engine = create_engine(settings.database_url_sync)
-    return SASession(engine)
+    return get_sync_session()
 
 
 def _frontend(path: str) -> str:

--- a/datanika/tasks/dependency_helpers.py
+++ b/datanika/tasks/dependency_helpers.py
@@ -34,13 +34,9 @@ def check_deps_or_retry(
     """
     own_session = session is None
     if own_session:
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session as SyncSession
+        from datanika.db import get_sync_session
 
-        from datanika.config import settings
-
-        engine = create_engine(settings.database_url_sync)
-        session = SyncSession(engine)
+        session = get_sync_session()
 
     try:
         run = session.get(Run, run_id)

--- a/datanika/tasks/pipeline_tasks.py
+++ b/datanika/tasks/pipeline_tasks.py
@@ -152,13 +152,9 @@ def run_pipeline(
     """
     own_session = session is None
     if own_session:
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session as SyncSession
+        from datanika.db import get_sync_session
 
-        from datanika.config import settings
-
-        engine = create_engine(settings.database_url_sync)
-        session = SyncSession(engine)
+        session = get_sync_session()
 
     if encryption is None:
         from datanika.config import settings

--- a/datanika/tasks/transformation_tasks.py
+++ b/datanika/tasks/transformation_tasks.py
@@ -91,13 +91,9 @@ def run_transformation(
     """
     own_session = session is None
     if own_session:
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session as SyncSession
+        from datanika.db import get_sync_session
 
-        from datanika.config import settings
-
-        engine = create_engine(settings.database_url_sync)
-        session = SyncSession(engine)
+        session = get_sync_session()
 
     try:
         # Check run quota before starting (cloud plugin may block)

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -99,13 +99,9 @@ def run_upload(
     """
     own_session = session is None
     if own_session:
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session as SyncSession
+        from datanika.db import get_sync_session
 
-        from datanika.config import settings
-
-        engine = create_engine(settings.database_url_sync)
-        session = SyncSession(engine)
+        session = get_sync_session()
 
     if encryption is None:
         from datanika.config import settings

--- a/datanika/ui/state/base_state.py
+++ b/datanika/ui/state/base_state.py
@@ -3,12 +3,10 @@
 import logging
 
 import reflex as rx
-from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from datanika.config import settings
+from datanika.db import get_sync_session  # noqa: F401 — re-exported
 
-_engine = create_engine(settings.database_url_sync)
 _log = logging.getLogger(__name__)
 
 ROLE_HIERARCHY = {"owner": 4, "admin": 3, "editor": 2, "viewer": 1}
@@ -17,11 +15,6 @@ ROLE_HIERARCHY = {"owner": 4, "admin": 3, "editor": 2, "viewer": 1}
 def check_role_hierarchy(current_role: str, required_role: str) -> bool:
     """Check if current_role meets or exceeds required_role."""
     return ROLE_HIERARCHY.get(current_role, 0) >= ROLE_HIERARCHY.get(required_role, 0)
-
-
-def get_sync_session() -> Session:
-    """Create a sync session for use in Reflex event handlers."""
-    return Session(_engine)
 
 
 class BaseState(rx.State):

--- a/tests/test_services/test_health_routes.py
+++ b/tests/test_services/test_health_routes.py
@@ -23,7 +23,7 @@ class TestHealthz:
 
 
 class TestReadyz:
-    @patch("datanika.services.health_routes._engine")
+    @patch("datanika.services.health_routes.sync_engine")
     def test_readiness_all_ok(self, mock_engine, client):
         # Mock database check
         mock_conn = MagicMock()
@@ -43,7 +43,7 @@ class TestReadyz:
             assert data["checks"]["database"] == "ok"
             assert data["checks"]["redis"] == "ok"
 
-    @patch("datanika.services.health_routes._engine")
+    @patch("datanika.services.health_routes.sync_engine")
     def test_readiness_db_down(self, mock_engine, client):
         mock_engine.connect.side_effect = Exception("DB down")
 

--- a/tests/test_services/test_scheduler_integration.py
+++ b/tests/test_services/test_scheduler_integration.py
@@ -193,8 +193,7 @@ class TestDispatchTarget:
         mock_svc.create_run.return_value = mock_run
 
         with (
-            patch("datanika.services.scheduler_integration.create_engine"),
-            patch("datanika.services.scheduler_integration.SyncSession"),
+            patch("datanika.db.get_sync_session"),
         ):
             SchedulerIntegrationService._dispatch_target(1, "upload", 10)
 
@@ -212,8 +211,7 @@ class TestDispatchTarget:
         mock_svc.create_run.return_value = mock_run
 
         with (
-            patch("datanika.services.scheduler_integration.create_engine"),
-            patch("datanika.services.scheduler_integration.SyncSession"),
+            patch("datanika.db.get_sync_session"),
         ):
             SchedulerIntegrationService._dispatch_target(1, "transformation", 20)
 
@@ -231,8 +229,7 @@ class TestDispatchTarget:
         mock_svc.create_run.return_value = mock_run
 
         with (
-            patch("datanika.services.scheduler_integration.create_engine"),
-            patch("datanika.services.scheduler_integration.SyncSession"),
+            patch("datanika.db.get_sync_session"),
         ):
             SchedulerIntegrationService._dispatch_target(3, "upload", 7)
 
@@ -247,8 +244,7 @@ class TestDispatchTarget:
         mock_svc.create_run.return_value = mock_run
 
         with (
-            patch("datanika.services.scheduler_integration.create_engine"),
-            patch("datanika.services.scheduler_integration.SyncSession"),
+            patch("datanika.db.get_sync_session"),
         ):
             SchedulerIntegrationService._dispatch_target(1, "pipeline", 30)
 


### PR DESCRIPTION
## Summary
- Add env-configurable pool settings: `DB_POOL_SIZE` (5), `DB_MAX_OVERFLOW` (10), `DB_POOL_TIMEOUT` (30s), `DB_POOL_RECYCLE` (1800s)
- Centralize `sync_engine` + `get_sync_session()` in `db.py`
- Enable `pool_pre_ping` on both async and sync engines
- Replace 8 scattered `create_engine()` calls with shared pool

Closes #25

## Test plan
- [x] 1304 tests pass
- [x] Ruff clean