### PR TITLE
Add Blackbox Exporter + external HTTP probes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,20 @@ services:
       - "--storage.tsdb.retention.time=30d"
     restart: unless-stopped
 
+  # Blackbox Exporter — probes external HTTP(S) endpoints and exposes metrics.
+  # Used for sitemap health checks and the SEO probe. Prometheus scrapes this
+  # via the scrape configs in monitoring/prometheus.yml.
+  blackbox:
+    image: prom/blackbox-exporter:latest
+    container_name: datanika-blackbox
+    ports:
+      - "127.0.0.1:9115:9115"
+    volumes:
+      - ./monitoring/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    command:
+      - "--config.file=/etc/blackbox_exporter/config.yml"
+    restart: unless-stopped
+
   grafana:
     image: grafana/grafana:latest
     container_name: datanika-grafana

--- a/monitoring/blackbox.yml
+++ b/monitoring/blackbox.yml
@@ -1,0 +1,11 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 10s
+    http:
+      preferred_ip_protocol: "ip4"
+      valid_status_codes: [200]
+      method: GET
+      follow_redirects: true
+      fail_if_ssl: false
+      fail_if_not_ssl: true

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -307,3 +307,107 @@ groups:
         annotations:
           summary: "Celery queue backlog: {{ $value }} tasks"
           description: "Celery queue has had more than 50 pending tasks for 10 minutes."
+
+  - orgId: 1
+    name: External Probes
+    folder: Datanika
+    interval: 5m
+    rules:
+      # --- Sitemap health (SEO-critical) ---
+      - uid: sitemap-down
+        title: Sitemap Unreachable
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'probe_success{instance="https://datanika.io/sitemap-index.xml"} == 0'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "datanika.io sitemap-index.xml is unreachable"
+          description: "Blackbox probe to https://datanika.io/sitemap-index.xml has failed for 15 minutes. Search engines cannot recrawl. Check Aweb, Nginx, and the landing deploy workflow."
+
+      # --- Landing site reachability ---
+      - uid: landing-down
+        title: Landing Site Down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'probe_success{instance="https://datanika.io/"} == 0'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "datanika.io landing site is down"
+          description: "Blackbox probe to https://datanika.io/ has failed for 5 minutes."
+
+      # --- App external health ---
+      - uid: app-external-down
+        title: App External Health Down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'probe_success{instance="https://app.datanika.io/healthz"} == 0'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "app.datanika.io /healthz not reachable externally"
+          description: "External blackbox probe to https://app.datanika.io/healthz has failed for 5 minutes. Distinct from the internal container healthcheck — this catches Nginx/Cloudflare/DNS problems."

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -18,3 +18,22 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets: ["app:8000"]
+
+  # Blackbox probes — HTTP health checks for external endpoints.
+  # Targets are probed via the blackbox exporter's http_2xx module.
+  - job_name: "blackbox-http"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - https://datanika.io/sitemap-index.xml
+          - https://datanika.io/
+          - https://app.datanika.io/healthz
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox:9115


### PR DESCRIPTION
## Summary
Add `prom/blackbox-exporter` as a docker-compose service, scraped by Prometheus, probing 3 external targets with Grafana alerts routed through the existing Telegram contact point.

### Probes
| Target | Purpose |
|---|---|
| `https://datanika.io/sitemap-index.xml` | SEO-critical — search engines can't recrawl if down |
| `https://datanika.io/` | Landing site reachability |
| `https://app.datanika.io/healthz` | External app health (distinct from internal container check — catches Nginx/Cloudflare/DNS) |

### Alert rules (new "External Probes" group)
- **Sitemap Unreachable** (warning, 15m) → Telegram
- **Landing Site Down** (critical, 5m) → Telegram
- **App External Health Down** (critical, 5m) → Telegram

### Out of scope
- URL-count-drop detection for sitemap — requires external state tracking. HTTP 200 check covers the main failure mode. Follow-up if we ever silently ship fewer URLs without a deploy.