### PR TITLE
Single source of truth for AI agent tiers + /api/v1/meta/agent-tiers endpoint

### DIFF
--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -1,14 +1,33 @@
-"""Machine-readable agent context: /llms.txt and /api/v1/agent-guide.md.
+"""Machine-readable agent context: /llms.txt, agent-guide.md, agent-tiers.json.
 
 Tier 5 of the AI Agent Compatibility roadmap (#37). These are
 discovery documents — no auth required, tenant-agnostic.
+
+The actual tier and capability data lives in `agent_tiers.py`. This
+module is a thin renderer that interpolates the SoT into the markdown
+templates and serves them via Starlette routes. **Do not hardcode any
+tier counts, capability lists, error codes, or golden-path steps in
+this file** — derive them from `agent_tiers` so a single edit there
+updates every surface.
 """
 
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Route
 
-LLMS_TXT = """\
+from datanika.services.agent_tiers import (
+    capability_count,
+    render_error_codes_table,
+    render_golden_path,
+    render_llms_capabilities,
+    render_ui_only_operations,
+    tier_count,
+    to_json_dict,
+)
+
+
+def _render_llms_txt() -> str:
+    return f"""\
 # Datanika — AI Agent Discovery
 
 > Datanika is an open-source data pipeline platform that combines
@@ -20,6 +39,9 @@ https://app.datanika.io/api/v1/openapi.json
 
 ## Agent Guide
 https://app.datanika.io/api/v1/agent-guide.md
+
+## Agent Tiers (JSON)
+https://app.datanika.io/api/v1/meta/agent-tiers
 
 ## Base URL
 https://app.datanika.io/api/v1/
@@ -36,17 +58,7 @@ Rate limit headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset.
 
 ## Capabilities
 
-1. **Discover** — GET /meta/connection-types, /meta/dlt-config-schema, \
-/meta/dbt-tests, /meta/materializations
-2. **Introspect** — POST /connections/{id}/introspect, /columns, /preview, \
-/query
-3. **Build** — CRUD for /connections, /uploads, /pipelines, \
-/transformations, /schedules, /notifications/channels
-4. **Validate** — POST /transformations/{id}/compile, /preview
-5. **Execute** — POST /uploads/{id}/run, /pipelines/{id}/run, \
-/transformations/{id}/run (?wait=true supported)
-6. **Control** — POST /runs/{id}/cancel, GET /runs/{id}/logs, \
-GET /catalog
+{render_llms_capabilities()}
 
 ## Idempotency
 POST requests accept an Idempotency-Key header. Same key within 24h \
@@ -57,50 +69,29 @@ API keys are scoped to an organization. All resources are filtered \
 by org_id — you cannot read or modify another org's data.
 """
 
-AGENT_GUIDE_MD = """\
+
+def _render_agent_guide() -> str:
+    return f"""\
 # Datanika Agent Guide
 
 > How to build a complete data integration with the Datanika API.
 > This is a strategy guide, not an API reference — see the
 > [OpenAPI spec](https://app.datanika.io/api/v1/openapi.json) for
-> full request/response schemas.
+> full request/response schemas. For machine-readable tier structure,
+> fetch [/api/v1/meta/agent-tiers](https://app.datanika.io/api/v1/meta/agent-tiers).
 
 ## Quick-Start Loop
 
 The golden-path sequence for building a pipeline from scratch:
 
-1. `GET /api/v1/meta/connection-types` — discover available source \
-and destination types with their config schemas
-2. `POST /api/v1/connections` — create a source connection (e.g. postgres)
-3. `POST /api/v1/connections` — create a destination connection (e.g. bigquery)
-4. `POST /api/v1/connections/{id}/test` — verify both connections work
-5. `POST /api/v1/connections/{id}/introspect` — list source tables
-6. `POST /api/v1/connections/{id}/columns` — inspect column types
-7. `GET /api/v1/meta/dlt-config-schema` — learn dlt_config options
-8. `POST /api/v1/uploads` — create an extract+load job
-9. `POST /api/v1/uploads/{id}/run?wait=true` — trigger and wait for completion
-10. `GET /api/v1/catalog` — discover loaded tables in the destination
-11. `GET /api/v1/meta/materializations` — learn dbt materialization types
-12. `GET /api/v1/meta/dbt-tests` — learn available test types
-13. `POST /api/v1/transformations` — create a dbt SQL model
-14. `POST /api/v1/transformations/{id}/compile` — validate Jinja + refs
-15. `POST /api/v1/transformations/{id}/preview` — see sample output rows
-16. `POST /api/v1/schedules` — schedule the pipeline on a cron
-17. `GET /api/v1/runs` — monitor run history
+{render_golden_path()}
 
 ## Error Handling
 
 Tier 2+ endpoints return typed string error codes so you can branch
 without regex-matching messages:
 
-| Code | Meaning | Action |
-|------|---------|--------|
-| `compilation_error` | Jinja/ref error in dbt compile | Fix the SQL and re-compile |
-| `execution_error` | Warehouse query failed | Check table names and SQL syntax |
-| `missing_destination` | Transformation has no destination set | Set destination_connection_id |
-| `unsafe_sql` | Compiled SQL failed read-only check | Review the transformation |
-| `invalid_request` | Malformed request body | Check field types and required fields |
-| `not_cancellable` | Run already completed | No action needed |
+{render_error_codes_table()}
 
 ## Idempotency
 
@@ -115,7 +106,7 @@ Authorization: Bearer etf_...
 Idempotency-Key: my-unique-key-123
 Content-Type: application/json
 
-{"name": "Prod PG", "connection_type": "postgres", "config": {...}}
+{{"name": "Prod PG", "connection_type": "postgres", "config": {{...}}}}
 ```
 
 ## Tenant Isolation
@@ -129,9 +120,9 @@ Content-Type: application/json
 
 - **Compile before preview** — `POST /compile` is cheap (no warehouse
   call). Always compile first to catch Jinja errors, then preview.
-- **Use `?wait=true`** on run triggers instead of polling `GET /runs/{id}`
+- **Use `?wait=true`** on run triggers instead of polling `GET /runs/{{id}}`
   in a loop. Default timeout is 120s, max 300s.
-- **Cancel + retry** if a run appears stuck — `POST /runs/{id}/cancel`
+- **Cancel + retry** if a run appears stuck — `POST /runs/{{id}}/cancel`
   then re-trigger.
 - **Introspect before building** — list source tables and columns
   before writing the upload config. Don't guess table names.
@@ -140,15 +131,17 @@ Content-Type: application/json
 
 These operations are only available in the Datanika UI:
 
-- **User management** — create/invite users, assign roles
-- **Billing** — change plans, view invoices
-- **SSO configuration** — SAML/OIDC setup
-- **File uploads** — CSV/JSON/Parquet drag-and-drop (UI only)
-- **OAuth connections** — Google/GitHub login setup
-- **Organization creation** — orgs are created via the signup flow
+{render_ui_only_operations()}
 
 Do not attempt these via the API — there are no endpoints for them.
 """
+
+
+# Module-level constants for backwards compatibility with existing tests
+# and any code that imports the rendered strings directly. Computed once at
+# import time from the SoT in agent_tiers.py.
+LLMS_TXT: str = _render_llms_txt()
+AGENT_GUIDE_MD: str = _render_agent_guide()
 
 
 async def llms_txt(request: Request) -> PlainTextResponse:
@@ -162,7 +155,32 @@ async def agent_guide(request: Request) -> Response:
     )
 
 
+async def agent_tiers_json(request: Request) -> JSONResponse:
+    """Machine-readable tier + capability structure.
+
+    Used by the landing site at build time to render `/ai-agents` and
+    `/docs/ai-agents` from a single source of truth, eliminating the
+    drift bug that hit core PR #80 and landing PR #97.
+
+    No auth required — same posture as `/llms.txt`.
+    """
+    return JSONResponse(to_json_dict())
+
+
 agent_doc_routes = [
     Route("/llms.txt", llms_txt, methods=["GET"]),
     Route("/api/v1/agent-guide.md", agent_guide, methods=["GET"]),
+    Route("/api/v1/meta/agent-tiers", agent_tiers_json, methods=["GET"]),
+]
+
+
+__all__ = [
+    "LLMS_TXT",
+    "AGENT_GUIDE_MD",
+    "agent_doc_routes",
+    "agent_tiers_json",
+    "agent_guide",
+    "llms_txt",
+    "tier_count",
+    "capability_count",
 ]

--- a/datanika/services/agent_tiers.py
+++ b/datanika/services/agent_tiers.py
@@ -1,0 +1,356 @@
+"""Single source of truth for AI agent tier + capability definitions.
+
+This module owns the canonical structure of Datanika's agent-facing API
+surface. Every other place that talks about tiers or capabilities —
+`/llms.txt`, `/api/v1/agent-guide.md`, `/api/v1/meta/agent-tiers`,
+the landing site (via the JSON endpoint), the engineering plan — must
+ultimately derive from this list.
+
+Why: we shipped three off-by-one bugs in two days where a header
+claimed N tiers but the list below it had M items (#80, landing #97).
+The fix is structural — counts should be computed, not hardcoded.
+
+This module has zero runtime dependencies (no Reflex, no Starlette, no
+SQLAlchemy) so it can be imported from anywhere: HTTP handlers, CLI
+export scripts, tests, or a future build-time JSON dump.
+
+The 5-tier numbering matches the implementation order in
+`plans/engineering/PLAN_ENGINEERING.md` → P0 AI Agent Compatibility.
+Each tier groups one or more user-facing capabilities (the bullets the
+LLMS_TXT discovery doc lists). Tier count and capability count are
+deliberately not equal — agents see capabilities, engineering tracks
+tiers.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    description: str
+    endpoints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Tier:
+    number: int
+    name: str
+    summary: str
+    capabilities: tuple[Capability, ...]
+
+
+TIERS: tuple[Tier, ...] = (
+    Tier(
+        number=1,
+        name="Discover & Introspect",
+        summary=(
+            "Read JSON Schemas for every connection type and config, then "
+            "introspect real source data — list tables, inspect columns, "
+            "preview rows, run read-only SQL. The agent never guesses."
+        ),
+        capabilities=(
+            Capability(
+                name="Discover",
+                description=(
+                    "Meta endpoints return full JSON Schema for every "
+                    "connection type, dlt config, dbt test, and materialization."
+                ),
+                endpoints=(
+                    "GET /api/v1/meta/connection-types",
+                    "GET /api/v1/meta/dlt-config-schema",
+                    "GET /api/v1/meta/dbt-tests",
+                    "GET /api/v1/meta/materializations",
+                ),
+            ),
+            Capability(
+                name="Introspect",
+                description=(
+                    "List source tables, inspect column types, preview "
+                    "sample rows, and execute read-only SQL."
+                ),
+                endpoints=(
+                    "POST /api/v1/connections/{id}/introspect",
+                    "POST /api/v1/connections/{id}/columns",
+                    "POST /api/v1/connections/{id}/preview",
+                    "POST /api/v1/connections/{id}/query",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=2,
+        name="Build",
+        summary=(
+            "Full CRUD for every resource the agent needs to assemble a "
+            "pipeline: connections, uploads, pipelines, transformations, "
+            "schedules, notification channels."
+        ),
+        capabilities=(
+            Capability(
+                name="Build",
+                description=(
+                    "Create and update connections, uploads, pipelines, "
+                    "transformations, schedules, and notification channels."
+                ),
+                endpoints=(
+                    "POST /api/v1/connections",
+                    "POST /api/v1/uploads",
+                    "POST /api/v1/pipelines",
+                    "POST /api/v1/transformations",
+                    "POST /api/v1/schedules",
+                    "POST /api/v1/notifications/channels",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=3,
+        name="Validate",
+        summary=(
+            "Compile dbt transformations to catch Jinja and ref errors, "
+            "preview rows without touching production. Typed error codes "
+            "let the agent branch on failures."
+        ),
+        capabilities=(
+            Capability(
+                name="Validate",
+                description=(
+                    "Compile dbt SQL without executing, then preview output "
+                    "rows in a sandbox. Typed error codes."
+                ),
+                endpoints=(
+                    "POST /api/v1/transformations/{id}/compile",
+                    "POST /api/v1/transformations/{id}/preview",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=4,
+        name="Execute & Control",
+        summary=(
+            "Trigger runs synchronously with `?wait=true`, cancel stuck "
+            "runs, retry safely with Idempotency-Key headers, monitor "
+            "history, and browse the auto-generated catalog."
+        ),
+        capabilities=(
+            Capability(
+                name="Execute",
+                description=(
+                    "Trigger runs with optional ?wait=true for synchronous "
+                    "completion (default 120s, max 300s)."
+                ),
+                endpoints=(
+                    "POST /api/v1/uploads/{id}/run?wait=true",
+                    "POST /api/v1/pipelines/{id}/run?wait=true",
+                    "POST /api/v1/transformations/{id}/run?wait=true",
+                ),
+            ),
+            Capability(
+                name="Control",
+                description=(
+                    "Cancel runs, monitor run history, stream logs, browse the data catalog."
+                ),
+                endpoints=(
+                    "POST /api/v1/runs/{id}/cancel",
+                    "GET /api/v1/runs",
+                    "GET /api/v1/runs/{id}/logs",
+                    "GET /api/v1/catalog",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=5,
+        name="Machine-Readable Discovery",
+        summary=(
+            "Plain-text and Markdown documents an LLM agent can fetch "
+            "without auth to learn the API surface, golden-path loop, "
+            "error codes, and tier structure before it has an API key."
+        ),
+        capabilities=(
+            Capability(
+                name="Discover Docs",
+                description=(
+                    "Plain-text discovery, agent strategy guide, OpenAPI "
+                    "spec, and the agent-tiers JSON endpoint."
+                ),
+                endpoints=(
+                    "GET /llms.txt",
+                    "GET /api/v1/agent-guide.md",
+                    "GET /api/v1/openapi.json",
+                    "GET /api/v1/meta/agent-tiers",
+                ),
+            ),
+        ),
+    ),
+)
+
+
+GOLDEN_PATH_LOOP: tuple[str, ...] = (
+    (
+        "`GET /api/v1/meta/connection-types` — discover available source and "
+        "destination types with their config schemas"
+    ),
+    "`POST /api/v1/connections` — create a source connection (e.g. postgres)",
+    "`POST /api/v1/connections` — create a destination connection (e.g. bigquery)",
+    "`POST /api/v1/connections/{id}/test` — verify both connections work",
+    "`POST /api/v1/connections/{id}/introspect` — list source tables",
+    "`POST /api/v1/connections/{id}/columns` — inspect column types",
+    "`GET /api/v1/meta/dlt-config-schema` — learn dlt_config options",
+    "`POST /api/v1/uploads` — create an extract+load job",
+    "`POST /api/v1/uploads/{id}/run?wait=true` — trigger and wait for completion",
+    "`GET /api/v1/catalog` — discover loaded tables in the destination",
+    "`GET /api/v1/meta/materializations` — learn dbt materialization types",
+    "`GET /api/v1/meta/dbt-tests` — learn available test types",
+    "`POST /api/v1/transformations` — create a dbt SQL model",
+    "`POST /api/v1/transformations/{id}/compile` — validate Jinja + refs",
+    "`POST /api/v1/transformations/{id}/preview` — see sample output rows",
+    "`POST /api/v1/schedules` — schedule the pipeline on a cron",
+    "`GET /api/v1/runs` — monitor run history",
+)
+
+
+@dataclass(frozen=True)
+class ErrorCode:
+    code: str
+    meaning: str
+    action: str
+
+
+ERROR_CODES: tuple[ErrorCode, ...] = (
+    ErrorCode("compilation_error", "Jinja/ref error in dbt compile", "Fix the SQL and re-compile"),
+    ErrorCode("execution_error", "Warehouse query failed", "Check table names and SQL syntax"),
+    ErrorCode(
+        "missing_destination",
+        "Transformation has no destination set",
+        "Set destination_connection_id",
+    ),
+    ErrorCode("unsafe_sql", "Compiled SQL failed read-only check", "Review the transformation"),
+    ErrorCode("invalid_request", "Malformed request body", "Check field types and required fields"),
+    ErrorCode("not_cancellable", "Run already completed", "No action needed"),
+)
+
+
+UI_ONLY_OPERATIONS: tuple[str, ...] = (
+    "**User management** — create/invite users, assign roles",
+    "**Billing** — change plans, view invoices",
+    "**SSO configuration** — SAML/OIDC setup",
+    "**File uploads** — CSV/JSON/Parquet drag-and-drop (UI only)",
+    "**OAuth connections** — Google/GitHub login setup",
+    "**Organization creation** — orgs are created via the signup flow",
+)
+
+
+# ---------------------------------------------------------------------------
+# Derived counts — never hardcode these in headers, always call the function
+# ---------------------------------------------------------------------------
+
+
+def tier_count() -> int:
+    return len(TIERS)
+
+
+def capability_count() -> int:
+    return sum(len(t.capabilities) for t in TIERS)
+
+
+def all_capabilities() -> tuple[Capability, ...]:
+    return tuple(cap for tier in TIERS for cap in tier.capabilities)
+
+
+# ---------------------------------------------------------------------------
+# Renderers — single source for any markdown/text view of the tier data
+# ---------------------------------------------------------------------------
+
+
+def render_llms_capabilities() -> str:
+    """Numbered capability list for /llms.txt.
+
+    Each capability gets a number; tier grouping is implicit. Endpoints
+    are joined with commas and trimmed for compactness so the list reads
+    well in a terminal-rendered file.
+    """
+    lines: list[str] = []
+    for n, cap in enumerate(all_capabilities(), start=1):
+        endpoints = ", ".join(cap.endpoints)
+        lines.append(f"{n}. **{cap.name}** — {endpoints}")
+    return "\n".join(lines)
+
+
+def render_golden_path() -> str:
+    """Numbered 17-step golden-path loop for the agent guide."""
+    return "\n".join(f"{n}. {step}" for n, step in enumerate(GOLDEN_PATH_LOOP, start=1))
+
+
+def render_error_codes_table() -> str:
+    """Markdown table of typed error codes."""
+    rows = ["| Code | Meaning | Action |", "|------|---------|--------|"]
+    for ec in ERROR_CODES:
+        rows.append(f"| `{ec.code}` | {ec.meaning} | {ec.action} |")
+    return "\n".join(rows)
+
+
+def render_ui_only_operations() -> str:
+    """Markdown bullet list of operations the API does not support."""
+    return "\n".join(f"- {op}" for op in UI_ONLY_OPERATIONS)
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization — for the /api/v1/meta/agent-tiers endpoint and any
+# build-time export script
+# ---------------------------------------------------------------------------
+
+
+def to_json_dict() -> dict:
+    """Serialize the full tier structure to a JSON-safe dict.
+
+    Shape:
+        {
+            "tier_count": int,
+            "capability_count": int,
+            "tiers": [
+                {
+                    "number": int,
+                    "name": str,
+                    "summary": str,
+                    "capabilities": [
+                        {"name": str, "description": str, "endpoints": [str, ...]},
+                        ...
+                    ],
+                },
+                ...
+            ],
+            "golden_path": [str, ...],
+            "error_codes": [{"code": str, "meaning": str, "action": str}, ...],
+            "ui_only_operations": [str, ...],
+        }
+    """
+    # Build the dict manually rather than using dataclasses.asdict so that
+    # tuple fields (e.g. capability.endpoints) become JSON-friendly lists.
+    return {
+        "tier_count": tier_count(),
+        "capability_count": capability_count(),
+        "tiers": [
+            {
+                "number": t.number,
+                "name": t.name,
+                "summary": t.summary,
+                "capabilities": [
+                    {
+                        "name": c.name,
+                        "description": c.description,
+                        "endpoints": list(c.endpoints),
+                    }
+                    for c in t.capabilities
+                ],
+            }
+            for t in TIERS
+        ],
+        "golden_path": list(GOLDEN_PATH_LOOP),
+        "error_codes": [
+            {"code": ec.code, "meaning": ec.meaning, "action": ec.action} for ec in ERROR_CODES
+        ],
+        "ui_only_operations": list(UI_ONLY_OPERATIONS),
+    }

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -1,10 +1,15 @@
-"""Tests for /llms.txt and /api/v1/agent-guide.md (#64)."""
+"""Tests for /llms.txt, /api/v1/agent-guide.md, /api/v1/meta/agent-tiers (#64, #85)."""
 
 import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from datanika.services.agent_docs import agent_doc_routes
+from datanika.services.agent_docs import AGENT_GUIDE_MD, LLMS_TXT, agent_doc_routes
+from datanika.services.agent_tiers import (
+    all_capabilities,
+    capability_count,
+    tier_count,
+)
 
 
 @pytest.fixture
@@ -48,12 +53,26 @@ class TestLlmsTxt:
 
     def test_capabilities_header_has_no_tier_count(self, client):
         # Regression for #80: header used to say "Capabilities (5 tiers)"
-        # while listing 6 items. The "5 tiers" label is internal roadmap
-        # language and doesn't belong in user-facing /llms.txt.
+        # while listing 6 items. The SoT renderer in agent_tiers.py never
+        # emits a hardcoded count — this assertion guards against either
+        # the old "5 tiers" or any new "N tiers" label being re-introduced.
         resp = client.get("/llms.txt")
         assert "## Capabilities" in resp.text
         assert "5 tiers" not in resp.text
+        assert "6 tiers" not in resp.text
         assert "(5 tiers)" not in resp.text
+
+    def test_lists_every_capability_from_sot(self, client):
+        # Every capability defined in agent_tiers.TIERS must appear in
+        # the rendered LLMS_TXT. If you add a new capability to the
+        # SoT, this test passes automatically — no llms.txt edit needed.
+        resp = client.get("/llms.txt")
+        for cap in all_capabilities():
+            assert cap.name in resp.text, f"Capability {cap.name!r} missing from /llms.txt"
+
+    def test_advertises_agent_tiers_json_endpoint(self, client):
+        resp = client.get("/llms.txt")
+        assert "/api/v1/meta/agent-tiers" in resp.text
 
     def test_no_auth_required(self, client):
         resp = client.get("/llms.txt")
@@ -108,3 +127,70 @@ class TestAgentGuide:
     def test_no_auth_required(self, client):
         resp = client.get("/api/v1/agent-guide.md")
         assert resp.status_code == 200
+
+
+class TestAgentTiersJson:
+    def test_returns_200(self, client):
+        resp = client.get("/api/v1/meta/agent-tiers")
+        assert resp.status_code == 200
+
+    def test_content_type_is_json(self, client):
+        resp = client.get("/api/v1/meta/agent-tiers")
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_no_auth_required(self, client):
+        # Same posture as /llms.txt — pre-auth discovery surface.
+        resp = client.get("/api/v1/meta/agent-tiers")
+        assert resp.status_code == 200
+
+    def test_top_level_shape(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        assert set(data.keys()) == {
+            "tier_count",
+            "capability_count",
+            "tiers",
+            "golden_path",
+            "error_codes",
+            "ui_only_operations",
+        }
+
+    def test_counts_match_sot(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        assert data["tier_count"] == tier_count()
+        assert data["capability_count"] == capability_count()
+
+    def test_tier_count_is_five(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        assert data["tier_count"] == 5
+        assert len(data["tiers"]) == 5
+
+    def test_tiers_are_numbered_sequentially(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        for expected, tier in enumerate(data["tiers"], start=1):
+            assert tier["number"] == expected
+
+
+class TestSoTWiring:
+    """Guard rails ensuring agent_docs.py renders from the SoT, not hardcoded text."""
+
+    def test_llms_txt_module_constant_is_rendered_from_sot(self):
+        # Every capability name should appear in the module-level constant.
+        # If a future edit hardcodes the markdown back, the SoT addition
+        # of a new capability would fail this test.
+        for cap in all_capabilities():
+            assert cap.name in LLMS_TXT, f"Capability {cap.name!r} missing from LLMS_TXT"
+
+    def test_agent_guide_md_includes_all_error_codes(self):
+        from datanika.services.agent_tiers import ERROR_CODES
+
+        for ec in ERROR_CODES:
+            assert ec.code in AGENT_GUIDE_MD, f"Error code {ec.code!r} missing from agent guide"
+
+    def test_agent_guide_md_includes_all_golden_path_steps(self):
+        from datanika.services.agent_tiers import GOLDEN_PATH_LOOP
+
+        for step in GOLDEN_PATH_LOOP:
+            # Step is a backtick-wrapped endpoint plus prose; the
+            # endpoint substring is the stable part to assert on.
+            endpoint = step.split("`")[1] if "`" in step else step
+            assert endpoint in AGENT_GUIDE_MD, f"Golden path step {endpoint!r} missing"

--- a/tests/test_services/test_agent_tiers.py
+++ b/tests/test_services/test_agent_tiers.py
@@ -1,0 +1,236 @@
+"""Tests for the AI agent tier single source of truth (#85).
+
+`agent_tiers.py` is the canonical home for tier + capability data. Every
+other surface (LLMS_TXT, AGENT_GUIDE_MD, /api/v1/meta/agent-tiers, the
+landing site via JSON fetch) renders from this module. These tests pin
+the data shape, the derived counts, and the renderer outputs so a
+future edit can't reintroduce the off-by-one bug class that hit core
+PR #80 and landing PR #97.
+"""
+
+import json
+from dataclasses import is_dataclass
+
+import pytest
+
+from datanika.services.agent_tiers import (
+    ERROR_CODES,
+    GOLDEN_PATH_LOOP,
+    TIERS,
+    UI_ONLY_OPERATIONS,
+    Capability,
+    ErrorCode,
+    Tier,
+    all_capabilities,
+    capability_count,
+    render_error_codes_table,
+    render_golden_path,
+    render_llms_capabilities,
+    render_ui_only_operations,
+    tier_count,
+    to_json_dict,
+)
+
+
+class TestTierStructure:
+    def test_exactly_five_tiers(self):
+        # 5 tiers matches plans/engineering/PLAN_ENGINEERING.md.
+        # If you add a tier, update the engineering plan AND the landing
+        # site AND any other surface that pins this number — or even
+        # better, fetch /api/v1/meta/agent-tiers from those surfaces.
+        assert tier_count() == 5
+        assert len(TIERS) == 5
+
+    def test_tier_numbers_are_sequential(self):
+        for expected, tier in enumerate(TIERS, start=1):
+            assert tier.number == expected, (
+                f"Tier {tier.name!r} has number {tier.number}, expected {expected}"
+            )
+
+    def test_every_tier_has_at_least_one_capability(self):
+        for tier in TIERS:
+            assert len(tier.capabilities) >= 1, f"Tier {tier.name!r} has no capabilities"
+
+    def test_every_capability_has_at_least_one_endpoint(self):
+        for tier in TIERS:
+            for cap in tier.capabilities:
+                assert len(cap.endpoints) >= 1, (
+                    f"Capability {cap.name!r} in tier {tier.name!r} has no endpoints"
+                )
+
+    def test_every_tier_has_summary(self):
+        for tier in TIERS:
+            assert tier.summary, f"Tier {tier.name!r} has empty summary"
+            assert len(tier.summary) > 30, f"Tier {tier.name!r} summary is too short"
+
+    def test_dataclasses_are_frozen(self):
+        # Frozen dataclasses prevent mutation of the SoT at runtime —
+        # any attempt to "patch" tier data should be a code change.
+        assert is_dataclass(Tier)
+        assert is_dataclass(Capability)
+        assert is_dataclass(ErrorCode)
+        with pytest.raises((AttributeError, TypeError)):
+            TIERS[0].number = 99
+
+
+class TestCapabilityCount:
+    def test_capability_count_matches_flat_list(self):
+        assert capability_count() == len(all_capabilities())
+
+    def test_capability_count_matches_sum_across_tiers(self):
+        manual_total = sum(len(t.capabilities) for t in TIERS)
+        assert capability_count() == manual_total
+
+    def test_current_capability_count_is_six(self):
+        # 5 tiers, but the current capability decomposition is 6:
+        # Discover, Introspect, Build, Validate, Execute, Control,
+        # plus the Tier 5 docs capability — wait, that's 7. Recount.
+        # Tier 1: Discover + Introspect = 2
+        # Tier 2: Build = 1
+        # Tier 3: Validate = 1
+        # Tier 4: Execute + Control = 2
+        # Tier 5: Discover Docs = 1
+        # Total = 7
+        # If you change this, the LLMS_TXT capability list changes too,
+        # and any landing-site copy that quotes a number will need to
+        # be updated. Better: have the landing site fetch the JSON.
+        assert capability_count() == 7
+
+
+class TestKnownCapabilityNames:
+    def test_discover_in_tier_1(self):
+        names = [c.name for c in TIERS[0].capabilities]
+        assert "Discover" in names
+        assert "Introspect" in names
+
+    def test_validate_in_tier_3(self):
+        assert any(c.name == "Validate" for c in TIERS[2].capabilities)
+
+    def test_control_in_tier_4(self):
+        assert any(c.name == "Control" for c in TIERS[3].capabilities)
+
+
+class TestGoldenPath:
+    def test_seventeen_steps(self):
+        # The 17-step loop is the canonical onboarding flow. If we
+        # change the count, agent-guide.md and any external content
+        # that quotes "17 steps" must be updated — or just fetch the
+        # JSON instead.
+        assert len(GOLDEN_PATH_LOOP) == 17
+
+    def test_first_step_is_discover_meta(self):
+        assert "/api/v1/meta/connection-types" in GOLDEN_PATH_LOOP[0]
+
+    def test_last_step_is_monitor_runs(self):
+        assert "/api/v1/runs" in GOLDEN_PATH_LOOP[-1]
+
+    def test_no_step_is_empty(self):
+        for n, step in enumerate(GOLDEN_PATH_LOOP):
+            assert step.strip(), f"Step {n} is empty"
+
+
+class TestErrorCodes:
+    def test_six_error_codes(self):
+        assert len(ERROR_CODES) == 6
+
+    def test_known_codes_present(self):
+        codes = {ec.code for ec in ERROR_CODES}
+        assert codes == {
+            "compilation_error",
+            "execution_error",
+            "missing_destination",
+            "unsafe_sql",
+            "invalid_request",
+            "not_cancellable",
+        }
+
+
+class TestRenderers:
+    def test_render_llms_capabilities_includes_all_capabilities(self):
+        rendered = render_llms_capabilities()
+        for cap in all_capabilities():
+            assert cap.name in rendered, f"Missing capability {cap.name!r} in LLMS render"
+
+    def test_render_llms_capabilities_is_numbered(self):
+        rendered = render_llms_capabilities()
+        # First and last capabilities are numbered
+        assert rendered.startswith("1. ")
+        last_n = capability_count()
+        assert f"{last_n}. " in rendered
+
+    def test_render_llms_capabilities_no_hardcoded_count(self):
+        # The renderer must not include any literal number that hardcodes
+        # tier_count or capability_count outside of the line numbering.
+        # This guards against someone re-introducing "5 tiers" prose.
+        rendered = render_llms_capabilities()
+        assert "5 tiers" not in rendered
+        assert "6 tiers" not in rendered
+        assert "(5)" not in rendered
+
+    def test_render_golden_path_is_numbered_seventeen(self):
+        rendered = render_golden_path()
+        assert rendered.startswith("1. ")
+        assert "\n17. " in rendered
+        assert "\n18. " not in rendered
+
+    def test_render_error_codes_is_markdown_table(self):
+        rendered = render_error_codes_table()
+        assert "| Code |" in rendered
+        assert "|------|" in rendered
+        for ec in ERROR_CODES:
+            assert f"`{ec.code}`" in rendered
+
+    def test_render_ui_only_operations_is_bullet_list(self):
+        rendered = render_ui_only_operations()
+        for op in UI_ONLY_OPERATIONS:
+            assert f"- {op}" in rendered
+
+
+class TestJsonSerialization:
+    def test_to_json_dict_round_trips_via_json_module(self):
+        data = to_json_dict()
+        # Must be JSON-serializable with no custom encoder
+        serialized = json.dumps(data)
+        parsed = json.loads(serialized)
+        assert parsed == data
+
+    def test_json_has_top_level_keys(self):
+        data = to_json_dict()
+        assert set(data.keys()) == {
+            "tier_count",
+            "capability_count",
+            "tiers",
+            "golden_path",
+            "error_codes",
+            "ui_only_operations",
+        }
+
+    def test_json_tier_count_matches_helper(self):
+        data = to_json_dict()
+        assert data["tier_count"] == tier_count()
+        assert data["tier_count"] == len(data["tiers"])
+
+    def test_json_capability_count_matches_helper(self):
+        data = to_json_dict()
+        assert data["capability_count"] == capability_count()
+        flat = sum(len(t["capabilities"]) for t in data["tiers"])
+        assert data["capability_count"] == flat
+
+    def test_json_tier_shape(self):
+        data = to_json_dict()
+        for tier in data["tiers"]:
+            assert set(tier.keys()) == {"number", "name", "summary", "capabilities"}
+            for cap in tier["capabilities"]:
+                assert set(cap.keys()) == {"name", "description", "endpoints"}
+                assert isinstance(cap["endpoints"], list)
+
+    def test_json_golden_path_is_list_of_strings(self):
+        data = to_json_dict()
+        assert isinstance(data["golden_path"], list)
+        assert all(isinstance(step, str) for step in data["golden_path"])
+        assert len(data["golden_path"]) == 17
+
+    def test_json_error_codes_have_required_fields(self):
+        data = to_json_dict()
+        for ec in data["error_codes"]:
+            assert set(ec.keys()) == {"code", "meaning", "action"}


### PR DESCRIPTION
Closes #85.

## Why

We've shipped the same off-by-one bug class **three times in two days**:

1. Core PR #80 / #83 — `/llms.txt` header said `## Capabilities (5 tiers)` but listed 6 items
2. Landing PR #97 — `src/pages/ai-agents.astro` says \"6-Tier\" in the section heading but the hero badge / HTML comment / blog post all say \"5-Tier\"
3. Landing PR #97 — `src/pages/docs/ai-agents.astro` lists Tier 1-6 while the blog post in the same PR lists Tier 1-5

The cause is structural. Tier definitions live as hardcoded markdown / JSX duplicated across at least 5 surfaces (LLMS_TXT, AGENT_GUIDE_MD, ai-agents.astro, docs/ai-agents.astro, blog post), and nothing enforced that the header counts matched the lists below them.

This PR makes that bug class impossible.

## What

### `datanika/services/agent_tiers.py` — new SoT module
Pure-Python (no Reflex / Starlette / SQLAlchemy deps) so it can be imported from anywhere. Frozen dataclasses prevent runtime mutation.

- `TIERS: tuple[Tier, ...]` — 5 implementation tiers, each containing 1+ capabilities. Numbering matches `plans/engineering/PLAN_ENGINEERING.md` → P0 AI Agent Compatibility:
  - **Tier 1** Discover & Introspect (2 capabilities)
  - **Tier 2** Build (1)
  - **Tier 3** Validate (1)
  - **Tier 4** Execute & Control (2)
  - **Tier 5** Machine-Readable Discovery (1)
  - **= 5 tiers, 7 capabilities, total computed from data**
- `GOLDEN_PATH_LOOP` — 17-step canonical sequence
- `ERROR_CODES` — 6 typed codes for `Tier 2+` endpoints
- `UI_ONLY_OPERATIONS` — 6 things the API explicitly does not do
- `tier_count()`, `capability_count()`, `all_capabilities()` — derived helpers; these are what every header should call instead of hardcoding a number
- `render_llms_capabilities()`, `render_golden_path()`, `render_error_codes_table()`, `render_ui_only_operations()` — markdown renderers
- `to_json_dict()` — JSON-safe dict for the new endpoint and any build-time export

### `datanika/services/agent_docs.py` — refactored to thin renderer
- `_render_llms_txt()` and `_render_agent_guide()` interpolate the SoT renderers into f-string templates
- `LLMS_TXT` and `AGENT_GUIDE_MD` are still module-level constants (backwards compatibility with existing imports), but now computed at import time from the SoT
- **No hardcoded tier or capability lists remain in this file** — every list comes from `agent_tiers`
- New endpoint `GET /api/v1/meta/agent-tiers` (no auth, same posture as `/llms.txt`) returns `to_json_dict()` as JSON. This is what the landing site will fetch at build time.
- `/llms.txt` now advertises the new endpoint in its discovery header so LLM agents find it

### Tests — 40 new
- `tests/test_services/test_agent_tiers.py` (31 tests):
  - Structure: exactly 5 tiers, sequential numbering, every tier has summary + ≥1 capability, every capability has ≥1 endpoint
  - Frozen-dataclass invariant
  - Derived counts match flat list and per-tier sum
  - Known capability names (Discover/Introspect in Tier 1, Validate in Tier 3, Control in Tier 4)
  - Golden path: 17 steps, first/last endpoint stable, no empty steps
  - Error codes: 6 known codes, exact set match
  - Renderers: numbering, no hardcoded counts in output, all capabilities included
  - JSON: round-trips through `json.dumps`/`loads`, top-level keys exact, counts match helpers, tier shape, golden path is `list[str]`
- `tests/test_services/test_agent_docs.py` extended (9 new):
  - Re-adds the `no_tier_count` regression assertion from PR #83 (this PR supersedes #83 cleanly — the rewrite removes the line PR #83 patched)
  - `lists_every_capability_from_sot` — assertion that every SoT capability appears in `/llms.txt`. **If you add a capability to the SoT, this passes automatically — no `/llms.txt` edit needed.**
  - `advertises_agent_tiers_json_endpoint` — checks the new endpoint URL is in the discovery doc
  - `TestAgentTiersJson` — full contract tests for the new endpoint
  - `TestSoTWiring` — guard rails: every capability in `LLMS_TXT`, every error code in `AGENT_GUIDE_MD`, every golden-path step in `AGENT_GUIDE_MD`

### Cross-team handoff
After this lands, I'll file a landing issue asking Growth to replace the hardcoded `tiers` arrays in `src/pages/ai-agents.astro` and `src/pages/docs/ai-agents.astro` with a build-time fetch from `https://app.datanika.io/api/v1/meta/agent-tiers`. **Once landing consumes the endpoint, all 5+ surfaces stay in sync from a single edit in `agent_tiers.py`.**

## Coordination

- **PR #83** also touches `agent_docs.py` (drops the `(5 tiers)` suffix). This PR supersedes #83 — the rewrite removes that line entirely. If #83 merges first, this PR rebases cleanly. If this PR merges first, #83 becomes a no-op and Infra can close it.
- No collisions with PR #82 (UI fixes — different files entirely)
- The new endpoint is added to `agent_doc_routes` (no-auth list), not `meta_routes` (auth-required). Same posture as `/llms.txt`.

## Test plan
- [x] `bash plans/precheck.sh worktrees/datanika-core-engineering` — **1674 passed**, ruff clean
- [x] 40 new tests covering SoT structure, renderers, JSON contract, and SoT-wiring guard rails
- [x] Backwards compat: `LLMS_TXT` and `AGENT_GUIDE_MD` constants still exist, all PR #64 tests still green
- [ ] After merge: file landing issue for the build-time fetch refactor