### PR TITLE
Add Getting Started checklist widget on dashboard (#50)

### DIFF
--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -29,6 +29,7 @@ from datanika.ui.state.dashboard_state import DashboardState
 from datanika.ui.state.model_detail_state import ModelDetailState
 from datanika.ui.state.model_state import ModelState
 from datanika.ui.state.notification_state import NotificationState
+from datanika.ui.state.onboarding_state import OnboardingState
 from datanika.ui.state.pipeline_state import PipelineState
 from datanika.ui.state.run_state import RunState
 from datanika.ui.state.schedule_state import ScheduleState
@@ -73,7 +74,11 @@ app.add_page(
     dashboard_page,
     route="/",
     title="Dashboard | Datanika",
-    on_load=[AuthState.check_auth, DashboardState.load_dashboard],
+    on_load=[
+        AuthState.check_auth,
+        DashboardState.load_dashboard,
+        OnboardingState.load_checklist,
+    ],
 )
 app.add_page(
     connections_page,

--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "ترقية الخطة",
   "dashboard.usage_title": "استخدام الخطة",
   "dashboard.usage_runs": "عمليات تشغيل النماذج هذا الشهر",
-  "dashboard.usage_upgrade": "ترقية للمزيد"
+  "dashboard.usage_upgrade": "ترقية للمزيد",
+  "onboarding.title": "ابدأ باستخدام Datanika",
+  "onboarding.subtitle": "أعدّ أول خط معالجة لديك في 5 خطوات",
+  "onboarding.dismiss": "إخفاء",
+  "onboarding.all_done": "اكتمل الإعداد — أنت جاهز.",
+  "onboarding.step_connection": "أضف اتصالك الأول",
+  "onboarding.step_pipeline": "أنشئ خط معالجة",
+  "onboarding.step_run": "شغّل خط معالجة",
+  "onboarding.step_transformation": "أضف تحويلاً",
+  "onboarding.step_schedule": "جدوِل خط معالجة"
 }

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Plan upgraden",
   "dashboard.usage_title": "Plannutzung",
   "dashboard.usage_runs": "Modellausführungen diesen Monat",
-  "dashboard.usage_upgrade": "Upgrade für mehr"
+  "dashboard.usage_upgrade": "Upgrade für mehr",
+  "onboarding.title": "Erste Schritte mit Datanika",
+  "onboarding.subtitle": "Richte deine erste Pipeline in 5 Schritten ein",
+  "onboarding.dismiss": "Ausblenden",
+  "onboarding.all_done": "Fertig — alles läuft.",
+  "onboarding.step_connection": "Erste Verbindung hinzufügen",
+  "onboarding.step_pipeline": "Pipeline erstellen",
+  "onboarding.step_run": "Pipeline ausführen",
+  "onboarding.step_transformation": "Transformation hinzufügen",
+  "onboarding.step_schedule": "Pipeline planen"
 }

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Αναβάθμιση πλάνου",
   "dashboard.usage_title": "Χρήση πλάνου",
   "dashboard.usage_runs": "εκτελέσεις μοντέλων αυτόν τον μήνα",
-  "dashboard.usage_upgrade": "Αναβάθμιση για περισσότερα"
+  "dashboard.usage_upgrade": "Αναβάθμιση για περισσότερα",
+  "onboarding.title": "Ξεκινήστε με το Datanika",
+  "onboarding.subtitle": "Ρυθμίστε το πρώτο σας pipeline σε 5 βήματα",
+  "onboarding.dismiss": "Απόκρυψη",
+  "onboarding.all_done": "Έτοιμο — όλα σε λειτουργία.",
+  "onboarding.step_connection": "Προσθέστε την πρώτη σύνδεση",
+  "onboarding.step_pipeline": "Δημιουργήστε ένα pipeline",
+  "onboarding.step_run": "Εκτελέστε ένα pipeline",
+  "onboarding.step_transformation": "Προσθέστε έναν μετασχηματισμό",
+  "onboarding.step_schedule": "Προγραμματίστε ένα pipeline"
 }

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Upgrade Plan",
   "dashboard.usage_title": "Plan Usage",
   "dashboard.usage_runs": "model runs this month",
