### PR TITLE
Fix notification bell outside-click + audit log combobox widths

### DIFF
--- a/datanika/ui/components/notification_bell.py
+++ b/datanika/ui/components/notification_bell.py
@@ -86,98 +86,87 @@ def _notification_row(n) -> rx.Component:
     )
 
 
-def notification_dropdown() -> rx.Component:
-    return rx.box(
-        rx.vstack(
-            rx.hstack(
-                rx.text(
-                    _t["notifications.center.title"],
-                    size="2",
-                    weight="bold",
-                ),
-                rx.spacer(),
-                rx.cond(
-                    NotificationCenterState.unread_count > 0,
-                    rx.button(
-                        _t["notifications.center.mark_all_read"],
-                        on_click=NotificationCenterState.mark_all_read,
-                        variant="ghost",
-                        size="1",
-                        color_scheme="violet",
-                    ),
-                    rx.fragment(),
-                ),
-                width="100%",
-                align="center",
+def _notification_dropdown_content() -> rx.Component:
+    return rx.vstack(
+        rx.hstack(
+            rx.text(
+                _t["notifications.center.title"],
+                size="2",
+                weight="bold",
             ),
-            rx.separator(),
+            rx.spacer(),
             rx.cond(
-                NotificationCenterState.notifications.length() == 0,
-                rx.vstack(
-                    rx.icon("bell-off", size=24, color="var(--slate-8)"),
-                    rx.text(
-                        _t["notifications.center.empty"],
-                        size="2",
-                        color="var(--slate-10)",
-                    ),
-                    align="center",
-                    padding_y="4",
+                NotificationCenterState.unread_count > 0,
+                rx.button(
+                    _t["notifications.center.mark_all_read"],
+                    on_click=NotificationCenterState.mark_all_read,
+                    variant="ghost",
+                    size="1",
+                    color_scheme="violet",
                 ),
-                rx.vstack(
-                    rx.foreach(
-                        NotificationCenterState.notifications,
-                        _notification_row,
-                    ),
-                    spacing="1",
-                    width="100%",
-                ),
+                rx.fragment(),
             ),
-            spacing="2",
-            padding="12px",
             width="100%",
+            align="center",
         ),
-        position="absolute",
-        bottom="56px",
-        left="8px",
-        width="320px",
-        max_height="400px",
-        overflow_y="auto",
-        border="1px solid var(--gray-a5)",
-        border_radius="8px",
-        bg="var(--color-background)",
-        box_shadow="0 4px 12px rgba(0,0,0,0.15)",
-        z_index="50",
+        rx.separator(),
+        rx.cond(
+            NotificationCenterState.notifications.length() == 0,
+            rx.vstack(
+                rx.icon("bell-off", size=24, color="var(--slate-8)"),
+                rx.text(
+                    _t["notifications.center.empty"],
+                    size="2",
+                    color="var(--slate-10)",
+                ),
+                align="center",
+                padding_y="4",
+            ),
+            rx.vstack(
+                rx.foreach(
+                    NotificationCenterState.notifications,
+                    _notification_row,
+                ),
+                spacing="1",
+                width="100%",
+            ),
+        ),
+        spacing="2",
+        width="100%",
     )
 
 
 def notification_bell() -> rx.Component:
-    return rx.box(
-        rx.icon_button(
-            rx.box(
-                rx.icon("bell", size=16),
-                rx.cond(
-                    NotificationCenterState.unread_count > 0,
-                    rx.badge(
-                        NotificationCenterState.unread_count,
-                        color_scheme="red",
-                        variant="solid",
-                        size="1",
-                        position="absolute",
-                        top="-4px",
-                        right="-4px",
+    return rx.popover.root(
+        rx.popover.trigger(
+            rx.icon_button(
+                rx.box(
+                    rx.icon("bell", size=16),
+                    rx.cond(
+                        NotificationCenterState.unread_count > 0,
+                        rx.badge(
+                            NotificationCenterState.unread_count,
+                            color_scheme="red",
+                            variant="solid",
+                            size="1",
+                            position="absolute",
+                            top="-4px",
+                            right="-4px",
+                        ),
+                        rx.fragment(),
                     ),
-                    rx.fragment(),
+                    position="relative",
                 ),
-                position="relative",
+                on_click=NotificationCenterState.load_notifications,
+                variant="ghost",
+                size="1",
             ),
-            on_click=NotificationCenterState.toggle_dropdown,
-            variant="ghost",
-            size="1",
         ),
-        rx.cond(
-            NotificationCenterState.dropdown_open,
-            notification_dropdown(),
-            rx.fragment(),
+        rx.popover.content(
+            _notification_dropdown_content(),
+            width="320px",
+            max_height="400px",
+            side="top",
+            align="start",
         ),
-        position="relative",
     )

--- a/datanika/ui/pages/audit_logs.py
+++ b/datanika/ui/pages/audit_logs.py
@@ -34,6 +34,7 @@ def audit_logs_page() -> rx.Component:
                         size="2",
                     ),
                     spacing="1",
+                    width="220px",
                 ),
                 rx.vstack(
                     rx.text(_t["audit.filter_resource"], size="2", weight="medium"),
@@ -53,6 +54,7 @@ def audit_logs_page() -> rx.Component:
                         size="2",
                     ),
                     spacing="1",
+                    width="220px",
                 ),
                 rx.button(
                     _t["audit.apply"],

--- a/datanika/ui/state/notification_center_state.py
+++ b/datanika/ui/state/notification_center_state.py
@@ -27,7 +27,6 @@ class NotificationItem(BaseModel):
 class NotificationCenterState(BaseState):
     notifications: list[NotificationItem] = []
     unread_count: int = 0
-    dropdown_open: bool = False
 
     async def load_notifications(self):
         from datanika.ui.state.auth_state import AuthState
@@ -111,6 +110,3 @@ class NotificationCenterState(BaseState):
             svc.dismiss(session, notification_id, org_id)
             session.commit()
         await self.load_notifications()
-
-    def toggle_dropdown(self):
-        self.dropdown_open = not self.dropdown_open

--- a/tests/test_ui/test_notification_bell.py
+++ b/tests/test_ui/test_notification_bell.py
@@ -1,0 +1,45 @@
+"""Regression tests for the notification bell component (#78).
+
+The bell dropdown was originally a hand-rolled `rx.box` toggled by a
+`dropdown_open` state field, with no outside-click or escape handler —
+users reported the popup never dismissed. The fix converts it to a
+`rx.popover.root`, which Radix wires to outside-click + escape natively.
+
+These tests guard against regressing back to the hand-rolled pattern.
+"""
+
+import reflex as rx
+
+from datanika.ui.components.notification_bell import notification_bell
+from datanika.ui.state.notification_center_state import NotificationCenterState
+
+
+class TestNotificationBellPopover:
+    def test_returns_radix_popover_root(self):
+        component = notification_bell()
+        # Radix popover root — Reflex wraps it in a class whose tag identifies it.
+        assert "popover" in type(component).__name__.lower() or any(
+            "popover" in type(child).__name__.lower()
+            for child in getattr(component, "children", [])
+        ), "notification_bell must use rx.popover.root so Radix handles outside-click + escape"
+
+    def test_state_has_no_dropdown_open_field(self):
+        # Radix manages open/close state internally — we must not reintroduce
+        # a Python-side `dropdown_open` flag, which previously caused the
+        # outside-click bug because nothing flipped it back to False.
+        state_attrs = set(NotificationCenterState.__annotations__.keys()) | set(
+            dir(NotificationCenterState)
+        )
+        assert "dropdown_open" not in state_attrs, (
+            "dropdown_open must not exist; let rx.popover.root manage open state"
+        )
+
+    def test_state_has_no_toggle_dropdown_method(self):
+        assert not hasattr(NotificationCenterState, "toggle_dropdown"), (
+            "toggle_dropdown must not exist; rx.popover.trigger handles toggling"
+        )
+
+    def test_renders_without_error(self):
+        component = notification_bell()
+        assert component is not None
+        assert isinstance(component, rx.Component)


### PR DESCRIPTION
Closes #78, #79.

## Summary

Two real-user UI bugs in `datanika-core`:

### #78 — Notification bell dropdown never closes
The bell in the sidebar opened a dropdown that wouldn't dismiss on outside-click or Escape. Root cause: `notification_bell.py` was a hand-rolled `rx.box` toggled by a `dropdown_open` state field. No outside-click handler, no Escape handler.

Converted to `rx.popover.root` / `rx.popover.trigger` / `rx.popover.content` (the same pattern `searchable_select.py` already uses correctly). Radix popover handles outside-click + escape natively. Dropped `dropdown_open` field and `toggle_dropdown` method from `NotificationCenterState` — Radix manages open state. Bell click still loads notifications via the trigger button's `on_click`.

**Audit**: I grepped all of `datanika/ui/` for the same anti-pattern (`dropdown_open|menu_open|popup_open|show_menu|is_open` + every `rx.popover/menu/dialog`). `notification_bell.py` was the only hand-rolled popover. All other dropdowns/menus/dialogs use `rx.popover` / `rx.dialog` / `rx.select` correctly. No systemic issue, no base-component fix needed.

### #79 — Audit log filter comboboxes too small
The action / resource-type filters on `/audit-logs` shrank to content width. Root cause: `searchable_select` defaults to `width="100%"`, but its parent `rx.vstack` had no fixed width, so 100% of nothing collapsed to text width.

Fix: added `width="220px"` to each filter `rx.vstack`. The longest enum value ("transformation") fits comfortably.

## Test plan
- [x] `tests/test_ui/test_notification_bell.py` — 4 new regression tests asserting `notification_bell` returns an `rx.popover` and that `dropdown_open` / `toggle_dropdown` can't be reintroduced
- [x] Existing `tests/test_ui/test_notification_center_state.py` — still green after dropping `dropdown_open` field
- [x] Full precheck: `bash plans/precheck.sh worktrees/datanika-core-engineering` — **1634 passed**, ruff clean
- [ ] Visual test on `app.datanika.io` after promotion: bell dropdown dismisses on outside-click and Escape; audit log comboboxes show full values

## Coordination
Product owns the notification UI component (`#74` shipped to `dev`). Their `current_state.txt` shows they've moved on to Tier 2 connector guides — not actively writing a fix for this. Backend (`InAppNotificationService`, hooks, API) untouched.