### PR TITLE
Add API discovery endpoints /api/v1/meta/*

### DIFF
--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -185,6 +185,12 @@ from datanika.services.api_v1_routes import api_v1_routes  # noqa: E402
 for _route in api_v1_routes:
     app._api.routes.append(_route)
 
+# Mount discovery (meta) routes — /api/v1/meta/*
+from datanika.services.meta_routes import meta_routes  # noqa: E402
+
+for _route in meta_routes:
+    app._api.routes.append(_route)
+
 # Mount health check routes
 from datanika.services.health_routes import health_routes  # noqa: E402
 

--- a/datanika/migrations/env.py
+++ b/datanika/migrations/env.py
@@ -1,3 +1,4 @@
+import contextlib
 import re
 from logging.config import fileConfig
 
@@ -11,10 +12,8 @@ from datanika.migrations.helpers import (
 )
 from datanika.models.base import Base
 
-try:
+with contextlib.suppress(ImportError):
     import datanika_cloud.billing.models  # noqa: F401
-except ImportError:
-    pass
 
 _TENANT_SCHEMA_RE = re.compile(r"^tenant_\d+$")
 

--- a/datanika/migrations/versions/d5d30abce35c_add_catalog_entries_table.py
+++ b/datanika/migrations/versions/d5d30abce35c_add_catalog_entries_table.py
@@ -5,17 +5,17 @@ Revises: a1b2c3d4e5f6
 Create Date: 2026-02-17 14:32:56.570448
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "d5d30abce35c"
-down_revision: Union[str, None] = "a1b2c3d4e5f6"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/i8e5f6g7h9b0_rename_ls_columns_to_paddle.py
+++ b/datanika/migrations/versions/i8e5f6g7h9b0_rename_ls_columns_to_paddle.py
@@ -5,15 +5,15 @@ Revises: h7d4e5f6g8a9
 Create Date: 2026-03-17 19:23:44.709276
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 from sqlalchemy import inspect
 
 revision: str = "i8e5f6g7h9b0"
-down_revision: Union[str, None] = "h7d4e5f6g8a9"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "h7d4e5f6g8a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def _table_exists(table_name: str) -> bool:

--- a/datanika/migrations/versions/j9f6g7h8i0c1_add_cloud_billing_tables.py
+++ b/datanika/migrations/versions/j9f6g7h8i0c1_add_cloud_billing_tables.py
@@ -5,16 +5,16 @@ Revises: i8e5f6g7h9b0
 Create Date: 2026-03-21 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import inspect
 
 revision: str = "j9f6g7h8i0c1"
-down_revision: Union[str, None] = "i8e5f6g7h9b0"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "i8e5f6g7h9b0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def _table_exists(table_name: str) -> bool:

--- a/datanika/migrations/versions/k0g7h8i9j1d2_add_hard_cap_runs_to_plans.py
+++ b/datanika/migrations/versions/k0g7h8i9j1d2_add_hard_cap_runs_to_plans.py
@@ -5,16 +5,16 @@ Revises: j9f6g7h8i0c1
 Create Date: 2026-03-22 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import inspect
 
 revision: str = "k0g7h8i9j1d2"
-down_revision: Union[str, None] = "j9f6g7h8i0c1"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "j9f6g7h8i0c1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def _table_exists(table_name: str) -> bool:

--- a/datanika/migrations/versions/l1h8i9j0k2e3_add_email_verified_to_users.py
+++ b/datanika/migrations/versions/l1h8i9j0k2e3_add_email_verified_to_users.py
@@ -5,15 +5,15 @@ Revises: k0g7h8i9j1d2
 Create Date: 2026-03-22 14:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "l1h8i9j0k2e3"
-down_revision: Union[str, None] = "k0g7h8i9j1d2"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "k0g7h8i9j1d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/m2i9j0k1l3f4_add_invitations_table.py
+++ b/datanika/migrations/versions/m2i9j0k1l3f4_add_invitations_table.py
@@ -5,15 +5,15 @@ Revises: l1h8i9j0k2e3
 Create Date: 2026-03-22 15:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "m2i9j0k1l3f4"
-down_revision: Union[str, None] = "l1h8i9j0k2e3"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "l1h8i9j0k2e3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/n3j0k1l2m4g5_add_sso_configs_table.py
+++ b/datanika/migrations/versions/n3j0k1l2m4g5_add_sso_configs_table.py
@@ -5,15 +5,15 @@ Revises: m2i9j0k1l3f4
 Create Date: 2026-03-24 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "n3j0k1l2m4g5"
-down_revision: Union[str, None] = "m2i9j0k1l3f4"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "m2i9j0k1l3f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/o4k1l2m3n5h6_update_enterprise_plan_pricing.py
+++ b/datanika/migrations/versions/o4k1l2m3n5h6_update_enterprise_plan_pricing.py
@@ -5,14 +5,14 @@ Revises: n3j0k1l2m4g5
 Create Date: 2026-03-24 18:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
 revision: str = "o4k1l2m3n5h6"
-down_revision: Union[str, None] = "n3j0k1l2m4g5"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "n3j0k1l2m4g5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/p5l2m3n4o6i7_add_sso_enabled_to_plans.py
+++ b/datanika/migrations/versions/p5l2m3n4o6i7_add_sso_enabled_to_plans.py
@@ -5,15 +5,15 @@ Revises: o4k1l2m3n5h6
 Create Date: 2026-03-24 20:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "p5l2m3n4o6i7"
-down_revision: Union[str, None] = "o4k1l2m3n5h6"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "o4k1l2m3n5h6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/q6m3n4o5p7j8_add_free_plan_fix_overage.py
+++ b/datanika/migrations/versions/q6m3n4o5p7j8_add_free_plan_fix_overage.py
@@ -5,14 +5,14 @@ Revises: p5l2m3n4o6i7
 Create Date: 2026-03-24 21:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
 revision: str = "q6m3n4o5p7j8"
-down_revision: Union[str, None] = "p5l2m3n4o6i7"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "p5l2m3n4o6i7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/r7n4o5p6q8k9_add_rate_limit_rpm_to_plans.py
+++ b/datanika/migrations/versions/r7n4o5p6q8k9_add_rate_limit_rpm_to_plans.py
@@ -5,15 +5,15 @@ Revises: q6m3n4o5p7j8
 Create Date: 2026-04-09 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "r7n4o5p6q8k9"
-down_revision: Union[str, None] = "q6m3n4o5p7j8"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "q6m3n4o5p7j8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/s8o5p6q7r9l0_add_max_parallel_runs_to_plans.py
+++ b/datanika/migrations/versions/s8o5p6q7r9l0_add_max_parallel_runs_to_plans.py
@@ -5,15 +5,15 @@ Revises: r7n4o5p6q8k9
 Create Date: 2026-04-10 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "s8o5p6q7r9l0"
-down_revision: Union[str, None] = "r7n4o5p6q8k9"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "r7n4o5p6q8k9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/t9p6q7r8s0m1_add_notification_channels_table.py
+++ b/datanika/migrations/versions/t9p6q7r8s0m1_add_notification_channels_table.py
@@ -5,15 +5,15 @@ Revises: s8o5p6q7r9l0
 Create Date: 2026-04-10 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "t9p6q7r8s0m1"
-down_revision: Union[str, None] = "s8o5p6q7r9l0"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "s8o5p6q7r9l0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/u0q7r8s9t1n2_add_uploaded_files_table.py
+++ b/datanika/migrations/versions/u0q7r8s9t1n2_add_uploaded_files_table.py
@@ -5,15 +5,15 @@ Revises: t9p6q7r8s0m1
 Create Date: 2026-04-10 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "u0q7r8s9t1n2"
-down_revision: Union[str, None] = "t9p6q7r8s0m1"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "t9p6q7r8s0m1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/migrations/versions/v1r8s9t0u2o3_add_warning_80_sent_to_usage_ledger.py
+++ b/datanika/migrations/versions/v1r8s9t0u2o3_add_warning_80_sent_to_usage_ledger.py
@@ -5,15 +5,15 @@ Revises: u0q7r8s9t1n2
 Create Date: 2026-04-10 12:00:00.000000
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "v1r8s9t0u2o3"
-down_revision: Union[str, None] = "u0q7r8s9t1n2"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "u0q7r8s9t1n2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -1,0 +1,364 @@
+"""Centralized JSON Schemas for connection configs.
+
+Single source of truth for what fields each connection type expects.
+Used by:
+- /api/v1/meta/connection-types discovery endpoint
+- (future) UI form rendering
+- (future) Connection.config validation
+
+Each schema follows JSON Schema Draft 7. Sensitive fields are marked
+with `"format": "password"` so the UI can render them as password inputs
+and AI agents know not to log them.
+"""
+
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import (
+    DESTINATION_TYPES,
+    SOURCE_TYPES,
+    infer_direction,
+)
+
+
+def _str(description: str, sensitive: bool = False) -> dict:
+    s = {"type": "string", "description": description}
+    if sensitive:
+        s["format"] = "password"
+    return s
+
+
+def _int(description: str, default: int | None = None) -> dict:
+    s = {"type": "integer", "description": description}
+    if default is not None:
+        s["default"] = default
+    return s
+
+
+def _bool(description: str, default: bool = False) -> dict:
+    return {"type": "boolean", "description": description, "default": default}
+
+
+def _schema(properties: dict, required: list[str]) -> dict:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+# JSON Schemas for each connection type's `config` field
+CONFIG_SCHEMAS: dict[str, dict] = {
+    # ---- Databases ----
+    "postgres": _schema(
+        {
+            "host": _str("Database hostname"),
+            "port": _int("Port number", default=5432),
+            "database": _str("Database name"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+        },
+        required=["host", "database", "user", "password"],
+    ),
+    "mysql": _schema(
+        {
+            "host": _str("Database hostname"),
+            "port": _int("Port number", default=3306),
+            "database": _str("Database name"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+        },
+        required=["host", "database", "user", "password"],
+    ),
+    "mssql": _schema(
+        {
+            "host": _str("SQL Server hostname"),
+            "port": _int("Port number", default=1433),
+            "database": _str("Database name"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+        },
+        required=["host", "database", "user", "password"],
+    ),
+    "sqlite": _schema(
+        {
+            "path": _str("Path to SQLite file (or :memory:)"),
+        },
+        required=["path"],
+    ),
+    "clickhouse": _schema(
+        {
+            "host": _str("ClickHouse hostname"),
+            "port": _int("HTTP port", default=8123),
+            "database": _str("Database name"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+            "secure": _bool("Use HTTPS"),
+        },
+        required=["host", "database", "user", "password"],
+    ),
+    "duckdb": _schema(
+        {
+            "path": _str("Path to DuckDB file (or :memory:)"),
+        },
+        required=["path"],
+    ),
+    # ---- Cloud warehouses ----
+    "bigquery": _schema(
+        {
+            "project": _str("GCP project ID"),
+            "dataset": _str("BigQuery dataset name"),
+            "service_account_json": _str(
+                "Service account JSON (paste the full JSON)",
+                sensitive=True,
+            ),
+        },
+        required=["project", "dataset", "service_account_json"],
+    ),
+    "snowflake": _schema(
+        {
+            "account": _str("Snowflake account identifier (e.g. xy12345.us-east-1)"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+            "database": _str("Database name"),
+            "warehouse": _str("Warehouse name"),
+            "schema": _str("Schema name"),
+            "role": _str("Role (optional)"),
+        },
+        required=["account", "user", "password", "database", "warehouse", "schema"],
+    ),
+    "redshift": _schema(
+        {
+            "host": _str("Redshift cluster endpoint"),
+            "port": _int("Port number", default=5439),
+            "database": _str("Database name"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+        },
+        required=["host", "database", "user", "password"],
+    ),
+    "databricks": _schema(
+        {
+            "host": _str("Databricks workspace host"),
+            "http_path": _str("SQL warehouse HTTP path"),
+            "token": _str("Personal access token", sensitive=True),
+            "catalog": _str("Unity Catalog name"),
+        },
+        required=["host", "http_path", "token", "catalog"],
+    ),
+    "synapse": _schema(
+        {
+            "host": _str("Synapse SQL endpoint"),
+            "port": _int("Port number", default=1433),
+            "database": _str("Database/pool name"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+        },
+        required=["host", "database", "user", "password"],
+    ),
+    # ---- SaaS APIs (source only) ----
+    "stripe": _schema(
+        {"api_key": _str("Stripe secret key", sensitive=True)},
+        required=["api_key"],
+    ),
+    "github": _schema(
+        {
+            "access_token": _str("GitHub personal access token", sensitive=True),
+            "owner": _str("Repository owner (org or user)"),
+            "repo": _str("Repository name"),
+        },
+        required=["access_token", "owner", "repo"],
+    ),
+    "hubspot": _schema(
+        {"api_key": _str("HubSpot API key", sensitive=True)},
+        required=["api_key"],
+    ),
+    "salesforce": _schema(
+        {
+            "client_id": _str("Connected app client ID"),
+            "client_secret": _str("Connected app client secret", sensitive=True),
+            "username": _str("Salesforce username"),
+            "password": _str("Salesforce password", sensitive=True),
+            "security_token": _str("Security token", sensitive=True),
+        },
+        required=[
+            "client_id",
+            "client_secret",
+            "username",
+            "password",
+            "security_token",
+        ],
+    ),
+    "shopify": _schema(
+        {
+            "shop_url": _str("Shop URL (e.g. my-store.myshopify.com)"),
+            "access_token": _str("Admin API access token", sensitive=True),
+        },
+        required=["shop_url", "access_token"],
+    ),
+    "jira": _schema(
+        {
+            "server_url": _str("Jira server URL"),
+            "email": _str("Account email"),
+            "api_token": _str("API token", sensitive=True),
+        },
+        required=["server_url", "email", "api_token"],
+    ),
+    "slack": _schema(
+        {"token": _str("Slack bot token", sensitive=True)},
+        required=["token"],
+    ),
+    "zendesk": _schema(
+        {
+            "subdomain": _str("Zendesk subdomain"),
+            "email": _str("Account email"),
+            "api_token": _str("API token", sensitive=True),
+        },
+        required=["subdomain", "email", "api_token"],
+    ),
+    "airtable": _schema(
+        {
+            "api_key": _str("Airtable personal access token", sensitive=True),
+            "base_id": _str("Base ID"),
+        },
+        required=["api_key", "base_id"],
+    ),
+    "notion": _schema(
+        {"api_key": _str("Notion integration token", sensitive=True)},
+        required=["api_key"],
+    ),
+    "google_analytics": _schema(
+        {
+            "property_id": _str("GA4 property ID"),
+            "service_account_json": _str(
+                "Service account JSON",
+                sensitive=True,
+            ),
+        },
+        required=["property_id", "service_account_json"],
+    ),
+    "google_ads": _schema(
+        {
+            "customer_id": _str("Google Ads customer ID"),
+            "service_account_json": _str(
+                "Service account JSON",
+                sensitive=True,
+            ),
+        },
+        required=["customer_id", "service_account_json"],
+    ),
+    "facebook_ads": _schema(
+        {
+            "access_token": _str("Marketing API access token", sensitive=True),
+            "account_id": _str("Ad account ID"),
+        },
+        required=["access_token", "account_id"],
+    ),
+    "google_sheets": _schema(
+        {
+            "spreadsheet_id": _str("Google Sheets spreadsheet ID"),
+            "service_account_json": _str(
+                "Service account JSON",
+                sensitive=True,
+            ),
+        },
+        required=["spreadsheet_id", "service_account_json"],
+    ),
+    "mongodb": _schema(
+        {
+            "connection_string": _str(
+                "MongoDB connection string (with credentials)",
+                sensitive=True,
+            ),
+            "database": _str("Database name"),
+        },
+        required=["connection_string", "database"],
+    ),
+    # ---- REST API ----
+    "rest_api": _schema(
+        {
+            "base_url": _str("API base URL"),
+            "auth_type": {
+                "type": "string",
+                "enum": ["none", "bearer", "api_key", "basic"],
+                "default": "none",
+                "description": "Authentication type",
+            },
+            "auth_token": _str("Auth token (for bearer/api_key)", sensitive=True),
+            "auth_user": _str("Username (for basic auth)"),
+            "auth_password": _str("Password (for basic auth)", sensitive=True),
+        },
+        required=["base_url"],
+    ),
+    # ---- Files ----
+    "s3": _schema(
+        {
+            "bucket": _str("S3 bucket name"),
+            "aws_access_key_id": _str("AWS access key ID", sensitive=True),
+            "aws_secret_access_key": _str("AWS secret access key", sensitive=True),
+            "region": _str("AWS region (e.g. us-east-1)"),
+            "prefix": _str("Optional key prefix"),
+        },
+        required=["bucket", "aws_access_key_id", "aws_secret_access_key", "region"],
+    ),
+    "csv": _schema(
+        {"path": _str("Path to CSV file or directory")},
+        required=["path"],
+    ),
+    "json": _schema(
+        {"path": _str("Path to JSON file or directory")},
+        required=["path"],
+    ),
+    "parquet": _schema(
+        {"path": _str("Path to Parquet file or directory")},
+        required=["path"],
+    ),
+    # ---- Streaming ----
+    "kafka": _schema(
+        {
+            "bootstrap_servers": _str("Comma-separated Kafka brokers"),
+            "topics": _str("Comma-separated topic names"),
+            "group_id": _str("Consumer group ID"),
+            "sasl_username": _str("SASL username (optional)"),
+            "sasl_password": _str("SASL password (optional)", sensitive=True),
+        },
+        required=["bootstrap_servers", "topics", "group_id"],
+    ),
+}
+
+
+def list_connection_types() -> list[dict]:
+    """Return a list of all connection types with their schemas and direction."""
+    items = []
+    for ct in ConnectionType:
+        slug = ct.value
+        if slug not in CONFIG_SCHEMAS:
+            # Should not happen — every connection type should have a schema
+            continue
+        direction = infer_direction(ct).value
+        items.append(
+            {
+                "type": slug,
+                "direction": direction,
+                "is_source": slug in SOURCE_TYPES,
+                "is_destination": slug in DESTINATION_TYPES,
+                "config_schema": CONFIG_SCHEMAS[slug],
+            }
+        )
+    return items
+
+
+def get_connection_type(slug: str) -> dict | None:
+    """Return a single connection type's schema, or None if unknown."""
+    if slug not in CONFIG_SCHEMAS:
+        return None
+    try:
+        ct = ConnectionType(slug)
+    except ValueError:
+        return None
+    return {
+        "type": slug,
+        "direction": infer_direction(ct).value,
+        "is_source": slug in SOURCE_TYPES,
+        "is_destination": slug in DESTINATION_TYPES,
+        "config_schema": CONFIG_SCHEMAS[slug],
+    }

--- a/datanika/services/meta_routes.py
+++ b/datanika/services/meta_routes.py
@@ -1,0 +1,89 @@
+"""REST API discovery endpoints (`/api/v1/meta/*`).
+
+These endpoints let AI agents (and human developers) discover what
+connection types, dlt config options, dbt tests, and materializations
+exist without reading source code or external docs.
+
+Auth: any valid API key (no required scope) — discovery is read-only
+and useful before any resources exist.
+"""
+
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from datanika.services.api_middleware import api_endpoint
+from datanika.services.connection_schemas import (
+    get_connection_type,
+    list_connection_types,
+)
+from datanika.services.meta_schemas import (
+    DLT_CONFIG_SCHEMA,
+    list_dbt_tests,
+    list_materializations,
+)
+
+
+@api_endpoint()
+async def meta_connection_types(request, api_key, session):
+    """List all connection types with their config JSON Schemas."""
+    return JSONResponse({"items": list_connection_types()})
+
+
+@api_endpoint()
+async def meta_connection_type(request, api_key, session):
+    """Get a single connection type's schema."""
+    slug = request.path_params["type"]
+    item = get_connection_type(slug)
+    if item is None:
+        return JSONResponse(
+            {"error": {"code": 404, "message": f"Unknown connection type: {slug}"}},
+            status_code=404,
+        )
+    return JSONResponse(item)
+
+
+@api_endpoint()
+async def meta_dlt_config_schema(request, api_key, session):
+    """Return the JSON Schema for `Upload.dlt_config`."""
+    return JSONResponse(DLT_CONFIG_SCHEMA)
+
+
+@api_endpoint()
+async def meta_dbt_tests(request, api_key, session):
+    """Return all available dbt test types."""
+    return JSONResponse({"items": list_dbt_tests()})
+
+
+@api_endpoint()
+async def meta_materializations(request, api_key, session):
+    """Return all available dbt materialization types."""
+    return JSONResponse({"items": list_materializations()})
+
+
+meta_routes = [
+    Route(
+        "/api/v1/meta/connection-types",
+        meta_connection_types,
+        methods=["GET"],
+    ),
+    Route(
+        "/api/v1/meta/connection-types/{type:str}",
+        meta_connection_type,
+        methods=["GET"],
+    ),
+    Route(
+        "/api/v1/meta/dlt-config-schema",
+        meta_dlt_config_schema,
+        methods=["GET"],
+    ),
+    Route(
+        "/api/v1/meta/dbt-tests",
+        meta_dbt_tests,
+        methods=["GET"],
+    ),
+    Route(
+        "/api/v1/meta/materializations",
+        meta_materializations,
+        methods=["GET"],
+    ),
+]

--- a/datanika/services/meta_schemas.py
+++ b/datanika/services/meta_schemas.py
@@ -1,0 +1,285 @@
+"""JSON Schemas for upload dlt_config, dbt tests, and dbt materializations.
+
+These mirror the validation logic in upload_service.py and
+transformation_service.py so AI agents (and humans) can discover
+the full set of valid options without reading source code.
+"""
+
+from datanika.models.transformation import Materialization
+from datanika.services.transformation_service import TransformationService
+from datanika.services.upload_service import (
+    VALID_FILTER_OPS,
+    VALID_MODES,
+    VALID_ROW_ORDERS,
+    VALID_SCHEMA_CONTRACT_ENTITIES,
+    VALID_SCHEMA_CONTRACT_VALUES,
+    VALID_WRITE_DISPOSITIONS,
+)
+
+# ---------------------------------------------------------------------------
+# dlt_config schema (for Upload.dlt_config)
+# ---------------------------------------------------------------------------
+
+DLT_CONFIG_SCHEMA: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Upload dlt_config",
+    "description": (
+        "Configuration for an extract+load operation. The schema "
+        "varies by `mode`: single_table loads one table with optional "
+        "incremental, full_database loads multiple tables in one run."
+    ),
+    "type": "object",
+    "properties": {
+        "mode": {
+            "type": "string",
+            "enum": sorted(VALID_MODES),
+            "default": "full_database",
+            "description": (
+                "single_table: load one specific table (supports incremental). "
+                "full_database: load multiple tables, optionally filtered."
+            ),
+        },
+        "write_disposition": {
+            "type": "string",
+            "enum": sorted(VALID_WRITE_DISPOSITIONS),
+            "description": (
+                "append: insert rows. replace: drop and recreate table. "
+                "merge: upsert by primary_key (requires merge_config in full_database mode)."
+            ),
+        },
+        "table": {
+            "type": "string",
+            "description": "Source table name (single_table mode only).",
+        },
+        "table_names": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of source table names (full_database mode only).",
+        },
+        "primary_key": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}},
+            ],
+            "description": ("Primary key column(s) for merge disposition (single_table mode)."),
+        },
+        "source_schema": {
+            "type": "string",
+            "description": "Source schema/dataset name (default: public).",
+        },
+        "incremental": {
+            "type": "object",
+            "description": "Incremental load config (single_table mode only).",
+            "properties": {
+                "cursor_path": {
+                    "type": "string",
+                    "description": "Column name to use as the cursor (e.g. updated_at).",
+                },
+                "initial_value": {
+                    "description": ("Starting cursor value for the first run."),
+                },
+                "row_order": {
+                    "type": "string",
+                    "enum": sorted(VALID_ROW_ORDERS),
+                    "description": ("Order rows are returned by the cursor column."),
+                },
+            },
+            "required": ["cursor_path"],
+        },
+        "merge_config": {
+            "type": "object",
+            "description": (
+                "Per-table merge config (full_database mode + merge disposition). "
+                "Keys are table names, values are {primary_key: str | [str]}."
+            ),
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "primary_key": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}},
+                        ],
+                    },
+                },
+                "required": ["primary_key"],
+            },
+        },
+        "batch_size": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of rows per batch sent to the destination.",
+        },
+        "schema_contract": {
+            "type": "object",
+            "description": (
+                "How to handle schema drift. Keys are entities, values are "
+                "behaviors when an unexpected change is detected."
+            ),
+            "properties": {
+                entity: {
+                    "type": "string",
+                    "enum": sorted(VALID_SCHEMA_CONTRACT_VALUES),
+                }
+                for entity in sorted(VALID_SCHEMA_CONTRACT_ENTITIES)
+            },
+        },
+        "filters": {
+            "type": "array",
+            "description": "Row-level filters to apply during extraction.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "column": {"type": "string"},
+                    "op": {
+                        "type": "string",
+                        "enum": sorted(VALID_FILTER_OPS),
+                    },
+                    "value": {"description": "Comparison value (type depends on op)."},
+                },
+                "required": ["column", "op", "value"],
+            },
+        },
+    },
+    "additionalProperties": False,
+    "examples": [
+        {
+            "mode": "single_table",
+            "table": "orders",
+            "write_disposition": "merge",
+            "primary_key": "id",
+            "incremental": {
+                "cursor_path": "updated_at",
+                "row_order": "asc",
+            },
+        },
+        {
+            "mode": "full_database",
+            "table_names": ["customers", "orders", "products"],
+            "write_disposition": "merge",
+            "merge_config": {
+                "customers": {"primary_key": "id"},
+                "orders": {"primary_key": "id"},
+                "products": {"primary_key": "sku"},
+            },
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# dbt test types
+# ---------------------------------------------------------------------------
+
+DBT_TESTS: list[dict] = [
+    {
+        "name": "not_null",
+        "description": "Asserts the column has no NULL values.",
+        "params_schema": {"type": "null"},
+        "example": {"columns": {"id": ["not_null"]}},
+    },
+    {
+        "name": "unique",
+        "description": "Asserts every value in the column is unique.",
+        "params_schema": {"type": "null"},
+        "example": {"columns": {"id": ["not_null", "unique"]}},
+    },
+    {
+        "name": "accepted_values",
+        "description": ("Asserts every value in the column is one of an allowed list."),
+        "params_schema": {
+            "type": "array",
+            "items": {"type": ["string", "number", "boolean"]},
+        },
+        "example": {
+            "columns": {"status": {"accepted_values": ["pending", "shipped", "delivered"]}}
+        },
+    },
+    {
+        "name": "relationships",
+        "description": ("Asserts every value in the column exists in another model's column."),
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "to": {
+                    "type": "string",
+                    "description": "Target model reference, e.g. ref('customers').",
+                },
+                "field": {
+                    "type": "string",
+                    "description": "Target column name.",
+                },
+            },
+            "required": ["to", "field"],
+        },
+        "example": {
+            "columns": {"customer_id": {"relationships": {"to": "ref('customers')", "field": "id"}}}
+        },
+    },
+]
+
+
+def list_dbt_tests() -> list[dict]:
+    return DBT_TESTS
+
+
+# ---------------------------------------------------------------------------
+# dbt materializations
+# ---------------------------------------------------------------------------
+
+MATERIALIZATIONS: list[dict] = [
+    {
+        "name": "view",
+        "description": (
+            "A SQL view in the destination warehouse. Re-evaluated every "
+            "query. Cheapest to build, slowest to query."
+        ),
+    },
+    {
+        "name": "table",
+        "description": (
+            "A physical table rebuilt on every run. Fast to query, expensive to build."
+        ),
+    },
+    {
+        "name": "incremental",
+        "description": (
+            "A table updated with new rows on each run. Requires "
+            "incremental_config to define the merge strategy and unique key."
+        ),
+    },
+    {
+        "name": "ephemeral",
+        "description": (
+            "Inlined as a CTE into downstream models. No physical object in the warehouse."
+        ),
+    },
+    {
+        "name": "snapshot",
+        "description": (
+            "Type 2 SCD: tracks changes over time with valid_from / valid_to "
+            "columns. Use for slowly-changing dimensions."
+        ),
+    },
+]
+
+
+def list_materializations() -> list[dict]:
+    """Verify all enum values are documented and return the list."""
+    documented = {m["name"] for m in MATERIALIZATIONS}
+    enum_values = {m.value for m in Materialization}
+    missing = enum_values - documented
+    if missing:
+        raise RuntimeError(f"Materialization enum values not documented: {missing}")
+    return MATERIALIZATIONS
+
+
+# Re-export for convenience
+__all__ = [
+    "DLT_CONFIG_SCHEMA",
+    "DBT_TESTS",
+    "MATERIALIZATIONS",
+    "list_dbt_tests",
+    "list_materializations",
+    "TransformationService",  # for tests that want VALID_GENERIC_TESTS
+]

--- a/tests/test_services/test_meta_routes.py
+++ b/tests/test_services/test_meta_routes.py
@@ -1,0 +1,268 @@
+"""Tests for /api/v1/meta/* discovery endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from datanika.models.connection import ConnectionType
+from datanika.services.meta_routes import meta_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+
+@pytest.fixture
+def fake_api_key():
+    key = MagicMock()
+    key.id = 1
+    key.org_id = 10
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def client():
+    app = Starlette(routes=meta_routes)
+    return TestClient(app)
+
+
+def _auth_headers():
+    return {"Authorization": "Bearer etf_test"}
+
+
+def _patch_auth(fake_api_key, rate_limit_ok):
+    """Patch middleware auth + rate limiting."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def fake_session():
+        yield MagicMock()
+
+    return [
+        patch("datanika.services.api_middleware._api_key_svc"),
+        patch("datanika.services.api_middleware._rate_limit_svc"),
+        patch("datanika.services.api_middleware._get_session", fake_session),
+    ]
+
+
+def _setup_mocks(stack, fake_api_key, rate_limit_ok):
+    """Configure mocks after entering the patch stack."""
+    mocks = [s.__enter__() for s in stack]
+    mocks[0].authenticate_api_key.return_value = fake_api_key
+    mocks[1].get_limit_for_org.return_value = 60
+    mocks[1].check_rate_limit.return_value = rate_limit_ok
+    return mocks
+
+
+class TestAuth:
+    def test_no_auth_returns_401(self, client):
+        resp = client.get("/api/v1/meta/connection-types")
+        assert resp.status_code == 401
+
+
+class TestConnectionTypes:
+    def test_lists_all_connection_types(self, client, fake_api_key, rate_limit_ok):
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/connection-types",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            items = resp.json()["items"]
+            slugs = {item["type"] for item in items}
+            # Every ConnectionType enum value must be present
+            for ct in ConnectionType:
+                assert ct.value in slugs, f"Missing {ct.value}"
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+    def test_each_item_has_required_fields(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+    ):
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/connection-types",
+                headers=_auth_headers(),
+            )
+            for item in resp.json()["items"]:
+                assert "type" in item
+                assert "direction" in item
+                assert "is_source" in item
+                assert "is_destination" in item
+                assert "config_schema" in item
+                schema = item["config_schema"]
+                assert schema["type"] == "object"
+                assert "properties" in schema
+                assert "required" in schema
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+    def test_postgres_schema_has_expected_fields(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+    ):
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/connection-types/postgres",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["type"] == "postgres"
+            schema = data["config_schema"]
+            assert "host" in schema["properties"]
+            assert "database" in schema["properties"]
+            assert "password" in schema["properties"]
+            assert schema["properties"]["password"]["format"] == "password"
+            assert "host" in schema["required"]
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+    def test_unknown_type_returns_404(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+    ):
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/connection-types/nonexistent",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 404
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+
+class TestDltConfigSchema:
+    def test_returns_schema(self, client, fake_api_key, rate_limit_ok):
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/dlt-config-schema",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            schema = resp.json()
+            assert schema["type"] == "object"
+            props = schema["properties"]
+            assert "mode" in props
+            assert "write_disposition" in props
+            assert "incremental" in props
+            assert "merge_config" in props
+            assert "filters" in props
+            assert schema["properties"]["mode"]["enum"] == [
+                "full_database",
+                "single_table",
+            ]
+            assert "examples" in schema
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+
+class TestDbtTests:
+    def test_lists_all_test_types(self, client, fake_api_key, rate_limit_ok):
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/dbt-tests",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            items = resp.json()["items"]
+            names = {t["name"] for t in items}
+            assert names == {
+                "not_null",
+                "unique",
+                "accepted_values",
+                "relationships",
+            }
+            for t in items:
+                assert "description" in t
+                assert "params_schema" in t
+                assert "example" in t
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+    def test_matches_validation_logic(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+    ):
+        """The exposed test types must match what TransformationService accepts."""
+        from datanika.services.transformation_service import TransformationService
+
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/dbt-tests",
+                headers=_auth_headers(),
+            )
+            exposed = {t["name"] for t in resp.json()["items"]}
+            assert exposed == TransformationService.VALID_GENERIC_TESTS
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)
+
+
+class TestMaterializations:
+    def test_lists_all_materializations(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+    ):
+        from datanika.models.transformation import Materialization
+
+        stack = _patch_auth(fake_api_key, rate_limit_ok)
+        try:
+            _setup_mocks(stack, fake_api_key, rate_limit_ok)
+            resp = client.get(
+                "/api/v1/meta/materializations",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            items = resp.json()["items"]
+            names = {m["name"] for m in items}
+            # Must cover all enum values
+            assert names == {m.value for m in Materialization}
+            for m in items:
+                assert "description" in m
+        finally:
+            for s in reversed(stack):
+                s.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
First step toward making Datanika usable by autonomous AI agents. Today, the OpenAPI spec for `Connection.config` is `{type: object}` — an agent literally cannot know that postgres needs `host/port/user/password/database`. This PR adds discovery endpoints exposing that schema.

## Endpoints
- `GET /api/v1/meta/connection-types` — list all 27 connection types with JSON Schemas
- `GET /api/v1/meta/connection-types/{type}` — single connection type schema
- `GET /api/v1/meta/dlt-config-schema` — full schema for `Upload.dlt_config`
- `GET /api/v1/meta/dbt-tests` — available test types with parameter schemas
- `GET /api/v1/meta/materializations` — dbt materialization types

Sensitive fields (passwords, API keys, tokens) are marked `"format": "password"` so agents and UIs know not to log them.

## Architecture
- `connection_schemas.py` — single source of truth for connection config JSON Schemas
- `meta_schemas.py` — dlt_config schema, dbt tests, materializations (all derived from existing validation constants in `upload_service.py` and `transformation_service.py`, so they stay in sync)
- `meta_routes.py` — Starlette route handlers using existing `@api_endpoint()` decorator

## Tests
9 tests covering:
- All 27 ConnectionType enum values appear in `/meta/connection-types`
- Each item has required fields (type, direction, is_source, is_destination, config_schema)
- Postgres schema has expected fields (host, database, password) and password is marked sensitive
- Unknown type returns 404
- dlt-config-schema returns valid JSON Schema with examples
- dbt-tests matches `TransformationService.VALID_GENERIC_TESTS` (parity check)
- materializations covers all `Materialization` enum values (parity check)

## Also includes
Pre-existing lint cleanup in alembic migration files (16 files): `Union[X, Y]` → `X | Y`, import sort, etc. Auto-fix from `ruff --fix`. No behavior changes. Was blocking precheck.

Part of #37
Closes #38

## Test plan
- [x] 9 new tests pass
- [x] 1477 total tests pass
- [x] Ruff clean
- [x] Ruff format check clean