### PR TITLE
Pin dbt-core and dlt to tested versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ readme = "README.md"
 license = "AGPL-3.0-only"
 requires-python = ">=3.12"
 dependencies = [
-    # Data pipeline
-    "dlt[postgres,snowflake,bigquery,mssql,clickhouse,duckdb,databricks,synapse]>=1.5",
-    "dbt-core>=1.7,<1.8",
+    # Data pipeline — pinned to tested versions; bump deliberately
+    "dlt[postgres,snowflake,bigquery,mssql,clickhouse,duckdb,databricks,synapse]>=1.21,<2",
+    "dbt-core>=1.7.19,<1.8",
     "dbt-postgres>=1.7,<1.8",
     "dbt-snowflake>=1.7,<1.8",
     "dbt-bigquery>=1.7,<1.8",


### PR DESCRIPTION
## Summary
- `dbt-core`: `>=1.7.19,<1.8` (pinned to tested patch, was `>=1.7`)
- `dlt`: `>=1.21,<2` (pinned to tested minor, was `>=1.5`)
- All dbt adapters remain at `>=1.7,<1.8` range
- Added comment: bump deliberately after testing

Closes #26

## Test plan
- [x] No runtime changes — dependency spec only