### PR TITLE
Promote dev → master: Pipeline Templates, UI bug fixes, agent tiers SoT, icon fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,5 @@ __marimo__/
 PLAN.md
 reflex.db*
 .secrets
+# Monorepo-wide secrets directory (defense in depth — actual secrets live at D:/Projects/Datanika/secrets/)
+secrets/

--- a/datanika/data/__init__.py
+++ b/datanika/data/__init__.py
@@ -1,0 +1,6 @@
+"""Static data registries: pipeline templates, presets, and similar.
+
+Modules in this package contain pure-Python data (dataclasses, dicts, frozensets)
+that the rest of the app reads but never writes. Nothing here touches the
+database or external services.
+"""

--- a/datanika/data/pipeline_templates.py
+++ b/datanika/data/pipeline_templates.py
@@ -1,0 +1,138 @@
+"""Pipeline templates — pre-configured source→destination starters.
+
+Each template captures the *non-credential* configuration decisions a new
+user would otherwise have to make on their own:
+
+- which source connector to set up
+- which destination connector to use
+- sensible default settings for both connections (schemas, regions, etc.)
+- which dlt resources/tables to extract and the right write disposition
+
+The user still enters their own credentials. Templates do not run pipelines
+end-to-end on their own — they prefill forms in the connection creation flow
+so a Google Ads visitor can go from "empty dashboard" to "first run" in
+roughly two minutes instead of stalling on configuration decisions.
+
+This module is intentionally pure data: a frozen dataclass plus a small
+registry. Templates are not stored in the database, do not require a
+migration, and do not have an admin UI. To add a template, append to
+LAUNCH_TEMPLATES, add the matching i18n keys to all locale files, and add a
+test row to ``tests/test_data/test_pipeline_templates.py``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from datanika.models.connection import ConnectionType
+
+
+@dataclass(frozen=True)
+class PipelineTemplate:
+    """A pre-configured source→destination starter pipeline.
+
+    Attributes:
+        slug: URL-safe stable identifier (e.g. ``"stripe-to-postgres"``).
+        name_key: i18n key for the human-readable display name.
+        description_key: i18n key for the one-line description shown on the card.
+        source_type: ConnectionType the template's source connection will use.
+        destination_type: ConnectionType the template's destination uses.
+        source_config_defaults: Non-credential connection-form fields to
+            prefill on the source side (e.g. default schema, region, port).
+        destination_config_defaults: Same for the destination connection.
+        dlt_config_defaults: Default extract/load configuration — at minimum
+            ``write_disposition``, plus connector-specific keys like
+            ``resources`` (Stripe) or ``tables`` (Postgres).
+        icon_source: Connector slug used to look up the source icon in the UI.
+        icon_destination: Connector slug used to look up the destination icon.
+    """
+
+    slug: str
+    name_key: str
+    description_key: str
+    source_type: ConnectionType
+    destination_type: ConnectionType
+    icon_source: str
+    icon_destination: str
+    source_config_defaults: dict[str, Any] = field(default_factory=dict)
+    destination_config_defaults: dict[str, Any] = field(default_factory=dict)
+    dlt_config_defaults: dict[str, Any] = field(default_factory=dict)
+
+
+LAUNCH_TEMPLATES: tuple[PipelineTemplate, ...] = (
+    PipelineTemplate(
+        slug="stripe-to-postgres",
+        name_key="templates.stripe_to_postgres.name",
+        description_key="templates.stripe_to_postgres.description",
+        source_type=ConnectionType.STRIPE,
+        destination_type=ConnectionType.POSTGRES,
+        icon_source="stripe",
+        icon_destination="postgres",
+        source_config_defaults={
+            # Stripe connections only require the API key — nothing else to
+            # prefill on the source side. Listed explicitly so future fields
+            # have an obvious place to land.
+        },
+        destination_config_defaults={
+            "schema": "raw_stripe",
+            "port": "5432",
+        },
+        dlt_config_defaults={
+            "resources": ["Customer", "Charge", "Invoice", "Subscription", "Product", "Price"],
+            "write_disposition": "merge",
+        },
+    ),
+    PipelineTemplate(
+        slug="postgres-to-bigquery",
+        name_key="templates.postgres_to_bigquery.name",
+        description_key="templates.postgres_to_bigquery.description",
+        source_type=ConnectionType.POSTGRES,
+        destination_type=ConnectionType.BIGQUERY,
+        icon_source="postgres",
+        icon_destination="bigquery",
+        source_config_defaults={
+            "port": "5432",
+            "schema": "public",
+        },
+        destination_config_defaults={
+            "dataset": "raw_postgres",
+        },
+        dlt_config_defaults={
+            "write_disposition": "merge",
+        },
+    ),
+    PipelineTemplate(
+        slug="csv-to-duckdb",
+        name_key="templates.csv_to_duckdb.name",
+        description_key="templates.csv_to_duckdb.description",
+        source_type=ConnectionType.CSV,
+        destination_type=ConnectionType.DUCKDB,
+        icon_source="csv",
+        icon_destination="duckdb",
+        source_config_defaults={},
+        destination_config_defaults={
+            "schema": "raw_csv",
+        },
+        dlt_config_defaults={
+            "write_disposition": "replace",
+        },
+    ),
+)
+
+
+def list_templates() -> list[PipelineTemplate]:
+    """Return a fresh list of all launch templates.
+
+    Returns a *copy* so callers can mutate the list freely without
+    corrupting the registry.
+    """
+    return list(LAUNCH_TEMPLATES)
+
+
+def get_template(slug: str) -> PipelineTemplate | None:
+    """Look up a template by slug. Returns ``None`` if no template matches."""
+    if not slug:
+        return None
+    for tpl in LAUNCH_TEMPLATES:
+        if tpl.slug == slug:
+            return tpl
+    return None

--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -11,6 +11,7 @@ from datanika.ui.pages.dashboard import dashboard_page
 from datanika.ui.pages.login import login_page
 from datanika.ui.pages.model_detail import model_detail_page
 from datanika.ui.pages.models import models_page
+from datanika.ui.pages.pipeline_templates import pipeline_templates_page
 from datanika.ui.pages.pipelines import pipelines_page
 from datanika.ui.pages.runs import runs_page
 from datanika.ui.pages.schedules import schedules_page
@@ -86,7 +87,11 @@ app.add_page(
     connections_page,
     route="/connections",
     title="Connections | Datanika",
-    on_load=[AuthState.check_auth, ConnectionState.load_connections],
+    on_load=[
+        AuthState.check_auth,
+        ConnectionState.load_connections,
+        ConnectionState.load_template_from_query,
+    ],
 )
 app.add_page(
     uploads_page,
@@ -111,6 +116,12 @@ app.add_page(
     route="/pipelines",
     title="Pipelines | Datanika",
     on_load=[AuthState.check_auth, PipelineState.load_pipelines],
+)
+app.add_page(
+    pipeline_templates_page,
+    route="/pipelines/templates",
+    title="Pipeline Templates | Datanika",
+    on_load=[AuthState.check_auth],
 )
 app.add_page(
     schedules_page,

--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "تحذير الحصة",
   "notifications.quota_exceeded.title": "تجاوز الحصة",
   "notifications.dismiss": "تجاهل",
-  "notifications.view_run": "عرض التشغيل"
+  "notifications.view_run": "عرض التشغيل",
+  "templates.heading": "قوالب خطوط الأنابيب",
+  "templates.subtitle": "نقاط بداية معدّة مسبقًا تتخطى القرارات المملة. اختر واحدة، أدخل بيانات الاعتماد، واحصل على خط أنابيب يعمل خلال دقائق.",
+  "templates.use_this_template": "استخدم هذا القالب",
+  "templates.help_text": "تملأ القوالب فقط القيم الافتراضية غير الحساسة — المخططات والمنافذ واختيارات الجداول. تدخل بيانات الاعتماد دائمًا بنفسك.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "حمّل عملاء Stripe والمدفوعات والفواتير والاشتراكات في مستودع Postgres الخاص بك لتحليل الإيرادات.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "زامن قاعدة بيانات Postgres التشغيلية الخاصة بك مع BigQuery — أكثر خطوط الأنابيب التحليلية شيوعًا.",
+  "templates.csv_to_duckdb.name": "رفع CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "اسحب ملف CSV واستعلم عنه فورًا باستخدام DuckDB. لا حاجة لبيانات اعتماد — أسرع طريقة لتجربة Datanika.",
+  "pipelines.empty_heading": "لا توجد خطوط أنابيب بعد",
+  "pipelines.empty_subtitle": "ابدأ من قالب معدّ مسبقًا، أو مرر للأسفل لبناء واحد من الصفر.",
+  "pipelines.start_from_template": "ابدأ من قالب"
 }

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Kontingentwarnung",
   "notifications.quota_exceeded.title": "Kontingent überschritten",
   "notifications.dismiss": "Verwerfen",
-  "notifications.view_run": "Ausführung anzeigen"
+  "notifications.view_run": "Ausführung anzeigen",
+  "templates.heading": "Pipeline-Vorlagen",
+  "templates.subtitle": "Vorkonfigurierte Starter, die langweilige Entscheidungen überspringen. Wähle eine, gib deine Zugangsdaten ein und du hast in wenigen Minuten eine funktionierende Pipeline.",
+  "templates.use_this_template": "Diese Vorlage verwenden",
+  "templates.help_text": "Vorlagen füllen nur unkritische Standardwerte vor — Schemas, Ports, Tabellenauswahl. Zugangsdaten gibst du immer selbst ein.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Lade Stripe-Kunden, Zahlungen, Rechnungen und Abonnements in dein Postgres-Warehouse für Umsatzanalysen.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Synchronisiere deine operative Postgres-Datenbank in BigQuery — die häufigste Analyse-Pipeline.",
+  "templates.csv_to_duckdb.name": "CSV-Upload → DuckDB",
+  "templates.csv_to_duckdb.description": "Zieh eine CSV-Datei hinein und frag sie sofort mit DuckDB ab. Keine Zugangsdaten nötig — der schnellste Weg, Datanika auszuprobieren.",
+  "pipelines.empty_heading": "Noch keine Pipelines",
+  "pipelines.empty_subtitle": "Starte mit einer vorkonfigurierten Vorlage oder scrolle nach unten, um eine von Grund auf zu erstellen.",
+  "pipelines.start_from_template": "Mit einer Vorlage starten"
 }

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Προειδοποίηση ορίου",
   "notifications.quota_exceeded.title": "Υπέρβαση ορίου",
   "notifications.dismiss": "Απόρριψη",
-  "notifications.view_run": "Προβολή εκτέλεσης"
+  "notifications.view_run": "Προβολή εκτέλεσης",
+  "templates.heading": "Πρότυπα Pipeline",
+  "templates.subtitle": "Προρυθμισμένα σημεία εκκίνησης που παρακάμπτουν τις βαρετές αποφάσεις. Επιλέξτε ένα, εισαγάγετε τα διαπιστευτήριά σας και αποκτήστε ένα λειτουργικό pipeline σε λίγα λεπτά.",
+  "templates.use_this_template": "Χρήση αυτού του προτύπου",
+  "templates.help_text": "Τα πρότυπα συμπληρώνουν μόνο μη ευαίσθητες προεπιλογές — σχήματα, θύρες, επιλογές πινάκων. Τα διαπιστευτήρια τα εισάγετε πάντα εσείς.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Φέρτε πελάτες, χρεώσεις, τιμολόγια και συνδρομές του Stripe στην αποθήκη Postgres για ανάλυση εσόδων.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Συγχρονίστε τη λειτουργική σας βάση Postgres στο BigQuery — το πιο συνηθισμένο αναλυτικό pipeline.",
+  "templates.csv_to_duckdb.name": "Μεταφόρτωση CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Σύρετε ένα CSV και κάντε αμέσως ερωτήματα με DuckDB. Δεν χρειάζονται διαπιστευτήρια — ο γρηγορότερος τρόπος να δοκιμάσετε το Datanika.",
+  "pipelines.empty_heading": "Δεν υπάρχουν ακόμα pipelines",
+  "pipelines.empty_subtitle": "Ξεκινήστε από ένα προρυθμισμένο πρότυπο ή κατεβείτε για να φτιάξετε ένα από την αρχή.",
+  "pipelines.start_from_template": "Ξεκινήστε από πρότυπο"
 }

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Quota warning",
   "notifications.quota_exceeded.title": "Quota exceeded",
   "notifications.dismiss": "Dismiss",
-  "notifications.view_run": "View run"
+  "notifications.view_run": "View run",
+  "templates.heading": "Pipeline Templates",
+  "templates.subtitle": "Pre-configured starters that skip the boring decisions. Pick one, plug in your credentials, and have a working pipeline in minutes.",
+  "templates.use_this_template": "Use this template",
+  "templates.help_text": "Templates only prefill non-sensitive defaults — schemas, ports, table selections. You always enter your own credentials.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Land Stripe customers, charges, invoices and subscriptions in your Postgres warehouse for revenue analytics.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Sync your operational Postgres database into BigQuery — the most common analytics pipeline.",
+  "templates.csv_to_duckdb.name": "CSV Upload → DuckDB",
+  "templates.csv_to_duckdb.description": "Drag a CSV in, query it instantly with DuckDB. No credentials needed — the fastest way to try Datanika.",
+  "pipelines.empty_heading": "No pipelines yet",
+  "pipelines.empty_subtitle": "Start from a pre-configured template, or scroll down to build one from scratch.",
+  "pipelines.start_from_template": "Start from a template"
 }

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Advertencia de cuota",
   "notifications.quota_exceeded.title": "Cuota excedida",
   "notifications.dismiss": "Descartar",
-  "notifications.view_run": "Ver ejecución"
+  "notifications.view_run": "Ver ejecución",
+  "templates.heading": "Plantillas de pipeline",
+  "templates.subtitle": "Inicios preconfigurados que evitan decisiones aburridas. Elige uno, introduce tus credenciales y consigue una canalización funcional en minutos.",
+  "templates.use_this_template": "Usar esta plantilla",
+  "templates.help_text": "Las plantillas solo rellenan valores no sensibles: esquemas, puertos, selección de tablas. Las credenciales las introduces siempre tú.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Lleva clientes, cargos, facturas y suscripciones de Stripe a tu almacén Postgres para análisis de ingresos.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Sincroniza tu base de datos operativa Postgres con BigQuery — la canalización analítica más común.",
+  "templates.csv_to_duckdb.name": "Subida de CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Arrastra un CSV y consúltalo al instante con DuckDB. Sin credenciales — la forma más rápida de probar Datanika.",
+  "pipelines.empty_heading": "Aún no hay canalizaciones",
+  "pipelines.empty_subtitle": "Comienza con una plantilla preconfigurada o desplázate para crear una desde cero.",
+  "pipelines.start_from_template": "Empezar con una plantilla"
 }

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Avertissement de quota",
   "notifications.quota_exceeded.title": "Quota dépassé",
   "notifications.dismiss": "Ignorer",
-  "notifications.view_run": "Voir l'exécution"
+  "notifications.view_run": "Voir l'exécution",
+  "templates.heading": "Modèles de pipeline",
+  "templates.subtitle": "Démarrages préconfigurés qui évitent les décisions ennuyeuses. Choisissez-en un, saisissez vos identifiants et obtenez un pipeline fonctionnel en quelques minutes.",
+  "templates.use_this_template": "Utiliser ce modèle",
+  "templates.help_text": "Les modèles ne préremplissent que des valeurs par défaut non sensibles : schémas, ports, sélections de tables. Vous saisissez toujours vos identifiants vous-même.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Chargez les clients, paiements, factures et abonnements Stripe dans votre entrepôt Postgres pour l'analyse du chiffre d'affaires.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Synchronisez votre base Postgres opérationnelle avec BigQuery — le pipeline d'analyse le plus courant.",
+  "templates.csv_to_duckdb.name": "Téléversement CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Glissez un CSV, interrogez-le instantanément avec DuckDB. Aucun identifiant nécessaire — le moyen le plus rapide d'essayer Datanika.",
+  "pipelines.empty_heading": "Aucun pipeline pour le moment",
+  "pipelines.empty_subtitle": "Démarrez avec un modèle préconfiguré ou faites défiler vers le bas pour en créer un de zéro.",
+  "pipelines.start_from_template": "Démarrer avec un modèle"
 }

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Предупреждение о квоте",
   "notifications.quota_exceeded.title": "Квота превышена",
   "notifications.dismiss": "Скрыть",
-  "notifications.view_run": "Перейти к запуску"
+  "notifications.view_run": "Перейти к запуску",
+  "templates.heading": "Шаблоны пайплайнов",
+  "templates.subtitle": "Готовые шаблоны, которые избавляют от рутинных решений. Выберите один, введите свои учётные данные и получите рабочий пайплайн за считанные минуты.",
+  "templates.use_this_template": "Использовать этот шаблон",
+  "templates.help_text": "Шаблоны заполняют только нечувствительные значения — схемы, порты, выбор таблиц. Учётные данные вы всегда вводите сами.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Загружайте клиентов, платежи, счета и подписки Stripe в Postgres для аналитики выручки.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Синхронизируйте операционную базу Postgres с BigQuery — самый распространённый аналитический пайплайн.",
+  "templates.csv_to_duckdb.name": "Загрузка CSV → DuckDB",
+  "templates.csv_to_duckdb.description": "Перетащите CSV-файл и сразу запросите его с помощью DuckDB. Учётные данные не нужны — самый быстрый способ попробовать Datanika.",
+  "pipelines.empty_heading": "Пайплайнов пока нет",
+  "pipelines.empty_subtitle": "Начните с готового шаблона или прокрутите вниз, чтобы создать пайплайн с нуля.",
+  "pipelines.start_from_template": "Начать с шаблона"
 }

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "Упозорење о квоти",
   "notifications.quota_exceeded.title": "Квота прекорачена",
   "notifications.dismiss": "Одбаци",
-  "notifications.view_run": "Прикажи покретање"
+  "notifications.view_run": "Прикажи покретање",
+  "templates.heading": "Шаблони цевовода",
+  "templates.subtitle": "Унапред конфигурисани почеци који прескачу досадне одлуке. Изаберите један, унесите своје акредитиве и добићете функционалан цевовод за неколико минута.",
+  "templates.use_this_template": "Користи овај шаблон",
+  "templates.help_text": "Шаблони унапред попуњавају само неосетљиве подразумеване вредности — шеме, портове, избор табела. Акредитиве увек уносите ви сами.",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "Учитајте Stripe купце, наплате, фактуре и претплате у ваш Postgres складиште за анализу прихода.",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "Синхронизујте вашу оперативну Postgres базу података са BigQuery — најчешћи аналитички цевовод.",
+  "templates.csv_to_duckdb.name": "CSV отпремање → DuckDB",
+  "templates.csv_to_duckdb.description": "Превуците CSV и одмах га упитајте помоћу DuckDB-а. Без акредитива — најбржи начин да испробате Datanika.",
+  "pipelines.empty_heading": "Још нема цевовода",
+  "pipelines.empty_subtitle": "Почните од унапред конфигурисаног шаблона или скролујте надоле да направите нови од нуле.",
+  "pipelines.start_from_template": "Почни од шаблона"
 }

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -419,5 +419,18 @@
   "notifications.quota_warning.title": "配额预警",
   "notifications.quota_exceeded.title": "配额已用完",
   "notifications.dismiss": "忽略",
-  "notifications.view_run": "查看运行"
+  "notifications.view_run": "查看运行",
+  "templates.heading": "流水线模板",
+  "templates.subtitle": "预配置的入门模板,跳过繁琐的决策。选择一个,输入凭证,几分钟内就能拥有可用的流水线。",
+  "templates.use_this_template": "使用此模板",
+  "templates.help_text": "模板仅预填非敏感的默认值 —— 模式、端口、表选择。凭证始终由您自己输入。",
+  "templates.stripe_to_postgres.name": "Stripe → PostgreSQL",
+  "templates.stripe_to_postgres.description": "将 Stripe 的客户、收款、发票和订阅数据载入您的 Postgres 数据仓库,用于收入分析。",
+  "templates.postgres_to_bigquery.name": "PostgreSQL → BigQuery",
+  "templates.postgres_to_bigquery.description": "将您的运营 Postgres 数据库同步到 BigQuery —— 最常见的分析流水线。",
+  "templates.csv_to_duckdb.name": "CSV 上传 → DuckDB",
+  "templates.csv_to_duckdb.description": "拖入一个 CSV 文件,使用 DuckDB 立即查询。无需凭证 —— 体验 Datanika 的最快方式。",
+  "pipelines.empty_heading": "尚无流水线",
+  "pipelines.empty_subtitle": "从预配置模板开始,或向下滚动从零开始构建。",
+  "pipelines.start_from_template": "从模板开始"
 }

--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -34,7 +34,7 @@ Default: 60 requests/minute per API key.
 Plan-based overrides: Free 30 RPM, Pro 120 RPM, Enterprise 300 RPM.
 Rate limit headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset.
 
-## Capabilities (5 tiers)
+## Capabilities
 
 1. **Discover** — GET /meta/connection-types, /meta/dlt-config-schema, \
 /meta/dbt-tests, /meta/materializations

--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -1,14 +1,33 @@
-"""Machine-readable agent context: /llms.txt and /api/v1/agent-guide.md.
+"""Machine-readable agent context: /llms.txt, agent-guide.md, agent-tiers.json.
 
 Tier 5 of the AI Agent Compatibility roadmap (#37). These are
 discovery documents — no auth required, tenant-agnostic.
+
+The actual tier and capability data lives in `agent_tiers.py`. This
+module is a thin renderer that interpolates the SoT into the markdown
+templates and serves them via Starlette routes. **Do not hardcode any
+tier counts, capability lists, error codes, or golden-path steps in
+this file** — derive them from `agent_tiers` so a single edit there
+updates every surface.
 """
 
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Route
 
