### PR TITLE
Add Database Performance Grafana dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,8 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ../datanika-cloud/monitoring/revenue-dashboard.json:/var/lib/grafana/dashboards/cloud/revenue.json:ro
+      - ./monitoring/db-performance-dashboard.json:/var/lib/grafana/dashboards/infra/db-performance.json:ro
+      - ./monitoring/grafana-dashboard.json:/var/lib/grafana/dashboards/infra/server-overview.json:ro
     depends_on:
       - prometheus
     restart: unless-stopped

--- a/monitoring/db-performance-dashboard.json
+++ b/monitoring/db-performance-dashboard.json
@@ -1,0 +1,212 @@
+{
+  "uid": "datanika-db-perf",
+  "title": "Database Performance",
+  "tags": ["datanika", "postgres", "database"],
+  "timezone": "utc",
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Top 10 Slowest Queries (avg time)",
+      "type": "table",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "topk(10, pg_stat_statements_mean_time_seconds{datname=\"datanika\"})",
+          "legendFormat": "{{query}}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true },
+            "renameByName": { "query": "Query", "Value": "Avg Time (s)", "datname": "Database", "calls": "Calls" }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "left" },
+          "thresholds": {
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 0.5, "color": "yellow" },
+              { "value": 2, "color": "red" }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Avg Time (s)" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              { "id": "custom.width", "value": 120 }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "title": "Query Calls/sec by Type",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "sum(rate(pg_stat_user_tables_idx_scan_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Index Scans",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(pg_stat_user_tables_seq_scan_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Seq Scans",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(pg_stat_user_tables_n_tup_ins_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Inserts",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(pg_stat_user_tables_n_tup_upd_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Updates",
+          "refId": "D"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Average Query Latency (pg_stat_statements)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_seconds_total{datname=\"datanika\"}[5m]) / rate(pg_stat_statements_calls_total{datname=\"datanika\"}[5m])",
+          "legendFormat": "Avg Latency",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 0.1, "color": "yellow" },
+              { "value": 1.0, "color": "red" }
+            ]
+          },
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Active Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count{datname=\"datanika\", state=\"active\"}",
+          "legendFormat": "Active",
+          "refId": "A"
+        },
+        {
+          "expr": "pg_stat_activity_count{datname=\"datanika\", state=\"idle\"}",
+          "legendFormat": "Idle",
+          "refId": "B"
+        },
+        {
+          "expr": "pg_stat_activity_count{datname=\"datanika\", state=\"idle in transaction\"}",
+          "legendFormat": "Idle in Txn",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Database Size",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 4, "x": 8, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_database_size_bytes{datname=\"datanika\"}",
+          "legendFormat": "Size",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "decbytes" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Locks",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_locks_count{datname=\"datanika\"}",
+          "legendFormat": "{{mode}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Cache Hit Ratio",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_stat_database_blks_hit{datname=\"datanika\"} / (pg_stat_database_blks_hit{datname=\"datanika\"} + pg_stat_database_blks_read{datname=\"datanika\"})",
+          "legendFormat": "Hit Ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "value": null, "color": "red" },
+              { "value": 0.9, "color": "yellow" },
+              { "value": 0.99, "color": "green" }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/monitoring/grafana/provisioning/dashboards/infra.yml
+++ b/monitoring/grafana/provisioning/dashboards/infra.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'datanika-infra'
+    orgId: 1
+    folder: 'Datanika Infrastructure'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/infra
+      foldersFromFilesStructure: false


### PR DESCRIPTION
7-panel dashboard ready to light up when pg_stat_statements goes live:

1. **Top 10 Slowest Queries** — table from pg_stat_statements mean time
2. **Query Calls/sec** — index scans, seq scans, inserts, updates
3. **Avg Query Latency** — time series from pg_stat_statements
4. **Active Connections** — stacked (active/idle/idle-in-txn)
5. **Database Size** — stat panel
6. **Locks** — time series by lock mode
7. **Cache Hit Ratio** — gauge (green >99%, yellow >90%, red <90%)

Also creates a 'Datanika Infrastructure' Grafana folder and moves the server overview dashboard into it.