### PR TITLE
Add empty states for Connections, Pipelines, Transformations (#56)

### DIFF
--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "أنشئ خط معالجة",
   "onboarding.step_run": "شغّل خط معالجة",
   "onboarding.step_transformation": "أضف تحويلاً",
-  "onboarding.step_schedule": "جدوِل خط معالجة"
+  "onboarding.step_schedule": "جدوِل خط معالجة",
+  "empty.connections.title": "لا توجد اتصالات بعد",
+  "empty.connections.body": "تخزن الاتصالات بيانات الاعتماد التي يحتاجها Datanika. أضف واحدًا أعلاه للبدء.",
+  "empty.connections.cta": "أضف اتصالك الأول",
+  "empty.pipelines.title": "لا توجد خطوط معالجة بعد",
+  "empty.pipelines.body": "تربط خطوط المعالجة نماذج dbt في مهام منسقة. أنشئ واحدًا بعد إضافة اتصال.",
+  "empty.pipelines.cta": "أنشئ أول خط معالجة",
+  "empty.transformations.title": "لا توجد تحويلات بعد",
+  "empty.transformations.body": "التحويلات هي نماذج SQL مبنية على dbt-core. أضف واحدًا لتحويل البيانات الخام إلى جداول تحليلية.",
+  "empty.transformations.cta": "أضف تحويلك الأول"
 }

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Pipeline erstellen",
   "onboarding.step_run": "Pipeline ausführen",
   "onboarding.step_transformation": "Transformation hinzufügen",
-  "onboarding.step_schedule": "Pipeline planen"
+  "onboarding.step_schedule": "Pipeline planen",
+  "empty.connections.title": "Noch keine Verbindungen",
+  "empty.connections.body": "Verbindungen speichern die Zugangsdaten, die Datanika zum Lesen oder Schreiben benötigt. Füge oben eine hinzu, um loszulegen.",
+  "empty.connections.cta": "Erste Verbindung hinzufügen",
+  "empty.pipelines.title": "Noch keine Pipelines",
+  "empty.pipelines.body": "Pipelines verketten dbt-Modelle zu orchestrierten Jobs. Erstelle eine, sobald du eine Verbindung und einen Upload hast.",
+  "empty.pipelines.cta": "Erste Pipeline erstellen",
+  "empty.transformations.title": "Noch keine Transformationen",
+  "empty.transformations.body": "Transformationen sind SQL-Modelle mit dbt-core. Füge eine hinzu, um Rohdaten in Analysetabellen umzuwandeln.",
+  "empty.transformations.cta": "Erste Transformation hinzufügen"
 }

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Δημιουργήστε ένα pipeline",
   "onboarding.step_run": "Εκτελέστε ένα pipeline",
   "onboarding.step_transformation": "Προσθέστε έναν μετασχηματισμό",
-  "onboarding.step_schedule": "Προγραμματίστε ένα pipeline"
+  "onboarding.step_schedule": "Προγραμματίστε ένα pipeline",
+  "empty.connections.title": "Δεν υπάρχουν συνδέσεις ακόμα",
+  "empty.connections.body": "Οι συνδέσεις αποθηκεύουν τα διαπιστευτήρια που χρειάζεται το Datanika. Προσθέστε μία παραπάνω για να ξεκινήσετε.",
+  "empty.connections.cta": "Προσθέστε την πρώτη σύνδεση",
+  "empty.pipelines.title": "Δεν υπάρχουν pipelines ακόμα",
+  "empty.pipelines.body": "Τα pipelines αλυσιδώνουν μοντέλα dbt σε οργανωμένες εργασίες. Δημιουργήστε ένα αφού έχετε σύνδεση.",
+  "empty.pipelines.cta": "Δημιουργήστε το πρώτο pipeline",
+  "empty.transformations.title": "Δεν υπάρχουν μετασχηματισμοί ακόμα",
+  "empty.transformations.body": "Οι μετασχηματισμοί είναι SQL μοντέλα dbt-core. Προσθέστε έναν για να μετατρέψετε ακατέργαστα δεδομένα σε αναλυτικούς πίνακες.",
+  "empty.transformations.cta": "Προσθέστε τον πρώτο μετασχηματισμό"
 }

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Create a pipeline",
   "onboarding.step_run": "Run a pipeline",
   "onboarding.step_transformation": "Add a transformation",
