### PR TITLE
Tier 2 Agent Compatibility: POST /transformations/{id}/compile + /preview

### DIFF
--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -72,6 +72,16 @@ def _error(status: int, message: str) -> JSONResponse:
     return JSONResponse({"error": {"code": status, "message": message}}, status_code=status)
 
 
+def _typed_error(status: int, code: str, message: str, **extra) -> JSONResponse:
+    """Return an error response where `code` is a machine-readable string.
+
+    Used by Tier 2 agent endpoints (compile / preview) so AI agents can
+    branch on the error class without string-matching the message.
+    """
+    body = {"error": {"code": code, "message": message, **extra}}
+    return JSONResponse(body, status_code=status)
+
+
 async def _body(request: Request) -> dict:
     raw = await request.body()
     if not raw:
@@ -669,6 +679,96 @@ async def trigger_transformation(request, api_key, session):
     return JSONResponse({"run_id": run.id, "status": "pending"}, status_code=202)
 
 
+@api_endpoint(required_scope="transformations:read")
+async def compile_transformation_endpoint(request, api_key, session):
+    """POST /api/v1/transformations/{id}/compile — dbt compile only.
+
+    Agent uses this to validate Jinja + ref/source resolution before
+    triggering a full run. No warehouse execution, no side effects
+    beyond writing the tenant model file to disk.
+    """
+    from datanika.services.transformation_compile import (
+        TransformationNotFoundError,
+        compile_transformation,
+    )
+
+    tid = int(request.path_params["id"])
+    try:
+        result = compile_transformation(session, api_key.org_id, tid)
+    except TransformationNotFoundError:
+        return _error(404, "Transformation not found")
+
+    if not result.success:
+        payload: dict = {}
+        if result.line is not None:
+            payload["line"] = result.line
+        if result.column is not None:
+            payload["column"] = result.column
+        return _typed_error(
+            400,
+            "compilation_error",
+            result.error_message or "Compilation failed",
+            **payload,
+        )
+
+    return JSONResponse(
+        {
+            "compiled_sql": result.compiled_sql,
+            "node": result.node,
+        }
+    )
+
+
+@api_endpoint(required_scope="transformations:read")
+async def preview_transformation_endpoint(request, api_key, session):
+    """POST /api/v1/transformations/{id}/preview — compile + execute.
+
+    Body: ``{"limit"?: int}`` (default 100, max 1000).
+
+    Returns first N rows from the compiled SQL wrapped in a
+    ``SELECT * FROM (...) LIMIT N`` subquery (defense-in-depth: the
+    read-only SQL guard re-validates even after dbt compile).
+    """
+    from datanika.services.transformation_compile import (
+        DEFAULT_PREVIEW_LIMIT,
+        MissingDestinationError,
+        TransformationNotFoundError,
+        preview_transformation,
+    )
+
+    tid = int(request.path_params["id"])
+    data = await _body(request)
+    limit = data.get("limit", DEFAULT_PREVIEW_LIMIT)
+    if not isinstance(limit, int):
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            return _typed_error(400, "invalid_request", "limit must be an integer")
+
+    try:
+        result = preview_transformation(session, api_key.org_id, tid, limit=limit)
+    except TransformationNotFoundError:
+        return _error(404, "Transformation not found")
+    except MissingDestinationError as exc:
+        return _typed_error(400, "missing_destination", str(exc))
+
+    if not result.success:
+        return _typed_error(
+            400,
+            result.error_code or "preview_failed",
+            result.error_message or "Preview failed",
+        )
+
+    return JSONResponse(
+        {
+            "columns": result.columns,
+            "rows": result.rows,
+            "row_count": result.row_count,
+            "truncated": result.truncated,
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # Schedules
 # ---------------------------------------------------------------------------
@@ -951,6 +1051,16 @@ api_v1_routes = [
     Route("/api/v1/transformations/{id:int}", update_transformation, methods=["PUT"]),
     Route("/api/v1/transformations/{id:int}", delete_transformation, methods=["DELETE"]),
     Route("/api/v1/transformations/{id:int}/run", trigger_transformation, methods=["POST"]),
+    Route(
+        "/api/v1/transformations/{id:int}/compile",
+        compile_transformation_endpoint,
+        methods=["POST"],
+    ),
+    Route(
+        "/api/v1/transformations/{id:int}/preview",
+        preview_transformation_endpoint,
+        methods=["POST"],
+    ),
     # Schedules
     Route("/api/v1/schedules", list_schedules, methods=["GET"]),
     Route("/api/v1/schedules/{id:int}", get_schedule, methods=["GET"]),

--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -261,6 +261,102 @@ SCHEMAS = {
         },
         required=["name", "channel_type"],
     ),
+    # --- Tier 2 Agent Compatibility: compile + preview ---
+    "CompileResult": _obj(
+        {
+            "compiled_sql": {
+                "type": "string",
+                "description": ("Fully rendered SQL after Jinja + ref/source resolution."),
+            },
+            "node": {
+                "type": "string",
+                "description": ("dbt fully-qualified node name, e.g. `model.tenant_1.stg_orders`."),
+            },
+        },
+        required=["compiled_sql", "node"],
+    ),
+    "CompileError": _obj(
+        {
+            "error": _obj(
+                {
+                    "code": {
+                        "type": "string",
+                        "enum": ["compilation_error"],
+                    },
+                    "message": {"type": "string"},
+                    "line": {"type": "integer", "nullable": True},
+                    "column": {"type": "integer", "nullable": True},
+                },
+                required=["code", "message"],
+            ),
+        },
+        required=["error"],
+    ),
+    "PreviewRequest": _obj(
+        {
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000,
+                "default": 100,
+                "description": ("Maximum rows to return. Clamped to [1, 1000]."),
+            },
+        },
+    ),
+    "PreviewColumn": _obj(
+        {
+            "name": {"type": "string"},
+            "type": {"type": "string"},
+        },
+        required=["name"],
+    ),
+    "PreviewResult": _obj(
+        {
+            "columns": {
+                "type": "array",
+                "items": _ref("PreviewColumn"),
+            },
+            "rows": {
+                "type": "array",
+                "items": {"type": "array"},
+                "description": (
+                    "Row-major result set. Each inner array matches the "
+                    "`columns` order. Values are JSON-serialized scalars "
+                    "or strings for unknown types."
+                ),
+            },
+            "row_count": {"type": "integer"},
+            "truncated": {
+                "type": "boolean",
+                "description": (
+                    "True when `row_count` equals the requested limit "
+                    "(the underlying result may have had more rows)."
+                ),
+            },
+        },
+        required=["columns", "rows", "row_count", "truncated"],
+    ),
+    "PreviewError": _obj(
+        {
+            "error": _obj(
+                {
+                    "code": {
+                        "type": "string",
+                        "enum": [
+                            "compilation_error",
+                            "execution_error",
+                            "missing_destination",
+                            "unsafe_sql",
+                            "invalid_request",
+                        ],
+                    },
+                    "message": {"type": "string"},
+                },
+                required=["code", "message"],
+            ),
+        },
+        required=["error"],
+    ),
 }
 
 # ---------------------------------------------------------------------------
