### PR TITLE
Tier 3: inline per-type Connection/Upload OpenAPI schemas via discriminator

### DIFF
--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -359,6 +359,13 @@ SCHEMAS = {
     ),
 }
 
+# Inline per-type Connection.config and per-mode Upload.dlt_config schemas
+# from the single source of truth. This replaces the placeholder
+# `{type: object}` entries with discriminated `oneOf` branches.
+from datanika.services.openapi_inline import apply_inlined_schemas  # noqa: E402
+
+apply_inlined_schemas(SCHEMAS)
+
 # ---------------------------------------------------------------------------
 # Response shortcuts
 # ---------------------------------------------------------------------------

--- a/datanika/services/openapi_inline.py
+++ b/datanika/services/openapi_inline.py
@@ -1,0 +1,290 @@
+"""Build inlined OpenAPI schemas with discriminator-based ``oneOf`` for
+``ConnectionCreate.config`` and ``UploadCreate.dlt_config`` (#57).
+
+The single source of truth lives in:
+- ``datanika.services.connection_schemas.CONFIG_SCHEMAS`` (per connection
+  type field shapes)
+- ``datanika.services.meta_schemas.DLT_CONFIG_SCHEMA`` (full dlt_config
+  schema covering both modes)
+
+This module walks those dicts and produces OpenAPI 3.0.3-compatible
+component schemas plus a ``oneOf`` + ``discriminator`` parent so AI agents
+reading the spec can see exactly what fields each connection type or
+upload mode requires — no more ``{type: object}`` placeholders.
+
+The resulting schemas are merged into the openapi.py ``SCHEMAS`` dict at
+import time. Adding a new connection type to ``CONFIG_SCHEMAS`` makes it
+appear in the spec automatically.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_schemas import CONFIG_SCHEMAS
+from datanika.services.meta_schemas import DLT_CONFIG_SCHEMA
+
+CONNECTION_TYPE_VALUES: list[str] = [ct.value for ct in ConnectionType]
+
+
+def _to_pascal(slug: str) -> str:
+    """Convert ``google_sheets`` → ``GoogleSheets``, ``rest_api`` → ``RestApi``."""
+    return "".join(part.capitalize() for part in re.split(r"[_\-]", slug) if part)
+
+
+def _example_for(slug: str, schema: dict) -> dict:
+    """Build a request-body example for a connection type.
+
+    Pulls plausible values from the schema's ``properties`` so agents
+    have a working template they can edit. Sensitive fields use
+    ``CHANGE_ME`` so the example never accidentally leaks credentials.
+    """
+    props: dict[str, Any] = schema.get("properties", {})
+    config: dict[str, Any] = {}
+    for field, prop in props.items():
+        if prop.get("format") == "password":
+            config[field] = "CHANGE_ME"
+        elif prop.get("type") == "integer":
+            config[field] = prop.get("default", 0)
+        elif prop.get("type") == "boolean":
+            config[field] = prop.get("default", False)
+        else:
+            # String — produce a placeholder hinting at the field name
+            config[field] = f"<{field}>"
+    return {
+        "name": f"My {_to_pascal(slug)}",
+        "connection_type": slug,
+        "config": config,
+    }
+
+
+def build_connection_inlined_schemas() -> dict[str, dict]:
+    """Return component schemas for inlined connection request bodies.
+
+    Produces three families per connection type ``<slug>``:
+    - ``<Pascal>ConnectionConfig`` — the config object only
+    - ``Create<Pascal>Connection`` — the full request body with
+      ``connection_type`` const-fixed to ``slug``
+    - All branches are gathered into ``ConnectionCreate`` (the parent
+      with discriminator on ``connection_type``)
+
+    The connection slugs come from ``CONFIG_SCHEMAS`` which is the
+    single source of truth (also used by
+    ``GET /api/v1/meta/connection-types``).
+    """
+    components: dict[str, dict] = {}
+    branches: list[dict] = []
+    mapping: dict[str, str] = {}
+
+    for slug, raw_config in CONFIG_SCHEMAS.items():
+        pascal = _to_pascal(slug)
+        config_name = f"{pascal}ConnectionConfig"
+        create_name = f"Create{pascal}Connection"
+
+        # 1. Standalone config schema (deep-copied so we don't mutate
+        #    the source-of-truth dict).
+        config_schema = copy.deepcopy(raw_config)
+        config_schema["title"] = f"{pascal} connection config"
+        components[config_name] = config_schema
+
+        # 2. Full create body with `connection_type` pinned via enum-of-one.
+        components[create_name] = {
+            "type": "object",
+            "title": f"Create {pascal} connection",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable connection name",
+                },
+                "connection_type": {
+                    "type": "string",
+                    "enum": [slug],
+                    "description": (
+                        f"Discriminator value: must be `{slug}` for this connection type."
+                    ),
+                },
+                "config": {
+                    "$ref": f"#/components/schemas/{config_name}",
+                    "description": (
+                        f"Per-type configuration. See `{config_name}` for field details."
+                    ),
+                },
+            },
+            "required": ["name", "connection_type", "config"],
+            "additionalProperties": False,
+            "example": _example_for(slug, raw_config),
+        }
+
+        branches.append({"$ref": f"#/components/schemas/{create_name}"})
+        mapping[slug] = f"#/components/schemas/{create_name}"
+
+    # Parent: oneOf with discriminator on `connection_type`.
+    components["ConnectionCreate"] = {
+        "title": "Create connection request",
+        "description": (
+            "Request body for `POST /api/v1/connections`. The discriminator "
+            "is `connection_type` — pick the variant matching your source "
+            "or destination type. Each variant has a fully-typed `config` "
+            "object so AI agents and code generators can produce a valid "
+            "payload from the spec alone."
+        ),
+        "oneOf": branches,
+        "discriminator": {
+            "propertyName": "connection_type",
+            "mapping": mapping,
+        },
+    }
+
+    return components
+
+
+def build_upload_inlined_schemas() -> dict[str, dict]:
+    """Return component schemas for inlined upload request bodies.
+
+    Splits the dlt_config into two variants based on ``mode``
+    (``single_table`` vs ``full_database``) and exposes them via a
+    discriminator on the ``dlt_config.mode`` field.
+
+    The dlt_config field shapes come from ``DLT_CONFIG_SCHEMA`` in
+    ``meta_schemas.py`` (also served by
+    ``GET /api/v1/meta/dlt-config-schema``).
+    """
+    base_props: dict[str, Any] = DLT_CONFIG_SCHEMA.get("properties", {})
+
+    def _pick(keys: list[str]) -> dict[str, Any]:
+        return {k: copy.deepcopy(base_props[k]) for k in keys if k in base_props}
+
+    # Fields shared by both modes
+    shared = ["write_disposition", "source_schema", "batch_size", "schema_contract", "filters"]
+
+    single_table_props: dict[str, Any] = {
+        "mode": {
+            "type": "string",
+            "enum": ["single_table"],
+            "description": "Discriminator: load a single source table.",
+        },
+        "table": copy.deepcopy(base_props.get("table", {"type": "string"})),
+        "primary_key": copy.deepcopy(base_props.get("primary_key", {})),
+        "incremental": copy.deepcopy(base_props.get("incremental", {})),
+        **_pick(shared),
+    }
+
+    full_database_props: dict[str, Any] = {
+        "mode": {
+            "type": "string",
+            "enum": ["full_database"],
+            "description": "Discriminator: load multiple tables from one source.",
+        },
+        "table_names": copy.deepcopy(base_props.get("table_names", {})),
+        "merge_config": copy.deepcopy(base_props.get("merge_config", {})),
+        **_pick(shared),
+    }
+
+    components: dict[str, dict] = {
+        "SingleTableDltConfig": {
+            "type": "object",
+            "title": "Single-table dlt_config",
+            "description": (
+                "Load one specific table from the source. Supports "
+                "incremental cursor-based extraction and per-row filters."
+            ),
+            "properties": single_table_props,
+            "required": ["mode", "table"],
+            "additionalProperties": False,
+        },
+        "FullDatabaseDltConfig": {
+            "type": "object",
+            "title": "Full-database dlt_config",
+            "description": (
+                "Load multiple tables in a single run. Use `table_names` "
+                "to whitelist or omit it to discover all tables. For "
+                "merge disposition, supply `merge_config` keyed by table."
+            ),
+            "properties": full_database_props,
+            "required": ["mode"],
+            "additionalProperties": False,
+        },
+    }
+
+    components["DltConfig"] = {
+        "title": "Upload dlt_config",
+        "description": (
+            "Configuration for an extract+load operation. Discriminator is "
+            "the nested `mode` field — `single_table` for one-table loads, "
+            "`full_database` for multi-table loads."
+        ),
+        "oneOf": [
+            {"$ref": "#/components/schemas/SingleTableDltConfig"},
+            {"$ref": "#/components/schemas/FullDatabaseDltConfig"},
+        ],
+        "discriminator": {
+            "propertyName": "mode",
+            "mapping": {
+                "single_table": "#/components/schemas/SingleTableDltConfig",
+                "full_database": "#/components/schemas/FullDatabaseDltConfig",
+            },
+        },
+    }
+
+    components["UploadCreate"] = {
+        "type": "object",
+        "title": "Create upload request",
+        "description": (
+            "Request body for `POST /api/v1/uploads`. The `dlt_config` "
+            "field is a discriminated union — see `DltConfig`."
+        ),
+        "properties": {
+            "name": {"type": "string"},
+            "source_connection_id": {"type": "integer"},
+            "destination_connection_id": {"type": "integer"},
+            "description": {"type": "string"},
+            "dlt_config": {"$ref": "#/components/schemas/DltConfig"},
+        },
+        "required": [
+            "name",
+            "source_connection_id",
+            "destination_connection_id",
+        ],
+        "example": {
+            "name": "Stripe Charges",
+            "source_connection_id": 1,
+            "destination_connection_id": 2,
+            "dlt_config": {
+                "mode": "single_table",
+                "table": "charges",
+                "write_disposition": "merge",
+                "primary_key": "id",
+                "incremental": {
+                    "cursor_path": "created",
+                    "row_order": "asc",
+                },
+            },
+        },
+    }
+
+    return components
+
+
+def apply_inlined_schemas(schemas: dict) -> None:
+    """Mutate the openapi.py SCHEMAS dict to add the inlined components
+    and replace ``ConnectionCreate`` / ``UploadCreate`` with their
+    discriminated variants.
+
+    Also pins ``Connection.connection_type`` to the ConnectionType enum
+    instead of a free-form string.
+    """
+    schemas.update(build_connection_inlined_schemas())
+    schemas.update(build_upload_inlined_schemas())
+
+    # Pin the read-side `Connection.connection_type` to the enum.
+    if "Connection" in schemas:
+        conn = schemas["Connection"]
+        if "properties" in conn and "connection_type" in conn["properties"]:
+            conn["properties"]["connection_type"] = {
+                "type": "string",
+                "enum": CONNECTION_TYPE_VALUES,
+                "description": "Slug of the connection type.",
+            }

--- a/tests/test_services/test_openapi.py
+++ b/tests/test_services/test_openapi.py
@@ -121,6 +121,142 @@ class TestOpenAPISpec:
         assert "limit" in param_names
 
 
+# ---------------------------------------------------------------------------
+# Tier 3: inlined per-type schemas (#57)
+# ---------------------------------------------------------------------------
+
+
+class TestTier3InlinedSchemas:
+    """Verify ConnectionCreate and UploadCreate use discriminator-based
+    oneOf instead of opaque {type: object} placeholders."""
+
+    def test_spec_round_trips_through_json(self):
+        """Spec must serialize and deserialize without loss."""
+        import json
+
+        spec = build_openapi_spec()
+        raw = json.dumps(spec)
+        parsed = json.loads(raw)
+        assert parsed["openapi"] == "3.0.3"
+        assert "ConnectionCreate" in parsed["components"]["schemas"]
+
+    def test_connection_create_is_oneof_with_discriminator(self):
+        spec = build_openapi_spec()
+        cc = spec["components"]["schemas"]["ConnectionCreate"]
+        assert "oneOf" in cc, "ConnectionCreate should be a oneOf"
+        assert cc["discriminator"]["propertyName"] == "connection_type"
+        assert len(cc["oneOf"]) >= 27  # at least 27 source types
+
+    def test_every_connection_type_has_a_branch(self):
+        from datanika.models.connection import ConnectionType
+
+        spec = build_openapi_spec()
+        cc = spec["components"]["schemas"]["ConnectionCreate"]
+        mapping = cc["discriminator"]["mapping"]
+        for ct in ConnectionType:
+            assert ct.value in mapping, (
+                f"ConnectionType.{ct.name} ({ct.value}) missing from discriminator mapping"
+            )
+
+    def test_per_type_config_schemas_have_properties_and_required(self):
+        from datanika.services.connection_schemas import CONFIG_SCHEMAS
+        from datanika.services.openapi_inline import _to_pascal
+
+        spec = build_openapi_spec()
+        schemas = spec["components"]["schemas"]
+        for slug in CONFIG_SCHEMAS:
+            config_name = f"{_to_pascal(slug)}ConnectionConfig"
+            assert config_name in schemas, f"Missing schema {config_name}"
+            schema = schemas[config_name]
+            assert "properties" in schema
+            assert "required" in schema
+            assert schema["type"] == "object"
+
+    def test_per_type_create_schemas_have_example(self):
+        from datanika.services.connection_schemas import CONFIG_SCHEMAS
+        from datanika.services.openapi_inline import _to_pascal
+
+        spec = build_openapi_spec()
+        schemas = spec["components"]["schemas"]
+        for slug in CONFIG_SCHEMAS:
+            create_name = f"Create{_to_pascal(slug)}Connection"
+            assert create_name in schemas, f"Missing {create_name}"
+            assert "example" in schemas[create_name], f"{create_name} missing example"
+            example = schemas[create_name]["example"]
+            assert example["connection_type"] == slug
+
+    def test_no_type_object_placeholder_in_connection_create(self):
+        """The old `config: {type: object}` must be gone."""
+        import json
+
+        spec = build_openapi_spec()
+        cc_raw = json.dumps(spec["components"]["schemas"]["ConnectionCreate"])
+        # The top-level ConnectionCreate has no `properties.config` anymore —
+        # it's a oneOf parent. And each branch references a typed schema.
+        assert '"config":{"type":"object"}' not in cc_raw
+
+    def test_connection_type_is_enum_on_read_schema(self):
+        from datanika.models.connection import ConnectionType
+
+        spec = build_openapi_spec()
+        conn = spec["components"]["schemas"]["Connection"]
+        ct_prop = conn["properties"]["connection_type"]
+        assert "enum" in ct_prop
+        assert set(ct_prop["enum"]) == {ct.value for ct in ConnectionType}
+
+    def test_upload_create_dlt_config_is_ref_to_dlt_config(self):
+        spec = build_openapi_spec()
+        uc = spec["components"]["schemas"]["UploadCreate"]
+        dlt_ref = uc["properties"]["dlt_config"].get("$ref", "")
+        assert dlt_ref.endswith("DltConfig")
+
+    def test_dlt_config_has_discriminator_on_mode(self):
+        spec = build_openapi_spec()
+        dc = spec["components"]["schemas"]["DltConfig"]
+        assert "oneOf" in dc
+        assert dc["discriminator"]["propertyName"] == "mode"
+        mapping = dc["discriminator"]["mapping"]
+        assert "single_table" in mapping
+        assert "full_database" in mapping
+
+    def test_single_table_config_has_table_field(self):
+        spec = build_openapi_spec()
+        st = spec["components"]["schemas"]["SingleTableDltConfig"]
+        assert "table" in st["properties"]
+        assert "table" in st["required"]
+        assert st["properties"]["mode"]["enum"] == ["single_table"]
+
+    def test_full_database_config_has_table_names(self):
+        spec = build_openapi_spec()
+        fd = spec["components"]["schemas"]["FullDatabaseDltConfig"]
+        assert "table_names" in fd["properties"]
+        assert fd["properties"]["mode"]["enum"] == ["full_database"]
+
+    def test_no_type_object_placeholder_in_upload_create(self):
+        import json
+
+        spec = build_openapi_spec()
+        uc_raw = json.dumps(spec["components"]["schemas"]["UploadCreate"])
+        assert '"dlt_config":{"type":"object"}' not in uc_raw
+
+    def test_upload_create_has_example(self):
+        spec = build_openapi_spec()
+        uc = spec["components"]["schemas"]["UploadCreate"]
+        assert "example" in uc
+        assert uc["example"]["dlt_config"]["mode"] == "single_table"
+
+    def test_sensitive_fields_have_password_format(self):
+        """Spot-check that password/API key fields keep format: password."""
+
+        spec = build_openapi_spec()
+        schemas = spec["components"]["schemas"]
+        pg = schemas["PostgresConnectionConfig"]
+        assert pg["properties"]["password"]["format"] == "password"
+
+        stripe = schemas["StripeConnectionConfig"]
+        assert stripe["properties"]["api_key"]["format"] == "password"
+
+
 class TestOpenAPIEndpoints:
     def test_openapi_json_returns_200(self, client):
         resp = client.get("/api/v1/openapi.json")


### PR DESCRIPTION
## Summary
Closes the "agent doesn't know what fields each connection type needs" gap from the spec side. The OpenAPI spec at \`/api/v1/openapi.json\` now tells agents exactly what fields postgres, bigquery, stripe, etc. need — directly in the spec, no discovery endpoint round-trip required.

**Before**: \`ConnectionCreate.config: {type: object}\`, \`UploadCreate.dlt_config: {type: object}\`
**After**: discriminator-based \`oneOf\` with 32 typed branches (connections) and 2 typed variants (upload modes)

## Connection changes
- \`ConnectionCreate\` → \`oneOf\` with discriminator on \`connection_type\` (32 branches)
- Each branch: \`Create<Type>Connection\` schema with \`connection_type\` pinned, \`config\` ref'd to \`<Type>ConnectionConfig\`
- Config schemas sourced from \`connection_schemas.CONFIG_SCHEMAS\` (same file that serves \`/api/v1/meta/connection-types\` — single source of truth)
- Sensitive fields keep \`format: password\`
- Every branch has a worked example with \`CHANGE_ME\` for credentials
- \`Connection.connection_type\` on the read side is now an enum instead of a free-form string

## Upload changes
- \`UploadCreate.dlt_config\` → \`$ref: DltConfig\`
- \`DltConfig\` → \`oneOf\` with discriminator on \`mode\` (single_table, full_database)
- \`SingleTableDltConfig\` requires mode + table, has incremental/filters
- \`FullDatabaseDltConfig\` has table_names/merge_config
- Sourced from \`meta_schemas.DLT_CONFIG_SCHEMA\`
- \`UploadCreate\` has a worked Stripe charges example

## Architecture
New \`openapi_inline.py\` module that walks the existing SoT dicts and produces OpenAPI 3.0.3-compatible component schemas. Called once at import via \`apply_inlined_schemas(SCHEMAS)\`. Adding a new connection type to \`CONFIG_SCHEMAS\` makes it appear in the spec automatically — no manual sync.

Part of #37
Closes #57

## Tests (+14)
- Spec JSON round-trip without loss
- ConnectionCreate is oneOf with 32+ branches + discriminator
- Every \`ConnectionType\` enum value has a mapping entry
- Per-type configs have properties, required, examples, password format
- No \`{type: object}\` placeholders left anywhere in ConnectionCreate or UploadCreate
- \`connection_type\` is an enum on read schema
- DltConfig has mode discriminator with both variants
- Each variant has the right fields (table vs table_names, incremental vs merge_config)
- UploadCreate has worked example

## Test plan
- [x] 14 new tests in \`test_openapi.py::TestTier3InlinedSchemas\`
- [x] 1556 total tests pass (was 1542)
- [x] Ruff + format clean
- [x] Precheck green
- [x] Manual: \`python -c "from datanika.services.openapi import SCHEMAS; print(len(SCHEMAS))"\` shows 90+ component schemas (was ~30)