-  "onboarding.step_schedule": "Schedule a pipeline"
+  "onboarding.step_schedule": "Schedule a pipeline",
+  "empty.connections.title": "No connections yet",
+  "empty.connections.body": "Connections store the credentials Datanika needs to read from a source or write to a destination. Add one above to get started.",
+  "empty.connections.cta": "Add your first connection",
+  "empty.pipelines.title": "No pipelines yet",
+  "empty.pipelines.body": "Pipelines chain dbt models into orchestrated transformation jobs. Create one above once you have a connection and an upload.",
+  "empty.pipelines.cta": "Create your first pipeline",
+  "empty.transformations.title": "No transformations yet",
+  "empty.transformations.body": "Transformations are SQL models powered by dbt-core. Add one above to turn raw data into analytics-ready tables.",
+  "empty.transformations.cta": "Add your first transformation"
 }

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Crea un pipeline",
   "onboarding.step_run": "Ejecuta un pipeline",
   "onboarding.step_transformation": "Añade una transformación",
-  "onboarding.step_schedule": "Programa un pipeline"
+  "onboarding.step_schedule": "Programa un pipeline",
+  "empty.connections.title": "Aún no hay conexiones",
+  "empty.connections.body": "Las conexiones almacenan las credenciales que Datanika necesita. Añade una arriba para empezar.",
+  "empty.connections.cta": "Añade tu primera conexión",
+  "empty.pipelines.title": "Aún no hay pipelines",
+  "empty.pipelines.body": "Los pipelines encadenan modelos dbt en trabajos orquestados. Crea uno cuando tengas una conexión y una carga.",
+  "empty.pipelines.cta": "Crea tu primer pipeline",
+  "empty.transformations.title": "Aún no hay transformaciones",
+  "empty.transformations.body": "Las transformaciones son modelos SQL con dbt-core. Añade una para convertir datos crudos en tablas analíticas.",
+  "empty.transformations.cta": "Añade tu primera transformación"
 }

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Créez un pipeline",
   "onboarding.step_run": "Exécutez un pipeline",
   "onboarding.step_transformation": "Ajoutez une transformation",
-  "onboarding.step_schedule": "Planifiez un pipeline"
+  "onboarding.step_schedule": "Planifiez un pipeline",
+  "empty.connections.title": "Aucune connexion pour le moment",
+  "empty.connections.body": "Les connexions stockent les identifiants nécessaires à Datanika. Ajoutez-en une ci-dessus pour commencer.",
+  "empty.connections.cta": "Ajoutez votre première connexion",
+  "empty.pipelines.title": "Aucun pipeline pour le moment",
+  "empty.pipelines.body": "Les pipelines enchaînent des modèles dbt en tâches orchestrées. Créez-en un après avoir ajouté une connexion.",
+  "empty.pipelines.cta": "Créez votre premier pipeline",
+  "empty.transformations.title": "Aucune transformation pour le moment",
+  "empty.transformations.body": "Les transformations sont des modèles SQL propulsés par dbt-core. Ajoutez-en une pour transformer vos données brutes.",
+  "empty.transformations.cta": "Ajoutez votre première transformation"
 }

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Создайте пайплайн",
   "onboarding.step_run": "Запустите пайплайн",
   "onboarding.step_transformation": "Добавьте трансформацию",
-  "onboarding.step_schedule": "Настройте расписание"
+  "onboarding.step_schedule": "Настройте расписание",
+  "empty.connections.title": "Подключений пока нет",
+  "empty.connections.body": "Подключения хранят учётные данные для чтения из источника или записи в хранилище. Добавьте первое выше, чтобы начать.",
+  "empty.connections.cta": "Добавьте первое подключение",
+  "empty.pipelines.title": "Пайплайнов пока нет",
+  "empty.pipelines.body": "Пайплайны объединяют модели dbt в оркестрированные задания. Создайте первый после добавления подключения и загрузки.",
+  "empty.pipelines.cta": "Создайте первый пайплайн",
+  "empty.transformations.title": "Трансформаций пока нет",
+  "empty.transformations.body": "Трансформации — это SQL-модели на dbt-core. Добавьте первую, чтобы превратить сырые данные в аналитические таблицы.",
+  "empty.transformations.cta": "Добавьте первую трансформацию"
 }

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "Направите пајплајн",
   "onboarding.step_run": "Покрените пајплајн",
   "onboarding.step_transformation": "Додајте трансформацију",
