### PR TITLE
Restore Grafana alerting provisioning (Telegram configured)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -1,0 +1,309 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Infrastructure Alerts
+    folder: Datanika
+    interval: 1m
+    rules:
+      # --- Container Health ---
+      - uid: container-down
+        title: Container Down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'time() - container_last_seen{name=~"datanika-(app|celery|postgres|redis)"} > 60'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Container {{ $labels.name }} is down"
+          description: "Container {{ $labels.name }} has not been seen for over 60 seconds."
+
+      # --- High CPU ---
+      - uid: high-cpu
+        title: High CPU Usage
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: '100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage: {{ $value }}%"
+          description: "CPU usage has been above 85% for 5 minutes."
+
+      # --- High Memory ---
+      - uid: high-memory
+        title: High Memory Usage
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: '(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 > 90'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage: {{ $value }}%"
+          description: "Memory usage has been above 90% for 5 minutes."
+
+      # --- Disk Space ---
+      - uid: disk-space-critical
+        title: Disk Space Critical
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: '(1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100 > 80'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk usage above 80%: {{ $value }}%"
+          description: "Root filesystem is running low on space."
+
+      # --- Container Restart Loop ---
+      - uid: container-restart-loop
+        title: Container Restart Loop
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'increase(container_start_time_seconds{name=~"datanika-.*"}[1h]) > 3'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 0s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Container {{ $labels.name }} is restart-looping"
+          description: "Container {{ $labels.name }} has restarted more than 3 times in the last hour."
+
+      # --- Container High Memory ---
+      - uid: container-high-memory
+        title: Container High Memory
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'container_memory_usage_bytes{name=~"datanika-(app|celery)"} > 1.5e+9'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.name }} memory > 1.5GB"
+          description: "Container {{ $labels.name }} is using {{ $value | humanize }} of memory."
+
+  - orgId: 1
+    name: Application Alerts
+    folder: Datanika
+    interval: 1m
+    rules:
+      # --- App Health Endpoint ---
+      - uid: app-unhealthy
+        title: App Unhealthy
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'up{job="datanika-app"} == 0'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Datanika app metrics endpoint is down"
+          description: "Prometheus cannot scrape the app metrics endpoint for 2 minutes."
+
+      # --- Celery Task Failures ---
+      - uid: celery-task-failures
+        title: High Celery Task Failure Rate
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'rate(celery_tasks_total{state="FAILURE"}[15m]) > 0.1'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High Celery task failure rate"
+          description: "More than 0.1 task failures per second over the last 15 minutes."
+
+      # --- Celery Queue Depth ---
+      - uid: celery-queue-depth
+        title: Celery Queue Backlog
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'celery_queue_length > 50'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Celery queue backlog: {{ $value }} tasks"
+          description: "Celery queue has had more than 50 pending tasks for 10 minutes."

--- a/monitoring/grafana/provisioning/alerting/contactpoints.yml
+++ b/monitoring/grafana/provisioning/alerting/contactpoints.yml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: telegram
+    receivers:
+      - uid: telegram-default
+        type: telegram
+        settings:
+          bottoken: "${TELEGRAM_BOT_TOKEN}"
+          chatid: "${TELEGRAM_CHAT_ID}"
+          parse_mode: HTML
+          message: |
+            <b>{{ .Status | toUpper }}</b>
+            <b>Alert:</b> {{ .CommonLabels.alertname }}
+            <b>Severity:</b> {{ .CommonLabels.severity }}
+            {{ range .Alerts }}
+            {{ .Annotations.summary }}
+            {{ .Annotations.description }}
+            {{ end }}

--- a/monitoring/grafana/provisioning/alerting/policies.yml
+++ b/monitoring/grafana/provisioning/alerting/policies.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: telegram
+    group_by:
+      - alertname
+      - severity
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    routes:
+      - receiver: telegram
+        matchers:
+          - severity = critical
+        group_wait: 10s
+        repeat_interval: 1h
+      - receiver: telegram
+        matchers:
+          - severity = warning
+        repeat_interval: 4h


### PR DESCRIPTION
## Summary
Restores the 9 Grafana alert rules and Telegram contact point that were temporarily removed in #46.

@DatanikaBot created and `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` are now set in `.env.docker` on Hetzner. Test message verified.

## Alerts restored
- Container down / restart loop / high memory
- High CPU (>85% 5m) / memory (>90% 5m) / disk (>80%)
- App unhealthy, Celery task failures, queue backlog
- Severity-based routing: critical = 1h repeat, warning = 4h repeat