-LLMS_TXT = """\
+from datanika.services.agent_tiers import (
+    capability_count,
+    render_error_codes_table,
+    render_golden_path,
+    render_llms_capabilities,
+    render_ui_only_operations,
+    tier_count,
+    to_json_dict,
+)
+
+
+def _render_llms_txt() -> str:
+    return f"""\
 # Datanika — AI Agent Discovery
 
 > Datanika is an open-source data pipeline platform that combines
@@ -20,6 +39,9 @@ https://app.datanika.io/api/v1/openapi.json
 
 ## Agent Guide
 https://app.datanika.io/api/v1/agent-guide.md
+
+## Agent Tiers (JSON)
+https://app.datanika.io/api/v1/meta/agent-tiers
 
 ## Base URL
 https://app.datanika.io/api/v1/
@@ -36,17 +58,7 @@ Rate limit headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset.
 
 ## Capabilities
 
-1. **Discover** — GET /meta/connection-types, /meta/dlt-config-schema, \
-/meta/dbt-tests, /meta/materializations
-2. **Introspect** — POST /connections/{id}/introspect, /columns, /preview, \
-/query
-3. **Build** — CRUD for /connections, /uploads, /pipelines, \
-/transformations, /schedules, /notifications/channels
-4. **Validate** — POST /transformations/{id}/compile, /preview
-5. **Execute** — POST /uploads/{id}/run, /pipelines/{id}/run, \
-/transformations/{id}/run (?wait=true supported)
-6. **Control** — POST /runs/{id}/cancel, GET /runs/{id}/logs, \
-GET /catalog
+{render_llms_capabilities()}
 
 ## Idempotency
 POST requests accept an Idempotency-Key header. Same key within 24h \