-  "onboarding.step_schedule": "Закажите пајплајн"
+  "onboarding.step_schedule": "Закажите пајплајн",
+  "empty.connections.title": "Нема конекција за сада",
+  "empty.connections.body": "Конекције чувају податке за приступ изворима и одредиштима. Додајте једну изнад да бисте почели.",
+  "empty.connections.cta": "Додајте прву конекцију",
+  "empty.pipelines.title": "Нема пајплајнова за сада",
+  "empty.pipelines.body": "Пајплајнови повезују dbt моделе у оркестриране задатке. Направите један након додавања конекције.",
+  "empty.pipelines.cta": "Направите први пајплајн",
+  "empty.transformations.title": "Нема трансформација за сада",
+  "empty.transformations.body": "Трансформације су SQL модели на dbt-core. Додајте једну да претворите сирове податке у аналитичке табеле.",
+  "empty.transformations.cta": "Додајте прву трансформацију"
 }

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -400,5 +400,14 @@
   "onboarding.step_pipeline": "创建管道",
   "onboarding.step_run": "运行管道",
   "onboarding.step_transformation": "添加转换",
-  "onboarding.step_schedule": "设置定时调度"
+  "onboarding.step_schedule": "设置定时调度",
+  "empty.connections.title": "暂无连接",
+  "empty.connections.body": "连接存储 Datanika 读取来源或写入目标所需的凭据。在上方添加一个连接即可开始。",
+  "empty.connections.cta": "添加第一个连接",
+  "empty.pipelines.title": "暂无管道",
+  "empty.pipelines.body": "管道将 dbt 模型编排为自动化任务。添加连接和上传后即可创建。",
+  "empty.pipelines.cta": "创建第一个管道",
+  "empty.transformations.title": "暂无转换",
+  "empty.transformations.body": "转换是基于 dbt-core 的 SQL 模型。添加一个转换，将原始数据变为分析表。",
+  "empty.transformations.cta": "添加第一个转换"
 }

--- a/datanika/ui/components/empty_state.py
+++ b/datanika/ui/components/empty_state.py
@@ -1,0 +1,96 @@
+"""Reusable empty-state component for list pages.
+
+Driven by a small preset table so callers pass a page key rather than
+a bag of strings. The onboarding checklist on the dashboard points to
+these pages; the CTA here is the second half of the same motion.
+"""
+
+from dataclasses import dataclass
+
+import reflex as rx
+
+from datanika.ui.state.i18n_state import I18nState
+
+_t = I18nState.translations
+
+
+@dataclass(frozen=True)
+class EmptyStatePreset:
+    icon: str
+    title_key: str
+    body_key: str
+    cta_key: str
+    cta_href: str
+
+
+_KEYS_FOR_SCANNER = (
+    _t["empty.connections.title"],
+    _t["empty.connections.body"],
+    _t["empty.connections.cta"],
+    _t["empty.pipelines.title"],
+    _t["empty.pipelines.body"],
+    _t["empty.pipelines.cta"],
+    _t["empty.transformations.title"],
+    _t["empty.transformations.body"],
+    _t["empty.transformations.cta"],
+)
+
+EMPTY_STATE_PRESETS: dict[str, EmptyStatePreset] = {
+    "connections": EmptyStatePreset(
+        icon="database",
+        title_key="empty.connections.title",
+        body_key="empty.connections.body",
+        cta_key="empty.connections.cta",
+        cta_href="#connection-form",
+    ),
+    "pipelines": EmptyStatePreset(
+        icon="git-branch",
+        title_key="empty.pipelines.title",
+        body_key="empty.pipelines.body",
+        cta_key="empty.pipelines.cta",
+        cta_href="#pipeline-form",
+    ),
+    "transformations": EmptyStatePreset(
+        icon="code",
+        title_key="empty.transformations.title",
+        body_key="empty.transformations.body",
+        cta_key="empty.transformations.cta",
+        cta_href="#transformation-form",
+    ),
+}
+
+
+def empty_state(page_key: str) -> rx.Component:
+    """Render the canonical empty state for a list page.
+
+    Raises KeyError if `page_key` is not in EMPTY_STATE_PRESETS so new
+    pages can't silently skip having an empty state designed.
+    """
+    preset = EMPTY_STATE_PRESETS[page_key]
+    return rx.card(
+        rx.vstack(
+            rx.icon(preset.icon, size=40, color="var(--violet-9)"),
+            rx.heading(_t[preset.title_key], size="4"),
+            rx.text(
+                _t[preset.body_key],
+                size="2",
+                color="var(--slate-10)",
+                text_align="center",
+                max_width="42ch",
+            ),
+            rx.link(
+                rx.button(
+                    _t[preset.cta_key],
+                    rx.icon("arrow-right", size=16),
+                    size="2",
+                    color_scheme="violet",
+                ),
+                href=preset.cta_href,
+                underline="none",
+            ),
+            align="center",
+            spacing="3",
+            padding_y="8",
+        ),
+        width="100%",
+    )

