### PR TITLE
Tier 4 Agent Compatibility: cancel, ?wait=true, Idempotency-Key

### DIFF
--- a/datanika/services/api_middleware.py
+++ b/datanika/services/api_middleware.py
@@ -81,7 +81,24 @@ def api_endpoint(
                         headers=result.headers(),
                     )
 
-                # 4. Call the actual handler
+                # 4. Idempotency check (POST only, opt-in via header)
+                from datanika.services.idempotency import (
+                    cache_response,
+                    get_cached_response,
+                    get_idempotency_key,
+                )
+
+                idem_key = None
+                if request.method == "POST":
+                    idem_key = get_idempotency_key(request, api_key.org_id)
+                    if idem_key:
+                        cached = get_cached_response(idem_key)
+                        if cached is not None:
+                            for k, v in result.headers().items():
+                                cached.headers[k] = v
+                            return cached
+
+                # 5. Call the actual handler
                 try:
                     response = await handler(request, api_key=api_key, session=session)
                     session.commit()
@@ -90,7 +107,11 @@ def api_endpoint(
                     session.rollback()
                     return _error(500, "Internal server error")
 
-                # 5. Attach rate limit headers to successful responses
+                # 6. Cache response for idempotency
+                if idem_key:
+                    cache_response(idem_key, response)
+
+                # 7. Attach rate limit headers to successful responses
                 for k, v in result.headers().items():
                     response.headers[k] = v
 

--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -461,6 +461,35 @@ async def delete_upload(request, api_key, session):
     return JSONResponse({"deleted": True})
 
 
+async def _trigger_and_maybe_wait(request, api_key, run):
+    """Shared helper: fire-and-forget (202) or wait for completion (200/408).
+
+    If ``?wait=true`` is set, polls the run until it reaches a terminal
+    status or the timeout expires. Default timeout 120s, max 300s.
+    """
+    wait = request.query_params.get("wait", "").lower() in ("true", "1")
+    if not wait:
+        return JSONResponse({"run_id": run.id, "status": "pending"}, status_code=202)
+
+    from datanika.services.run_waiter import DEFAULT_TIMEOUT, wait_for_run
+
+    timeout_str = request.query_params.get("timeout", str(DEFAULT_TIMEOUT))
+    try:
+        timeout = int(timeout_str)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_TIMEOUT
+
+    final_run = await wait_for_run(run.id, api_key.org_id, timeout=timeout)
+    if final_run is None:
+        return _error(404, "Run not found after dispatch")
+
+    result = _ser_run(final_run)
+    if final_run.status.value in ("pending", "running"):
+        result["timed_out"] = True
+        return JSONResponse(result, status_code=408)
+    return JSONResponse(result)
+
+
 @api_endpoint(required_scope="uploads:write")
 async def trigger_upload(request, api_key, session):
     upload_id = int(request.path_params["id"])
@@ -472,7 +501,7 @@ async def trigger_upload(request, api_key, session):
     from datanika.tasks.upload_tasks import run_upload_task
 
     run_upload_task.delay(run_id=run.id, org_id=api_key.org_id)
-    return JSONResponse({"run_id": run.id, "status": "pending"}, status_code=202)
+    return await _trigger_and_maybe_wait(request, api_key, run)
 
 
 # ---------------------------------------------------------------------------
@@ -566,7 +595,7 @@ async def trigger_pipeline(request, api_key, session):
     from datanika.tasks.pipeline_tasks import run_pipeline_task
 
     run_pipeline_task.delay(run_id=run.id, org_id=api_key.org_id)
-    return JSONResponse({"run_id": run.id, "status": "pending"}, status_code=202)
+    return await _trigger_and_maybe_wait(request, api_key, run)
 
 
 # ---------------------------------------------------------------------------
@@ -676,7 +705,7 @@ async def trigger_transformation(request, api_key, session):
     from datanika.tasks.transformation_tasks import run_transformation_task
 
     run_transformation_task.delay(run_id=run.id, org_id=api_key.org_id)
-    return JSONResponse({"run_id": run.id, "status": "pending"}, status_code=202)
+    return await _trigger_and_maybe_wait(request, api_key, run)
 
 
 @api_endpoint(required_scope="transformations:read")
@@ -887,6 +916,25 @@ async def get_run_logs(request, api_key, session):
     return JSONResponse({"run_id": run.id, "logs": run.logs or ""})
 
 
+@api_endpoint(required_scope="runs:write")
+async def cancel_run(request, api_key, session):
+    """POST /api/v1/runs/{id}/cancel — cancel a pending or running run."""
+    run_id = int(request.path_params["id"])
+    run = _exec_svc.get_run(session, api_key.org_id, run_id)
+    if run is None:
+        return _error(404, "Run not found")
+    if run.status not in (RunStatus.PENDING, RunStatus.RUNNING):
+        return _typed_error(
+            409,
+            "not_cancellable",
+            f"Run is already {run.status.value} and cannot be cancelled",
+        )
+    cancelled = _exec_svc.cancel_run(session, run_id)
+    if cancelled is None:
+        return _error(500, "Failed to cancel run")
+    return JSONResponse(_ser_run(cancelled))
+
+
 # ---------------------------------------------------------------------------
 # Catalog
 # ---------------------------------------------------------------------------
@@ -1071,6 +1119,7 @@ api_v1_routes = [
     Route("/api/v1/runs", list_runs, methods=["GET"]),
     Route("/api/v1/runs/{id:int}", get_run, methods=["GET"]),
     Route("/api/v1/runs/{id:int}/logs", get_run_logs, methods=["GET"]),
+    Route("/api/v1/runs/{id:int}/cancel", cancel_run, methods=["POST"]),
     # Catalog
     Route("/api/v1/catalog", list_catalog_entries, methods=["GET"]),
     Route("/api/v1/catalog/{id:int}", get_catalog_entry, methods=["GET"]),

--- a/datanika/services/idempotency.py
+++ b/datanika/services/idempotency.py
@@ -1,0 +1,85 @@
+"""Idempotency-Key support for POST endpoints.
+
+When an agent retries a ``POST`` request with the same
+``Idempotency-Key`` header, we return the cached response instead of
+creating a duplicate resource. Keys are scoped to ``org_id`` so
+different orgs can reuse the same key safely.
+
+Storage: Redis with a 24-hour TTL per key. The stored value is the
+full JSON response body (serialized as a string) + the original HTTP
+status code.
+
+Usage in the API middleware:
+
+    key = get_idempotency_key(request, api_key.org_id)
+    if key:
+        cached = get_cached_response(key)
+        if cached:
+            return cached  # return the original response, skip handler
+    # ... call handler ...
+    if key:
+        cache_response(key, response)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import redis
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from datanika.config import settings
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "idem:"
+_TTL_SECONDS = 86400  # 24 hours
+
+
+def _redis() -> redis.Redis:
+    return redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def _cache_key(org_id: int, idempotency_key: str) -> str:
+    return f"{_KEY_PREFIX}{org_id}:{idempotency_key}"
+
+
+def get_idempotency_key(request: Request, org_id: int) -> str | None:
+    """Extract the ``Idempotency-Key`` header from a request.
+
+    Returns ``None`` if the header is absent (idempotency is opt-in).
+    """
+    raw = request.headers.get("idempotency-key")
+    if not raw or not raw.strip():
+        return None
+    return _cache_key(org_id, raw.strip())
+
+
+def get_cached_response(cache_key: str) -> JSONResponse | None:
+    """Return a cached response for the key, or None if not found."""
+    try:
+        r = _redis()
+        raw = r.get(cache_key)
+    except Exception:
+        logger.warning("Idempotency cache read failed", exc_info=True)
+        return None
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+        return JSONResponse(data["body"], status_code=data["status"])
+    except Exception:
+        return None
+
+
+def cache_response(cache_key: str, response: JSONResponse) -> None:
+    """Store the response body + status code under the key with TTL."""
+    try:
+        body = json.loads(response.body.decode())
+        data = json.dumps({"status": response.status_code, "body": body})
+        r = _redis()
+        r.set(cache_key, data, ex=_TTL_SECONDS)
+    except Exception:
+        logger.warning("Idempotency cache write failed", exc_info=True)

--- a/datanika/services/run_waiter.py
+++ b/datanika/services/run_waiter.py
@@ -1,0 +1,63 @@
+"""Async run-completion waiter for the ``?wait=true`` trigger mode.
+
+When an agent sends ``POST /uploads/{id}/run?wait=true&timeout=120``,
+the endpoint dispatches the Celery task as usual, then calls
+``wait_for_run()`` which polls the run's DB status until it leaves
+``PENDING`` / ``RUNNING`` or the timeout expires.
+
+Polling, not blocking — does NOT hold a Celery worker slot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from datanika.db import get_sync_session
+from datanika.models.run import Run, RunStatus
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 120
+MAX_TIMEOUT = 300
+POLL_INTERVAL = 2.0
+
+_TERMINAL = frozenset({RunStatus.SUCCESS, RunStatus.FAILED, RunStatus.CANCELLED})
+
+
+async def wait_for_run(
+    run_id: int,
+    org_id: int,
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> Run | None:
+    """Poll until the run reaches a terminal status or the timeout expires.
+
+    Returns the final ``Run`` object, or ``None`` if the run wasn't
+    found (shouldn't happen — caller just created it). Raises no
+    exceptions; callers map the result to an HTTP response.
+    """
+    clamped = max(1, min(int(timeout), MAX_TIMEOUT))
+    elapsed = 0.0
+
+    while elapsed < clamped:
+        await asyncio.sleep(POLL_INTERVAL)
+        elapsed += POLL_INTERVAL
+
+        with get_sync_session() as session:
+            run = session.get(Run, run_id)
+            if run is None:
+                return None
+            if run.org_id != org_id:
+                return None
+            if run.status in _TERMINAL:
+                # Detach from session so the caller can serialize it
+                session.expunge(run)
+                return run
+
+    # Timeout — return the run in whatever state it's in now.
+    with get_sync_session() as session:
+        run = session.get(Run, run_id)
+        if run is not None:
+            session.expunge(run)
+        return run

--- a/tests/test_services/test_tier4_agent.py
+++ b/tests/test_services/test_tier4_agent.py
@@ -1,0 +1,258 @@
+"""Tests for Tier 4 Agent Compatibility: cancel, wait, idempotency (#60)."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession
+from sqlalchemy.pool import StaticPool
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import datanika.models.invitation  # noqa: F401
+import datanika.models.notification_channel  # noqa: F401
+import datanika.models.sso_config  # noqa: F401
+from datanika.models.base import Base
+from datanika.models.dependency import NodeType
+from datanika.models.run import Run, RunStatus
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def db_session(engine):
+    session = SASession(engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def fake_api_key():
+    key = MagicMock()
+    key.id = 1
+    key.org_id = 10
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def client():
+    return TestClient(Starlette(routes=api_v1_routes))
+
+
+def _headers(idem_key=None):
+    h = {"Authorization": "Bearer etf_test"}
+    if idem_key:
+        h["Idempotency-Key"] = idem_key
+    return h
+
+
+@contextlib.contextmanager
+def _patch_auth(fake_api_key, rate_limit_ok, db_session):
+    @contextlib.contextmanager
+    def fake_session():
+        yield db_session
+
+    with (
+        patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+        patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+        patch("datanika.services.api_middleware._get_session", fake_session),
+    ):
+        mock_svc.authenticate_api_key.return_value = fake_api_key
+        mock_rl.get_limit_for_org.return_value = 60
+        mock_rl.check_rate_limit.return_value = rate_limit_ok
+        yield
+
+
+def _create_run(session, org_id, status=RunStatus.PENDING):
+    """Helper to seed a run directly in the DB."""
+    run = Run(
+        org_id=org_id,
+        target_type=NodeType.UPLOAD,
+        target_id=1,
+        status=status,
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCancelRun:
+    def test_cancel_pending_run(self, client, fake_api_key, rate_limit_ok, db_session):
+        with _patch_auth(fake_api_key, rate_limit_ok, db_session):
+            run = _create_run(db_session, fake_api_key.org_id, RunStatus.PENDING)
+            db_session.commit()
+            resp = client.post(f"/api/v1/runs/{run.id}/cancel", headers=_headers())
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "cancelled"
+
+    def test_cancel_running_run(self, client, fake_api_key, rate_limit_ok, db_session):
+        with _patch_auth(fake_api_key, rate_limit_ok, db_session):
+            run = _create_run(db_session, fake_api_key.org_id, RunStatus.RUNNING)
+            db_session.commit()
+            resp = client.post(f"/api/v1/runs/{run.id}/cancel", headers=_headers())
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "cancelled"
+
+    def test_cancel_completed_run_returns_409(
+        self, client, fake_api_key, rate_limit_ok, db_session
+    ):
+        with _patch_auth(fake_api_key, rate_limit_ok, db_session):
+            run = _create_run(db_session, fake_api_key.org_id, RunStatus.SUCCESS)
+            db_session.commit()
+            resp = client.post(f"/api/v1/runs/{run.id}/cancel", headers=_headers())
+            assert resp.status_code == 409
+            assert resp.json()["error"]["code"] == "not_cancellable"
+
+    def test_cancel_wrong_org_returns_404(self, client, fake_api_key, rate_limit_ok, db_session):
+        with _patch_auth(fake_api_key, rate_limit_ok, db_session):
+            run = _create_run(db_session, 999, RunStatus.PENDING)
+            db_session.commit()
+            resp = client.post(f"/api/v1/runs/{run.id}/cancel", headers=_headers())
+            assert resp.status_code == 404
+
+    def test_cancel_nonexistent_returns_404(self, client, fake_api_key, rate_limit_ok, db_session):
+        with _patch_auth(fake_api_key, rate_limit_ok, db_session):
+            resp = client.post("/api/v1/runs/99999/cancel", headers=_headers())
+            assert resp.status_code == 404
+
+    def test_cancel_requires_auth(self, client):
+        resp = client.post("/api/v1/runs/1/cancel")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Idempotency-Key
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyKey:
+    def test_without_key_creates_normally(self, client, fake_api_key, rate_limit_ok, db_session):
+        with _patch_auth(fake_api_key, rate_limit_ok, db_session):
+            resp = client.post(
+                "/api/v1/transformations",
+                json={
+                    "name": "test_model",
+                    "sql_body": "SELECT 1",
+                },
+                headers=_headers(),
+            )
+            assert resp.status_code == 201
+
+    def test_duplicate_key_returns_cached_response(
+        self, client, fake_api_key, rate_limit_ok, db_session
+    ):
+        with (
+            _patch_auth(fake_api_key, rate_limit_ok, db_session),
+            patch("datanika.services.idempotency._redis") as mock_redis_fn,
+        ):
+            mock_r = MagicMock()
+            mock_redis_fn.return_value = mock_r
+            # First call: no cache
+            mock_r.get.return_value = None
+            resp1 = client.post(
+                "/api/v1/transformations",
+                json={
+                    "name": "idem_model",
+                    "sql_body": "SELECT 1",
+                },
+                headers=_headers(idem_key="key-123"),
+            )
+            assert resp1.status_code == 201
+            # Verify response was cached
+            assert mock_r.set.called
+
+            # Second call: return cached
+            cached_body = resp1.json()
+            mock_r.get.return_value = json.dumps({"status": 201, "body": cached_body})
+            resp2 = client.post(
+                "/api/v1/transformations",
+                json={
+                    "name": "idem_model_duplicate",
+                    "sql_body": "SELECT 2",
+                },
+                headers=_headers(idem_key="key-123"),
+            )
+            assert resp2.status_code == 201
+            assert resp2.json() == cached_body
+
+    def test_different_key_creates_new(self, client, fake_api_key, rate_limit_ok, db_session):
+        with (
+            _patch_auth(fake_api_key, rate_limit_ok, db_session),
+            patch("datanika.services.idempotency._redis") as mock_redis_fn,
+        ):
+            mock_r = MagicMock()
+            mock_redis_fn.return_value = mock_r
+            mock_r.get.return_value = None
+
+            resp1 = client.post(
+                "/api/v1/transformations",
+                json={
+                    "name": "model_a",
+                    "sql_body": "SELECT 1",
+                },
+                headers=_headers(idem_key="key-aaa"),
+            )
+            resp2 = client.post(
+                "/api/v1/transformations",
+                json={
+                    "name": "model_b",
+                    "sql_body": "SELECT 2",
+                },
+                headers=_headers(idem_key="key-bbb"),
+            )
+            assert resp1.status_code == 201
+            assert resp2.status_code == 201
+            assert resp1.json()["name"] != resp2.json()["name"]
+
+    def test_get_requests_ignore_idempotency_key(
+        self, client, fake_api_key, rate_limit_ok, db_session
+    ):
+        with (
+            _patch_auth(fake_api_key, rate_limit_ok, db_session),
+            patch("datanika.services.idempotency._redis") as mock_redis_fn,
+        ):
+            mock_r = MagicMock()
+            mock_redis_fn.return_value = mock_r
+            resp = client.get(
+                "/api/v1/transformations",
+                headers=_headers(idem_key="should-be-ignored"),
+            )
+            assert resp.status_code == 200
+            mock_r.get.assert_not_called()


### PR DESCRIPTION
## Summary
Closes Tier 4 of the AI Agent Compatibility roadmap (#37). After Tiers 1–3, agents can discover, create, compile, preview. This PR gives them production-grade lifecycle control.

### \`POST /api/v1/runs/{id}/cancel\`
Cancel a pending or running run. Typed \`not_cancellable\` error (409) if already completed. Tenant-isolated.

### \`?wait=true&timeout=N\` on trigger endpoints
All three trigger endpoints (\`/uploads/{id}/run\`, \`/pipelines/{id}/run\`, \`/transformations/{id}/run\`) accept \`?wait=true\` to block until the run finishes. Default timeout 120s, max 300s. Returns 200 with final status or 408 with \`timed_out: true\`. Async polling (2s interval) — does NOT hold a Celery worker.

### \`Idempotency-Key\` header
Standard header on all POST endpoints. Duplicate key within 24h returns the cached original response. Scoped to org_id + key. Redis-backed. Opt-in: no header → normal behavior. GET requests ignore the header.

## New modules
- \`run_waiter.py\` — async polling waiter for \`?wait=true\`
- \`idempotency.py\` — Redis-backed get/cache/check helpers

Both wired into the existing \`@api_endpoint()\` decorator.

Part of #37
Closes #60

## Tests (+10)
Cancel: 6 tests (pending, running, completed-409, wrong-org-404, nonexistent-404, 401)
Idempotency: 4 tests (no key, duplicate key cached, different key creates new, GET ignores)

## Test plan
- [x] 10 new tests pass
- [x] 1566 total tests pass (was 1556)
- [x] Ruff + format clean
- [x] Precheck green