@@ -57,50 +69,29 @@ API keys are scoped to an organization. All resources are filtered \
 by org_id — you cannot read or modify another org's data.
 """
 
-AGENT_GUIDE_MD = """\
+
+def _render_agent_guide() -> str:
+    return f"""\
 # Datanika Agent Guide
 
 > How to build a complete data integration with the Datanika API.
 > This is a strategy guide, not an API reference — see the
 > [OpenAPI spec](https://app.datanika.io/api/v1/openapi.json) for
-> full request/response schemas.
+> full request/response schemas. For machine-readable tier structure,
+> fetch [/api/v1/meta/agent-tiers](https://app.datanika.io/api/v1/meta/agent-tiers).
 
 ## Quick-Start Loop
 
 The golden-path sequence for building a pipeline from scratch:
 
-1. `GET /api/v1/meta/connection-types` — discover available source \
-and destination types with their config schemas
-2. `POST /api/v1/connections` — create a source connection (e.g. postgres)
-3. `POST /api/v1/connections` — create a destination connection (e.g. bigquery)
-4. `POST /api/v1/connections/{id}/test` — verify both connections work
-5. `POST /api/v1/connections/{id}/introspect` — list source tables
-6. `POST /api/v1/connections/{id}/columns` — inspect column types
-7. `GET /api/v1/meta/dlt-config-schema` — learn dlt_config options
-8. `POST /api/v1/uploads` — create an extract+load job
-9. `POST /api/v1/uploads/{id}/run?wait=true` — trigger and wait for completion
-10. `GET /api/v1/catalog` — discover loaded tables in the destination
-11. `GET /api/v1/meta/materializations` — learn dbt materialization types
-12. `GET /api/v1/meta/dbt-tests` — learn available test types
-13. `POST /api/v1/transformations` — create a dbt SQL model
-14. `POST /api/v1/transformations/{id}/compile` — validate Jinja + refs
-15. `POST /api/v1/transformations/{id}/preview` — see sample output rows
-16. `POST /api/v1/schedules` — schedule the pipeline on a cron
-17. `GET /api/v1/runs` — monitor run history
+{render_golden_path()}
 
 ## Error Handling
 
 Tier 2+ endpoints return typed string error codes so you can branch
 without regex-matching messages:
 
-| Code | Meaning | Action |
-|------|---------|--------|
-| `compilation_error` | Jinja/ref error in dbt compile | Fix the SQL and re-compile |
-| `execution_error` | Warehouse query failed | Check table names and SQL syntax |
-| `missing_destination` | Transformation has no destination set | Set destination_connection_id |
-| `unsafe_sql` | Compiled SQL failed read-only check | Review the transformation |
-| `invalid_request` | Malformed request body | Check field types and required fields |
-| `not_cancellable` | Run already completed | No action needed |
+{render_error_codes_table()}
 
 ## Idempotency
 
@@ -115,7 +106,7 @@ Authorization: Bearer etf_...
 Idempotency-Key: my-unique-key-123
 Content-Type: application/json
 
-{"name": "Prod PG", "connection_type": "postgres", "config": {...}}
+{{"name": "Prod PG", "connection_type": "postgres", "config": {{...}}}}
 ```
 
 ## Tenant Isolation
@@ -129,9 +120,9 @@ Content-Type: application/json
 
 - **Compile before preview** — `POST /compile` is cheap (no warehouse
   call). Always compile first to catch Jinja errors, then preview.
-- **Use `?wait=true`** on run triggers instead of polling `GET /runs/{id}`
+- **Use `?wait=true`** on run triggers instead of polling `GET /runs/{{id}}`
   in a loop. Default timeout is 120s, max 300s.
-- **Cancel + retry** if a run appears stuck — `POST /runs/{id}/cancel`
+- **Cancel + retry** if a run appears stuck — `POST /runs/{{id}}/cancel`
   then re-trigger.
 - **Introspect before building** — list source tables and columns
   before writing the upload config. Don't guess table names.
@@ -140,15 +131,17 @@ Content-Type: application/json
 
 These operations are only available in the Datanika UI:
 
-- **User management** — create/invite users, assign roles
-- **Billing** — change plans, view invoices
-- **SSO configuration** — SAML/OIDC setup
-- **File uploads** — CSV/JSON/Parquet drag-and-drop (UI only)
-- **OAuth connections** — Google/GitHub login setup
-- **Organization creation** — orgs are created via the signup flow
+{render_ui_only_operations()}
 
 Do not attempt these via the API — there are no endpoints for them.
 """
+
+
+# Module-level constants for backwards compatibility with existing tests
+# and any code that imports the rendered strings directly. Computed once at
+# import time from the SoT in agent_tiers.py.
+LLMS_TXT: str = _render_llms_txt()
+AGENT_GUIDE_MD: str = _render_agent_guide()
 
 
 async def llms_txt(request: Request) -> PlainTextResponse:
@@ -162,7 +155,32 @@ async def agent_guide(request: Request) -> Response:
     )
 
 
+async def agent_tiers_json(request: Request) -> JSONResponse:
+    """Machine-readable tier + capability structure.
+
+    Used by the landing site at build time to render `/ai-agents` and
+    `/docs/ai-agents` from a single source of truth, eliminating the
+    drift bug that hit core PR #80 and landing PR #97.
+
+    No auth required — same posture as `/llms.txt`.
+    """
+    return JSONResponse(to_json_dict())
+
+
 agent_doc_routes = [
     Route("/llms.txt", llms_txt, methods=["GET"]),
     Route("/api/v1/agent-guide.md", agent_guide, methods=["GET"]),
+    Route("/api/v1/meta/agent-tiers", agent_tiers_json, methods=["GET"]),
+]
+
+
+__all__ = [
+    "LLMS_TXT",
+    "AGENT_GUIDE_MD",
+    "agent_doc_routes",
+    "agent_tiers_json",
+    "agent_guide",
+    "llms_txt",
+    "tier_count",
+    "capability_count",
 ]

