### PR TITLE
Hotfix: settings page crash + remove GHCR build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,30 @@ jobs:
       - name: Run tests
         run: pytest tests/ --tb=short -q
 
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Reflex compile check
+        run: reflex export --no-zip --frontend-only 2>&1 | tee /tmp/reflex-compile.log; test ${PIPESTATUS[0]} -eq 0
+        env:
+          DATABASE_URL_SYNC: "sqlite:///test.db"
+          DATABASE_URL: "sqlite+aiosqlite:///test.db"
+
   deploy:
+    needs: [lint, test, compile]
     needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/datanika/migrations/versions/t9p6q7r8s0m1_add_notification_channels_table.py
+++ b/datanika/migrations/versions/t9p6q7r8s0m1_add_notification_channels_table.py
@@ -1,0 +1,45 @@
+"""Add notification_channels table
+
+Revision ID: t9p6q7r8s0m1
+Revises: s8o5p6q7r9l0
+Create Date: 2026-04-10 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "t9p6q7r8s0m1"
+down_revision: Union[str, None] = "s8o5p6q7r9l0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_channels",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "channel_type",
+            sa.Enum("email", "slack", "telegram", "webhook", native_enum=False, length=20),
+            nullable=False,
+        ),
+        sa.Column("config", sa.JSON(), nullable=False),
+        sa.Column("events", sa.JSON(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("org_id", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    op.drop_table("notification_channels")
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/migrations/versions/u0q7r8s9t1n2_add_uploaded_files_table.py
+++ b/datanika/migrations/versions/u0q7r8s9t1n2_add_uploaded_files_table.py
@@ -1,0 +1,41 @@
+"""Add uploaded_files table
+
+Revision ID: u0q7r8s9t1n2
+Revises: t9p6q7r8s0m1
+Create Date: 2026-04-10 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "u0q7r8s9t1n2"
+down_revision: Union[str, None] = "t9p6q7r8s0m1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "uploaded_files",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("original_name", sa.String(length=500), nullable=False),
+        sa.Column("content_type", sa.String(length=100), nullable=False),
+        sa.Column("file_size", sa.BigInteger(), nullable=False),
+        sa.Column("file_hash", sa.String(length=64), nullable=False),
+        sa.Column("archive_path", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    op.drop_table("uploaded_files")
+    connection = op.get_bind()
+    connection.commit()

--- a/tests/test_migrations/test_migration_coverage.py
+++ b/tests/test_migrations/test_migration_coverage.py
@@ -1,0 +1,66 @@
+"""Verify every model table has a corresponding migration.
+
+Catches the case where a new model is added but the developer forgets
+to generate an Alembic migration, which leads to 'relation does not exist'
+errors in production.
+"""
+
+import importlib
+import pkgutil
+import re
+from pathlib import Path
+
+import datanika.models as models_pkg
+
+
+def _collect_model_tables() -> set[str]:
+    """Import all model modules and extract __tablename__ values."""
+    tables = set()
+    pkg_path = Path(models_pkg.__file__).parent
+    for info in pkgutil.iter_modules([str(pkg_path)]):
+        if info.name == "base":
+            continue
+        mod = importlib.import_module(f"datanika.models.{info.name}")
+        for attr_name in dir(mod):
+            attr = getattr(mod, attr_name)
+            if isinstance(attr, type) and hasattr(attr, "__tablename__"):
+                tablename = getattr(attr, "__tablename__", None)
+                if tablename and not tablename.startswith("_"):
+                    tables.add(tablename)
+    return tables
+
+
+def _collect_migrated_tables() -> set[str]:
+    """Scan all migration files for create_table/rename_table and CREATE TABLE."""
+    tables = set()
+    versions_dir = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
+    # Match: op.create_table("name" or CREATE TABLE name or rename_table(..., "name")
+    create_pattern = re.compile(
+        r"""(?:create_table|CREATE\s+TABLE)\s*\(?\s*['"](\w+)['"]""", re.I
+    )
+    # rename_table("old", "new") — the new name is the second arg
+    rename_pattern = re.compile(
+        r"""rename_table\s*\(\s*['"](\w+)['"]\s*,\s*['"](\w+)['"]""", re.I
+    )
+    for f in versions_dir.glob("*.py"):
+        content = f.read_text(encoding="utf-8")
+        for match in create_pattern.finditer(content):
+            tables.add(match.group(1))
+        for match in rename_pattern.finditer(content):
+            tables.add(match.group(2))  # new table name
+    return tables
+
+
+# Tables managed by cloud plugin — not in core migrations
+_CLOUD_TABLES = {"plans", "subscriptions", "usage_ledger"}
+
+
+class TestMigrationCoverage:
+    def test_every_model_has_migration(self):
+        model_tables = _collect_model_tables() - _CLOUD_TABLES
+        migrated_tables = _collect_migrated_tables()
+        missing = model_tables - migrated_tables
+        assert not missing, (
+            f"Models define tables that have no migration: {sorted(missing)}. "
+            f"Run: uv run alembic revision --autogenerate -m 'add <table>'"
+        )


### PR DESCRIPTION
## Summary
- Fix `TypeError: can only join an iterable` crash in settings page — `ch.events` is a Reflex Var, use `Var.join()` instead of `str.join()`
- Remove redundant GHCR Docker build step from CI — Hetzner builds from source anyway

## Context
The settings page crash caused a 502 on production after PR #28 was merged. Server was hotfixed directly, this PR brings master in sync.