### PR TITLE
Wire revenue dashboard into Grafana provisioning (#41)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../datanika-cloud/monitoring/revenue-dashboard.json:/var/lib/grafana/dashboards/cloud/revenue.json:ro
     depends_on:
       - prometheus
     restart: unless-stopped

--- a/monitoring/grafana/provisioning/dashboards/cloud.yml
+++ b/monitoring/grafana/provisioning/dashboards/cloud.yml
@@ -1,0 +1,21 @@
+# Grafana dashboard provisioning config — auto-loads dashboards from a folder.
+#
+# Drop into:
+#   /etc/grafana/provisioning/dashboards/cloud.yml
+#
+# Or in the Hetzner setup:
+#   /opt/datanika/datanika/monitoring/grafana/provisioning/dashboards/cloud.yml
+
+apiVersion: 1
+
+providers:
+  - name: 'datanika-cloud'
+    orgId: 1
+    folder: 'Datanika Cloud'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/cloud
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/postgres.yml
+++ b/monitoring/grafana/provisioning/datasources/postgres.yml
@@ -1,0 +1,35 @@
+# Grafana datasource provisioning for the Datanika Postgres database.
+#
+# Drop this file into Grafana's datasources provisioning directory:
+#   /etc/grafana/provisioning/datasources/postgres.yml
+#
+# Or, in the Hetzner setup, into:
+#   /opt/datanika/datanika/monitoring/grafana/provisioning/datasources/postgres.yml
+#
+# Restart grafana to pick up changes:
+#   docker compose restart grafana
+#
+# Required env vars (set in .env.docker on the host):
+#   POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
+
+apiVersion: 1
+
+datasources:
+  - name: Datanika Postgres
+    uid: datanika-postgres
+    type: postgres
+    access: proxy
+    url: postgres:5432
+    user: ${POSTGRES_USER}
+    secureJsonData:
+      password: ${POSTGRES_PASSWORD}
+    jsonData:
+      database: ${POSTGRES_DB}
+      sslmode: disable
+      maxOpenConns: 5
+      maxIdleConns: 2
+      connMaxLifetime: 14400
+      postgresVersion: 1500
+      timescaledb: false
+    isDefault: false
+    editable: false


### PR DESCRIPTION
## Summary
- Add Postgres datasource provisioning for Grafana (auth via existing POSTGRES_* env vars)
- Add `Datanika Cloud` dashboard provider config
- Mount `datanika-cloud/monitoring/revenue-dashboard.json` into Grafana via docker-compose

## Result
On next deploy, Grafana will auto-load the revenue metrics dashboard (8 panels: MRR, churn, ARPU, conversion, quota walls, warning emails) under the "Datanika Cloud" folder, querying production Postgres directly.

Closes #41.