### PR TITLE
Fix container-high-memory alert template

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -202,7 +202,7 @@ groups:
           severity: warning
         annotations:
           summary: "Container {{ $labels.name }} memory > 1.5GB"
-          description: "Container {{ $labels.name }} is using {{ $value | humanize }} of memory."
+          description: "Container {{ $labels.name }} is using more than 1.5GB of memory."
 
   - orgId: 1
     name: Application Alerts


### PR DESCRIPTION
The `{{ $value | humanize }}` template in the description fails when Prometheus returns an empty value for $value, producing repeated 'strconv.ParseFloat: parsing "": invalid syntax' errors in Grafana logs.

Simplify to a static description.