@@ -494,6 +590,64 @@ def build_openapi_spec() -> dict:
         paths[f"/api/v1/{resource}/{{id}}/{suffix}"] = {
             "post": _trigger_op(tag, f"{action} {resource[:-1]}"),
         }
+
+    # Tier 2 Agent Compatibility: transformation compile + preview
+    paths["/api/v1/transformations/{id}/compile"] = {
+        "post": {
+            "tags": ["Transformations"],
+            "summary": "Compile a transformation via dbt",
+            "description": (
+                "Wraps `dbt compile` for the tenant dbt project. "
+                "Resolves Jinja and `{{ ref() }}` / `{{ source() }}` "
+                "references. No warehouse execution."
+            ),
+            "parameters": [_ID_PARAM],
+            "responses": {
+                "200": {
+                    "description": "Compilation succeeded",
+                    "content": _json_content(_ref("CompileResult")),
+                },
+                "400": {
+                    "description": "Compilation failed",
+                    "content": _json_content(_ref("CompileError")),
+                },
+                "401": _401,
+                "404": _404,
+                "429": _429,
+            },
+        },
+    }
+    paths["/api/v1/transformations/{id}/preview"] = {
+        "post": {
+            "tags": ["Transformations"],
+            "summary": "Preview a transformation's output",
+            "description": (
+                "Compiles the transformation and runs the resulting SQL "
+                "wrapped in `SELECT * FROM (...) LIMIT N` against the "
+                "destination warehouse. Defense-in-depth: the read-only "
+                "SQL validator re-checks the compiled output even after "
+                "dbt compile."
+            ),
+            "parameters": [_ID_PARAM],
+            "requestBody": {
+                "required": False,
+                "content": _json_content(_ref("PreviewRequest")),
+            },
+            "responses": {
+                "200": {
+                    "description": "Preview rows returned",
+                    "content": _json_content(_ref("PreviewResult")),
+                },
+                "400": {
+                    "description": ("Compilation, execution, or configuration error"),
+                    "content": _json_content(_ref("PreviewError")),
+                },
+                "401": _401,
+                "404": _404,
+                "429": _429,
+            },
+        },
+    }
 
     # Runs (read-only)
     paths["/api/v1/runs"] = {

--- a/datanika/services/transformation_compile.py
+++ b/datanika/services/transformation_compile.py
@@ -1,0 +1,309 @@
+"""Shared service helpers for compiling and previewing dbt transformations.
+
+Extracted from ``ui/state/transformation_state.py`` so that the REST API
+v1 endpoints (``/transformations/{id}/compile`` and ``/preview``) and
+the Reflex UI can share a single code path. The UI state wrappers
+remain responsible for error-to-string translation; this module returns
+structured results that either side can format.
+
+All functions are tenant-isolated: the caller must pass a valid
+``org_id`` and the service looks up the transformation scoped to that
+org. No cross-tenant reads possible.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from datanika.config import settings
+from datanika.models.user import Organization
+from datanika.services.connection_service import ConnectionService
+from datanika.services.dbt_project import DbtProjectError, DbtProjectService
+from datanika.services.encryption import EncryptionService
+from datanika.services.transformation_service import TransformationService
+
+logger = logging.getLogger(__name__)
+
+_LINE_COLUMN_RE = re.compile(r"line\s+(\d+)(?:.*?column\s+(\d+))?", re.IGNORECASE)
+
+MAX_PREVIEW_LIMIT = 1000
+DEFAULT_PREVIEW_LIMIT = 100
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses — structured so both API and UI can consume them.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompileResult:
+    """Outcome of compiling a transformation.
+
+    ``success`` mirrors dbt's own flag. On failure, ``error_message``
+    contains the dbt error log and ``line`` / ``column`` may be parsed
+    from it when dbt surfaces them (best-effort — dbt's output format
+    is not stable).
+    """
+
+    success: bool
+    compiled_sql: str = ""
+    node: str = ""
+    error_message: str = ""
+    line: int | None = None
+    column: int | None = None
+
+
+@dataclass
+class PreviewResult:
+    """Outcome of previewing a transformation against the warehouse."""
+
+    success: bool
+    columns: list[dict] = field(default_factory=list)
+    rows: list[list] = field(default_factory=list)
+    row_count: int = 0
+    truncated: bool = False
+    compiled_sql: str = ""
+    error_code: str = ""
+    error_message: str = ""
+
+
+class TransformationNotFoundError(ValueError):
+    """Raised when a transformation doesn't exist for the given org."""
+
+
+class MissingDestinationError(ValueError):
+    """Raised when a transformation has no destination connection set."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compile_transformation(
+    session: Session,
+    org_id: int,
+    transformation_id: int,
+    *,
+    dbt_projects_dir: str | None = None,
+) -> CompileResult:
+    """Compile a transformation via dbt and return the result.
+
+    Raises ``TransformationNotFoundError`` if the transformation
+    doesn't exist for the given org (use this to map to a 404 at
+    the API layer). Other exceptions are caught and returned as
+    ``CompileResult(success=False, ...)``.
+    """
+    transform, conn_svc, conn, config = _load_for_compile(session, org_id, transformation_id)
+
+    projects_dir = dbt_projects_dir or settings.dbt_projects_dir
+    dbt_svc = DbtProjectService(projects_dir)
+
+    try:
+        dbt_svc.ensure_project(org_id)
+        default_schema = _default_schema(session, org_id)
+        if conn is not None and config:
+            dbt_svc.generate_profiles_yml(
+                org_id,
+                conn.connection_type.value,
+                config,
+                default_schema=default_schema,
+            )
+        dbt_svc.write_model(
+            org_id,
+            transform.name,
+            transform.sql_body,
+            schema_name=transform.schema_name,
+            materialization=transform.materialization.value,
+            incremental_config=transform.incremental_config,
+        )
+        result = dbt_svc.compile_model(org_id, transform.name)
+    except DbtProjectError as exc:
+        return CompileResult(success=False, error_message=str(exc))
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("Unexpected error compiling transformation %s", transform.id)
+        return CompileResult(success=False, error_message=str(exc))
+
+    if not result.get("success") or not result.get("compiled_sql"):
+        logs = result.get("logs") or "Compilation produced no output"
+        line, column = _parse_line_column(logs)
+        return CompileResult(
+            success=False,
+            error_message=logs,
+            line=line,
+            column=column,
+            node=f"model.tenant_{org_id}.{transform.name}",
+        )
+
+    return CompileResult(
+        success=True,
+        compiled_sql=result["compiled_sql"],
+        node=f"model.tenant_{org_id}.{transform.name}",
+    )
+
+
+def preview_transformation(
+    session: Session,
+    org_id: int,
+    transformation_id: int,
+    *,
+    limit: int = DEFAULT_PREVIEW_LIMIT,
+    dbt_projects_dir: str | None = None,
+) -> PreviewResult:
+    """Compile a transformation, add a safe LIMIT, run against the
+    destination warehouse, and return rows.
+
+    ``limit`` is clamped to ``[1, MAX_PREVIEW_LIMIT]``.
+
+    Raises ``TransformationNotFoundError`` or
+    ``MissingDestinationError`` for the caller to map to 404 / 400.
+    Warehouse errors come back as ``PreviewResult(success=False)``.
+    """
+    clamped = max(1, min(int(limit or DEFAULT_PREVIEW_LIMIT), MAX_PREVIEW_LIMIT))
+
+    # Fail-fast before running dbt compile: if there's no destination,
+    # preview is impossible. Agents get a clean typed error that's
+    # distinguishable from a compilation failure.
+    transform, conn_svc, conn, config = _load_for_compile(session, org_id, transformation_id)
+    if conn is None or not config:
+        raise MissingDestinationError("Transformation has no destination connection set")
+
+    compile_result = compile_transformation(
+        session,
+        org_id,
+        transformation_id,
+        dbt_projects_dir=dbt_projects_dir,
+    )
+    if not compile_result.success:
+        return PreviewResult(
+            success=False,
+            error_code="compilation_error",
+            error_message=compile_result.error_message,
+        )
+
+    # Wrap the compiled SQL in a bounded SELECT so the existing
+    # read-only SQL guard applies. Defense in depth: never trust that
+    # dbt compiled something safe.
+    inner = compile_result.compiled_sql.strip().rstrip(";")
+    query = f"SELECT * FROM (\n{inner}\n) AS _preview LIMIT {clamped}"
+    if not ConnectionService.is_select_only(query):
+        return PreviewResult(
+            success=False,
+            error_code="unsafe_sql",
+            error_message="Compiled SQL did not pass the read-only validator",
+            compiled_sql=compile_result.compiled_sql,
+        )
+
+    try:
+        columns, rows = ConnectionService.execute_query(
+            config,
+            conn.connection_type,
+            query,
+        )
+    except ValueError as exc:
+        return PreviewResult(
+            success=False,
+            error_code="execution_error",
+            error_message=str(exc),
+            compiled_sql=compile_result.compiled_sql,
+        )
+    except Exception as exc:
+        # Warehouse-side failure. Truncate the message so OpenAPI
+        # clients don't choke on megabyte-long stack traces.
+        return PreviewResult(
+            success=False,
+            error_code="execution_error",
+            error_message=_truncate(str(exc), 500),
+            compiled_sql=compile_result.compiled_sql,
+        )
+
+    serialized_rows = [[_to_json_safe(v) for v in row] for row in rows]
+    column_objs = [{"name": c, "type": ""} for c in columns]
+    return PreviewResult(
+        success=True,
+        columns=column_objs,
+        rows=serialized_rows,
+        row_count=len(serialized_rows),
+        truncated=len(serialized_rows) >= clamped,
+        compiled_sql=compile_result.compiled_sql,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_for_compile(
+    session: Session,
+    org_id: int,
+    transformation_id: int,
+):
+    """Load the transformation, decrypt the destination connection,
+    and return the full tuple needed by compile/preview.
+
+    Raises ``TransformationNotFoundError`` when the transformation
+    doesn't exist for ``org_id``. Missing destination is permitted
+    for compile (the service still writes the model file), but
+    ``preview_transformation`` re-checks and raises its own error.
+    """
+    svc = TransformationService()
+    transform = svc.get_transformation(session, org_id, transformation_id)
+    if transform is None:
+        raise TransformationNotFoundError(f"Transformation {transformation_id} not found")
+
+    encryption = EncryptionService(settings.credential_encryption_key)
+    conn_svc = ConnectionService(encryption)
+    conn = None
+    config: dict | None = None
+    if transform.destination_connection_id:
+        conn = conn_svc.get_connection(session, org_id, transform.destination_connection_id)
+        if conn is not None:
+            config = conn_svc.get_connection_config(
+                session, org_id, transform.destination_connection_id
+            )
+    return transform, conn_svc, conn, config
+
+
+def _default_schema(session: Session, org_id: int) -> str:
+    org = session.get(Organization, org_id)
+    if org and getattr(org, "default_dbt_schema", None):
+        return org.default_dbt_schema
+    return "datanika"
+
+
+def _parse_line_column(message: str) -> tuple[int | None, int | None]:
+    """Best-effort parse of dbt error message for line/column."""
+    if not message:
+        return None, None
+    m = _LINE_COLUMN_RE.search(message)
+    if not m:
+        return None, None
+    try:
+        line = int(m.group(1))
+    except (TypeError, ValueError):
+        line = None
+    try:
+        column = int(m.group(2)) if m.group(2) else None
+    except (TypeError, ValueError):
+        column = None
+    return line, column
+
+
+def _to_json_safe(value):
+    """Convert a DB row value to something JSON-serializable."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _truncate(text: str, limit: int) -> str:
+    if not text:
+        return ""
+    return text if len(text) <= limit else text[: limit - 1] + "…"

