### PR TITLE
Drop /llms.txt "(5 tiers)" header — list has 6 items

### DIFF
--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -34,7 +34,7 @@ Default: 60 requests/minute per API key.
 Plan-based overrides: Free 30 RPM, Pro 120 RPM, Enterprise 300 RPM.
 Rate limit headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset.
 
-## Capabilities (5 tiers)
+## Capabilities
 
 1. **Discover** — GET /meta/connection-types, /meta/dlt-config-schema, \
 /meta/dbt-tests, /meta/materializations

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -46,6 +46,15 @@ class TestLlmsTxt:
         assert "Validate" in resp.text
         assert "Execute" in resp.text
 
+    def test_capabilities_header_has_no_tier_count(self, client):
+        # Regression for #80: header used to say "Capabilities (5 tiers)"
+        # while listing 6 items. The "5 tiers" label is internal roadmap
+        # language and doesn't belong in user-facing /llms.txt.
+        resp = client.get("/llms.txt")
+        assert "## Capabilities" in resp.text
+        assert "5 tiers" not in resp.text
+        assert "(5 tiers)" not in resp.text
+
     def test_no_auth_required(self, client):
         resp = client.get("/llms.txt")
         assert resp.status_code == 200


### PR DESCRIPTION
Closes #80.

## Summary

`/llms.txt` had `## Capabilities (5 tiers)` followed by a numbered list with **six** items (Discover, Introspect, Build, Validate, Execute, Control). The "5 tiers" label was internal roadmap language from the AI Agent Compatibility plan and shouldn't have leaked into the user-facing discovery doc.

Dropped the suffix. Header is now `## Capabilities`. Pure docs fix.

## Test plan
- [x] Added `test_capabilities_header_has_no_tier_count` regression assertion to `tests/test_services/test_agent_docs.py`
- [x] Full precheck: `bash plans/precheck.sh worktrees/datanika-core-engineering` — **1631 passed**, ruff clean