-  "dashboard.usage_upgrade": "Upgrade for more"
+  "dashboard.usage_upgrade": "Upgrade for more",
+  "onboarding.title": "Get started with Datanika",
+  "onboarding.subtitle": "Set up your first pipeline in 5 quick steps",
+  "onboarding.dismiss": "Dismiss",
+  "onboarding.all_done": "All set — you're up and running.",
+  "onboarding.step_connection": "Add your first connection",
+  "onboarding.step_pipeline": "Create a pipeline",
+  "onboarding.step_run": "Run a pipeline",
+  "onboarding.step_transformation": "Add a transformation",
+  "onboarding.step_schedule": "Schedule a pipeline"
 }

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Mejorar plan",
   "dashboard.usage_title": "Uso del plan",
   "dashboard.usage_runs": "ejecuciones de modelos este mes",
-  "dashboard.usage_upgrade": "Mejorar para más"
+  "dashboard.usage_upgrade": "Mejorar para más",
+  "onboarding.title": "Empieza con Datanika",
+  "onboarding.subtitle": "Configura tu primer pipeline en 5 pasos",
+  "onboarding.dismiss": "Ocultar",
+  "onboarding.all_done": "Listo: todo está en marcha.",
+  "onboarding.step_connection": "Añade tu primera conexión",
+  "onboarding.step_pipeline": "Crea un pipeline",
+  "onboarding.step_run": "Ejecuta un pipeline",
+  "onboarding.step_transformation": "Añade una transformación",
+  "onboarding.step_schedule": "Programa un pipeline"
 }

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Mettre à niveau",
   "dashboard.usage_title": "Utilisation du plan",
   "dashboard.usage_runs": "exécutions de modèles ce mois",
-  "dashboard.usage_upgrade": "Passer au niveau supérieur"
+  "dashboard.usage_upgrade": "Passer au niveau supérieur",
+  "onboarding.title": "Prise en main de Datanika",
+  "onboarding.subtitle": "Configurez votre premier pipeline en 5 étapes",
+  "onboarding.dismiss": "Masquer",
+  "onboarding.all_done": "C'est prêt — tout est opérationnel.",
+  "onboarding.step_connection": "Ajoutez votre première connexion",
+  "onboarding.step_pipeline": "Créez un pipeline",
+  "onboarding.step_run": "Exécutez un pipeline",
+  "onboarding.step_transformation": "Ajoutez une transformation",
+  "onboarding.step_schedule": "Planifiez un pipeline"
 }

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Улучшить тариф",
   "dashboard.usage_title": "Использование тарифа",
   "dashboard.usage_runs": "запусков моделей в этом месяце",
-  "dashboard.usage_upgrade": "Улучшить для большего"
+  "dashboard.usage_upgrade": "Улучшить для большего",
+  "onboarding.title": "Начните работу с Datanika",
+  "onboarding.subtitle": "Настройте первый пайплайн за 5 шагов",
+  "onboarding.dismiss": "Скрыть",
+  "onboarding.all_done": "Готово — вы всё настроили.",
+  "onboarding.step_connection": "Добавьте первое подключение",
+  "onboarding.step_pipeline": "Создайте пайплайн",
+  "onboarding.step_run": "Запустите пайплайн",
+  "onboarding.step_transformation": "Добавьте трансформацию",
+  "onboarding.step_schedule": "Настройте расписание"
 }

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "Надогради план",
   "dashboard.usage_title": "Коришћење плана",
   "dashboard.usage_runs": "покретања модела овог месеца",