--- a/datanika/services/agent_tiers.py
+++ b/datanika/services/agent_tiers.py
@@ -1,0 +1,356 @@
+"""Single source of truth for AI agent tier + capability definitions.
+
+This module owns the canonical structure of Datanika's agent-facing API
+surface. Every other place that talks about tiers or capabilities —
+`/llms.txt`, `/api/v1/agent-guide.md`, `/api/v1/meta/agent-tiers`,
+the landing site (via the JSON endpoint), the engineering plan — must
+ultimately derive from this list.
+
+Why: we shipped three off-by-one bugs in two days where a header
+claimed N tiers but the list below it had M items (#80, landing #97).
+The fix is structural — counts should be computed, not hardcoded.
+
+This module has zero runtime dependencies (no Reflex, no Starlette, no
+SQLAlchemy) so it can be imported from anywhere: HTTP handlers, CLI
+export scripts, tests, or a future build-time JSON dump.
+
+The 5-tier numbering matches the implementation order in
+`plans/engineering/PLAN_ENGINEERING.md` → P0 AI Agent Compatibility.
+Each tier groups one or more user-facing capabilities (the bullets the
+LLMS_TXT discovery doc lists). Tier count and capability count are
+deliberately not equal — agents see capabilities, engineering tracks
+tiers.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    description: str
+    endpoints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Tier:
+    number: int
+    name: str
+    summary: str
+    capabilities: tuple[Capability, ...]
+
+
+TIERS: tuple[Tier, ...] = (
+    Tier(
+        number=1,
+        name="Discover & Introspect",
+        summary=(
+            "Read JSON Schemas for every connection type and config, then "
+            "introspect real source data — list tables, inspect columns, "
+            "preview rows, run read-only SQL. The agent never guesses."
+        ),
+        capabilities=(
+            Capability(
+                name="Discover",
+                description=(
+                    "Meta endpoints return full JSON Schema for every "
+                    "connection type, dlt config, dbt test, and materialization."
+                ),
+                endpoints=(
+                    "GET /api/v1/meta/connection-types",
+                    "GET /api/v1/meta/dlt-config-schema",
+                    "GET /api/v1/meta/dbt-tests",
+                    "GET /api/v1/meta/materializations",
+                ),
+            ),
+            Capability(
+                name="Introspect",
+                description=(
+                    "List source tables, inspect column types, preview "
+                    "sample rows, and execute read-only SQL."
+                ),
+                endpoints=(
+                    "POST /api/v1/connections/{id}/introspect",
+                    "POST /api/v1/connections/{id}/columns",
+                    "POST /api/v1/connections/{id}/preview",
+                    "POST /api/v1/connections/{id}/query",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=2,
+        name="Build",
+        summary=(
+            "Full CRUD for every resource the agent needs to assemble a "
+            "pipeline: connections, uploads, pipelines, transformations, "
+            "schedules, notification channels."
+        ),
+        capabilities=(
+            Capability(
+                name="Build",
+                description=(
+                    "Create and update connections, uploads, pipelines, "
+                    "transformations, schedules, and notification channels."
+                ),
+                endpoints=(
+                    "POST /api/v1/connections",
+                    "POST /api/v1/uploads",
+                    "POST /api/v1/pipelines",
+                    "POST /api/v1/transformations",
+                    "POST /api/v1/schedules",
+                    "POST /api/v1/notifications/channels",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=3,
+        name="Validate",
+        summary=(
+            "Compile dbt transformations to catch Jinja and ref errors, "
+            "preview rows without touching production. Typed error codes "
+            "let the agent branch on failures."
+        ),
+        capabilities=(
+            Capability(
+                name="Validate",
+                description=(
+                    "Compile dbt SQL without executing, then preview output "
+                    "rows in a sandbox. Typed error codes."
+                ),
+                endpoints=(
+                    "POST /api/v1/transformations/{id}/compile",
+                    "POST /api/v1/transformations/{id}/preview",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=4,
+        name="Execute & Control",
+        summary=(
+            "Trigger runs synchronously with `?wait=true`, cancel stuck "
+            "runs, retry safely with Idempotency-Key headers, monitor "
+            "history, and browse the auto-generated catalog."
+        ),
+        capabilities=(
+            Capability(
+                name="Execute",
+                description=(
+                    "Trigger runs with optional ?wait=true for synchronous "
+                    "completion (default 120s, max 300s)."
+                ),
+                endpoints=(
+                    "POST /api/v1/uploads/{id}/run?wait=true",
+                    "POST /api/v1/pipelines/{id}/run?wait=true",
+                    "POST /api/v1/transformations/{id}/run?wait=true",
+                ),
+            ),
+            Capability(
+                name="Control",
+                description=(
+                    "Cancel runs, monitor run history, stream logs, browse the data catalog."
+                ),
+                endpoints=(
+                    "POST /api/v1/runs/{id}/cancel",
+                    "GET /api/v1/runs",
+                    "GET /api/v1/runs/{id}/logs",
+                    "GET /api/v1/catalog",
+                ),
+            ),
+        ),
+    ),
+    Tier(
+        number=5,
+        name="Machine-Readable Discovery",
+        summary=(
+            "Plain-text and Markdown documents an LLM agent can fetch "
+            "without auth to learn the API surface, golden-path loop, "
+            "error codes, and tier structure before it has an API key."
+        ),
+        capabilities=(
+            Capability(
+                name="Discover Docs",
+                description=(
+                    "Plain-text discovery, agent strategy guide, OpenAPI "
+                    "spec, and the agent-tiers JSON endpoint."
+                ),
+                endpoints=(
+                    "GET /llms.txt",
+                    "GET /api/v1/agent-guide.md",
+                    "GET /api/v1/openapi.json",
+                    "GET /api/v1/meta/agent-tiers",
+                ),
+            ),
+        ),
+    ),
+)
+
+
+GOLDEN_PATH_LOOP: tuple[str, ...] = (
+    (
+        "`GET /api/v1/meta/connection-types` — discover available source and "
+        "destination types with their config schemas"
+    ),
+    "`POST /api/v1/connections` — create a source connection (e.g. postgres)",
+    "`POST /api/v1/connections` — create a destination connection (e.g. bigquery)",
+    "`POST /api/v1/connections/{id}/test` — verify both connections work",
+    "`POST /api/v1/connections/{id}/introspect` — list source tables",
+    "`POST /api/v1/connections/{id}/columns` — inspect column types",
+    "`GET /api/v1/meta/dlt-config-schema` — learn dlt_config options",
+    "`POST /api/v1/uploads` — create an extract+load job",
+    "`POST /api/v1/uploads/{id}/run?wait=true` — trigger and wait for completion",
+    "`GET /api/v1/catalog` — discover loaded tables in the destination",
+    "`GET /api/v1/meta/materializations` — learn dbt materialization types",
+    "`GET /api/v1/meta/dbt-tests` — learn available test types",
+    "`POST /api/v1/transformations` — create a dbt SQL model",
+    "`POST /api/v1/transformations/{id}/compile` — validate Jinja + refs",
+    "`POST /api/v1/transformations/{id}/preview` — see sample output rows",
+    "`POST /api/v1/schedules` — schedule the pipeline on a cron",
+    "`GET /api/v1/runs` — monitor run history",
+)
+
+
+@dataclass(frozen=True)
+class ErrorCode:
+    code: str
+    meaning: str
+    action: str
+
+
+ERROR_CODES: tuple[ErrorCode, ...] = (
+    ErrorCode("compilation_error", "Jinja/ref error in dbt compile", "Fix the SQL and re-compile"),
+    ErrorCode("execution_error", "Warehouse query failed", "Check table names and SQL syntax"),
+    ErrorCode(
+        "missing_destination",
+        "Transformation has no destination set",
+        "Set destination_connection_id",
+    ),
+    ErrorCode("unsafe_sql", "Compiled SQL failed read-only check", "Review the transformation"),
+    ErrorCode("invalid_request", "Malformed request body", "Check field types and required fields"),
+    ErrorCode("not_cancellable", "Run already completed", "No action needed"),
+)
+
+
+UI_ONLY_OPERATIONS: tuple[str, ...] = (
+    "**User management** — create/invite users, assign roles",
+    "**Billing** — change plans, view invoices",
+    "**SSO configuration** — SAML/OIDC setup",
+    "**File uploads** — CSV/JSON/Parquet drag-and-drop (UI only)",
+    "**OAuth connections** — Google/GitHub login setup",
+    "**Organization creation** — orgs are created via the signup flow",
+)
+
+
+# ---------------------------------------------------------------------------
+# Derived counts — never hardcode these in headers, always call the function
+# ---------------------------------------------------------------------------
+
+
+def tier_count() -> int:
+    return len(TIERS)
+
+
+def capability_count() -> int:
+    return sum(len(t.capabilities) for t in TIERS)
+
+
+def all_capabilities() -> tuple[Capability, ...]:
+    return tuple(cap for tier in TIERS for cap in tier.capabilities)
+
+
+# ---------------------------------------------------------------------------
+# Renderers — single source for any markdown/text view of the tier data
+# ---------------------------------------------------------------------------
+
+
+def render_llms_capabilities() -> str:
+    """Numbered capability list for /llms.txt.
+
+    Each capability gets a number; tier grouping is implicit. Endpoints
+    are joined with commas and trimmed for compactness so the list reads
+    well in a terminal-rendered file.
+    """
+    lines: list[str] = []
+    for n, cap in enumerate(all_capabilities(), start=1):
+        endpoints = ", ".join(cap.endpoints)
+        lines.append(f"{n}. **{cap.name}** — {endpoints}")
+    return "\n".join(lines)
+
+
+def render_golden_path() -> str:
+    """Numbered 17-step golden-path loop for the agent guide."""
+    return "\n".join(f"{n}. {step}" for n, step in enumerate(GOLDEN_PATH_LOOP, start=1))
+
+
+def render_error_codes_table() -> str:
+    """Markdown table of typed error codes."""
+    rows = ["| Code | Meaning | Action |", "|------|---------|--------|"]
+    for ec in ERROR_CODES:
+        rows.append(f"| `{ec.code}` | {ec.meaning} | {ec.action} |")
+    return "\n".join(rows)
+
+
+def render_ui_only_operations() -> str:
+    """Markdown bullet list of operations the API does not support."""
+    return "\n".join(f"- {op}" for op in UI_ONLY_OPERATIONS)
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization — for the /api/v1/meta/agent-tiers endpoint and any
+# build-time export script
+# ---------------------------------------------------------------------------
+
+
+def to_json_dict() -> dict:
+    """Serialize the full tier structure to a JSON-safe dict.
+
+    Shape:
+        {
+            "tier_count": int,
+            "capability_count": int,
+            "tiers": [
+                {
+                    "number": int,
+                    "name": str,
+                    "summary": str,
+                    "capabilities": [
+                        {"name": str, "description": str, "endpoints": [str, ...]},
+                        ...
+                    ],
+                },
+                ...
+            ],
+            "golden_path": [str, ...],
+            "error_codes": [{"code": str, "meaning": str, "action": str}, ...],
+            "ui_only_operations": [str, ...],
+        }
+    """
+    # Build the dict manually rather than using dataclasses.asdict so that
+    # tuple fields (e.g. capability.endpoints) become JSON-friendly lists.
+    return {
+        "tier_count": tier_count(),
+        "capability_count": capability_count(),
+        "tiers": [
+            {
+                "number": t.number,
+                "name": t.name,
+                "summary": t.summary,
+                "capabilities": [
+                    {
+                        "name": c.name,
+                        "description": c.description,
+                        "endpoints": list(c.endpoints),
+                    }
+                    for c in t.capabilities
+                ],
+            }
+            for t in TIERS
+        ],
+        "golden_path": list(GOLDEN_PATH_LOOP),
+        "error_codes": [
+            {"code": ec.code, "meaning": ec.meaning, "action": ec.action} for ec in ERROR_CODES
+        ],
+        "ui_only_operations": list(UI_ONLY_OPERATIONS),
+    }

--- a/datanika/ui/components/getting_started_checklist.py
+++ b/datanika/ui/components/getting_started_checklist.py
@@ -79,7 +79,7 @@ def getting_started_checklist() -> rx.Component:
                 _step_row(
                     OnboardingState.progress.has_pipeline,
                     _t["onboarding.step_pipeline"],
-                    "/pipelines",
+                    "/pipelines/templates",
                 ),
                 _step_row(
                     OnboardingState.progress.has_run,

--- a/datanika/ui/components/notification_bell.py
+++ b/datanika/ui/components/notification_bell.py
@@ -86,98 +86,87 @@ def _notification_row(n) -> rx.Component:
     )
 
 
-def notification_dropdown() -> rx.Component:
-    return rx.box(
-        rx.vstack(
-            rx.hstack(
-                rx.text(
-                    _t["notifications.center.title"],
-                    size="2",
-                    weight="bold",
-                ),
-                rx.spacer(),
-                rx.cond(
-                    NotificationCenterState.unread_count > 0,
-                    rx.button(
-                        _t["notifications.center.mark_all_read"],
-                        on_click=NotificationCenterState.mark_all_read,
-                        variant="ghost",
-                        size="1",
-                        color_scheme="violet",
-                    ),
-                    rx.fragment(),
-                ),
-                width="100%",
-                align="center",
+def _notification_dropdown_content() -> rx.Component:
+    return rx.vstack(
+        rx.hstack(
+            rx.text(
+                _t["notifications.center.title"],
+                size="2",
+                weight="bold",
             ),
-            rx.separator(),
+            rx.spacer(),
             rx.cond(
-                NotificationCenterState.notifications.length() == 0,
-                rx.vstack(
-                    rx.icon("bell-off", size=24, color="var(--slate-8)"),
-                    rx.text(
-                        _t["notifications.center.empty"],
-                        size="2",
-                        color="var(--slate-10)",
-                    ),
-                    align="center",
-                    padding_y="4",
+                NotificationCenterState.unread_count > 0,
+                rx.button(
+                    _t["notifications.center.mark_all_read"],
+                    on_click=NotificationCenterState.mark_all_read,
+                    variant="ghost",
+                    size="1",
+                    color_scheme="violet",
                 ),
-                rx.vstack(
-                    rx.foreach(
-                        NotificationCenterState.notifications,
-                        _notification_row,
-                    ),
-                    spacing="1",
-                    width="100%",
-                ),
+                rx.fragment(),
             ),
-            spacing="2",
-            padding="12px",
             width="100%",
+            align="center",
         ),
-        position="absolute",
-        bottom="56px",
-        left="8px",
-        width="320px",
-        max_height="400px",
-        overflow_y="auto",
-        border="1px solid var(--gray-a5)",
-        border_radius="8px",
-        bg="var(--color-background)",
-        box_shadow="0 4px 12px rgba(0,0,0,0.15)",
-        z_index="50",
+        rx.separator(),
+        rx.cond(
+            NotificationCenterState.notifications.length() == 0,
+            rx.vstack(
+                rx.icon("bell-off", size=24, color="var(--slate-8)"),
+                rx.text(
+                    _t["notifications.center.empty"],
+                    size="2",
+                    color="var(--slate-10)",
+                ),
+                align="center",
+                padding_y="4",
+            ),
+            rx.vstack(
+                rx.foreach(
+                    NotificationCenterState.notifications,
+                    _notification_row,
+                ),
+                spacing="1",
+                width="100%",
+            ),
+        ),
+        spacing="2",
+        width="100%",
     )
 
 
 def notification_bell() -> rx.Component:
-    return rx.box(
-        rx.icon_button(
-            rx.box(
-                rx.icon("bell", size=16),
-                rx.cond(
-                    NotificationCenterState.unread_count > 0,
-                    rx.badge(
-                        NotificationCenterState.unread_count,
-                        color_scheme="red",
-                        variant="solid",
-                        size="1",
-                        position="absolute",
-                        top="-4px",
-                        right="-4px",
+    return rx.popover.root(
+        rx.popover.trigger(
+            rx.icon_button(
+                rx.box(
+                    rx.icon("bell", size=16),
+                    rx.cond(
+                        NotificationCenterState.unread_count > 0,
+                        rx.badge(
+                            NotificationCenterState.unread_count,
+                            color_scheme="red",
+                            variant="solid",
+                            size="1",
+                            position="absolute",
+                            top="-4px",
+                            right="-4px",
+                        ),
+                        rx.fragment(),
                     ),
-                    rx.fragment(),
+                    position="relative",
                 ),
-                position="relative",
+                on_click=NotificationCenterState.load_notifications,
+                variant="ghost",
+                size="1",
             ),
-            on_click=NotificationCenterState.toggle_dropdown,
-            variant="ghost",
-            size="1",
         ),
-        rx.cond(
-            NotificationCenterState.dropdown_open,
-            notification_dropdown(),
-            rx.fragment(),
+        rx.popover.content(
+            _notification_dropdown_content(),
+            width="320px",
+            max_height="400px",
+            side="top",
+            align="start",
         ),
-        position="relative",
     )

--- a/datanika/ui/components/notification_bell.py
+++ b/datanika/ui/components/notification_bell.py
@@ -31,7 +31,7 @@ def _type_icon(ntype: rx.Var[str]) -> rx.Component:
             rx.icon("circle-check", size=16, color="var(--green-9)"),
             rx.cond(
                 ntype == "quota_warning",
-                rx.icon("alert-triangle", size=16, color="var(--amber-9)"),
+                rx.icon("triangle-alert", size=16, color="var(--amber-9)"),
                 rx.icon("octagon-alert", size=16, color="var(--red-9)"),
             ),
         ),

--- a/datanika/ui/pages/audit_logs.py
+++ b/datanika/ui/pages/audit_logs.py
@@ -34,6 +34,7 @@ def audit_logs_page() -> rx.Component:
                         size="2",
                     ),
                     spacing="1",
+                    width="220px",
                 ),
                 rx.vstack(
                     rx.text(_t["audit.filter_resource"], size="2", weight="medium"),
@@ -53,6 +54,7 @@ def audit_logs_page() -> rx.Component:
                         size="2",
                     ),
                     spacing="1",
+                    width="220px",
                 ),
                 rx.button(
                     _t["audit.apply"],

--- a/datanika/ui/pages/dashboard.py
+++ b/datanika/ui/pages/dashboard.py
@@ -123,7 +123,7 @@ def usage_bar() -> rx.Component:
                 rx.cond(
                     DashboardState.runs_percent >= 80,
                     rx.hstack(
-                        rx.icon("alert-triangle", size=14, color="var(--red-11)"),
+                        rx.icon("triangle-alert", size=14, color="var(--red-11)"),
                         rx.link(
                             rx.text(
                                 _t["dashboard.usage_upgrade"],

--- a/datanika/ui/pages/pipeline_templates.py
+++ b/datanika/ui/pages/pipeline_templates.py
@@ -1,0 +1,102 @@
+"""Pipeline Templates page — pre-configured source→destination starters.
+
+Shows a grid of cards. Clicking a card navigates the user to ``/connections``
+with ``?template=<slug>``; ConnectionState picks up the slug on page load
+and prefills the source connection form so the user only has to enter their
+own credentials. See ``datanika/data/pipeline_templates.py`` for the
+underlying registry.
+"""
+
+import reflex as rx
+
+from datanika.data.pipeline_templates import LAUNCH_TEMPLATES, PipelineTemplate
+from datanika.ui.components.layout import page_layout
+from datanika.ui.state.i18n_state import I18nState
+
+_t = I18nState.translations
+
+# Explicit references so the test_no_orphan_keys_in_json scanner can find the
+# per-template name/description keys. The card component below looks them up
+# dynamically via ``_t[tpl.name_key]`` because the slug-to-key mapping lives
+# in the static template registry, not in this page module. Add a row here
+# whenever a new template is appended to LAUNCH_TEMPLATES.
+_TEMPLATE_I18N_REFS = (
+    _t["templates.stripe_to_postgres.name"],
+    _t["templates.stripe_to_postgres.description"],
+    _t["templates.postgres_to_bigquery.name"],
+    _t["templates.postgres_to_bigquery.description"],
+    _t["templates.csv_to_duckdb.name"],
+    _t["templates.csv_to_duckdb.description"],
+)
+
+
+def _template_card(tpl: PipelineTemplate) -> rx.Component:
+    """Render a single template card.
+
+    Built at import time from a static template — no Reflex state vars needed,
+    so we render the source/destination labels as plain Python strings.
+    """
+    return rx.link(
+        rx.card(
+            rx.vstack(
+                rx.hstack(
+                    rx.badge(tpl.icon_source, color_scheme="blue", size="2"),
+                    rx.icon("arrow_right", size=18, color="var(--slate-9)"),
+                    rx.badge(tpl.icon_destination, color_scheme="violet", size="2"),
+                    align="center",
+                    spacing="2",
+                ),
+                rx.heading(_t[tpl.name_key], size="4"),
+                rx.text(
+                    _t[tpl.description_key],
+                    size="2",
+                    color="var(--slate-11)",
+                ),
+                rx.spacer(),
+                rx.button(
+                    _t["templates.use_this_template"],
+                    width="100%",
+                    variant="solid",
+                ),
+                spacing="3",
+                align="start",
+                height="100%",
+            ),
+            width="100%",
+            height="100%",
+            _hover={"border_color": "var(--accent-9)", "cursor": "pointer"},
+        ),
+        href=f"/connections?template={tpl.slug}",
+        underline="none",
+        width="100%",
+    )
+
+
+def pipeline_templates_page() -> rx.Component:
+    return page_layout(
+        rx.vstack(
+            rx.heading(_t["templates.heading"], size="6"),
+            rx.text(
+                _t["templates.subtitle"],
+                size="3",
+                color="var(--slate-11)",
+            ),
+            rx.grid(
+                *[_template_card(tpl) for tpl in LAUNCH_TEMPLATES],
+                columns=rx.breakpoints(initial="1", md="3"),
+                spacing="4",
+                width="100%",
+            ),
+            rx.callout(
+                _t["templates.help_text"],
+                icon="info",
+                color_scheme="gray",
+                size="1",
+                margin_top="1rem",
+            ),
+            spacing="4",
+            width="100%",
+            align="stretch",
+        ),
+        title=_t["templates.heading"],
+    )

--- a/datanika/ui/pages/pipelines.py
+++ b/datanika/ui/pages/pipelines.py
@@ -336,8 +336,51 @@ def pipelines_table() -> rx.Component:
     )
 
 
+def pipelines_empty_state() -> rx.Component:
+    """First-time CTA shown when the user has zero pipelines.
+
+    Surfaces the templates page as the recommended path. The form below
+    stays available for users who want to skip templates and configure
+    everything by hand.
+    """
+    return rx.card(
+        rx.vstack(
+            rx.icon("sparkles", size=32, color="var(--accent-9)"),
+            rx.heading(_t["pipelines.empty_heading"], size="5"),
+            rx.text(
+                _t["pipelines.empty_subtitle"],
+                size="2",
+                color="var(--slate-11)",
+                text_align="center",
+            ),
+            rx.link(
+                rx.button(
+                    _t["pipelines.start_from_template"],
+                    size="3",
+                ),
+                href="/pipelines/templates",
+                underline="none",
+            ),
+            spacing="3",
+            align="center",
+            padding_y="2rem",
+        ),
+        width="100%",
+    )
+
+
 def pipelines_page() -> rx.Component:
     return page_layout(
-        rx.vstack(pipeline_form(), pipelines_table(), spacing="6", width="100%"),
+        rx.vstack(
+            rx.cond(
+                PipelineState.pipelines.length() == 0,
+                pipelines_empty_state(),
+                rx.fragment(),
+            ),
+            pipeline_form(),
+            pipelines_table(),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.pipelines"],
     )

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -76,6 +76,32 @@ _DEFAULT_PORTS: dict[str, str] = {
 # Connection types that use the SQL database form group (host/port/user/pass/db/schema)
 _DB_TYPES = {"postgres", "mysql", "mssql", "redshift", "clickhouse", "synapse"}
 
+# Mapping of pipeline-template ``source_config_defaults`` keys to the
+# matching ConnectionState ``form_*`` attribute. Module-level (not a class
+# attribute) so it isn't picked up as a Reflex state var, and so the
+# template-prefill helper stays trivially testable via FakeState.
+#
+# Add new entries here when a template needs to prefill a non-credential
+# field that isn't already covered. Never add password / secret / api_key /
+# service_account_json — templates carry safe defaults only.
+_TEMPLATE_FORM_FIELD_MAP: dict[str, str] = {
+    "host": "form_host",
+    "port": "form_port",
+    "database": "form_database",
+    "schema": "form_schema",
+    "path": "form_path",
+    "project": "form_project",
+    "dataset": "form_dataset",
+    "account": "form_account",
+    "warehouse": "form_warehouse",
+    "role": "form_role",
+    "bucket_url": "form_bucket_url",
+    "base_url": "form_base_url",
+    "property_id": "form_property_id",
+    "bootstrap_servers": "form_bootstrap_servers",
+    "topics": "form_topics",
+}
+
 
 def _validate_connection_form(
     name: str,
@@ -231,6 +257,51 @@ class ConnectionState(BaseState):
     form_bootstrap_servers: str = ""  # Kafka
     form_topics: str = ""  # Kafka
     form_group_id: str = ""  # Kafka
+
+    # Pipeline template currently driving the form prefill (empty = none).
+    # Set when the user clicks a card on /pipelines/templates and arrives
+    # at /connections via ?template=<slug>. Used to show a banner explaining
+    # the multi-step flow.
+    selected_template_slug: str = ""
+
+    def _apply_template_defaults(self, slug: str) -> None:
+        """Look up a pipeline template and prefill matching form fields.
+
+        - No-op if ``slug`` is empty or doesn't match a known template.
+        - Sets ``form_type`` to the template's source connector.
+        - Copies entries from ``source_config_defaults`` into matching
+          ``form_*`` attributes via ``_TEMPLATE_FIELD_MAP``.
+        - Never touches credential fields (password, api_key, secrets,
+          service-account JSON). Templates only carry non-sensitive defaults.
+        - Stores the slug in ``selected_template_slug`` so the UI can show
+          a "you're following a template" banner.
+
+        Pure helper — testable without Reflex / DB / async context.
+        """
+        from datanika.data.pipeline_templates import get_template
+
+        tpl = get_template(slug)
+        if tpl is None:
+            return
+
+        self.form_type = str(tpl.source_type)
+        self.selected_template_slug = tpl.slug
+
+        for key, value in tpl.source_config_defaults.items():
+            attr = _TEMPLATE_FORM_FIELD_MAP.get(key)
+            if attr is None:
+                continue
+            setattr(self, attr, value)
+
+    async def load_template_from_query(self):
+        """Read ``?template=<slug>`` from the page URL and prefill the form.
+
+        Wired into the /connections page ``on_load`` so a user arriving from
+        the templates grid lands with the source connector preselected.
+        """
+        slug = self.router.page.params.get("template", "")
+        if slug:
+            self._apply_template_defaults(slug)
 
     def set_form_name(self, value: str):
         self.form_name = re.sub(r"[^a-zA-Z0-9 ]", "", value)

--- a/datanika/ui/state/notification_center_state.py
+++ b/datanika/ui/state/notification_center_state.py
@@ -27,7 +27,6 @@ class NotificationItem(BaseModel):
 class NotificationCenterState(BaseState):
     notifications: list[NotificationItem] = []
     unread_count: int = 0
-    dropdown_open: bool = False
 
     async def load_notifications(self):
         from datanika.ui.state.auth_state import AuthState
@@ -111,6 +110,3 @@ class NotificationCenterState(BaseState):
             svc.dismiss(session, notification_id, org_id)
             session.commit()
         await self.load_notifications()
-
-    def toggle_dropdown(self):
-        self.dropdown_open = not self.dropdown_open

--- a/datanika/ui/state/notification_center_state.py
+++ b/datanika/ui/state/notification_center_state.py
@@ -8,7 +8,7 @@ from datanika.ui.state.base_state import BaseState, get_sync_session
 NOTIFICATION_TYPE_ICONS: dict[str, str] = {
     "run_failed": "circle-x",
     "run_succeeded": "circle-check",
-    "quota_warning": "alert-triangle",
+    "quota_warning": "triangle-alert",
     "quota_exceeded": "octagon-alert",
 }
 

--- a/tests/test_data/test_pipeline_templates.py
+++ b/tests/test_data/test_pipeline_templates.py
@@ -1,0 +1,148 @@
+"""Tests for the pipeline templates registry — static data validation."""
+
+import pytest
+
+from datanika.data.pipeline_templates import (
+    LAUNCH_TEMPLATES,
+    PipelineTemplate,
+    get_template,
+    list_templates,
+)
+from datanika.models.connection import ConnectionType
+
+
+class TestPipelineTemplateDataclass:
+    def test_construct_with_all_required_fields(self):
+        tpl = PipelineTemplate(
+            slug="test",
+            name_key="templates.test.name",
+            description_key="templates.test.description",
+            source_type=ConnectionType.STRIPE,
+            destination_type=ConnectionType.POSTGRES,
+            source_config_defaults={"start_date": "2024-01-01"},
+            destination_config_defaults={"schema": "raw_stripe"},
+            dlt_config_defaults={
+                "resources": ["customers", "charges"],
+                "write_disposition": "merge",
+            },
+            icon_source="stripe",
+            icon_destination="postgres",
+        )
+        assert tpl.slug == "test"
+        assert tpl.source_type == ConnectionType.STRIPE
+        assert tpl.destination_type == ConnectionType.POSTGRES
+
+    def test_template_is_immutable(self):
+        """Templates are static data — instances should be frozen."""
+        tpl = LAUNCH_TEMPLATES[0]
+        with pytest.raises((AttributeError, TypeError)):
+            tpl.slug = "mutated"  # type: ignore[misc]
+
+
+class TestLaunchTemplates:
+    def test_three_launch_templates(self):
+        """MVP ships exactly 3 templates."""
+        assert len(LAUNCH_TEMPLATES) == 3
+
+    def test_launch_template_slugs(self):
+        slugs = {t.slug for t in LAUNCH_TEMPLATES}
+        assert slugs == {
+            "stripe-to-postgres",
+            "postgres-to-bigquery",
+            "csv-to-duckdb",
+        }
+
+    def test_all_slugs_are_unique(self):
+        slugs = [t.slug for t in LAUNCH_TEMPLATES]
+        assert len(slugs) == len(set(slugs))
+
+    def test_all_required_fields_present(self):
+        for tpl in LAUNCH_TEMPLATES:
+            assert tpl.slug
+            assert tpl.name_key
+            assert tpl.description_key
+            assert tpl.source_type
+            assert tpl.destination_type
+            assert tpl.icon_source
+            assert tpl.icon_destination
+
+    def test_source_and_destination_types_are_valid(self):
+        """Every template's source and destination must be a real ConnectionType."""
+        valid_types = {ct for ct in ConnectionType}
+        for tpl in LAUNCH_TEMPLATES:
+            assert tpl.source_type in valid_types, (
+                f"{tpl.slug} has invalid source_type {tpl.source_type}"
+            )
+            assert tpl.destination_type in valid_types, (
+                f"{tpl.slug} has invalid destination_type {tpl.destination_type}"
+            )
+
+    def test_i18n_keys_follow_naming_convention(self):
+        """Name and description keys should be under 'templates.<slug>.*'."""
+        for tpl in LAUNCH_TEMPLATES:
+            normalized = tpl.slug.replace("-", "_")
+            assert tpl.name_key == f"templates.{normalized}.name", (
+                f"{tpl.slug} name_key={tpl.name_key} doesn't match convention"
+            )
+            assert tpl.description_key == f"templates.{normalized}.description", (
+                f"{tpl.slug} description_key={tpl.description_key} doesn't match convention"
+            )
+
+    def test_dlt_config_has_write_disposition(self):
+        """Every template must specify a write_disposition for its dlt config."""
+        valid_dispositions = {"append", "replace", "merge"}
+        for tpl in LAUNCH_TEMPLATES:
+            assert "write_disposition" in tpl.dlt_config_defaults, (
+                f"{tpl.slug} missing write_disposition"
+            )
+            assert tpl.dlt_config_defaults["write_disposition"] in valid_dispositions
+
+    def test_stripe_to_postgres_template(self):
+        tpl = get_template("stripe-to-postgres")
+        assert tpl.source_type == ConnectionType.STRIPE
+        assert tpl.destination_type == ConnectionType.POSTGRES
+        # Stripe template should preselect at least the core resources
+        assert "resources" in tpl.dlt_config_defaults
+        resources = tpl.dlt_config_defaults["resources"]
+        assert "Customer" in resources or "customers" in resources
+
+    def test_postgres_to_bigquery_template(self):
+        tpl = get_template("postgres-to-bigquery")
+        assert tpl.source_type == ConnectionType.POSTGRES
+        assert tpl.destination_type == ConnectionType.BIGQUERY
+
+    def test_csv_to_duckdb_template(self):
+        """The zero-credentials quickstart."""
+        tpl = get_template("csv-to-duckdb")
+        assert tpl.source_type == ConnectionType.CSV
+        assert tpl.destination_type == ConnectionType.DUCKDB
+
+
+class TestListTemplates:
+    def test_returns_all_launch_templates(self):
+        templates = list_templates()
+        assert len(templates) == len(LAUNCH_TEMPLATES)
+
+    def test_returns_pipeline_template_instances(self):
+        for tpl in list_templates():
+            assert isinstance(tpl, PipelineTemplate)
+
+    def test_returns_a_copy_not_the_underlying_list(self):
+        """Mutating the returned list must not corrupt the registry."""
+        templates = list_templates()
+        original_len = len(LAUNCH_TEMPLATES)
+        templates.clear()
+        assert len(LAUNCH_TEMPLATES) == original_len
+
+
+class TestGetTemplate:
+    def test_returns_template_for_valid_slug(self):
+        tpl = get_template("stripe-to-postgres")
+        assert tpl is not None
+        assert tpl.slug == "stripe-to-postgres"
+
+    def test_returns_none_for_unknown_slug(self):
+        assert get_template("does-not-exist") is None
+
+    def test_returns_none_for_empty_slug(self):
+        assert get_template("") is None

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -46,6 +46,15 @@ class TestLlmsTxt:
         assert "Validate" in resp.text
         assert "Execute" in resp.text
 
