### PR TITLE
Hardcode Telegram chat_id to work around Grafana env expansion bug

### DIFF
--- a/monitoring/grafana/provisioning/alerting/contactpoints.yml
+++ b/monitoring/grafana/provisioning/alerting/contactpoints.yml
@@ -8,7 +8,9 @@ contactPoints:
         type: telegram
         settings:
           bottoken: "${TELEGRAM_BOT_TOKEN}"
-          chatid: "${TELEGRAM_CHAT_ID}"
+          # Hardcoded: Grafana env var expansion strips string type when value is all-digit
+          # (https://github.com/grafana/grafana/issues/90353). Chat ID isn't a secret.
+          chatid: "1201995"
           parse_mode: HTML
           message: |
             <b>{{ .Status | toUpper }}</b>


### PR DESCRIPTION
## Problem
Grafana fails to start with `cannot unmarshal number into Go struct field Config.chatid of type string` when the chat_id comes from `\${TELEGRAM_CHAT_ID}` env var expansion.

Known Grafana bug: https://github.com/grafana/grafana/issues/90353 — env expansion of all-digit values strips the string type.

## Fix
Hardcode `chatid: "1201995"` directly. The chat ID isn't a secret (only the bot token is), so hardcoding is safe.

The bot token stays in `\${TELEGRAM_BOT_TOKEN}` as before.