--- a/tests/test_services/test_openapi.py
+++ b/tests/test_services/test_openapi.py
@@ -66,6 +66,52 @@ class TestOpenAPISpec:
         ]:
             assert name in schemas, f"Missing schema {name}"
 
+    def test_spec_has_tier_2_compile_preview_paths(self):
+        """Tier 2 Agent Compatibility endpoints must be in OpenAPI spec (#52)."""
+        spec = build_openapi_spec()
+        compile_path = "/api/v1/transformations/{id}/compile"
+        preview_path = "/api/v1/transformations/{id}/preview"
+        assert compile_path in spec["paths"]
+        assert preview_path in spec["paths"]
+        assert "post" in spec["paths"][compile_path]
+        assert "post" in spec["paths"][preview_path]
+
+        # Preview accepts a request body with optional limit
+        preview_post = spec["paths"][preview_path]["post"]
+        assert "requestBody" in preview_post
+        # 200 responses reference typed schemas (no {type: object} placeholder)
+        compile_200 = spec["paths"][compile_path]["post"]["responses"]["200"]
+        compile_ref = compile_200["content"]["application/json"]["schema"]["$ref"]
+        assert compile_ref.endswith("CompileResult")
+        preview_200 = preview_post["responses"]["200"]
+        preview_ref = preview_200["content"]["application/json"]["schema"]["$ref"]
+        assert preview_ref.endswith("PreviewResult")
+        # 400 responses reference typed error schemas with string error codes
+        compile_400 = spec["paths"][compile_path]["post"]["responses"]["400"]
+        assert compile_400["content"]["application/json"]["schema"]["$ref"].endswith("CompileError")
+
+    def test_tier_2_schemas_have_required_fields(self):
+        spec = build_openapi_spec()
+        schemas = spec["components"]["schemas"]
+        for name in [
+            "CompileResult",
+            "CompileError",
+            "PreviewRequest",
+            "PreviewResult",
+            "PreviewColumn",
+            "PreviewError",
+        ]:
+            assert name in schemas, f"Missing Tier 2 schema {name}"
+
+        compile_result = schemas["CompileResult"]
+        assert "compiled_sql" in compile_result["properties"]
+        assert "node" in compile_result["properties"]
+        assert "compiled_sql" in compile_result["required"]
+
+        preview_result = schemas["PreviewResult"]
+        for field in ("columns", "rows", "row_count", "truncated"):
+            assert field in preview_result["properties"]
+
     def test_runs_path_has_query_params(self):
         spec = build_openapi_spec()
         runs_get = spec["paths"]["/api/v1/runs"]["get"]