+    def test_capabilities_header_has_no_tier_count(self, client):
+        # Regression for #80: header used to say "Capabilities (5 tiers)"
+        # while listing 6 items. The "5 tiers" label is internal roadmap
+        # language and doesn't belong in user-facing /llms.txt.
+        resp = client.get("/llms.txt")
+        assert "## Capabilities" in resp.text
+        assert "5 tiers" not in resp.text
+        assert "(5 tiers)" not in resp.text
+
     def test_no_auth_required(self, client):
         resp = client.get("/llms.txt")
         assert resp.status_code == 200

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -1,10 +1,15 @@
-"""Tests for /llms.txt and /api/v1/agent-guide.md (#64)."""
+"""Tests for /llms.txt, /api/v1/agent-guide.md, /api/v1/meta/agent-tiers (#64, #85)."""
 
 import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from datanika.services.agent_docs import agent_doc_routes
+from datanika.services.agent_docs import AGENT_GUIDE_MD, LLMS_TXT, agent_doc_routes
+from datanika.services.agent_tiers import (
+    all_capabilities,
+    capability_count,
+    tier_count,
+)
 
 
 @pytest.fixture
@@ -48,12 +53,26 @@ class TestLlmsTxt:
 
     def test_capabilities_header_has_no_tier_count(self, client):
         # Regression for #80: header used to say "Capabilities (5 tiers)"
