### PR TITLE
Promote dev → master: slow query monitoring, DB dashboard, full sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,36 @@ services:
       - pgdata:/var/lib/postgresql/data
       - pg_backups:/backups
       - ./scripts:/scripts:ro
+      - ./scripts/pg-init:/docker-entrypoint-initdb.d:ro
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "pg_stat_statements.track=all"
+      - "-c"
+      - "log_min_duration_statement=500"
+      - "-c"
+      - "log_line_prefix=%t [%p] %q%u@%d "
+      - "-c"
+      - "log_statement=none"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:latest
+    container_name: datanika-postgres-exporter
+    ports:
+      - "127.0.0.1:9187:9187"
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-datanika}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-datanika}?sslmode=disable"
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
 
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,8 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ../datanika-cloud/monitoring/revenue-dashboard.json:/var/lib/grafana/dashboards/cloud/revenue.json:ro
+      - ./monitoring/db-performance-dashboard.json:/var/lib/grafana/dashboards/infra/db-performance.json:ro
+      - ./monitoring/grafana-dashboard.json:/var/lib/grafana/dashboards/infra/server-overview.json:ro
     depends_on:
       - prometheus
     restart: unless-stopped

--- a/monitoring/db-performance-dashboard.json
+++ b/monitoring/db-performance-dashboard.json
@@ -1,0 +1,212 @@
+{
+  "uid": "datanika-db-perf",
+  "title": "Database Performance",
+  "tags": ["datanika", "postgres", "database"],
+  "timezone": "utc",
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Top 10 Slowest Queries (avg time)",
+      "type": "table",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "topk(10, pg_stat_statements_mean_time_seconds{datname=\"datanika\"})",
+          "legendFormat": "{{query}}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true },
+            "renameByName": { "query": "Query", "Value": "Avg Time (s)", "datname": "Database", "calls": "Calls" }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "left" },
+          "thresholds": {
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 0.5, "color": "yellow" },
+              { "value": 2, "color": "red" }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Avg Time (s)" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              { "id": "custom.width", "value": 120 }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "title": "Query Calls/sec by Type",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "sum(rate(pg_stat_user_tables_idx_scan_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Index Scans",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(pg_stat_user_tables_seq_scan_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Seq Scans",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(pg_stat_user_tables_n_tup_ins_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Inserts",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(pg_stat_user_tables_n_tup_upd_total{datname=\"datanika\"}[5m]))",
+          "legendFormat": "Updates",
+          "refId": "D"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Average Query Latency (pg_stat_statements)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_seconds_total{datname=\"datanika\"}[5m]) / rate(pg_stat_statements_calls_total{datname=\"datanika\"}[5m])",
+          "legendFormat": "Avg Latency",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 0.1, "color": "yellow" },
+              { "value": 1.0, "color": "red" }
+            ]
+          },
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Active Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count{datname=\"datanika\", state=\"active\"}",
+          "legendFormat": "Active",
+          "refId": "A"
+        },
+        {
+          "expr": "pg_stat_activity_count{datname=\"datanika\", state=\"idle\"}",
+          "legendFormat": "Idle",
+          "refId": "B"
+        },
+        {
+          "expr": "pg_stat_activity_count{datname=\"datanika\", state=\"idle in transaction\"}",
+          "legendFormat": "Idle in Txn",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Database Size",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 4, "x": 8, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_database_size_bytes{datname=\"datanika\"}",
+          "legendFormat": "Size",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "decbytes" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Locks",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_locks_count{datname=\"datanika\"}",
+          "legendFormat": "{{mode}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Cache Hit Ratio",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        {
+          "expr": "pg_stat_database_blks_hit{datname=\"datanika\"} / (pg_stat_database_blks_hit{datname=\"datanika\"} + pg_stat_database_blks_read{datname=\"datanika\"})",
+          "legendFormat": "Hit Ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "value": null, "color": "red" },
+              { "value": 0.9, "color": "yellow" },
+              { "value": 0.99, "color": "green" }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -435,3 +435,43 @@ groups:
         annotations:
           summary: "app.datanika.io /healthz not reachable externally"
           description: "External blackbox probe to https://app.datanika.io/healthz has failed for 5 minutes. Distinct from the internal container healthcheck — this catches Nginx/Cloudflare/DNS problems."
+
+  - orgId: 1
+    name: Database Alerts
+    folder: Datanika
+    interval: 5m
+    rules:
+      # --- Slow query rate spike ---
+      - uid: pg-slow-queries
+        title: PostgreSQL Slow Query Spike
+        condition: C
+        noDataState: OK
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'rate(pg_stat_statements_seconds_total{datname="datanika"}[5m]) > 0.5'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL slow query rate elevated"
+          description: "pg_stat_statements reports elevated query time. Check docker logs datanika-postgres for queries over 500ms."

--- a/monitoring/grafana/provisioning/dashboards/infra.yml
+++ b/monitoring/grafana/provisioning/dashboards/infra.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'datanika-infra'
+    orgId: 1
+    folder: 'Datanika Infrastructure'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/infra
+      foldersFromFilesStructure: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -19,6 +19,10 @@ scrape_configs:
     static_configs:
       - targets: ["app:8000"]
 
+  - job_name: "postgres-exporter"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
   # Blackbox probes — HTTP health checks for external endpoints.
   # Targets are probed via the blackbox exporter's http_2xx module.
   - job_name: "blackbox-http"

--- a/scripts/pg-init/01-pg-stat-statements.sql
+++ b/scripts/pg-init/01-pg-stat-statements.sql
@@ -1,0 +1,3 @@
+-- Enable pg_stat_statements extension (requires shared_preload_libraries set in postgres command).
+-- This runs once on container first start via /docker-entrypoint-initdb.d/.
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;


### PR DESCRIPTION
Bundled promotion after syncing master → dev (PR #72).

Brings to master:
- Slow query logging + pg_stat_statements + postgres-exporter (#67)
- Database Performance Grafana dashboard (7 panels) (#69)
- Full sync with all Engineering work (Tiers 4-5, Notification Center)

After this merges, dev and master are identical. Future Engineering PRs will target dev per the RUNBOOK_DEV_TO_MASTER.md workflow.