### PR TITLE
Add slow query logging + PostgreSQL metrics exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,36 @@ services:
       - pgdata:/var/lib/postgresql/data
       - pg_backups:/backups
       - ./scripts:/scripts:ro
+      - ./scripts/pg-init:/docker-entrypoint-initdb.d:ro
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "pg_stat_statements.track=all"
+      - "-c"
+      - "log_min_duration_statement=500"
+      - "-c"
+      - "log_line_prefix=%t [%p] %q%u@%d "
+      - "-c"
+      - "log_statement=none"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:latest
+    container_name: datanika-postgres-exporter
+    ports:
+      - "127.0.0.1:9187:9187"
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-datanika}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-datanika}?sslmode=disable"
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
 
   redis:

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -435,3 +435,43 @@ groups:
         annotations:
           summary: "app.datanika.io /healthz not reachable externally"
           description: "External blackbox probe to https://app.datanika.io/healthz has failed for 5 minutes. Distinct from the internal container healthcheck — this catches Nginx/Cloudflare/DNS problems."
+
+  - orgId: 1
+    name: Database Alerts
+    folder: Datanika
+    interval: 5m
+    rules:
+      # --- Slow query rate spike ---
+      - uid: pg-slow-queries
+        title: PostgreSQL Slow Query Spike
+        condition: C
+        noDataState: OK
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'rate(pg_stat_statements_seconds_total{datname="datanika"}[5m]) > 0.5'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL slow query rate elevated"
+          description: "pg_stat_statements reports elevated query time. Check docker logs datanika-postgres for queries over 500ms."

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -19,6 +19,10 @@ scrape_configs:
     static_configs:
       - targets: ["app:8000"]
 
+  - job_name: "postgres-exporter"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
   # Blackbox probes — HTTP health checks for external endpoints.
   # Targets are probed via the blackbox exporter's http_2xx module.
   - job_name: "blackbox-http"

--- a/scripts/pg-init/01-pg-stat-statements.sql
+++ b/scripts/pg-init/01-pg-stat-statements.sql
@@ -1,0 +1,3 @@
+-- Enable pg_stat_statements extension (requires shared_preload_libraries set in postgres command).
+-- This runs once on container first start via /docker-entrypoint-initdb.d/.
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;


### PR DESCRIPTION
## Summary
Enables PostgreSQL slow query diagnostics now that real traffic from Google Ads is flowing.

### Changes
- **Postgres config** (command flags): `shared_preload_libraries=pg_stat_statements`, `log_min_duration_statement=500` (queries > 500ms logged), `pg_stat_statements.track=all`
- **postgres-exporter** container: Prometheus exporter for pg_stat_statements + standard pg_stat metrics (connections, locks, table sizes)
- **Prometheus**: new scrape target for postgres-exporter
- **Grafana alert**: "PostgreSQL Slow Query Spike" (warning, 10m for period)
- **Init script**: creates pg_stat_statements extension on first container start

### Deploy note
Postgres container restarts to load shared_preload_libraries. Data preserved via pgdata volume. For existing installs, run manually after deploy:
```sql
docker exec datanika-postgres psql -U datanika -d datanika -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
```

Closes the "Slow query logging and monitoring" item in P1 Database Operations.