### PR TITLE
Ignore monorepo secrets/ folder (defense in depth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,5 @@ __marimo__/
 PLAN.md
 reflex.db*
 .secrets
+# Monorepo-wide secrets directory (defense in depth — actual secrets live at D:/Projects/Datanika/secrets/)
+secrets/


### PR DESCRIPTION
Adds `secrets/` to .gitignore as defense in depth. Actual secrets live outside the repo at `D:/Projects/Datanika/secrets/`; this just prevents accidents if anyone ever creates a `secrets/` folder inside the repo.