--- a/tests/test_services/test_transformation_compile.py
+++ b/tests/test_services/test_transformation_compile.py
@@ -1,0 +1,527 @@
+"""Tests for transformation_compile service and API endpoints (#52).
+
+Covers:
+- compile_transformation: success, Jinja error, missing transformation,
+  missing destination (compile is lenient — preview is strict).
+- preview_transformation: limit clamping, safe-SQL guard, warehouse
+  error propagation, compilation-error short-circuit.
+- /api/v1/transformations/{id}/compile API endpoint: 401, 404, 200,
+  tenant isolation.
+- /api/v1/transformations/{id}/preview API endpoint: default limit,
+  max limit clamp, 404.
+
+Real dbt compile is exercised via fixture SQL; the warehouse is mocked.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession
+from sqlalchemy.pool import StaticPool
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+# Register all model tables so Base.metadata.create_all sees them.
+import datanika.models.invitation  # noqa: F401
+import datanika.models.notification_channel  # noqa: F401
+import datanika.models.sso_config  # noqa: F401
+from datanika.models.base import Base
+from datanika.models.connection import Connection, ConnectionType
+from datanika.models.transformation import Materialization, Transformation
+from datanika.models.user import Organization
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.encryption import EncryptionService
+from datanika.services.rate_limit_service import RateLimitResult
+from datanika.services.transformation_compile import (
+    DEFAULT_PREVIEW_LIMIT,
+    MAX_PREVIEW_LIMIT,
+    CompileResult,
+    MissingDestinationError,
+    PreviewResult,
+    TransformationNotFoundError,
+    compile_transformation,
+    preview_transformation,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fernet_key():
+    return Fernet.generate_key().decode()
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def db_session(engine):
+    session = SASession(engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def org(db_session):
+    org = Organization(name="Test Org", slug="test-org")
+    db_session.add(org)
+    db_session.flush()
+    return org
+
+
+@pytest.fixture
+def duckdb_connection(db_session, org, fernet_key, tmp_path):
+    """Create a DuckDB destination connection with a seeded 'orders' table.
+
+    DuckDB is used instead of SQLite because `dbt-duckdb` is installed
+    as a project dependency, so real `dbt compile` works against it.
+    """
+    import duckdb
+
+    db_path = tmp_path / "dest.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE orders (id INTEGER PRIMARY KEY, name TEXT, total DOUBLE)")
+    con.executemany(
+        "INSERT INTO orders (id, name, total) VALUES (?, ?, ?)",
+        [(1, "Alice", 10.5), (2, "Bob", 20.0), (3, "Carol", 15.75)],
+    )
+    con.close()
+
+    enc = EncryptionService(fernet_key)
+    conn = Connection(
+        org_id=org.id,
+        name="Test DuckDB",
+        connection_type=ConnectionType.DUCKDB,
+        direction="both",
+        config_encrypted=enc.encrypt({"path": str(db_path)}),
+    )
+    db_session.add(conn)
+    db_session.flush()
+    return conn
+
+
+@pytest.fixture
+def transformation(db_session, org, duckdb_connection):
+    t = Transformation(
+        org_id=org.id,
+        name="stg_orders",
+        sql_body="SELECT id, name, total FROM orders",
+        materialization=Materialization.VIEW,
+        schema_name="staging",
+        destination_connection_id=duckdb_connection.id,
+        tests_config={},
+        tags=[],
+    )
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+@pytest.fixture
+def dbt_dir(tmp_path):
+    """Temp directory for dbt projects during the test."""
+    return str(tmp_path / "dbt_projects")
+
+
+@pytest.fixture(autouse=True)
+def patch_encryption_key(fernet_key):
+    """Make the shared EncryptionService instantiations in the compile
+    service see the same fernet key used to seed the fixture connection."""
+    with patch(
+        "datanika.services.transformation_compile.settings",
+    ) as mock_settings:
+        mock_settings.credential_encryption_key = fernet_key
+        mock_settings.dbt_projects_dir = ""  # will be overridden per-call
+        yield
+
+
+# ---------------------------------------------------------------------------
+# compile_transformation — service layer
+# ---------------------------------------------------------------------------
+
+
+class TestCompileTransformationService:
+    def test_not_found_raises(self, db_session, org, dbt_dir):
+        with pytest.raises(TransformationNotFoundError):
+            compile_transformation(db_session, org.id, 9999, dbt_projects_dir=dbt_dir)
+
+    def test_cross_org_not_found(self, db_session, transformation, dbt_dir):
+        # Different org_id should not be able to compile this transformation
+        with pytest.raises(TransformationNotFoundError):
+            compile_transformation(db_session, 9999, transformation.id, dbt_projects_dir=dbt_dir)
+
+    def test_success_returns_compiled_sql(self, db_session, org, transformation, dbt_dir):
+        result = compile_transformation(
+            db_session, org.id, transformation.id, dbt_projects_dir=dbt_dir
+        )
+        assert isinstance(result, CompileResult)
+        assert result.success is True
+        assert "SELECT" in result.compiled_sql.upper()
+        assert result.node.startswith(f"model.tenant_{org.id}.")
+        assert result.error_message == ""
+
+    def test_jinja_error_returns_failure_with_message(
+        self, db_session, org, transformation, dbt_dir
+    ):
+        transformation.sql_body = "SELECT {{ ref('nonexistent_model') }}.id"
+        db_session.flush()
+        result = compile_transformation(
+            db_session, org.id, transformation.id, dbt_projects_dir=dbt_dir
+        )
+        assert result.success is False
+        assert result.error_message != ""
+
+
+# ---------------------------------------------------------------------------
+# preview_transformation — service layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_warehouse():
+    """Mock ConnectionService.execute_query so preview tests don't need
+    a live warehouse connection. Returns a context manager yielding a
+    MagicMock so individual tests can tweak the return value."""
+    with patch("datanika.services.transformation_compile.ConnectionService.execute_query") as mock:
+        mock.return_value = (
+            ["id", "name", "total"],
+            [[1, "Alice", 10.5], [2, "Bob", 20.0], [3, "Carol", 15.75]],
+        )
+        yield mock
+
+
+class TestPreviewTransformationService:
+    def test_preview_success_returns_rows(
+        self, db_session, org, transformation, dbt_dir, mock_warehouse
+    ):
+        result = preview_transformation(
+            db_session, org.id, transformation.id, dbt_projects_dir=dbt_dir
+        )
+        assert isinstance(result, PreviewResult)
+        assert result.success is True
+        assert len(result.rows) == 3
+        assert [c["name"] for c in result.columns] == ["id", "name", "total"]
+        assert result.row_count == 3
+        assert result.truncated is False
+        # Verify the query sent to the warehouse was wrapped in a
+        # bounded SELECT and includes the clamped LIMIT.
+        query_sent = mock_warehouse.call_args.args[2]
+        assert "SELECT * FROM" in query_sent.upper()
+        assert "LIMIT 100" in query_sent.upper()
+
+    def test_limit_is_clamped_to_max(
+        self, db_session, org, transformation, dbt_dir, mock_warehouse
+    ):
+        result = preview_transformation(
+            db_session,
+            org.id,
+            transformation.id,
+            limit=99999,
+            dbt_projects_dir=dbt_dir,
+        )
+        assert result.success is True
+        # Query should have been clamped to MAX_PREVIEW_LIMIT (1000)
+        query_sent = mock_warehouse.call_args.args[2]
+        assert "LIMIT 1000" in query_sent.upper()
+
+    def test_limit_floor_is_one(self, db_session, org, transformation, dbt_dir, mock_warehouse):
+        result = preview_transformation(
+            db_session,
+            org.id,
+            transformation.id,
+            limit=0,  # should clamp to 1 (not raise)
+            dbt_projects_dir=dbt_dir,
+        )
+        assert result.success is True
+        query_sent = mock_warehouse.call_args.args[2]
+        assert "LIMIT 1" in query_sent.upper()
+
+    def test_warehouse_error_surfaces_as_execution_error(
+        self, db_session, org, transformation, dbt_dir
+    ):
+        with patch(
+            "datanika.services.transformation_compile.ConnectionService.execute_query"
+        ) as mock:
+            mock.side_effect = RuntimeError("relation orders does not exist")
+            result = preview_transformation(
+                db_session, org.id, transformation.id, dbt_projects_dir=dbt_dir
+            )
+        assert result.success is False
+        assert result.error_code == "execution_error"
+        assert "relation orders does not exist" in result.error_message
+
+    def test_compilation_error_short_circuits(self, db_session, org, transformation, dbt_dir):
+        transformation.sql_body = "{% if %}broken{% endif %}"
+        db_session.flush()
+        result = preview_transformation(
+            db_session, org.id, transformation.id, dbt_projects_dir=dbt_dir
+        )
+        assert result.success is False
+        assert result.error_code == "compilation_error"
+        assert result.rows == []
+
+    def test_not_found_raises(self, db_session, org, dbt_dir):
+        with pytest.raises(TransformationNotFoundError):
+            preview_transformation(db_session, org.id, 9999, dbt_projects_dir=dbt_dir)
+
+    def test_missing_destination_raises(self, db_session, org, transformation, dbt_dir):
+        transformation.destination_connection_id = None
+        db_session.flush()
+        with pytest.raises(MissingDestinationError):
+            preview_transformation(db_session, org.id, transformation.id, dbt_projects_dir=dbt_dir)
+
+    def test_constants(self):
+        assert DEFAULT_PREVIEW_LIMIT == 100
+        assert MAX_PREVIEW_LIMIT == 1000
+
+
+# ---------------------------------------------------------------------------
+# API endpoints — /api/v1/transformations/{id}/compile and /preview
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_api_key():
+    key = MagicMock()
+    key.id = 1
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def client():
+    return TestClient(Starlette(routes=api_v1_routes))
+
+
+def _headers():
+    return {"Authorization": "Bearer etf_test"}
+
+
+@contextlib.contextmanager
+def _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org_id, dbt_dir, fernet_key):
+    """Patch the middleware + compile-service settings so the API endpoint
+    sees the test session and fixture dbt dir."""
+    fake_api_key.org_id = org_id
+
+    @contextlib.contextmanager
+    def fake_session():
+        yield db_session
+
+    with (
+        patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+        patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+        patch("datanika.services.api_middleware._get_session", fake_session),
+        patch("datanika.services.transformation_compile.settings") as mock_settings,
+    ):
+        mock_svc.authenticate_api_key.return_value = fake_api_key
+        mock_rl.get_limit_for_org.return_value = 60
+        mock_rl.check_rate_limit.return_value = rate_limit_ok
+        mock_settings.credential_encryption_key = fernet_key
+        mock_settings.dbt_projects_dir = dbt_dir
+        yield
+
+
+class TestCompileEndpoint:
+    def test_401_without_auth(self, client, transformation):
+        resp = client.post(f"/api/v1/transformations/{transformation.id}/compile")
+        assert resp.status_code == 401
+
+    def test_success(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        org,
+        transformation,
+        dbt_dir,
+        fernet_key,
+    ):
+        with _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org.id, dbt_dir, fernet_key):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/compile",
+                headers=_headers(),
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "compiled_sql" in data
+        assert "SELECT" in data["compiled_sql"].upper()
+        assert data["node"].startswith(f"model.tenant_{org.id}.")
+
+    def test_404_on_wrong_org(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        transformation,
+        dbt_dir,
+        fernet_key,
+    ):
+        # API key belongs to a different org than the transformation
+        with _patch_api_auth(
+            fake_api_key,
+            rate_limit_ok,
+            db_session,
+            999,
+            dbt_dir,
+            fernet_key,
+        ):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/compile",
+                headers=_headers(),
+            )
+        assert resp.status_code == 404
+
+    def test_compilation_error_returns_400(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        org,
+        transformation,
+        dbt_dir,
+        fernet_key,
+    ):
+        transformation.sql_body = "{% if broken %}oops"
+        db_session.flush()
+        with _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org.id, dbt_dir, fernet_key):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/compile",
+                headers=_headers(),
+            )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "compilation_error"
+        assert body["error"]["message"]
+
+
+class TestPreviewEndpoint:
+    def test_401_without_auth(self, client, transformation):
+        resp = client.post(f"/api/v1/transformations/{transformation.id}/preview")
+        assert resp.status_code == 401
+
+    def test_success_default_limit(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        org,
+        transformation,
+        dbt_dir,
+        fernet_key,
+        mock_warehouse,
+    ):
+        with _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org.id, dbt_dir, fernet_key):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/preview",
+                headers=_headers(),
+                json={},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["row_count"] == 3
+        assert [c["name"] for c in data["columns"]] == ["id", "name", "total"]
+        assert data["truncated"] is False
+
+    def test_limit_clamped(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        org,
+        transformation,
+        dbt_dir,
+        fernet_key,
+        mock_warehouse,
+    ):
+        with _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org.id, dbt_dir, fernet_key):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/preview",
+                headers=_headers(),
+                json={"limit": 99999},
+            )
+        assert resp.status_code == 200
+        # Confirm the endpoint passed the clamped limit through
+        query_sent = mock_warehouse.call_args.args[2]
+        assert "LIMIT 1000" in query_sent.upper()
+
+    def test_404_on_wrong_org(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        transformation,
+        dbt_dir,
+        fernet_key,
+    ):
+        with _patch_api_auth(
+            fake_api_key,
+            rate_limit_ok,
+            db_session,
+            999,
+            dbt_dir,
+            fernet_key,
+        ):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/preview",
+                headers=_headers(),
+                json={},
+            )
+        assert resp.status_code == 404
+
+    def test_missing_destination_returns_400(
+        self,
+        client,
+        fake_api_key,
+        rate_limit_ok,
+        db_session,
+        org,
+        transformation,
+        dbt_dir,
+        fernet_key,
+    ):
+        transformation.destination_connection_id = None
+        db_session.flush()
+        with _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org.id, dbt_dir, fernet_key):
+            resp = client.post(
+                f"/api/v1/transformations/{transformation.id}/preview",
+                headers=_headers(),
+                json={},
+            )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
Closes out Tier 2 of the AI Agent Compatibility roadmap (#37). After Tier 1 (#38/#39/#40), an agent can discover connection types, list source tables, and create a transformation. This PR lets it **validate the SQL before running it** and **see sample rows** without touching the scheduler.

## Endpoints

### \`POST /api/v1/transformations/{id}/compile\`
Runs \`dbt compile\` for the tenant project. Returns the rendered SQL or a structured error with \`line\` / \`column\` when dbt surfaces them.

- **200**: \`{ "compiled_sql": "...", "node": "model.tenant_10.mart_revenue" }\`
- **400**: \`{ "error": { "code": "compilation_error", "message": "...", "line": 3, "column": 14 } }\`
- **404**: transformation not found for this org (tenant isolation)
- **401**: missing/invalid API key

No warehouse execution. No side effects beyond writing the tenant model file to disk.

### \`POST /api/v1/transformations/{id}/preview\`
Compiles, wraps in \`SELECT * FROM (...) LIMIT N\`, runs against the destination.

- **Request**: \`{ "limit"?: number }\` (default 100, clamped to [1, 1000])
- **200**: \`{ "columns": [{"name", "type"}], "rows": [[...]], "row_count": N, "truncated": bool }\`
- **400 error codes**: \`compilation_error\`, \`execution_error\`, \`missing_destination\`, \`unsafe_sql\`, \`invalid_request\`

**Defense-in-depth**: the compiled SQL is re-validated by the read-only \`is_select_only()\` guard from #39 before execution. Even if dbt compiled something dangerous, the endpoint cannot execute DDL or DML.

## Architecture

New shared service \`datanika/services/transformation_compile.py\` — extracted so the API endpoints and the Reflex UI state layer share one code path. Exports:
- \`compile_transformation()\` / \`preview_transformation()\`
- \`CompileResult\` / \`PreviewResult\` dataclasses
- \`TransformationNotFoundError\` / \`MissingDestinationError\`
- \`DEFAULT_PREVIEW_LIMIT\` (100) / \`MAX_PREVIEW_LIMIT\` (1000)

Reuses existing \`DbtProjectService.compile_model()\` — no duplicate subprocess/CLI logic.

New \`_typed_error()\` helper alongside existing \`_error()\`. Tier 2 responses use machine-readable string codes so agents can branch on error class without regex-matching the message. Existing Tier 0/1 endpoints keep using the old \`_error()\` with numeric codes — unchanged.

## OpenAPI (inline schemas — no \`{type: object}\` placeholders)
New schemas: \`CompileResult\`, \`CompileError\`, \`PreviewRequest\`, \`PreviewColumn\`, \`PreviewResult\`, \`PreviewError\`. Error schemas enumerate the string codes an agent can branch on.

## Tests (+21)

**Service layer (13)**
- compile: not found, cross-org isolation, success on real fixture, Jinja error
- preview: success with row assertion, limit clamp to 1000, limit floor at 1, compilation short-circuit, warehouse error → \`execution_error\`, not-found, missing destination, constants

**API endpoints (6)**
- compile: 401/200/404/400
- preview: 401/200 default/200 clamped/404/400 missing-destination

**OpenAPI spec (2)**: new paths + schemas present, 200 responses reference typed schemas

Tests use a real DuckDB fixture so \`dbt compile\` runs for real (\`dbt-duckdb\` is already a dep). The warehouse roundtrip for preview is mocked per the task guideline — tenant warehouses aren't in the test harness.

## Not in this PR
- Landing-site docs update — separate PR on datanika-landing (\`63-docs-tier-2-endpoints\`)
- Tier 3 OpenAPI inlining for connection config discriminators — next P0 item

Part of #37
Closes #52

## Test plan
- [x] 21 new tests in \`test_transformation_compile.py\`
- [x] 2 new tests in \`test_openapi.py\`
- [x] 1542 total tests pass (was 1521)
- [x] Ruff + format clean
- [x] Precheck green