-  "dashboard.usage_upgrade": "Надогради за више"
+  "dashboard.usage_upgrade": "Надогради за више",
+  "onboarding.title": "Почните са Datanika",
+  "onboarding.subtitle": "Подесите свој први пајплајн у 5 корака",
+  "onboarding.dismiss": "Сакриј",
+  "onboarding.all_done": "Готово — све ради.",
+  "onboarding.step_connection": "Додајте прву конекцију",
+  "onboarding.step_pipeline": "Направите пајплајн",
+  "onboarding.step_run": "Покрените пајплајн",
+  "onboarding.step_transformation": "Додајте трансформацију",
+  "onboarding.step_schedule": "Закажите пајплајн"
 }

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -391,5 +391,14 @@
   "quota.upgrade_button": "升级计划",
   "dashboard.usage_title": "计划使用情况",
   "dashboard.usage_runs": "本月模型运行次数",
-  "dashboard.usage_upgrade": "升级获取更多"
+  "dashboard.usage_upgrade": "升级获取更多",
+  "onboarding.title": "开始使用 Datanika",
+  "onboarding.subtitle": "通过 5 个步骤搭建您的第一个数据管道",
+  "onboarding.dismiss": "隐藏",
+  "onboarding.all_done": "全部完成，一切就绪。",
+  "onboarding.step_connection": "添加第一个连接",
+  "onboarding.step_pipeline": "创建管道",
+  "onboarding.step_run": "运行管道",
+  "onboarding.step_transformation": "添加转换",
+  "onboarding.step_schedule": "设置定时调度"
 }