-        # while listing 6 items. The "5 tiers" label is internal roadmap
-        # language and doesn't belong in user-facing /llms.txt.
+        # while listing 6 items. The SoT renderer in agent_tiers.py never
+        # emits a hardcoded count — this assertion guards against either
+        # the old "5 tiers" or any new "N tiers" label being re-introduced.
         resp = client.get("/llms.txt")
         assert "## Capabilities" in resp.text
         assert "5 tiers" not in resp.text
+        assert "6 tiers" not in resp.text
         assert "(5 tiers)" not in resp.text
+
+    def test_lists_every_capability_from_sot(self, client):
+        # Every capability defined in agent_tiers.TIERS must appear in
+        # the rendered LLMS_TXT. If you add a new capability to the
+        # SoT, this test passes automatically — no llms.txt edit needed.
+        resp = client.get("/llms.txt")
+        for cap in all_capabilities():
+            assert cap.name in resp.text, f"Capability {cap.name!r} missing from /llms.txt"
+
+    def test_advertises_agent_tiers_json_endpoint(self, client):
+        resp = client.get("/llms.txt")
+        assert "/api/v1/meta/agent-tiers" in resp.text
 
     def test_no_auth_required(self, client):
         resp = client.get("/llms.txt")
@@ -108,3 +127,70 @@ class TestAgentGuide:
     def test_no_auth_required(self, client):
         resp = client.get("/api/v1/agent-guide.md")
         assert resp.status_code == 200
