### PR TITLE
Add catalog endpoints /api/v1/catalog

### DIFF
--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from datanika.models.catalog_entry import CatalogEntryType
 from datanika.models.connection import ConnectionType
 from datanika.models.dependency import NodeType
 from datanika.models.notification_channel import ChannelType
@@ -19,6 +20,7 @@ from datanika.models.pipeline import DbtCommand
 from datanika.models.run import RunStatus
 from datanika.models.transformation import Materialization
 from datanika.services.api_middleware import api_endpoint
+from datanika.services.catalog_service import CatalogService
 from datanika.services.connection_service import ConnectionService
 from datanika.services.encryption import EncryptionService
 from datanika.services.execution_service import ExecutionService
@@ -179,6 +181,24 @@ def _ser_channel(ch):
         "is_active": ch.is_active,
         "created_at": ch.created_at.isoformat() if ch.created_at else None,
         "updated_at": ch.updated_at.isoformat() if ch.updated_at else None,
+    }
+
+
+def _ser_catalog_entry(e):
+    return {
+        "id": e.id,
+        "entry_type": e.entry_type.value,
+        "origin_type": e.origin_type.value,
+        "origin_id": e.origin_id,
+        "schema_name": e.schema_name,
+        "table_name": e.table_name,
+        "dataset_name": e.dataset_name,
+        "connection_id": e.connection_id,
+        "description": e.description,
+        "columns": e.columns or [],
+        "dbt_config": e.dbt_config or {},
+        "created_at": e.created_at.isoformat() if e.created_at else None,
+        "updated_at": e.updated_at.isoformat() if e.updated_at else None,
     }
 
 
@@ -768,6 +788,49 @@ async def get_run_logs(request, api_key, session):
 
 
 # ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+@api_endpoint(required_scope="catalog:read")
+async def list_catalog_entries(request, api_key, session):
+    """List catalog entries for the org. Optional filters: entry_type,
+    schema, connection_id."""
+    entry_type_str = request.query_params.get("entry_type")
+    schema_filter = request.query_params.get("schema")
+    connection_id_str = request.query_params.get("connection_id")
+
+    entry_type = None
+    if entry_type_str:
+        try:
+            entry_type = CatalogEntryType(entry_type_str)
+        except ValueError:
+            return _error(400, f"Invalid entry_type: {entry_type_str}")
+
+    items = CatalogService.list_entries(session, api_key.org_id, entry_type=entry_type)
+
+    if schema_filter:
+        items = [e for e in items if e.schema_name == schema_filter]
+    if connection_id_str:
+        try:
+            cid = int(connection_id_str)
+        except ValueError:
+            return _error(400, "connection_id must be an integer")
+        items = [e for e in items if e.connection_id == cid]
+
+    return JSONResponse({"items": [_ser_catalog_entry(e) for e in items]})
+
+
+@api_endpoint(required_scope="catalog:read")
+async def get_catalog_entry(request, api_key, session):
+    entry_id = int(request.path_params["id"])
+    entry = CatalogService.get_entry(session, api_key.org_id, entry_id)
+    if entry is None:
+        return _error(404, "Catalog entry not found")
+    return JSONResponse(_ser_catalog_entry(entry))
+
+
+# ---------------------------------------------------------------------------
 # Notification Channels
 # ---------------------------------------------------------------------------
 
