### PR TITLE
Pipeline Templates: pre-configured source→destination starters

### DIFF
--- a/datanika/data/__init__.py
+++ b/datanika/data/__init__.py
@@ -1,0 +1,6 @@
+"""Static data registries: pipeline templates, presets, and similar.
+
+Modules in this package contain pure-Python data (dataclasses, dicts, frozensets)
+that the rest of the app reads but never writes. Nothing here touches the
+database or external services.
+"""

--- a/datanika/data/pipeline_templates.py
+++ b/datanika/data/pipeline_templates.py
@@ -1,0 +1,138 @@
+"""Pipeline templates — pre-configured source→destination starters.
+
+Each template captures the *non-credential* configuration decisions a new
+user would otherwise have to make on their own:
+
+- which source connector to set up
+- which destination connector to use
+- sensible default settings for both connections (schemas, regions, etc.)
+- which dlt resources/tables to extract and the right write disposition
+
+The user still enters their own credentials. Templates do not run pipelines
+end-to-end on their own — they prefill forms in the connection creation flow
+so a Google Ads visitor can go from "empty dashboard" to "first run" in
+roughly two minutes instead of stalling on configuration decisions.
+
+This module is intentionally pure data: a frozen dataclass plus a small
+registry. Templates are not stored in the database, do not require a
+migration, and do not have an admin UI. To add a template, append to
+LAUNCH_TEMPLATES, add the matching i18n keys to all locale files, and add a
+test row to ``tests/test_data/test_pipeline_templates.py``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from datanika.models.connection import ConnectionType
+
+
+@dataclass(frozen=True)
+class PipelineTemplate:
+    """A pre-configured source→destination starter pipeline.
+
+    Attributes:
+        slug: URL-safe stable identifier (e.g. ``"stripe-to-postgres"``).
+        name_key: i18n key for the human-readable display name.
+        description_key: i18n key for the one-line description shown on the card.
+        source_type: ConnectionType the template's source connection will use.
+        destination_type: ConnectionType the template's destination uses.
+        source_config_defaults: Non-credential connection-form fields to
+            prefill on the source side (e.g. default schema, region, port).
+        destination_config_defaults: Same for the destination connection.
+        dlt_config_defaults: Default extract/load configuration — at minimum
+            ``write_disposition``, plus connector-specific keys like
+            ``resources`` (Stripe) or ``tables`` (Postgres).
+        icon_source: Connector slug used to look up the source icon in the UI.
+        icon_destination: Connector slug used to look up the destination icon.
+    """
+
+    slug: str
+    name_key: str
+    description_key: str
+    source_type: ConnectionType
+    destination_type: ConnectionType
+    icon_source: str
+    icon_destination: str
+    source_config_defaults: dict[str, Any] = field(default_factory=dict)
+    destination_config_defaults: dict[str, Any] = field(default_factory=dict)
+    dlt_config_defaults: dict[str, Any] = field(default_factory=dict)
+
+
+LAUNCH_TEMPLATES: tuple[PipelineTemplate, ...] = (
+    PipelineTemplate(
+        slug="stripe-to-postgres",
+        name_key="templates.stripe_to_postgres.name",
+        description_key="templates.stripe_to_postgres.description",
+        source_type=ConnectionType.STRIPE,
+        destination_type=ConnectionType.POSTGRES,
+        icon_source="stripe",
+        icon_destination="postgres",
+        source_config_defaults={
+            # Stripe connections only require the API key — nothing else to
+            # prefill on the source side. Listed explicitly so future fields
+            # have an obvious place to land.
+        },
+        destination_config_defaults={
+            "schema": "raw_stripe",
+            "port": "5432",
+        },
+        dlt_config_defaults={
+            "resources": ["Customer", "Charge", "Invoice", "Subscription", "Product", "Price"],
+            "write_disposition": "merge",
+        },
+    ),
+    PipelineTemplate(
+        slug="postgres-to-bigquery",
+        name_key="templates.postgres_to_bigquery.name",
+        description_key="templates.postgres_to_bigquery.description",
+        source_type=ConnectionType.POSTGRES,
+        destination_type=ConnectionType.BIGQUERY,
+        icon_source="postgres",
+        icon_destination="bigquery",
+        source_config_defaults={
+            "port": "5432",
+            "schema": "public",
+        },
+        destination_config_defaults={
+            "dataset": "raw_postgres",
+        },
+        dlt_config_defaults={
+            "write_disposition": "merge",
+        },
+    ),
+    PipelineTemplate(
+        slug="csv-to-duckdb",
+        name_key="templates.csv_to_duckdb.name",
+        description_key="templates.csv_to_duckdb.description",
+        source_type=ConnectionType.CSV,
+        destination_type=ConnectionType.DUCKDB,
+        icon_source="csv",
+        icon_destination="duckdb",
+        source_config_defaults={},
+        destination_config_defaults={
+            "schema": "raw_csv",
+        },
+        dlt_config_defaults={
+            "write_disposition": "replace",
+        },
+    ),
+)
+
+
+def list_templates() -> list[PipelineTemplate]:
+    """Return a fresh list of all launch templates.
+
+    Returns a *copy* so callers can mutate the list freely without
+    corrupting the registry.
+    """
+    return list(LAUNCH_TEMPLATES)
+
+
+def get_template(slug: str) -> PipelineTemplate | None:
+    """Look up a template by slug. Returns ``None`` if no template matches."""
+    if not slug:
+        return None
+    for tpl in LAUNCH_TEMPLATES:
+        if tpl.slug == slug:
+            return tpl
+    return None

--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -11,6 +11,7 @@ from datanika.ui.pages.dashboard import dashboard_page
 from datanika.ui.pages.login import login_page
 from datanika.ui.pages.model_detail import model_detail_page
 from datanika.ui.pages.models import models_page
+from datanika.ui.pages.pipeline_templates import pipeline_templates_page
 from datanika.ui.pages.pipelines import pipelines_page
 from datanika.ui.pages.runs import runs_page
 from datanika.ui.pages.schedules import schedules_page
@@ -86,7 +87,11 @@ app.add_page(
     connections_page,
     route="/connections",
     title="Connections | Datanika",
-    on_load=[AuthState.check_auth, ConnectionState.load_connections],
+    on_load=[
+        AuthState.check_auth,
+        ConnectionState.load_connections,
+        ConnectionState.load_template_from_query,
+    ],
 )
 app.add_page(
     uploads_page,
@@ -111,6 +116,12 @@ app.add_page(
     route="/pipelines",
     title="Pipelines | Datanika",
     on_load=[AuthState.check_auth, PipelineState.load_pipelines],
+)
+app.add_page(
+    pipeline_templates_page,
+    route="/pipelines/templates",
+    title="Pipeline Templates | Datanika",
+    on_load=[AuthState.check_auth],
 )
 app.add_page(
     schedules_page,

--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "تحذير الحصة",
   "notifications.quota_exceeded.title": "تجاوز الحصة",
   "notifications.dismiss": "تجاهل",
-  "notifications.view_run": "عرض التشغيل"
+  "notifications.view_run": "عرض التشغيل",
+  "templates.heading": "قوالب خطوط الأنابيب",
+  "templates.subtitle": "نقاط بداية معدّة مسبقًا تتخطى القرارات المملة. اختر واحدة، أدخل بيانات الاعتماد، واحصل على خط أنابيب يعمل خلال دقائق.",
+  "templates.use_this_template": "استخدم هذا القالب",
+  "templates.help_text": "تملأ القوالب فقط القيم الافتراضية غير الحساسة — المخططات والمنافذ واختيارات الجداول. تدخل بيانات الاعتماد دائمًا بنفسك.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "حمّل عملاء Stripe والمدفوعات والفواتير والاشتراكات في مستودع Postgres الخاص بك لتحليل الإيرادات.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "زامن قاعدة بيانات Postgres التشغيلية الخاصة بك مع BigQuery — أكثر خطوط الأنابيب التحليلية شيوعًا.",
+  "templates.csv_to_duckdb.name": "رفع CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "اسحب ملف CSV واستعلم عنه فورًا باستخدام DuckDB. لا حاجة لبيانات اعتماد — أسرع طريقة لتجربة Datanika.",
+  "pipelines.empty_heading": "لا توجد خطوط أنابيب بعد",
+  "pipelines.empty_subtitle": "ابدأ من قالب معدّ مسبقًا، أو مرر للأسفل لبناء واحد من الصفر.",
+  "pipelines.start_from_template": "ابدأ من قالب"
 }

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Kontingentwarnung",
   "notifications.quota_exceeded.title": "Kontingent überschritten",
   "notifications.dismiss": "Verwerfen",
-  "notifications.view_run": "Ausführung anzeigen"
+  "notifications.view_run": "Ausführung anzeigen",
+  "templates.heading": "Pipeline-Vorlagen",
+  "templates.subtitle": "Vorkonfigurierte Starter, die langweilige Entscheidungen überspringen. Wähle eine, gib deine Zugangsdaten ein und du hast in wenigen Minuten eine funktionierende Pipeline.",
+  "templates.use_this_template": "Diese Vorlage verwenden",
+  "templates.help_text": "Vorlagen füllen nur unkritische Standardwerte vor — Schemas, Ports, Tabellenauswahl. Zugangsdaten gibst du immer selbst ein.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Lade Stripe-Kunden, Zahlungen, Rechnungen und Abonnements in dein Postgres-Warehouse für Umsatzanalysen.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Synchronisiere deine operative Postgres-Datenbank in BigQuery — die häufigste Analyse-Pipeline.",
+  "templates.csv_to_duckdb.name": "CSV-Upload → DuckDB",
+  "templates.csv_to_duckdb.description": "Zieh eine CSV-Datei hinein und frag sie sofort mit DuckDB ab. Keine Zugangsdaten nötig — der schnellste Weg, Datanika auszuprobieren.",
+  "pipelines.empty_heading": "Noch keine Pipelines",
+  "pipelines.empty_subtitle": "Starte mit einer vorkonfigurierten Vorlage oder scrolle nach unten, um eine von Grund auf zu erstellen.",
+  "pipelines.start_from_template": "Mit einer Vorlage starten"
 }

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Προειδοποίηση ορίου",
   "notifications.quota_exceeded.title": "Υπέρβαση ορίου",
   "notifications.dismiss": "Απόρριψη",
-  "notifications.view_run": "Προβολή εκτέλεσης"
+  "notifications.view_run": "Προβολή εκτέλεσης",
+  "templates.heading": "Πρότυπα Pipeline",
+  "templates.subtitle": "Προρυθμισμένα σημεία εκκίνησης που παρακάμπτουν τις βαρετές αποφάσεις. Επιλέξτε ένα, εισαγάγετε τα διαπιστευτήριά σας και αποκτήστε ένα λειτουργικό pipeline σε λίγα λεπτά.",
+  "templates.use_this_template": "Χρήση αυτού του προτύπου",
+  "templates.help_text": "Τα πρότυπα συμπληρώνουν μόνο μη ευαίσθητες προεπιλογές — σχήματα, θύρες, επιλογές πινάκων. Τα διαπιστευτήρια τα εισάγετε πάντα εσείς.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Φέρτε πελάτες, χρεώσεις, τιμολόγια και συνδρομές του Stripe στην αποθήκη Postgres για ανάλυση εσόδων.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Συγχρονίστε τη λειτουργική σας βάση Postgres στο BigQuery — το πιο συνηθισμένο αναλυτικό pipeline.",
+  "templates.csv_to_duckdb.name": "Μεταφόρτωση CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Σύρετε ένα CSV και κάντε αμέσως ερωτήματα με DuckDB. Δεν χρειάζονται διαπιστευτήρια — ο γρηγορότερος τρόπος να δοκιμάσετε το Datanika.",
+  "pipelines.empty_heading": "Δεν υπάρχουν ακόμα pipelines",
+  "pipelines.empty_subtitle": "Ξεκινήστε από ένα προρυθμισμένο πρότυπο ή κατεβείτε για να φτιάξετε ένα από την αρχή.",
+  "pipelines.start_from_template": "Ξεκινήστε από πρότυπο"
 }

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Quota warning",
   "notifications.quota_exceeded.title": "Quota exceeded",
   "notifications.dismiss": "Dismiss",
-  "notifications.view_run": "View run"
+  "notifications.view_run": "View run",
+  "templates.heading": "Pipeline Templates",
+  "templates.subtitle": "Pre-configured starters that skip the boring decisions. Pick one, plug in your credentials, and have a working pipeline in minutes.",
+  "templates.use_this_template": "Use this template",
+  "templates.help_text": "Templates only prefill non-sensitive defaults — schemas, ports, table selections. You always enter your own credentials.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Land Stripe customers, charges, invoices and subscriptions in your Postgres warehouse for revenue analytics.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Sync your operational Postgres database into BigQuery — the most common analytics pipeline.",
+  "templates.csv_to_duckdb.name": "CSV Upload → DuckDB",
+  "templates.csv_to_duckdb.description": "Drag a CSV in, query it instantly with DuckDB. No credentials needed — the fastest way to try Datanika.",
+  "pipelines.empty_heading": "No pipelines yet",
+  "pipelines.empty_subtitle": "Start from a pre-configured template, or scroll down to build one from scratch.",
+  "pipelines.start_from_template": "Start from a template"
 }

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Advertencia de cuota",
   "notifications.quota_exceeded.title": "Cuota excedida",
   "notifications.dismiss": "Descartar",
-  "notifications.view_run": "Ver ejecución"
+  "notifications.view_run": "Ver ejecución",
+  "templates.heading": "Plantillas de pipeline",
+  "templates.subtitle": "Inicios preconfigurados que evitan decisiones aburridas. Elige uno, introduce tus credenciales y consigue una canalización funcional en minutos.",
+  "templates.use_this_template": "Usar esta plantilla",
+  "templates.help_text": "Las plantillas solo rellenan valores no sensibles: esquemas, puertos, selección de tablas. Las credenciales las introduces siempre tú.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Lleva clientes, cargos, facturas y suscripciones de Stripe a tu almacén Postgres para análisis de ingresos.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Sincroniza tu base de datos operativa Postgres con BigQuery — la canalización analítica más común.",
+  "templates.csv_to_duckdb.name": "Subida de CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Arrastra un CSV y consúltalo al instante con DuckDB. Sin credenciales — la forma más rápida de probar Datanika.",
+  "pipelines.empty_heading": "Aún no hay canalizaciones",
+  "pipelines.empty_subtitle": "Comienza con una plantilla preconfigurada o desplázate para crear una desde cero.",
+  "pipelines.start_from_template": "Empezar con una plantilla"
 }

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Avertissement de quota",
   "notifications.quota_exceeded.title": "Quota dépassé",
   "notifications.dismiss": "Ignorer",
-  "notifications.view_run": "Voir l'exécution"
+  "notifications.view_run": "Voir l'exécution",
+  "templates.heading": "Modèles de pipeline",
+  "templates.subtitle": "Démarrages préconfigurés qui évitent les décisions ennuyeuses. Choisissez-en un, saisissez vos identifiants et obtenez un pipeline fonctionnel en quelques minutes.",
+  "templates.use_this_template": "Utiliser ce modèle",
+  "templates.help_text": "Les modèles ne préremplissent que des valeurs par défaut non sensibles : schémas, ports, sélections de tables. Vous saisissez toujours vos identifiants vous-même.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Chargez les clients, paiements, factures et abonnements Stripe dans votre entrepôt Postgres pour l'analyse du chiffre d'affaires.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Synchronisez votre base Postgres opérationnelle avec BigQuery — le pipeline d'analyse le plus courant.",
+  "templates.csv_to_duckdb.name": "Téléversement CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Glissez un CSV, interrogez-le instantanément avec DuckDB. Aucun identifiant nécessaire — le moyen le plus rapide d'essayer Datanika.",
+  "pipelines.empty_heading": "Aucun pipeline pour le moment",
+  "pipelines.empty_subtitle": "Démarrez avec un modèle préconfiguré ou faites défiler vers le bas pour en créer un de zéro.",
+  "pipelines.start_from_template": "Démarrer avec un modèle"
 }

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Предупреждение о квоте",
   "notifications.quota_exceeded.title": "Квота превышена",
   "notifications.dismiss": "Скрыть",
-  "notifications.view_run": "Перейти к запуску"
+  "notifications.view_run": "Перейти к запуску",
+  "templates.heading": "Шаблоны пайплайнов",
+  "templates.subtitle": "Готовые шаблоны, которые избавляют от рутинных решений. Выберите один, введите свои учётные данные и получите рабочий пайплайн за считанные минуты.",
+  "templates.use_this_template": "Использовать этот шаблон",
+  "templates.help_text": "Шаблоны заполняют только нечувствительные значения — схемы, порты, выбор таблиц. Учётные данные вы всегда вводите сами.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Загружайте клиентов, платежи, счета и подписки Stripe в Postgres для аналитики выручки.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Синхронизируйте операционную базу Postgres с BigQuery — самый распространённый аналитический пайплайн.",
+  "templates.csv_to_duckdb.name": "Загрузка CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Перетащите CSV-файл и сразу запросите его с помощью DuckDB. Учётные данные не нужны — самый быстрый способ попробовать Datanika.",
+  "pipelines.empty_heading": "Пайплайнов пока нет",
+  "pipelines.empty_subtitle": "Начните с готового шаблона или прокрутите вниз, чтобы создать пайплайн с нуля.",
+  "pipelines.start_from_template": "Начать с шаблона"
 }

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Упозорење о квоти",
   "notifications.quota_exceeded.title": "Квота прекорачена",
   "notifications.dismiss": "Одбаци",
-  "notifications.view_run": "Прикажи покретање"
+  "notifications.view_run": "Прикажи покретање",
+  "templates.heading": "Шаблони цевовода",
+  "templates.subtitle": "Унапред конфигурисани почеци који прескачу досадне одлуке. Изаберите један, унесите своје акредитиве и добићете функционалан цевовод за неколико минута.",
+  "templates.use_this_template": "Користи овај шаблон",
+  "templates.help_text": "Шаблони унапред попуњавају само неосетљиве подразумеване вредности — шеме, портове, избор табела. Акредитиве увек уносите ви сами.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Учитајте Stripe купце, наплате, фактуре и претплате у ваш Postgres складиште за анализу прихода.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Синхронизујте вашу оперативну Postgres базу података са BigQuery — најчешћи аналитички цевовод.",
+  "templates.csv_to_duckdb.name": "CSV отпремање → DuckDB",
+  "templates.csv_to_duckdb.description": "Превуците CSV и одмах га упитајте помоћу DuckDB-а. Без акредитива — најбржи начин да испробате Datanika.",
+  "pipelines.empty_heading": "Још нема цевовода",
+  "pipelines.empty_subtitle": "Почните од унапред конфигурисаног шаблона или скролујте надоле да направите нови од нуле.",
+  "pipelines.start_from_template": "Почни од шаблона"
 }

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "配额预警",
   "notifications.quota_exceeded.title": "配额已用完",
   "notifications.dismiss": "忽略",
-  "notifications.view_run": "查看运行"
+  "notifications.view_run": "查看运行",
+  "templates.heading": "流水线模板",
+  "templates.subtitle": "预配置的入门模板,跳过繁琐的决策。选择一个,输入凭证,几分钟内就能拥有可用的流水线。",
+  "templates.use_this_template": "使用此模板",
+  "templates.help_text": "模板仅预填非敏感的默认值 —— 模式、端口、表选择。凭证始终由您自己输入。",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "将 Stripe 的客户、收款、发票和订阅数据载入您的 Postgres 数据仓库,用于收入分析。",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "将您的运营 Postgres 数据库同步到 BigQuery —— 最常见的分析流水线。",
+  "templates.csv_to_duckdb.name": "CSV 上传 → DuckDB",
+  "templates.csv_to_duckdb.description": "拖入一个 CSV 文件,使用 DuckDB 立即查询。无需凭证 —— 体验 Datanika 的最快方式。",
+  "pipelines.empty_heading": "尚无流水线",
+  "pipelines.empty_subtitle": "从预配置模板开始,或向下滚动从零开始构建。",
+  "pipelines.start_from_template": "从模板开始"
 }

--- a/datanika/ui/components/getting_started_checklist.py
+++ b/datanika/ui/components/getting_started_checklist.py
@@ -79,7 +79,7 @@ def getting_started_checklist() -> rx.Component:
                 _step_row(
                     OnboardingState.progress.has_pipeline,
                     _t["onboarding.step_pipeline"],
-                    "/pipelines",
+                    "/pipelines/templates",
                 ),
                 _step_row(
                     OnboardingState.progress.has_run,

--- a/datanika/ui/pages/pipeline_templates.py
+++ b/datanika/ui/pages/pipeline_templates.py
@@ -1,0 +1,102 @@
+"""Pipeline Templates page — pre-configured source→destination starters.
+
+Shows a grid of cards. Clicking a card navigates the user to ``/connections``
+with ``?template=<slug>``; ConnectionState picks up the slug on page load
+and prefills the source connection form so the user only has to enter their
+own credentials. See ``datanika/data/pipeline_templates.py`` for the
+underlying registry.
+"""
+
+import reflex as rx
+
+from datanika.data.pipeline_templates import LAUNCH_TEMPLATES, PipelineTemplate
+from datanika.ui.components.layout import page_layout
+from datanika.ui.state.i18n_state import I18nState
+
+_t = I18nState.translations
+
+# Explicit references so the test_no_orphan_keys_in_json scanner can find the
+# per-template name/description keys. The card component below looks them up
+# dynamically via ``_t[tpl.name_key]`` because the slug-to-key mapping lives
+# in the static template registry, not in this page module. Add a row here
+# whenever a new template is appended to LAUNCH_TEMPLATES.
+_TEMPLATE_I18N_REFS = (
+    _t["templates.stripe_to_postgres.name"],
+    _t["templates.stripe_to_postgres.description"],
+    _t["templates.postgres_to_bigquery.name"],
+    _t["templates.postgres_to_bigquery.description"],
+    _t["templates.csv_to_duckdb.name"],
+    _t["templates.csv_to_duckdb.description"],
+)
+
+
+def _template_card(tpl: PipelineTemplate) -> rx.Component:
+    """Render a single template card.
+
+    Built at import time from a static template — no Reflex state vars needed,
+    so we render the source/destination labels as plain Python strings.
+    """
+    return rx.link(
+        rx.card(
+            rx.vstack(
+                rx.hstack(
+                    rx.badge(tpl.icon_source, color_scheme="blue", size="2"),
+                    rx.icon("arrow_right", size=18, color="var(--slate-9)"),
+                    rx.badge(tpl.icon_destination, color_scheme="violet", size="2"),
+                    align="center",
+                    spacing="2",
+                ),
+                rx.heading(_t[tpl.name_key], size="4"),
+                rx.text(
+                    _t[tpl.description_key],
+                    size="2",
+                    color="var(--slate-11)",
+                ),
+                rx.spacer(),
+                rx.button(
+                    _t["templates.use_this_template"],
+                    width="100%",
+                    variant="solid",
+                ),
+                spacing="3",
+                align="start",
+                height="100%",
+            ),
+            width="100%",
+            height="100%",
+            _hover={"border_color": "var(--accent-9)", "cursor": "pointer"},
+        ),
+        href=f"/connections?template={tpl.slug}",
+        underline="none",
+        width="100%",
+    )
+
+
+def pipeline_templates_page() -> rx.Component:
+    return page_layout(
+        rx.vstack(
+            rx.heading(_t["templates.heading"], size="6"),
+            rx.text(
+                _t["templates.subtitle"],
+                size="3",
+                color="var(--slate-11)",
+            ),
+            rx.grid(
+                *[_template_card(tpl) for tpl in LAUNCH_TEMPLATES],
+                columns=rx.breakpoints(initial="1", md="3"),
+                spacing="4",
+                width="100%",
+            ),
+            rx.callout(
+                _t["templates.help_text"],
+                icon="info",
+                color_scheme="gray",
+                size="1",
+                margin_top="1rem",
+            ),
+            spacing="4",
+            width="100%",
+            align="stretch",
+        ),
+        title=_t["templates.heading"],
+    )

--- a/datanika/ui/pages/pipelines.py
+++ b/datanika/ui/pages/pipelines.py
@@ -336,8 +336,51 @@ def pipelines_table() -> rx.Component:
     )
 
 
+def pipelines_empty_state() -> rx.Component:
+    """First-time CTA shown when the user has zero pipelines.
+
+    Surfaces the templates page as the recommended path. The form below
+    stays available for users who want to skip templates and configure
+    everything by hand.
+    """
+    return rx.card(
+        rx.vstack(
+            rx.icon("sparkles", size=32, color="var(--accent-9)"),
+            rx.heading(_t["pipelines.empty_heading"], size="5"),
+            rx.text(
+                _t["pipelines.empty_subtitle"],
+                size="2",
+                color="var(--slate-11)",
+                text_align="center",
+            ),
+            rx.link(
+                rx.button(
+                    _t["pipelines.start_from_template"],
+                    size="3",
+                ),
+                href="/pipelines/templates",
+                underline="none",
+            ),
+            spacing="3",
+            align="center",
+            padding_y="2rem",
+        ),
+        width="100%",
+    )
+
+
 def pipelines_page() -> rx.Component:
     return page_layout(
-        rx.vstack(pipeline_form(), pipelines_table(), spacing="6", width="100%"),
+        rx.vstack(
+            rx.cond(
+                PipelineState.pipelines.length() == 0,
+                pipelines_empty_state(),
+                rx.fragment(),
+            ),
+            pipeline_form(),
+            pipelines_table(),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.pipelines"],
     )

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -76,6 +76,32 @@ _DEFAULT_PORTS: dict[str, str] = {
 # Connection types that use the SQL database form group (host/port/user/pass/db/schema)
 _DB_TYPES = {"postgres", "mysql", "mssql", "redshift", "clickhouse", "synapse"}
 
+# Mapping of pipeline-template ``source_config_defaults`` keys to the
+# matching ConnectionState ``form_*`` attribute. Module-level (not a class
+# attribute) so it isn't picked up as a Reflex state var, and so the
+# template-prefill helper stays trivially testable via FakeState.
+#
+# Add new entries here when a template needs to prefill a non-credential
+# field that isn't already covered. Never add password / secret / api_key /
+# service_account_json — templates carry safe defaults only.
+_TEMPLATE_FORM_FIELD_MAP: dict[str, str] = {
+    "host": "form_host",
+    "port": "form_port",
+    "database": "form_database",
+    "schema": "form_schema",
+    "path": "form_path",
+    "project": "form_project",
+    "dataset": "form_dataset",
+    "account": "form_account",
+    "warehouse": "form_warehouse",
+    "role": "form_role",
+    "bucket_url": "form_bucket_url",
+    "base_url": "form_base_url",
+    "property_id": "form_property_id",
+    "bootstrap_servers": "form_bootstrap_servers",
+    "topics": "form_topics",
+}
+
 
 def _validate_connection_form(
     name: str,
@@ -231,6 +257,51 @@ class ConnectionState(BaseState):
     form_bootstrap_servers: str = ""  # Kafka
     form_topics: str = ""  # Kafka
     form_group_id: str = ""  # Kafka
+
+    # Pipeline template currently driving the form prefill (empty = none).
+    # Set when the user clicks a card on /pipelines/templates and arrives
+    # at /connections via ?template=<slug>. Used to show a banner explaining
+    # the multi-step flow.
+    selected_template_slug: str = ""
+
+    def _apply_template_defaults(self, slug: str) -> None:
+        """Look up a pipeline template and prefill matching form fields.
+
+        - No-op if ``slug`` is empty or doesn't match a known template.
+        - Sets ``form_type`` to the template's source connector.
+        - Copies entries from ``source_config_defaults`` into matching
+          ``form_*`` attributes via ``_TEMPLATE_FIELD_MAP``.
+        - Never touches credential fields (password, api_key, secrets,
+          service-account JSON). Templates only carry non-sensitive defaults.
+        - Stores the slug in ``selected_template_slug`` so the UI can show
+          a "you're following a template" banner.
+
+        Pure helper — testable without Reflex / DB / async context.
+        """
+        from datanika.data.pipeline_templates import get_template
+
+        tpl = get_template(slug)
+        if tpl is None:
+            return
+
+        self.form_type = str(tpl.source_type)
+        self.selected_template_slug = tpl.slug
+
+        for key, value in tpl.source_config_defaults.items():
+            attr = _TEMPLATE_FORM_FIELD_MAP.get(key)
+            if attr is None:
+                continue
+            setattr(self, attr, value)
+
+    async def load_template_from_query(self):
+        """Read ``?template=<slug>`` from the page URL and prefill the form.
+
+        Wired into the /connections page ``on_load`` so a user arriving from
+        the templates grid lands with the source connector preselected.
+        """
+        slug = self.router.page.params.get("template", "")
+        if slug:
+            self._apply_template_defaults(slug)
 
     def set_form_name(self, value: str):
         self.form_name = re.sub(r"[^a-zA-Z0-9 ]", "", value)

--- a/tests/test_data/test_pipeline_templates.py
+++ b/tests/test_data/test_pipeline_templates.py
@@ -1,0 +1,148 @@
+"""Tests for the pipeline templates registry — static data validation."""
+
+import pytest
+
+from datanika.data.pipeline_templates import (
+    LAUNCH_TEMPLATES,
+    PipelineTemplate,
+    get_template,
+    list_templates,
+)
+from datanika.models.connection import ConnectionType
+
+
+class TestPipelineTemplateDataclass:
+    def test_construct_with_all_required_fields(self):
+        tpl = PipelineTemplate(
+            slug="test",
+            name_key="templates.test.name",
+            description_key="templates.test.description",
+            source_type=ConnectionType.STRIPE,
+            destination_type=ConnectionType.POSTGRES,
+            source_config_defaults={"start_date": "2024-01-01"},
+            destination_config_defaults={"schema": "raw_stripe"},
+            dlt_config_defaults={
+                "resources": ["customers", "charges"],
+                "write_disposition": "merge",
+            },
+            icon_source="stripe",
+            icon_destination="postgres",
+        )
+        assert tpl.slug == "test"
+        assert tpl.source_type == ConnectionType.STRIPE
+        assert tpl.destination_type == ConnectionType.POSTGRES
+
+    def test_template_is_immutable(self):
+        """Templates are static data — instances should be frozen."""
+        tpl = LAUNCH_TEMPLATES[0]
+        with pytest.raises((AttributeError, TypeError)):
+            tpl.slug = "mutated"  # type: ignore[misc]
+
+
+class TestLaunchTemplates:
+    def test_three_launch_templates(self):
+        """MVP ships exactly 3 templates."""
+        assert len(LAUNCH_TEMPLATES) == 3
+
+    def test_launch_template_slugs(self):
+        slugs = {t.slug for t in LAUNCH_TEMPLATES}
+        assert slugs == {
+            "stripe-to-postgres",
+            "postgres-to-bigquery",
+            "csv-to-duckdb",
+        }
+
+    def test_all_slugs_are_unique(self):
+        slugs = [t.slug for t in LAUNCH_TEMPLATES]
+        assert len(slugs) == len(set(slugs))
+
+    def test_all_required_fields_present(self):
+        for tpl in LAUNCH_TEMPLATES:
+            assert tpl.slug
+            assert tpl.name_key
+            assert tpl.description_key
+            assert tpl.source_type
+            assert tpl.destination_type
+            assert tpl.icon_source
+            assert tpl.icon_destination
+
+    def test_source_and_destination_types_are_valid(self):
+        """Every template's source and destination must be a real ConnectionType."""
+        valid_types = {ct for ct in ConnectionType}
+        for tpl in LAUNCH_TEMPLATES:
+            assert tpl.source_type in valid_types, (
+                f"{tpl.slug} has invalid source_type {tpl.source_type}"
+            )
+            assert tpl.destination_type in valid_types, (
+                f"{tpl.slug} has invalid destination_type {tpl.destination_type}"
+            )
+
+    def test_i18n_keys_follow_naming_convention(self):
+        """Name and description keys should be under 'templates.<slug>.*'."""
+        for tpl in LAUNCH_TEMPLATES:
+            normalized = tpl.slug.replace("-", "_")
+            assert tpl.name_key == f"templates.{normalized}.name", (
+                f"{tpl.slug} name_key={tpl.name_key} doesn't match convention"
+            )
+            assert tpl.description_key == f"templates.{normalized}.description", (
+                f"{tpl.slug} description_key={tpl.description_key} doesn't match convention"
+            )
+
+    def test_dlt_config_has_write_disposition(self):
+        """Every template must specify a write_disposition for its dlt config."""
+        valid_dispositions = {"append", "replace", "merge"}
+        for tpl in LAUNCH_TEMPLATES:
+            assert "write_disposition" in tpl.dlt_config_defaults, (
+                f"{tpl.slug} missing write_disposition"
+            )
+            assert tpl.dlt_config_defaults["write_disposition"] in valid_dispositions
+
+    def test_stripe_to_postgres_template(self):
+        tpl = get_template("stripe-to-postgres")
+        assert tpl.source_type == ConnectionType.STRIPE
+        assert tpl.destination_type == ConnectionType.POSTGRES
+        # Stripe template should preselect at least the core resources
+        assert "resources" in tpl.dlt_config_defaults
+        resources = tpl.dlt_config_defaults["resources"]
+        assert "Customer" in resources or "customers" in resources
+
+    def test_postgres_to_bigquery_template(self):
+        tpl = get_template("postgres-to-bigquery")
+        assert tpl.source_type == ConnectionType.POSTGRES
+        assert tpl.destination_type == ConnectionType.BIGQUERY
+
+    def test_csv_to_duckdb_template(self):
+        """The zero-credentials quickstart."""
+        tpl = get_template("csv-to-duckdb")
+        assert tpl.source_type == ConnectionType.CSV
+        assert tpl.destination_type == ConnectionType.DUCKDB
+
+
+class TestListTemplates:
+    def test_returns_all_launch_templates(self):
+        templates = list_templates()
+        assert len(templates) == len(LAUNCH_TEMPLATES)
+
+    def test_returns_pipeline_template_instances(self):
+        for tpl in list_templates():
+            assert isinstance(tpl, PipelineTemplate)
+
+    def test_returns_a_copy_not_the_underlying_list(self):
+        """Mutating the returned list must not corrupt the registry."""
+        templates = list_templates()
+        original_len = len(LAUNCH_TEMPLATES)
+        templates.clear()
+        assert len(LAUNCH_TEMPLATES) == original_len
+
+
+class TestGetTemplate:
+    def test_returns_template_for_valid_slug(self):
+        tpl = get_template("stripe-to-postgres")
+        assert tpl is not None
+        assert tpl.slug == "stripe-to-postgres"
+
+    def test_returns_none_for_unknown_slug(self):
+        assert get_template("does-not-exist") is None
+
+    def test_returns_none_for_empty_slug(self):
+        assert get_template("") is None