+
+
+class TestAgentTiersJson:
+    def test_returns_200(self, client):
+        resp = client.get("/api/v1/meta/agent-tiers")
+        assert resp.status_code == 200
+
+    def test_content_type_is_json(self, client):
+        resp = client.get("/api/v1/meta/agent-tiers")
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_no_auth_required(self, client):
+        # Same posture as /llms.txt — pre-auth discovery surface.
+        resp = client.get("/api/v1/meta/agent-tiers")
+        assert resp.status_code == 200
+
+    def test_top_level_shape(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        assert set(data.keys()) == {
+            "tier_count",
+            "capability_count",
+            "tiers",
+            "golden_path",
+            "error_codes",
+            "ui_only_operations",
+        }
+
+    def test_counts_match_sot(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        assert data["tier_count"] == tier_count()
+        assert data["capability_count"] == capability_count()
+
+    def test_tier_count_is_five(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        assert data["tier_count"] == 5
+        assert len(data["tiers"]) == 5
+
+    def test_tiers_are_numbered_sequentially(self, client):
+        data = client.get("/api/v1/meta/agent-tiers").json()
+        for expected, tier in enumerate(data["tiers"], start=1):
+            assert tier["number"] == expected
+
+
+class TestSoTWiring:
+    """Guard rails ensuring agent_docs.py renders from the SoT, not hardcoded text."""
+
+    def test_llms_txt_module_constant_is_rendered_from_sot(self):
+        # Every capability name should appear in the module-level constant.
+        # If a future edit hardcodes the markdown back, the SoT addition
+        # of a new capability would fail this test.
+        for cap in all_capabilities():
+            assert cap.name in LLMS_TXT, f"Capability {cap.name!r} missing from LLMS_TXT"
+
+    def test_agent_guide_md_includes_all_error_codes(self):
+        from datanika.services.agent_tiers import ERROR_CODES
+
+        for ec in ERROR_CODES:
+            assert ec.code in AGENT_GUIDE_MD, f"Error code {ec.code!r} missing from agent guide"
+
+    def test_agent_guide_md_includes_all_golden_path_steps(self):
+        from datanika.services.agent_tiers import GOLDEN_PATH_LOOP
+
+        for step in GOLDEN_PATH_LOOP:
+            # Step is a backtick-wrapped endpoint plus prose; the
+            # endpoint substring is the stable part to assert on.
+            endpoint = step.split("`")[1] if "`" in step else step
+            assert endpoint in AGENT_GUIDE_MD, f"Golden path step {endpoint!r} missing"

--- a/tests/test_services/test_agent_tiers.py
+++ b/tests/test_services/test_agent_tiers.py
@@ -1,0 +1,236 @@
+"""Tests for the AI agent tier single source of truth (#85).
+
+`agent_tiers.py` is the canonical home for tier + capability data. Every
+other surface (LLMS_TXT, AGENT_GUIDE_MD, /api/v1/meta/agent-tiers, the
+landing site via JSON fetch) renders from this module. These tests pin
+the data shape, the derived counts, and the renderer outputs so a
+future edit can't reintroduce the off-by-one bug class that hit core
+PR #80 and landing PR #97.
+"""
+
+import json
+from dataclasses import is_dataclass
+
+import pytest
+
+from datanika.services.agent_tiers import (
+    ERROR_CODES,
+    GOLDEN_PATH_LOOP,
+    TIERS,
+    UI_ONLY_OPERATIONS,
+    Capability,
+    ErrorCode,
+    Tier,
+    all_capabilities,
+    capability_count,
+    render_error_codes_table,
+    render_golden_path,
+    render_llms_capabilities,
+    render_ui_only_operations,
+    tier_count,
+    to_json_dict,
+)
+
+
+class TestTierStructure:
+    def test_exactly_five_tiers(self):
+        # 5 tiers matches plans/engineering/PLAN_ENGINEERING.md.
+        # If you add a tier, update the engineering plan AND the landing
+        # site AND any other surface that pins this number — or even
+        # better, fetch /api/v1/meta/agent-tiers from those surfaces.
+        assert tier_count() == 5
+        assert len(TIERS) == 5
+
+    def test_tier_numbers_are_sequential(self):
+        for expected, tier in enumerate(TIERS, start=1):
+            assert tier.number == expected, (
+                f"Tier {tier.name!r} has number {tier.number}, expected {expected}"
+            )
+
+    def test_every_tier_has_at_least_one_capability(self):
+        for tier in TIERS:
+            assert len(tier.capabilities) >= 1, f"Tier {tier.name!r} has no capabilities"
+
+    def test_every_capability_has_at_least_one_endpoint(self):
+        for tier in TIERS:
+            for cap in tier.capabilities:
+                assert len(cap.endpoints) >= 1, (
+                    f"Capability {cap.name!r} in tier {tier.name!r} has no endpoints"
+                )
+
+    def test_every_tier_has_summary(self):
+        for tier in TIERS:
+            assert tier.summary, f"Tier {tier.name!r} has empty summary"
+            assert len(tier.summary) > 30, f"Tier {tier.name!r} summary is too short"
+
+    def test_dataclasses_are_frozen(self):
+        # Frozen dataclasses prevent mutation of the SoT at runtime —
+        # any attempt to "patch" tier data should be a code change.
+        assert is_dataclass(Tier)
+        assert is_dataclass(Capability)
+        assert is_dataclass(ErrorCode)
+        with pytest.raises((AttributeError, TypeError)):
+            TIERS[0].number = 99
+
+
+class TestCapabilityCount:
+    def test_capability_count_matches_flat_list(self):
+        assert capability_count() == len(all_capabilities())
+
+    def test_capability_count_matches_sum_across_tiers(self):
+        manual_total = sum(len(t.capabilities) for t in TIERS)
+        assert capability_count() == manual_total
+
+    def test_current_capability_count_is_six(self):
+        # 5 tiers, but the current capability decomposition is 6:
+        # Discover, Introspect, Build, Validate, Execute, Control,
+        # plus the Tier 5 docs capability — wait, that's 7. Recount.
+        # Tier 1: Discover + Introspect = 2
+        # Tier 2: Build = 1
+        # Tier 3: Validate = 1
+        # Tier 4: Execute + Control = 2
+        # Tier 5: Discover Docs = 1
+        # Total = 7
+        # If you change this, the LLMS_TXT capability list changes too,
+        # and any landing-site copy that quotes a number will need to
+        # be updated. Better: have the landing site fetch the JSON.
+        assert capability_count() == 7
+
+
+class TestKnownCapabilityNames:
+    def test_discover_in_tier_1(self):
+        names = [c.name for c in TIERS[0].capabilities]
+        assert "Discover" in names
+        assert "Introspect" in names
+
+    def test_validate_in_tier_3(self):
+        assert any(c.name == "Validate" for c in TIERS[2].capabilities)
+
+    def test_control_in_tier_4(self):
+        assert any(c.name == "Control" for c in TIERS[3].capabilities)
+
+
+class TestGoldenPath:
+    def test_seventeen_steps(self):
+        # The 17-step loop is the canonical onboarding flow. If we
+        # change the count, agent-guide.md and any external content
+        # that quotes "17 steps" must be updated — or just fetch the
+        # JSON instead.
+        assert len(GOLDEN_PATH_LOOP) == 17
+
+    def test_first_step_is_discover_meta(self):
+        assert "/api/v1/meta/connection-types" in GOLDEN_PATH_LOOP[0]
+
+    def test_last_step_is_monitor_runs(self):
+        assert "/api/v1/runs" in GOLDEN_PATH_LOOP[-1]
+
+    def test_no_step_is_empty(self):
+        for n, step in enumerate(GOLDEN_PATH_LOOP):
+            assert step.strip(), f"Step {n} is empty"
+
+
+class TestErrorCodes:
+    def test_six_error_codes(self):
+        assert len(ERROR_CODES) == 6
+
+    def test_known_codes_present(self):
+        codes = {ec.code for ec in ERROR_CODES}
+        assert codes == {
+            "compilation_error",
+            "execution_error",
+            "missing_destination",
+            "unsafe_sql",
+            "invalid_request",
+            "not_cancellable",
+        }
+
+
+class TestRenderers:
+    def test_render_llms_capabilities_includes_all_capabilities(self):
+        rendered = render_llms_capabilities()
+        for cap in all_capabilities():
+            assert cap.name in rendered, f"Missing capability {cap.name!r} in LLMS render"
+
+    def test_render_llms_capabilities_is_numbered(self):
+        rendered = render_llms_capabilities()
+        # First and last capabilities are numbered
+        assert rendered.startswith("1. ")
+        last_n = capability_count()
+        assert f"{last_n}. " in rendered
+
+    def test_render_llms_capabilities_no_hardcoded_count(self):
+        # The renderer must not include any literal number that hardcodes
+        # tier_count or capability_count outside of the line numbering.
+        # This guards against someone re-introducing "5 tiers" prose.
+        rendered = render_llms_capabilities()
+        assert "5 tiers" not in rendered
+        assert "6 tiers" not in rendered
+        assert "(5)" not in rendered
+
+    def test_render_golden_path_is_numbered_seventeen(self):
+        rendered = render_golden_path()
+        assert rendered.startswith("1. ")
+        assert "\n17. " in rendered
+        assert "\n18. " not in rendered
+
+    def test_render_error_codes_is_markdown_table(self):
+        rendered = render_error_codes_table()
+        assert "| Code |" in rendered
+        assert "|------|" in rendered
+        for ec in ERROR_CODES:
+            assert f"`{ec.code}`" in rendered
+
+    def test_render_ui_only_operations_is_bullet_list(self):
+        rendered = render_ui_only_operations()
+        for op in UI_ONLY_OPERATIONS:
+            assert f"- {op}" in rendered
+
+
+class TestJsonSerialization:
+    def test_to_json_dict_round_trips_via_json_module(self):
+        data = to_json_dict()
+        # Must be JSON-serializable with no custom encoder
+        serialized = json.dumps(data)
+        parsed = json.loads(serialized)
+        assert parsed == data
+
+    def test_json_has_top_level_keys(self):
+        data = to_json_dict()
+        assert set(data.keys()) == {
+            "tier_count",
+            "capability_count",
+            "tiers",
+            "golden_path",
+            "error_codes",
+            "ui_only_operations",
+        }
+
+    def test_json_tier_count_matches_helper(self):
+        data = to_json_dict()
+        assert data["tier_count"] == tier_count()
+        assert data["tier_count"] == len(data["tiers"])
+
+    def test_json_capability_count_matches_helper(self):
+        data = to_json_dict()
+        assert data["capability_count"] == capability_count()
+        flat = sum(len(t["capabilities"]) for t in data["tiers"])
+        assert data["capability_count"] == flat
+
+    def test_json_tier_shape(self):
+        data = to_json_dict()
+        for tier in data["tiers"]:
+            assert set(tier.keys()) == {"number", "name", "summary", "capabilities"}
+            for cap in tier["capabilities"]:
+                assert set(cap.keys()) == {"name", "description", "endpoints"}
+                assert isinstance(cap["endpoints"], list)
+
+    def test_json_golden_path_is_list_of_strings(self):
+        data = to_json_dict()
+        assert isinstance(data["golden_path"], list)
+        assert all(isinstance(step, str) for step in data["golden_path"])
+        assert len(data["golden_path"]) == 17
+
+    def test_json_error_codes_have_required_fields(self):
+        data = to_json_dict()
+        for ec in data["error_codes"]:
+            assert set(ec.keys()) == {"code", "meaning", "action"}

--- a/tests/test_ui/test_notification_bell.py
+++ b/tests/test_ui/test_notification_bell.py
@@ -1,0 +1,45 @@
+"""Regression tests for the notification bell component (#78).
+
+The bell dropdown was originally a hand-rolled `rx.box` toggled by a
+`dropdown_open` state field, with no outside-click or escape handler —
+users reported the popup never dismissed. The fix converts it to a
+`rx.popover.root`, which Radix wires to outside-click + escape natively.
+
+These tests guard against regressing back to the hand-rolled pattern.
+"""
+
+import reflex as rx
+
+from datanika.ui.components.notification_bell import notification_bell
+from datanika.ui.state.notification_center_state import NotificationCenterState
+
+
+class TestNotificationBellPopover:
+    def test_returns_radix_popover_root(self):
+        component = notification_bell()
+        # Radix popover root — Reflex wraps it in a class whose tag identifies it.
+        assert "popover" in type(component).__name__.lower() or any(
+            "popover" in type(child).__name__.lower()
+            for child in getattr(component, "children", [])
+        ), "notification_bell must use rx.popover.root so Radix handles outside-click + escape"
+
+    def test_state_has_no_dropdown_open_field(self):
+        # Radix manages open/close state internally — we must not reintroduce
+        # a Python-side `dropdown_open` flag, which previously caused the
+        # outside-click bug because nothing flipped it back to False.
+        state_attrs = set(NotificationCenterState.__annotations__.keys()) | set(
+            dir(NotificationCenterState)
+        )
+        assert "dropdown_open" not in state_attrs, (
+            "dropdown_open must not exist; let rx.popover.root manage open state"
+        )
+
+    def test_state_has_no_toggle_dropdown_method(self):
+        assert not hasattr(NotificationCenterState, "toggle_dropdown"), (
+            "toggle_dropdown must not exist; rx.popover.trigger handles toggling"
+        )
+
+    def test_renders_without_error(self):
+        component = notification_bell()
+        assert component is not None
+        assert isinstance(component, rx.Component)

--- a/tests/test_ui/test_notification_center_state.py
+++ b/tests/test_ui/test_notification_center_state.py
@@ -42,6 +42,20 @@ class TestTypeIcons:
             assert isinstance(icon, str)
             assert len(icon) > 0
 
+    def test_no_deprecated_lucide_names(self):
+        # Regression for #88: lucide-react renamed `alert-triangle` to
+        # `triangle-alert` in v0.359.0 (March 2024). Reflex emits a
+        # deprecation warning at compile time for the old name. Pin
+        # the new name so we don't drift back.
+        deprecated = {"alert-triangle"}
+        for type_name, icon in NOTIFICATION_TYPE_ICONS.items():
+            assert icon not in deprecated, (
+                f"{type_name} uses deprecated lucide icon {icon!r}; use the new name"
+            )
+
+    def test_quota_warning_uses_triangle_alert(self):
+        assert NOTIFICATION_TYPE_ICONS["quota_warning"] == "triangle-alert"
+
 
 class TestNotificationCenterStateStructure:
     def test_has_required_fields(self):

--- a/tests/test_ui/test_pipeline_template_state.py
+++ b/tests/test_ui/test_pipeline_template_state.py
@@ -1,0 +1,117 @@
+"""Tests for the connection-state side of pipeline templates.
+
+Covers ``ConnectionState._apply_template_defaults`` — the pure helper that
+takes a template slug, looks up the template, and prefills the matching
+``form_*`` fields on the state object. This is the bridge between the
+static template registry and the existing connection creation form.
+"""
+
+import types
+
+from datanika.data.pipeline_templates import get_template
+
+
+class _FakeConnectionState:
+    """Stand-in for ConnectionState that exposes only the form_* fields the
+    template prefill logic touches. Mirrors the FakeState pattern in
+    ``tests/test_ui/test_state_models.py::TestConnectionBuildConfig``.
+    """
+
+
+def _make_state(**overrides):
+    from datanika.ui.state.connection_state import ConnectionState
+
+    defaults = {
+        "form_type": "postgres",
+        "form_host": "",
+        "form_port": "5432",
+        "form_user": "",
+        "form_password": "",
+        "form_database": "",
+        "form_schema": "",
+        "form_path": "",
+        "form_project": "",
+        "form_dataset": "",
+        "form_keyfile_json": "",
+        "form_account": "",
+        "form_warehouse": "",
+        "form_role": "",
+        "form_bucket_url": "",
+        "form_base_url": "",
+        "form_property_id": "",
+        "form_bootstrap_servers": "",
+        "form_topics": "",
+        "selected_template_slug": "",
+    }
+    defaults.update(overrides)
+
+    obj = _FakeConnectionState()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    obj._apply_template_defaults = types.MethodType(ConnectionState._apply_template_defaults, obj)
+    return obj
+
+
+class TestApplyTemplateDefaults:
+    def test_unknown_slug_is_noop(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("does-not-exist")
+        # No fields should change
+        assert state.form_type == "postgres"
+        assert state.selected_template_slug == ""
+
+    def test_empty_slug_is_noop(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("")
+        assert state.form_type == "postgres"
+
+    def test_stripe_template_sets_source_type_to_stripe(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("stripe-to-postgres")
+        assert state.form_type == "stripe"
+        assert state.selected_template_slug == "stripe-to-postgres"
+
+    def test_postgres_template_prefills_port_and_schema(self):
+        state = _make_state(form_type="bigquery", form_port="", form_schema="")
+        state._apply_template_defaults("postgres-to-bigquery")
+        assert state.form_type == "postgres"
+        assert state.form_port == "5432"
+        assert state.form_schema == "public"
+
+    def test_csv_template_sets_source_type_to_csv(self):
+        state = _make_state(form_type="postgres")
+        state._apply_template_defaults("csv-to-duckdb")
+        assert state.form_type == "csv"
+        assert state.selected_template_slug == "csv-to-duckdb"
+
+    def test_template_does_not_overwrite_credentials(self):
+        """Template prefill must never touch password/secret/api_key fields."""
+        state = _make_state(
+            form_type="postgres",
+            form_password="user-typed-secret",
+            form_user="alice",
+        )
+        # Even if we apply a template that targets postgres source, the
+        # user-entered credentials must survive.
+        state._apply_template_defaults("postgres-to-bigquery")
+        assert state.form_password == "user-typed-secret"
+        assert state.form_user == "alice"
+
+    def test_apply_template_is_idempotent(self):
+        state = _make_state()
+        state._apply_template_defaults("stripe-to-postgres")
+        state._apply_template_defaults("stripe-to-postgres")
+        assert state.form_type == "stripe"
+        assert state.selected_template_slug == "stripe-to-postgres"
+
+
+class TestTemplateLookupHelper:
+    """Sanity check that get_template (already tested in test_data) is the
+    contract the state code relies on. If this fails, the state tests above
+    will too — but this localizes the failure mode for debugging."""
+
+    def test_get_template_returns_object_with_source_type_attribute(self):
+        tpl = get_template("stripe-to-postgres")
+        assert tpl is not None
+        assert hasattr(tpl, "source_type")
+        assert hasattr(tpl, "source_config_defaults")


### PR DESCRIPTION
## Summary

Bundled release since PR #75:

**Product**
- **#81** Pipeline Templates MVP — pre-configured source → destination starters, new \`/pipelines/templates\` page

**Engineering**
- **#82** Fix notification bell outside-click dismiss + audit log combobox widths (UI bugs from the 2026-04-12 promotion)
- **#83** Drop \`/llms.txt\` \`(5 tiers)\` header — list had 6 items, header count was off-by-one
- **#87** Single source of truth for AI agent tiers + capabilities. New \`datanika/services/agent_tiers.py\` + \`/api/v1/meta/agent-tiers\` JSON endpoint. \`/llms.txt\` now renders from the SoT — no hardcoded tier counts.
- **#89** Rename deprecated lucide icon \`alert-triangle\` → \`triangle-alert\` (fixes the cosmetic fallback observed in datanika-app logs after PR #75, issue #86)

## Rebase notes
- **#87** had an i18n conflict on \`tests/test_services/test_agent_docs.py\` with #83 (both modified the capabilities-header assertion). Resolved by taking #87's strict superset of assertions (keeps the "5 tiers" check from #83 AND adds the "6 tiers" guard from #87). Also ran \`ruff format\` to fix a format check failure caused by a stray blank line.

## Impact
- Standard CD: app + celery restart, ~30s downtime during health check wait
- No DB migration needed — \`pg_stat_statements\` already enabled from PR #73
- Notification bell UI bugs fixed → existing user-visible improvement

## Post-deploy verification (I will run these)
- [ ] Containers up and healthy on Hetzner
- [ ] Notification bell renders in app header and dismisses on outside-click
- [ ] Audit log comboboxes wide enough to show labels
- [ ] \`/pipelines/templates\` page renders with at least one template
- [ ] \`/llms.txt\` Capabilities header has no tier count
- [ ] No \`alert-triangle\` warning in \`docker logs datanika-app\` (icon renders, no fallback)
- [ ] \`/api/v1/meta/agent-tiers\` returns canonical tier JSON
- [ ] Slow query dashboard still live in Grafana