--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -3,6 +3,7 @@
 import reflex as rx
 
 from datanika.ui.components.connection_config_fields import type_fields
+from datanika.ui.components.empty_state import empty_state
 from datanika.ui.components.layout import page_layout
 from datanika.ui.components.quota_callout import error_or_quota_callout
 from datanika.ui.components.searchable_select import searchable_select
@@ -190,6 +191,15 @@ def connections_table() -> rx.Component:
 
 def connections_page() -> rx.Component:
     return page_layout(
-        rx.vstack(connection_form(), connections_table(), spacing="6", width="100%"),
+        rx.vstack(
+            rx.box(connection_form(), id="connection-form"),
+            rx.cond(
+                ConnectionState.connections.length() == 0,
+                empty_state("connections"),
+                connections_table(),
+            ),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.connections"],
     )

--- a/datanika/ui/pages/pipelines.py
+++ b/datanika/ui/pages/pipelines.py
@@ -2,6 +2,7 @@
 
 import reflex as rx
 
+from datanika.ui.components.empty_state import empty_state
 from datanika.ui.components.layout import page_layout
 from datanika.ui.components.quota_callout import error_or_quota_callout
 from datanika.ui.components.searchable_select import searchable_select
@@ -338,6 +339,15 @@ def pipelines_table() -> rx.Component:
 
 def pipelines_page() -> rx.Component:
     return page_layout(
-        rx.vstack(pipeline_form(), pipelines_table(), spacing="6", width="100%"),
+        rx.vstack(
+            rx.box(pipeline_form(), id="pipeline-form"),
+            rx.cond(
+                PipelineState.pipelines.length() == 0,
+                empty_state("pipelines"),
+                pipelines_table(),
+            ),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.pipelines"],
     )

--- a/datanika/ui/pages/transformations.py
+++ b/datanika/ui/pages/transformations.py
@@ -2,6 +2,7 @@
 
 import reflex as rx
 
+from datanika.ui.components.empty_state import empty_state
 from datanika.ui.components.layout import page_layout
 from datanika.ui.components.searchable_select import searchable_select
 from datanika.ui.components.sql_autocomplete import (
@@ -364,8 +365,12 @@ def transformations_table() -> rx.Component:
 def transformations_page() -> rx.Component:
     return page_layout(
         rx.vstack(
-            transformation_form(),
-            transformations_table(),
+            rx.box(transformation_form(), id="transformation-form"),
+            rx.cond(
+                TransformationState.transformations.length() == 0,
+                empty_state("transformations"),
+                transformations_table(),
+            ),
             preview_display(),
             spacing="6",
             width="100%",

--- a/tests/test_ui/test_empty_state.py
+++ b/tests/test_ui/test_empty_state.py
@@ -1,0 +1,62 @@
+"""Tests for the reusable EmptyState component and its preset table.
+
+The component itself is a Reflex render function — we don't walk its
+internal tree here. What we can test in pure Python is the preset
+dictionary that drives it: every page has a preset, every preset uses
+the `empty.<page>.<field>` i18n key shape, and the factory returns a
+Reflex component without raising.
+"""
+
+import pytest
+
+from datanika.ui.components.empty_state import (
+    EMPTY_STATE_PRESETS,
+    EmptyStatePreset,
+    empty_state,
+)
+
+EXPECTED_PAGES = ("connections", "pipelines", "transformations")
+
+
+class TestPresetsCoverThreePages:
+    def test_all_three_pages_have_presets(self):
+        for page in EXPECTED_PAGES:
+            assert page in EMPTY_STATE_PRESETS, f"missing preset for {page}"
+
+    def test_no_extra_presets(self):
+        # If someone adds a 4th page, they need to update the test and
+        # confirm the i18n keys exist for it.
+        assert set(EMPTY_STATE_PRESETS.keys()) == set(EXPECTED_PAGES)
+
+
+class TestPresetShape:
+    @pytest.mark.parametrize("page", EXPECTED_PAGES)
+    def test_preset_has_required_fields(self, page):
+        preset = EMPTY_STATE_PRESETS[page]
+        assert isinstance(preset, EmptyStatePreset)
+        assert preset.icon, f"{page} preset is missing an icon"
+        assert preset.title_key, f"{page} preset is missing title_key"
+        assert preset.body_key, f"{page} preset is missing body_key"
+        assert preset.cta_key, f"{page} preset is missing cta_key"
+        assert preset.cta_href, f"{page} preset is missing cta_href"
+
+    @pytest.mark.parametrize("page", EXPECTED_PAGES)
+    def test_i18n_keys_use_empty_namespace(self, page):
+        preset = EMPTY_STATE_PRESETS[page]
+        assert preset.title_key == f"empty.{page}.title"
+        assert preset.body_key == f"empty.{page}.body"
+        assert preset.cta_key == f"empty.{page}.cta"
+
+
+class TestFactory:
+    def test_empty_state_returns_component(self):
+        component = empty_state("connections")
+        assert component is not None
+
+    def test_empty_state_unknown_key_raises(self):
+        with pytest.raises(KeyError):
+            empty_state("bogus-page")
+
+    @pytest.mark.parametrize("page", EXPECTED_PAGES)
+    def test_empty_state_renders_for_every_page(self, page):
+        assert empty_state(page) is not None


### PR DESCRIPTION
## Summary

- Reusable **EmptyState component** with a preset table — icon, i18n keys, CTA anchor per page
- Wired on **connections, pipelines, transformations** pages via \`rx.cond(State.items.length() == 0, ...)\`
- Completes slice 2 of P0 Onboarding: the Getting Started checklist (PR #51) sends users to these pages; they now see guidance + CTA instead of a blank table

Closes #56.

## Design

\`EmptyStatePreset\` is a frozen dataclass holding \`icon\`, \`title_key\`, \`body_key\`, \`cta_key\`, \`cta_href\`. Three presets in \`EMPTY_STATE_PRESETS\`:

| Page | Icon | CTA target |
|------|------|------------|
| connections | \`database\` | \`#connection-form\` (same-page scroll) |
| pipelines | \`git-branch\` | \`#pipeline-form\` |
| transformations | \`code\` | \`#transformation-form\` |

The factory \`empty_state(page_key)\` raises \`KeyError\` for unregistered pages — new list pages must add a preset before they can render an empty state.

Form sections on each page are wrapped with \`id=\` anchors so the CTA links scroll to the form.

\`_KEYS_FOR_SCANNER\` bridges dynamic preset lookups (\`_t[preset.title_key]\`) with the literal \`_t["..."]\` pattern the orphan-key test expects.

## i18n

9 new keys in all 9 locales: \`empty.{connections,pipelines,transformations}.{title,body,cta}\`.

## Test plan

- [x] \`tests/test_ui/test_empty_state.py\` — 13 tests: preset coverage, shape checks, factory smoke
- [x] \`tests/test_i18n/\` — 15 tests green (parity + orphan-key + code-sync)
- [x] Full suite: **1555 passed**
- [x] \`ruff check\` + \`ruff format\` — clean