--- a/tests/test_ui/test_pipeline_template_state.py
+++ b/tests/test_ui/test_pipeline_template_state.py
@@ -1,0 +1,117 @@
+"""Tests for the connection-state side of pipeline templates.
+
+Covers ``ConnectionState._apply_template_defaults`` — the pure helper that
+takes a template slug, looks up the template, and prefills the matching
+``form_*`` fields on the state object. This is the bridge between the
+static template registry and the existing connection creation form.
+"""
+
+import types
+
+from datanika.data.pipeline_templates import get_template
+
+
+class _FakeConnectionState:
+    """Stand-in for ConnectionState that exposes only the form_* fields the
+    template prefill logic touches. Mirrors the FakeState pattern in
+    ``tests/test_ui/test_state_models.py::TestConnectionBuildConfig``.
+    """
+
+
+def _make_state(**overrides):
+    from datanika.ui.state.connection_state import ConnectionState
+
+    defaults = {
+        "form_type": "postgres",
+        "form_host": "",
+        "form_port": "5432",
+        "form_user": "",
+        "form_password": "",
+        "form_database": "",
+        "form_schema": "",
+        "form_path": "",
+        "form_project": "",
+        "form_dataset": "",
+        "form_keyfile_json": "",
+        "form_account": "",
+        "form_warehouse": "",
+        "form_role": "",
+        "form_bucket_url": "",
+        "form_base_url": "",
+        "form_property_id": "",
+        "form_bootstrap_servers": "",
+        "form_topics": "",
+        "selected_template_slug": "",
+    }
+    defaults.update(overrides)
+
+    obj = _FakeConnectionState()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    obj._apply_template_defaults = types.MethodType(ConnectionState._apply_template_defaults, obj)
+    return obj
+
+
+class TestApplyTemplateDefaults:
+    def test_unknown_slug_is_noop(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("does-not-exist")
+        # No fields should change
+        assert state.form_type == "postgres"
+        assert state.selected_template_slug == ""
+
+    def test_empty_slug_is_noop(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("")
+        assert state.form_type == "postgres"
+
+    def test_stripe_template_sets_source_type_to_stripe(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("stripe-to-postgres")
+        assert state.form_type == "stripe"
+        assert state.selected_template_slug == "stripe-to-postgres"
+
+    def test_postgres_template_prefills_port_and_schema(self):
+        state = _make_state(form_type="bigquery", form_port="", form_schema="")
+        state._apply_template_defaults("postgres-to-bigquery")
+        assert state.form_type == "postgres"
+        assert state.form_port == "5432"
+        assert state.form_schema == "public"
+
+    def test_csv_template_sets_source_type_to_csv(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("csv-to-duckdb")
+        assert state.form_type == "csv"
+        assert state.selected_template_slug == "csv-to-duckdb"
+
+    def test_template_does_not_overwrite_credentials(self):
+        """Template prefill must never touch password/secret/api_key fields."""
+        state = _make_state(
+            form_type="postgres",
+            form_password="user-typed-secret",
+            form_user="alice",
+        )
+        # Even if we apply a template that targets postgres source, the
+        # user-entered credentials must survive.
+        state._apply_template_defaults("postgres-to-bigquery")
+        assert state.form_password == "user-typed-secret"
+        assert state.form_user == "alice"
+
+    def test_apply_template_is_idempotent(self):
+        state = _make_state()
+        state._apply_template_defaults("stripe-to-postgres")
+        state._apply_template_defaults("stripe-to-postgres")
+        assert state.form_type == "stripe"
+        assert state.selected_template_slug == "stripe-to-postgres"
+
+
+class TestTemplateLookupHelper:
+    """Sanity check that get_template (already tested in test_data) is the
+    contract the state code relies on. If this fails, the state tests above
+    will too — but this localizes the failure mode for debugging."""
+
+    def test_get_template_returns_object_with_source_type_attribute(self):
+        tpl = get_template("stripe-to-postgres")
+        assert tpl is not None
+        assert hasattr(tpl, "source_type")
+        assert hasattr(tpl, "source_config_defaults")


### PR DESCRIPTION
Closes #76

## Summary

Adds **Pipeline Templates** — pre-configured source+destination starters that prefill connection-form defaults so new users can go from "empty dashboard" to "first run" in roughly two minutes instead of stalling on configuration decisions ("which tables? what schema? what write disposition?").

This is the first MVP slice (single PR). The end-to-end orchestration (source → destination → dlt config → run) is intentionally left as follow-up work.

## What's in this PR

### New static data
- `datanika/data/pipeline_templates.py` — frozen `PipelineTemplate` dataclass + a registry of 3 launch templates. Pure-Python data, no DB model, no migration.
- 3 launch templates:
  - **Stripe → PostgreSQL** — revenue analytics, matches the Google Ads audience
  - **PostgreSQL → BigQuery** — most common pipeline, matches the top blog post
  - **CSV Upload → DuckDB** — zero-credentials quickstart, the "hello world" pipeline

### New UI
- `/pipelines/templates` route — grid of 3 cards (source icon → arrow → destination icon, name, description, "Use this template" button). Each card links to `/connections?template=<slug>`.
- Empty state on `/pipelines` — first-time users with zero pipelines see a "Start from a template" CTA card above the form. The form stays available for users who want to configure everything by hand.

### State / wiring
- `ConnectionState._apply_template_defaults(slug)` — looks up the template, sets `form_type` to the source connector, and copies non-credential `source_config_defaults` into matching `form_*` attributes via a module-level `_TEMPLATE_FORM_FIELD_MAP`. Never touches password / api_key / service-account fields.
- `ConnectionState.load_template_from_query` — wired into the `/connections` `on_load` so a user arriving from the templates grid lands with the source connector preselected.
- `selected_template_slug` field — stored on `ConnectionState` so future PRs can show a "you're following the X template" banner and orchestrate the multi-step flow.
- Getting Started checklist — "Create a pipeline" step now points at `/pipelines/templates` instead of `/pipelines`.

### i18n
13 new keys added to all 9 locale files (en, ru, el, de, fr, es, zh, ar, sr):
- `templates.heading`, `templates.subtitle`, `templates.use_this_template`, `templates.help_text`
- `templates.{slug}.name` and `templates.{slug}.description` for each template
- `pipelines.empty_heading`, `pipelines.empty_subtitle`, `pipelines.start_from_template`

`test_i18n` key parity, code/JSON sync, and orphan-keys tests all pass.

### Tests (TDD)
- `tests/test_data/test_pipeline_templates.py` — 18 tests covering dataclass immutability, registry shape, slug uniqueness, every template's source/destination type being a valid `ConnectionType`, write_disposition presence, naming conventions, and `get_template`/`list_templates` semantics.
- `tests/test_ui/test_pipeline_template_state.py` — 8 tests covering `_apply_template_defaults`: noop on unknown/empty slug, prefills source type for each template, never overwrites credentials, idempotent.
- Full suite: **1656 passed**, no regressions.

## What this is NOT

- **Not** a community templates marketplace (future work)
- **Not** a fully-automated one-click pipeline — the user still enters their own credentials
- **Not** a new DB model or migration — templates are static Python data
- **Not** the multi-step source → destination → dlt config orchestration. The MVP is: data structure + selection UI + connection-form prefill + onboarding wiring.

## Why this matters

Shortest path from Google Ads click to value: ad → pricing → signup → empty dashboard → "Start from a template" → "Stripe → PostgreSQL" → enter Stripe API key → pipeline runs.

Templates solve the "I don't know what to configure" problem without needing a fake demo data source. After this ships, the remaining onboarding bullets (sample connection / demo DB) become less urgent — revisit then.

## Test plan

- [x] `pytest tests/` — full suite passes (1656 tests)
- [x] `ruff check` clean on all changed files
- [x] `ruff format` applied
- [x] `test_i18n` key parity passes across all 9 locales
- [x] Module imports cleanly (`from datanika.ui.pages.pipeline_templates import pipeline_templates_page`)
- [ ] Manual verification: `/pipelines/templates` renders 3 cards
- [ ] Manual verification: clicking "Stripe → PostgreSQL" navigates to `/connections` with `form_type = "stripe"`
- [ ] Manual verification: empty `/pipelines` shows the new CTA card
- [ ] Manual verification: Getting Started checklist "Create a pipeline" step links to `/pipelines/templates`