--- a/datanika/migrations/versions/w2s9t0u1v3p4_add_onboarding_dismissed_at_to_users.py
+++ b/datanika/migrations/versions/w2s9t0u1v3p4_add_onboarding_dismissed_at_to_users.py
@@ -1,0 +1,35 @@
+"""Add onboarding_checklist_dismissed_at column to users
+
+Revision ID: w2s9t0u1v3p4
+Revises: v1r8s9t0u2o3
+Create Date: 2026-04-10 20:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "w2s9t0u1v3p4"
+down_revision: str | None = "v1r8s9t0u2o3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "onboarding_checklist_dismissed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    op.drop_column("users", "onboarding_checklist_dismissed_at")
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/user.py
+++ b/datanika/models/user.py
@@ -1,6 +1,7 @@
 import enum
+from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, Enum, ForeignKey, String
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datanika.models.base import Base, TimestampMixin
@@ -35,6 +36,9 @@ class User(Base, TimestampMixin):
     email_verified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     oauth_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
     oauth_provider_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    onboarding_checklist_dismissed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     memberships: Mapped[list["Membership"]] = relationship(back_populates="user")
 

--- a/datanika/services/onboarding.py
+++ b/datanika/services/onboarding.py
@@ -1,0 +1,78 @@
+"""Onboarding service — Getting Started checklist progress for a single org.
+
+The checklist has 5 fixed steps. Progress is derived from existing tables
+(connections, pipelines, runs, transformations, schedules) filtered by
+org_id — no new columns are stored for the progress itself. Dismissal is
+tracked separately on the user model.
+"""
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from datanika.models.connection import Connection
+from datanika.models.pipeline import Pipeline
+from datanika.models.run import Run
+from datanika.models.schedule import Schedule
+from datanika.models.transformation import Transformation
+
+CHECKLIST_TOTAL = 5
+
+
+class ChecklistProgress(BaseModel):
+    has_connection: bool = False
+    has_pipeline: bool = False
+    has_run: bool = False
+    has_transformation: bool = False
+    has_schedule: bool = False
+
+    @property
+    def done_count(self) -> int:
+        return sum(
+            (
+                self.has_connection,
+                self.has_pipeline,
+                self.has_run,
+                self.has_transformation,
+                self.has_schedule,
+            )
+        )
+
+    @property
+    def total(self) -> int:
+        return CHECKLIST_TOTAL
+
+    @property
+    def all_done(self) -> bool:
+        return self.done_count == CHECKLIST_TOTAL
+
+
+def compute_checklist(
+    *,
+    connection_count: int,
+    pipeline_count: int,
+    run_count: int,
+    transformation_count: int,
+    schedule_count: int,
+) -> ChecklistProgress:
+    return ChecklistProgress(
+        has_connection=connection_count > 0,
+        has_pipeline=pipeline_count > 0,
+        has_run=run_count > 0,
+        has_transformation=transformation_count > 0,
+        has_schedule=schedule_count > 0,
+    )
+
+
+def load_checklist_for_org(session: Session, org_id: int) -> ChecklistProgress:
+    def _count(model) -> int:
+        stmt = select(func.count()).select_from(model).where(model.org_id == org_id)
+        return int(session.execute(stmt).scalar_one())
+
+    return compute_checklist(
+        connection_count=_count(Connection),
+        pipeline_count=_count(Pipeline),
+        run_count=_count(Run),
+        transformation_count=_count(Transformation),
+        schedule_count=_count(Schedule),
+    )

--- a/datanika/ui/components/getting_started_checklist.py
+++ b/datanika/ui/components/getting_started_checklist.py
@@ -1,0 +1,115 @@
+"""Getting Started checklist widget — 5 steps to first successful pipeline."""
+
+import reflex as rx
+
+from datanika.ui.state.i18n_state import I18nState
+from datanika.ui.state.onboarding_state import OnboardingState
+
+_t = I18nState.translations
+
+
+def _step_row(done: rx.Var[bool], label: rx.Var[str], href: str) -> rx.Component:
+    return rx.link(
+        rx.hstack(
+            rx.cond(
+                done,
+                rx.icon("circle_check", size=18, color="var(--green-9)"),
+                rx.icon("circle", size=18, color="var(--slate-8)"),
+            ),
+            rx.text(
+                label,
+                size="2",
+                color=rx.cond(done, "var(--slate-10)", "var(--slate-12)"),
+                style={"textDecoration": rx.cond(done, "line-through", "none")},
+            ),
+            align="center",
+            spacing="2",
+        ),
+        href=href,
+        underline="none",
+        width="100%",
+    )
+
+
+def getting_started_checklist() -> rx.Component:
+    return rx.cond(
+        OnboardingState.visible,
+        rx.card(
+            rx.vstack(
+                rx.hstack(
+                    rx.vstack(
+                        rx.heading(_t["onboarding.title"], size="4"),
+                        rx.text(
+                            _t["onboarding.subtitle"],
+                            size="2",
+                            color="var(--slate-10)",
+                        ),
+                        spacing="1",
+                        align="start",
+                    ),
+                    rx.spacer(),
+                    rx.hstack(
+                        rx.badge(
+                            OnboardingState.done_count.to_string()
+                            + " / "
+                            + OnboardingState.total_count.to_string(),
+                            color_scheme=rx.cond(OnboardingState.all_done, "green", "violet"),
+                            variant="soft",
+                            size="2",
+                        ),
+                        rx.button(
+                            _t["onboarding.dismiss"],
+                            on_click=OnboardingState.dismiss_checklist,
+                            variant="ghost",
+                            size="1",
+                            color_scheme="gray",
+                        ),
+                        align="center",
+                        spacing="2",
+                    ),
+                    align="start",
+                    width="100%",
+                ),
+                rx.divider(),
+                _step_row(
+                    OnboardingState.progress.has_connection,
+                    _t["onboarding.step_connection"],
+                    "/connections",
+                ),
+                _step_row(
+                    OnboardingState.progress.has_pipeline,
+                    _t["onboarding.step_pipeline"],
+                    "/pipelines",
+                ),
+                _step_row(
+                    OnboardingState.progress.has_run,
+                    _t["onboarding.step_run"],
+                    "/runs",
+                ),
+                _step_row(
+                    OnboardingState.progress.has_transformation,
+                    _t["onboarding.step_transformation"],
+                    "/transformations",
+                ),
+                _step_row(
+                    OnboardingState.progress.has_schedule,
+                    _t["onboarding.step_schedule"],
+                    "/schedules",
+                ),
+                rx.cond(
+                    OnboardingState.all_done,
+                    rx.callout(
+                        _t["onboarding.all_done"],
+                        icon="party_popper",
+                        color_scheme="green",
+                    ),
+                    rx.fragment(),
+                ),
+                spacing="3",
+                align="stretch",
+            ),
+            width="100%",
+            margin_bottom="1rem",
+        ),
+        rx.fragment(),
+    )

--- a/datanika/ui/pages/dashboard.py
+++ b/datanika/ui/pages/dashboard.py
@@ -2,6 +2,7 @@
 
 import reflex as rx
 
+from datanika.ui.components.getting_started_checklist import getting_started_checklist
 from datanika.ui.components.layout import page_layout
 from datanika.ui.state.dashboard_state import DashboardState
 from datanika.ui.state.i18n_state import I18nState
@@ -195,6 +196,7 @@ def dashboard_page() -> rx.Component:
                 ),
                 width="100%",
             ),
+            getting_started_checklist(),
             getting_started_card(),
             rx.hstack(
                 stat_card(

--- a/datanika/ui/state/onboarding_state.py
+++ b/datanika/ui/state/onboarding_state.py
@@ -1,0 +1,66 @@
+"""Getting Started checklist state — 5 derived steps + per-user dismissal."""
+
+from datetime import UTC, datetime
+
+import reflex as rx
+
+from datanika.models.user import User
+from datanika.services.onboarding import ChecklistProgress, load_checklist_for_org
+from datanika.ui.state.base_state import BaseState, get_sync_session
+
+
+class OnboardingState(BaseState):
+    progress: ChecklistProgress = ChecklistProgress()
+    dismissed: bool = False
+    loaded: bool = False
+
+    @rx.var
+    def visible(self) -> bool:
+        return self.loaded and not self.dismissed
+
+    @rx.var
+    def done_count(self) -> int:
+        return self.progress.done_count
+
+    @rx.var
+    def total_count(self) -> int:
+        return self.progress.total
+
+    @rx.var
+    def all_done(self) -> bool:
+        return self.progress.all_done
+
+    async def load_checklist(self):
+        from datanika.ui.state.auth_state import AuthState
+
+        auth = await self.get_state(AuthState)
+        org_id = auth.current_org.id or 0
+        user_id = auth.current_user.id or 0
+
+        if org_id == 0 or user_id == 0:
+            self.loaded = False
+            return
+
+        with get_sync_session() as session:
+            self.progress = load_checklist_for_org(session, org_id)
+            user = session.get(User, user_id)
+            self.dismissed = bool(user and user.onboarding_checklist_dismissed_at is not None)
+
+        self.loaded = True
+
+    async def dismiss_checklist(self):
+        from datanika.ui.state.auth_state import AuthState
+
+        auth = await self.get_state(AuthState)
+        user_id = auth.current_user.id or 0
+        if user_id == 0:
+            return
+
+        with get_sync_session() as session:
+            user = session.get(User, user_id)
+            if user is None:
+                return
+            user.onboarding_checklist_dismissed_at = datetime.now(UTC)
+            session.commit()
+
+        self.dismissed = True

--- a/tests/test_services/test_onboarding.py
+++ b/tests/test_services/test_onboarding.py
@@ -1,0 +1,123 @@
+"""Tests for Getting Started onboarding checklist logic.
+
+Pure-function tests for `compute_checklist` — the helper that converts
+per-org entity counts into the 5 booleans the dashboard widget renders.
+"""
+
+from datanika.services.onboarding import ChecklistProgress, compute_checklist
+
+
+class TestComputeChecklistFresh:
+    def test_fresh_org_has_zero_done(self):
+        progress = compute_checklist(
+            connection_count=0,
+            pipeline_count=0,
+            run_count=0,
+            transformation_count=0,
+            schedule_count=0,
+        )
+        assert progress.done_count == 0
+        assert progress.total == 5
+        assert progress.all_done is False
+        assert progress.has_connection is False
+        assert progress.has_pipeline is False
+        assert progress.has_run is False
+        assert progress.has_transformation is False
+        assert progress.has_schedule is False
+
+
+class TestComputeChecklistPartial:
+    def test_single_connection_marks_first_step(self):
+        progress = compute_checklist(
+            connection_count=1,
+            pipeline_count=0,
+            run_count=0,
+            transformation_count=0,
+            schedule_count=0,
+        )
+        assert progress.has_connection is True
+        assert progress.done_count == 1
+        assert progress.all_done is False
+
+    def test_many_connections_still_counts_as_one_step(self):
+        # Existence, not cardinality — 42 connections is still "1 out of 5"
+        progress = compute_checklist(
+            connection_count=42,
+            pipeline_count=0,
+            run_count=0,
+            transformation_count=0,
+            schedule_count=0,
+        )
+        assert progress.has_connection is True
+        assert progress.done_count == 1
+
+    def test_three_of_five_done(self):
+        progress = compute_checklist(
+            connection_count=2,
+            pipeline_count=1,
+            run_count=5,
+            transformation_count=0,
+            schedule_count=0,
+        )
+        assert progress.done_count == 3
+        assert progress.all_done is False
+        assert progress.has_connection is True
+        assert progress.has_pipeline is True
+        assert progress.has_run is True
+        assert progress.has_transformation is False
+        assert progress.has_schedule is False
+
+    def test_four_of_five_done_not_all_done(self):
+        progress = compute_checklist(
+            connection_count=1,
+            pipeline_count=1,
+            run_count=1,
+            transformation_count=1,
+            schedule_count=0,
+        )
+        assert progress.done_count == 4
+        assert progress.all_done is False
+
+
+class TestComputeChecklistComplete:
+    def test_all_five_done(self):
+        progress = compute_checklist(
+            connection_count=1,
+            pipeline_count=1,
+            run_count=1,
+            transformation_count=1,
+            schedule_count=1,
+        )
+        assert progress.done_count == 5
+        assert progress.total == 5
+        assert progress.all_done is True
+        assert progress.has_connection is True
+        assert progress.has_pipeline is True
+        assert progress.has_run is True
+        assert progress.has_transformation is True
+        assert progress.has_schedule is True
+
+
+class TestChecklistProgressModel:
+    def test_defaults(self):
+        progress = ChecklistProgress()
+        assert progress.has_connection is False
+        assert progress.has_pipeline is False
+        assert progress.has_run is False
+        assert progress.has_transformation is False
+        assert progress.has_schedule is False
+        assert progress.done_count == 0
+        assert progress.total == 5
+        assert progress.all_done is False
+
+    def test_total_is_always_five(self):
+        # The 5 onboarding steps are a product decision, not a count of
+        # whatever tables exist. Keep the denominator stable.
+        progress = compute_checklist(
+            connection_count=0,
+            pipeline_count=0,
+            run_count=0,
+            transformation_count=0,
+            schedule_count=0,
+        )
+        assert progress.total == 5


### PR DESCRIPTION
## Summary

- Dismissible 5-step **Getting Started checklist widget** on the dashboard — first slice of P0 Onboarding Experience, the connective tissue that ties empty states, template pipelines, and sample-connection work together
- 5 steps derived from existing entity counts (**no new progress columns**): add connection → create pipeline → run a pipeline → add transformation → schedule a pipeline
- Per-user dismissal via **one new nullable column** \`users.onboarding_checklist_dismissed_at\` (single Alembic migration)
- Full i18n parity across all 9 locales; pure-Python helper + 8 new tests

Closes #50.

## Architecture

| Layer | File | Responsibility |
|---|---|---|
| Pure helper | \`datanika/services/onboarding.py\` | \`compute_checklist(**counts) -> ChecklistProgress\`, \`load_checklist_for_org(session, org_id)\` |
| Model | \`datanika/models/user.py\` | +\`onboarding_checklist_dismissed_at: datetime \| None\` |
| Migration | \`datanika/migrations/versions/w2s9t0u1v3p4_…\` | \`add_column\` / \`drop_column\`, explicit \`connection.commit()\` per the env.py pattern |
| State | \`datanika/ui/state/onboarding_state.py\` | \`OnboardingState\` — loads progress + dismissed, \`dismiss_checklist\` action |
| Component | \`datanika/ui/components/getting_started_checklist.py\` | \`getting_started_checklist()\` — renders when \`visible\`, hides otherwise |
| Wire | \`datanika/datanika.py\` + \`datanika/ui/pages/dashboard.py\` | \`OnboardingState.load_checklist\` added to dashboard \`on_load\`, component rendered above the existing static docs-links card |

### Why derived state, not a \`checklist_items\` table

Each of the 5 steps is a cheap \`SELECT COUNT(*) WHERE org_id = :org_id LIMIT 1\` against a table that already exists. Caching or a dedicated table would mean a second source of truth that can drift from reality. The checklist is read-mostly on a single page; the computation is fast.

### Why per-user dismissal, not per-org

Two members of the same org are often at different points in their journey. A new hire in an existing org should still see the checklist even if the org admin dismissed it months ago. One nullable timestamp column on \`users\` is the smallest durable surface for that.

## TDD

Test-first — the red phase:

\`\`\`
tests\test_services\test_onboarding.py: ModuleNotFoundError: No module named 'datanika.services.onboarding'
\`\`\`

Then green after \`services/onboarding.py\` landed. 8 tests covering fresh / 1-done / 3-done / 4-done / 5-done / existence-not-count / defaults / total-is-always-five.

## i18n

9 new keys in all 9 locale files (\`en\`, \`ru\`, \`el\`, \`de\`, \`fr\`, \`es\`, \`zh\`, \`ar\`, \`sr\`): \`onboarding.title\`, \`onboarding.subtitle\`, \`onboarding.dismiss\`, \`onboarding.all_done\`, and one per step (\`step_connection\`, \`step_pipeline\`, \`step_run\`, \`step_transformation\`, \`step_schedule\`).

\`test_all_locales_have_same_keys\` stays green.

## Test plan

- [x] \`tests/test_services/test_onboarding.py\` — 8 pure-Python tests pass
- [x] \`tests/test_i18n/\` — all 15 i18n tests pass, no orphan keys, full parity across 9 locales
- [x] \`tests/test_migrations/test_migration_coverage.py\` — new column detected by the static scanner
- [x] \`tests/test_ui/\` — all existing state-model tests still green (253 total)
- [x] Full suite: \`uv run pytest tests/\` → **1519 passed**
- [x] \`uv run ruff check datanika tests\` → clean
- [x] \`uv run ruff format datanika tests\` → clean

## Manual verification (for reviewer)

After \`alembic upgrade head\`:

1. Sign in as a user whose org has zero connections — dashboard shows the checklist with 0/5.
2. Add a connection — reload the dashboard, checklist shows 1/5 with the first row checked off.
3. Create a pipeline, run it, add a transformation, add a schedule — each refresh ticks another box.
4. Once 5/5, the widget shows a green "all set" callout.
5. Click **Dismiss** — widget disappears and stays hidden on subsequent loads (per-user).
6. Sign in as a different user in the same org — their checklist state is independent.

## Out of scope (tracked separately under P0 Onboarding)

- Empty state designs for Connections / Pipelines / Transformations pages
- Contextual tooltips for complex concepts
- Pre-built template pipelines
- Sample connection (demo database)

Each will be its own issue + PR following the same workflow.