### PR TITLE
Rename deprecated lucide icon alert-triangle → triangle-alert

### DIFF
--- a/datanika/ui/components/notification_bell.py
+++ b/datanika/ui/components/notification_bell.py
@@ -31,7 +31,7 @@ def _type_icon(ntype: rx.Var[str]) -> rx.Component:
             rx.icon("circle-check", size=16, color="var(--green-9)"),
             rx.cond(
                 ntype == "quota_warning",
-                rx.icon("alert-triangle", size=16, color="var(--amber-9)"),
+                rx.icon("triangle-alert", size=16, color="var(--amber-9)"),
                 rx.icon("octagon-alert", size=16, color="var(--red-9)"),
             ),
         ),

--- a/datanika/ui/pages/dashboard.py
+++ b/datanika/ui/pages/dashboard.py
@@ -123,7 +123,7 @@ def usage_bar() -> rx.Component:
                 rx.cond(
                     DashboardState.runs_percent >= 80,
                     rx.hstack(
-                        rx.icon("alert-triangle", size=14, color="var(--red-11)"),
+                        rx.icon("triangle-alert", size=14, color="var(--red-11)"),
                         rx.link(
                             rx.text(
                                 _t["dashboard.usage_upgrade"],

--- a/datanika/ui/state/notification_center_state.py
+++ b/datanika/ui/state/notification_center_state.py
@@ -8,7 +8,7 @@ from datanika.ui.state.base_state import BaseState, get_sync_session
 NOTIFICATION_TYPE_ICONS: dict[str, str] = {
     "run_failed": "circle-x",
     "run_succeeded": "circle-check",
-    "quota_warning": "alert-triangle",
+    "quota_warning": "triangle-alert",
     "quota_exceeded": "octagon-alert",
 }
 

--- a/tests/test_ui/test_notification_center_state.py
+++ b/tests/test_ui/test_notification_center_state.py
@@ -42,6 +42,20 @@ class TestTypeIcons:
             assert isinstance(icon, str)
             assert len(icon) > 0
 
+    def test_no_deprecated_lucide_names(self):
+        # Regression for #88: lucide-react renamed `alert-triangle` to
+        # `triangle-alert` in v0.359.0 (March 2024). Reflex emits a
+        # deprecation warning at compile time for the old name. Pin
+        # the new name so we don't drift back.
+        deprecated = {"alert-triangle"}
+        for type_name, icon in NOTIFICATION_TYPE_ICONS.items():
+            assert icon not in deprecated, (
+                f"{type_name} uses deprecated lucide icon {icon!r}; use the new name"
+            )
+
+    def test_quota_warning_uses_triangle_alert(self):
+        assert NOTIFICATION_TYPE_ICONS["quota_warning"] == "triangle-alert"
+
 
 class TestNotificationCenterStateStructure:
     def test_has_required_fields(self):


### PR DESCRIPTION
Closes #88.

## Summary
lucide-react renamed `alert-triangle` to `triangle-alert` in v0.359.0 (March 2024). Reflex's bundled lucide emits a deprecation warning at compile time for the old name; future lucide releases will remove it entirely. Pure rename — same glyph, new name.

## Files
- `datanika/ui/state/notification_center_state.py:11` — `NOTIFICATION_TYPE_ICONS[\"quota_warning\"]` registry value (the SoT for icon names)
- `datanika/ui/components/notification_bell.py:34` — `_type_icon` dispatch for quota_warning notifications
- `datanika/ui/pages/dashboard.py:126` — usage upgrade hint icon when runs quota ≥ 80%

## Test plan
- [x] `tests/test_ui/test_notification_center_state.py::TestTypeIcons::test_no_deprecated_lucide_names` — pins the deprecated set so we can't drift back
- [x] `test_quota_warning_uses_triangle_alert` — explicit assertion on the new name
- [x] `bash plans/precheck.sh worktrees/datanika-core-engineering` — **1632 passed**, ruff clean
- [ ] Visual: confirm Reflex deprecation warning gone from app logs after Infra promotion

## Coordination
Tiny scope, no collisions with PR #82 (already touched `notification_bell.py` for the popover fix — different lines), PR #87 (different files), PR #83 (different files).