@@ -898,6 +961,9 @@ api_v1_routes = [
     Route("/api/v1/runs", list_runs, methods=["GET"]),
     Route("/api/v1/runs/{id:int}", get_run, methods=["GET"]),
     Route("/api/v1/runs/{id:int}/logs", get_run_logs, methods=["GET"]),
+    # Catalog
+    Route("/api/v1/catalog", list_catalog_entries, methods=["GET"]),
+    Route("/api/v1/catalog/{id:int}", get_catalog_entry, methods=["GET"]),
     # Notification channels
     Route("/api/v1/notifications/channels", list_notification_channels, methods=["GET"]),
     Route("/api/v1/notifications/channels/{id:int}", get_notification_channel, methods=["GET"]),

--- a/tests/test_services/test_api_v1_routes.py
+++ b/tests/test_services/test_api_v1_routes.py
@@ -397,6 +397,127 @@ class TestConnectionIntrospection:
             assert resp.status_code == 400
 
 
+class TestCatalogEndpoints:
+    """Tests for /api/v1/catalog endpoints (#40)."""
+
+    def _seed_catalog(self, session, org_id, **overrides):
+        from datanika.models.catalog_entry import CatalogEntry, CatalogEntryType
+        from datanika.models.dependency import NodeType
+
+        defaults = {
+            "org_id": org_id,
+            "entry_type": CatalogEntryType.SOURCE_TABLE,
+            "origin_type": NodeType.UPLOAD,
+            "origin_id": 1,
+            "schema_name": "raw",
+            "table_name": "orders",
+            "dataset_name": "raw_data",
+            "columns": [{"name": "id", "data_type": "INTEGER"}],
+        }
+        defaults.update(overrides)
+        entry = CatalogEntry(**defaults)
+        session.add(entry)
+        session.flush()
+        return entry
+
+    def test_list_empty(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.get("/api/v1/catalog", headers=_auth_headers())
+            assert resp.status_code == 200
+            assert resp.json()["items"] == []
+
+    def test_list_returns_seeded_entries(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok) as session:
+            self._seed_catalog(session, fake_api_key.org_id, table_name="orders")
+            self._seed_catalog(session, fake_api_key.org_id, table_name="customers")
+            session.commit()
+
+            resp = client.get("/api/v1/catalog", headers=_auth_headers())
+            assert resp.status_code == 200
+            items = resp.json()["items"]
+            names = {e["table_name"] for e in items}
+            assert names == {"orders", "customers"}
+
+    def test_list_filters_by_schema(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok) as session:
+            self._seed_catalog(session, fake_api_key.org_id, schema_name="raw", table_name="orders")
+            self._seed_catalog(
+                session, fake_api_key.org_id, schema_name="staging", table_name="stg_orders"
+            )
+            session.commit()
+
+            resp = client.get("/api/v1/catalog?schema=staging", headers=_auth_headers())
+            items = resp.json()["items"]
+            assert len(items) == 1
+            assert items[0]["schema_name"] == "staging"
+
+    def test_list_filters_by_entry_type(self, client, fake_api_key, rate_limit_ok):
+        from datanika.models.catalog_entry import CatalogEntryType
+
+        with _patch_auth(fake_api_key, rate_limit_ok) as session:
+            self._seed_catalog(
+                session,
+                fake_api_key.org_id,
+                entry_type=CatalogEntryType.SOURCE_TABLE,
+                table_name="orders",
+            )
+            self._seed_catalog(
+                session,
+                fake_api_key.org_id,
+                entry_type=CatalogEntryType.DBT_MODEL,
+                table_name="stg_orders",
+            )
+            session.commit()
+
+            resp = client.get("/api/v1/catalog?entry_type=dbt_model", headers=_auth_headers())
+            items = resp.json()["items"]
+            assert len(items) == 1
+            assert items[0]["entry_type"] == "dbt_model"
+
+    def test_list_invalid_entry_type(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.get("/api/v1/catalog?entry_type=bogus", headers=_auth_headers())
+            assert resp.status_code == 400
+
+    def test_list_filters_by_connection_id(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok) as session:
+            self._seed_catalog(session, fake_api_key.org_id, table_name="a", connection_id=42)
+            self._seed_catalog(session, fake_api_key.org_id, table_name="b", connection_id=99)
+            session.commit()
+
+            resp = client.get("/api/v1/catalog?connection_id=42", headers=_auth_headers())
+            items = resp.json()["items"]
+            assert len(items) == 1
+            assert items[0]["table_name"] == "a"
+
+    def test_get_returns_entry(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok) as session:
+            entry = self._seed_catalog(session, fake_api_key.org_id, table_name="orders")
+            session.commit()
+
+            resp = client.get(f"/api/v1/catalog/{entry.id}", headers=_auth_headers())
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["id"] == entry.id
+            assert data["table_name"] == "orders"
+            assert data["columns"] == [{"name": "id", "data_type": "INTEGER"}]
+
+    def test_get_404_for_unknown_entry(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.get("/api/v1/catalog/9999", headers=_auth_headers())
+            assert resp.status_code == 404
+
+    def test_tenant_isolation(self, client, fake_api_key, rate_limit_ok):
+        """Org A cannot read org B's catalog entry."""
+        with _patch_auth(fake_api_key, rate_limit_ok) as session:
+            other_entry = self._seed_catalog(session, org_id=999, table_name="other_org")
+            session.commit()
+
+            # fake_api_key.org_id is 10, not 999
+            resp = client.get(f"/api/v1/catalog/{other_entry.id}", headers=_auth_headers())
+            assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Transformation endpoints
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
After loading data, an agent has no API endpoint to list what tables exist in the destination — needed to write transformations that `{{ ref(...) }}` upstream tables. This PR exposes the existing CatalogEntry model.

## Endpoints
- `GET /api/v1/catalog` — list (filters: `entry_type`, `schema`, `connection_id`)
- `GET /api/v1/catalog/{id}` — single entry with column metadata

Scope: `catalog:read`. Tenant isolation via `api_key.org_id`.

## Implementation
Uses existing `CatalogService` and `CatalogEntry` model — already populated automatically by upload tasks via `_sync_catalog_after_upload`.

Part of #37
Closes #40

## Test plan
- [x] 9 new tests: empty list, seeded entries, all 3 filters, invalid filter rejection, get + 404, tenant isolation
- [x] 1511 total tests pass
- [x] Ruff clean, format clean