### PR TITLE
Promote dev → master: Plausible template events instrumentation

### DIFF
--- a/datanika/config.py
+++ b/datanika/config.py
@@ -36,6 +36,13 @@ class Settings(BaseSettings):
     recaptcha_site_key: str = ""
     recaptcha_secret_key: str = ""
 
+    # Analytics (Plausible CE) — issue #92. Both must be set to enable.
+    # When either is empty, no script tag is emitted and inline event
+    # scripts become no-ops. This lets the code ship before Infra creates
+    # the app.datanika.io site in the Plausible dashboard.
+    analytics_domain: str = ""
+    analytics_script_src: str = ""
+
     # dbt
     dbt_projects_dir: str = "./dbt_projects"
 

--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -3,6 +3,7 @@ import reflex as rx
 from datanika.config import settings as _settings
 from datanika.logging_config import setup_logging
 from datanika.scheduler import scheduler_integration
+from datanika.ui.analytics import plausible_head_component
 from datanika.ui.pages.audit_logs import audit_logs_page
 from datanika.ui.pages.auth_complete import auth_complete_page
 from datanika.ui.pages.connections import connections_page
@@ -41,11 +42,18 @@ from datanika.ui.state.upload_state import UploadState
 
 setup_logging(debug=_settings.debug)
 
-app = rx.App(
-    head_components=[
-        rx.el.link(rel="icon", href="/favicon.ico", type="image/x-icon"),
-    ],
-)
+# Analytics head tag is conditional — gated on settings.analytics_domain +
+# settings.analytics_script_src (issue #92). Returns None when disabled,
+# in which case the inline event scripts in the UI become no-ops on the
+# client because window.plausible is undefined.
+_head_components: list[rx.Component] = [
+    rx.el.link(rel="icon", href="/favicon.ico", type="image/x-icon"),
+]
+_plausible = plausible_head_component()
+if _plausible is not None:
+    _head_components.append(_plausible)
+
+app = rx.App(head_components=_head_components)
 
 # Load cloud plugin if running in cloud edition
 if _settings.datanika_edition == "cloud":

--- a/datanika/ui/analytics.py
+++ b/datanika/ui/analytics.py
@@ -1,0 +1,80 @@
+"""Plausible analytics instrumentation for the Reflex app (issue #92).
+
+Two public surfaces:
+
+1. ``plausible_head_component()`` — emits the Plausible ``<script>`` tag
+   into ``rx.App(head_components=[...])`` when both ``analytics_domain``
+   and ``analytics_script_src`` are configured. Returns ``None`` otherwise
+   so ``datanika.py`` can splice it into the head list conditionally.
+
+2. ``ANALYTICS_EVENTS`` — the canonical set of custom event names we fire
+   from inline ``rx.script`` blocks in the UI pages. A test scanner in
+   ``tests/test_ui/test_analytics.py`` walks every ``.py`` file under
+   ``datanika/ui/`` looking for ``window.plausible('NAME', ...)`` calls
+   and asserts ``NAME`` is in this set — that's how we catch typos before
+   they silently break a Growth dashboard.
+
+Design notes:
+
+- Analytics is **gated off by default**. Both settings default to empty.
+  This lets the instrumentation code ship before Infra creates the
+  ``app.datanika.io`` site in Plausible CE — the inline event scripts
+  guard ``window.plausible && window.plausible(...)`` so they're no-ops
+  when the global isn't defined.
+- The Plausible script tag uses the standard (non-manual) form so SPA
+  pageviews are auto-tracked. Manual pageview firing is a follow-up if
+  we find Reflex's router doesn't trigger the history events Plausible
+  listens for.
+- We intentionally do NOT wrap event firing in Python. JavaScript emits
+  the events directly via inline ``rx.script`` blocks at the call sites,
+  because event firing must happen synchronously on the client before
+  navigation. A server round-trip would race the browser's link follow.
+"""
+
+from __future__ import annotations
+
+import reflex as rx
+
+from datanika.config import settings
+
+# Canonical event name catalog. Add an entry here when you wire a new
+# ``window.plausible('...')`` call in the UI, and also update
+# ``tests/test_ui/test_analytics.py::TestAnalyticsEvents::test_catalog_has_no_surprising_extras``.
+# The set is intentionally small — each entry is a real funnel step Growth
+# measures. Don't dump raw UI interactions in here.
+ANALYTICS_EVENTS: set[str] = {
+    # User clicked a card on /pipelines/templates (top of funnel).
+    "template_selected",
+    # /connections page loaded with ?template=<slug> and prefill ran
+    # (middle of funnel — credential step is imminent).
+    "template_prefill_applied",
+    # "template_first_run_triggered" is a follow-up — see issue #92 body
+    # for the design trade-off (needs DB column or cross-state threading).
+}
+
+
+def plausible_head_component() -> rx.Component | None:
+    """Return a Reflex script tag for Plausible, or None if disabled.
+
+    Called once from ``datanika.py`` when building ``rx.App``. Callers
+    splice the return value into the ``head_components`` list and filter
+    out ``None``::
+
+        head = [favicon]
+        plausible = plausible_head_component()
+        if plausible is not None:
+            head.append(plausible)
+        app = rx.App(head_components=head)
+    """
+    domain = settings.analytics_domain.strip()
+    src = settings.analytics_script_src.strip()
+    if not domain or not src:
+        return None
+
+    # ``defer`` so the script doesn't block rendering. ``data-domain`` is
+    # what Plausible uses to bucket events into the right site dashboard.
+    return rx.script(
+        src=src,
+        defer=True,
+        custom_attrs={"data-domain": domain},
+    )

--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -11,6 +11,40 @@ from datanika.ui.state.i18n_state import I18nState
 
 _t = I18nState.translations
 
+# Inline Plausible event firing for the template-prefill funnel step
+# (issue #92). When the user lands on /connections with ``?template=<slug>``,
+# ConnectionState.load_template_from_query runs on_load and prefills the
+# form. This script fires the ``template_prefill_applied`` event from the
+# client side so Plausible sees a first-party event with the slug prop.
+#
+# Why client-side instead of returning rx.call_script from the state
+# handler: the on_load handler runs server-side and its return value
+# would arrive at the client asynchronously after the initial HTML render.
+# Firing from DOMContentLoaded ensures the event lands during the same page
+# view as the prefill, which is what Growth's funnel dashboard expects.
+#
+# Guarded on ``window.plausible`` so this is a silent no-op when analytics
+# is disabled via empty settings.analytics_domain / analytics_script_src.
+_CONNECTIONS_TEMPLATE_ANALYTICS_JS = """
+(function() {
+    if (window.__templatePrefillBound) return;
+    window.__templatePrefillBound = true;
+    function fire() {
+        var params = new URLSearchParams(window.location.search);
+        var slug = params.get('template');
+        if (!slug) return;
+        if (window.plausible) {
+            window.plausible('template_prefill_applied', { props: { slug: slug } });
+        }
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', fire, { once: true });
+    } else {
+        fire();
+    }
+})();
+"""
+
 
 def connection_form() -> rx.Component:
     return rx.card(
@@ -190,6 +224,12 @@ def connections_table() -> rx.Component:
 
 def connections_page() -> rx.Component:
     return page_layout(
-        rx.vstack(connection_form(), connections_table(), spacing="6", width="100%"),
+        rx.vstack(
+            connection_form(),
+            connections_table(),
+            rx.script(_CONNECTIONS_TEMPLATE_ANALYTICS_JS),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.connections"],
     )

--- a/datanika/ui/pages/pipeline_templates.py
+++ b/datanika/ui/pages/pipeline_templates.py
@@ -36,6 +36,10 @@ def _template_card(tpl: PipelineTemplate) -> rx.Component:
     Built at import time from a static template — no Reflex state vars needed,
     so we render the source/destination labels as plain Python strings.
     """
+    # ``data-template-slug`` is what the inline click listener below
+    # delegates off of to fire the ``template_selected`` Plausible event
+    # (issue #92). The attribute also serves as a stable selector for any
+    # future e2e/visual test that wants to click a specific card.
     return rx.link(
         rx.card(
             rx.vstack(
@@ -69,7 +73,34 @@ def _template_card(tpl: PipelineTemplate) -> rx.Component:
         href=f"/connections?template={tpl.slug}",
         underline="none",
         width="100%",
+        custom_attrs={"data-template-slug": tpl.slug},
     )
+
+
+# Delegated click listener on the templates page. Fires a Plausible
+# ``template_selected`` event the first time a click bubbles up through an
+# element carrying ``data-template-slug``. The guard on ``window.plausible``
+# makes this a silent no-op when analytics isn't configured (issue #92).
+#
+# Delegation (one listener on document) is deliberate — it survives Reflex
+# re-renders that would blow away listeners attached to individual cards.
+# The ``once`` flag via a module-level ``__templateSelectedBound`` guards
+# against double-binding if the page is mounted twice in one session.
+_TEMPLATES_ANALYTICS_JS = """
+(function() {
+    if (window.__templateSelectedBound) return;
+    window.__templateSelectedBound = true;
+    document.addEventListener('click', function(e) {
+        var el = e.target.closest && e.target.closest('[data-template-slug]');
+        if (!el) return;
+        var slug = el.getAttribute('data-template-slug');
+        if (!slug) return;
+        if (window.plausible) {
+            window.plausible('template_selected', { props: { slug: slug } });
+        }
+    }, true);
+})();
+"""
 
 
 def pipeline_templates_page() -> rx.Component:
@@ -94,6 +125,7 @@ def pipeline_templates_page() -> rx.Component:
                 size="1",
                 margin_top="1rem",
             ),
+            rx.script(_TEMPLATES_ANALYTICS_JS),
             spacing="4",
             width="100%",
             align="stretch",

--- a/tests/test_ui/test_analytics.py
+++ b/tests/test_ui/test_analytics.py
@@ -1,0 +1,139 @@
+"""Tests for the Plausible analytics instrumentation (issue #92).
+
+The analytics module exposes two things the rest of the app uses:
+
+1. ``plausible_head_component()`` — returns an ``rx.script`` when analytics
+   is fully configured, ``None`` otherwise. Called from ``datanika.py``'s
+   ``rx.App(head_components=[...])`` list, where ``None`` is filtered out.
+2. ``ANALYTICS_EVENTS`` — a frozen set of canonical event names. Any inline
+   ``rx.script`` in the UI that calls ``window.plausible('...')`` must
+   reference a name in this set. The scanner test below enforces that so
+   a typo can't silently break a Growth dashboard.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import datanika.ui.analytics as analytics_module
+from datanika.config import settings
+from datanika.ui.analytics import (
+    ANALYTICS_EVENTS,
+    plausible_head_component,
+)
+
+
+@pytest.fixture
+def reset_analytics_settings():
+    """Snapshot + restore analytics settings around each test."""
+    original_domain = settings.analytics_domain
+    original_src = settings.analytics_script_src
+    yield
+    settings.analytics_domain = original_domain
+    settings.analytics_script_src = original_src
+
+
+class TestAnalyticsEvents:
+    def test_catalog_is_a_set(self):
+        assert isinstance(ANALYTICS_EVENTS, (set, frozenset))
+
+    def test_catalog_contains_template_selected(self):
+        assert "template_selected" in ANALYTICS_EVENTS
+
+    def test_catalog_contains_template_prefill_applied(self):
+        assert "template_prefill_applied" in ANALYTICS_EVENTS
+
+    def test_catalog_has_no_surprising_extras(self):
+        # If you're adding a new event, update this list AND the PR description
+        # AND ping Growth so the dashboard picks it up. The catalog is the
+        # single source of truth — don't let it drift from the UI scripts.
+        expected = {
+            "template_selected",
+            "template_prefill_applied",
+            # "template_first_run_triggered" is intentionally excluded — it's
+            # a follow-up issue, not part of issue #92.
+        }
+        assert expected == ANALYTICS_EVENTS
+
+    def test_event_names_are_snake_case_strings(self):
+        for name in ANALYTICS_EVENTS:
+            assert isinstance(name, str)
+            assert re.fullmatch(r"[a-z][a-z0-9_]*", name), (
+                f"{name!r} is not a valid snake_case event name"
+            )
+
+
+class TestPlausibleHeadComponent:
+    def test_returns_none_when_both_config_values_empty(self, reset_analytics_settings):
+        settings.analytics_domain = ""
+        settings.analytics_script_src = ""
+        assert plausible_head_component() is None
+
+    def test_returns_none_when_only_domain_set(self, reset_analytics_settings):
+        settings.analytics_domain = "app.datanika.io"
+        settings.analytics_script_src = ""
+        assert plausible_head_component() is None
+
+    def test_returns_none_when_only_script_src_set(self, reset_analytics_settings):
+        settings.analytics_domain = ""
+        settings.analytics_script_src = "https://plausible.datanika.io/js/script.js"
+        assert plausible_head_component() is None
+
+    def test_returns_script_component_when_both_set(self, reset_analytics_settings):
+        settings.analytics_domain = "app.datanika.io"
+        settings.analytics_script_src = "https://plausible.datanika.io/js/script.js"
+        component = plausible_head_component()
+        assert component is not None
+
+    def test_script_component_carries_domain_and_src(self, reset_analytics_settings):
+        settings.analytics_domain = "app.datanika.io"
+        settings.analytics_script_src = "https://plausible.datanika.io/js/script.js"
+        component = plausible_head_component()
+        rendered = str(component)
+        # The rendered string should mention the configured domain and src.
+        assert "app.datanika.io" in rendered
+        assert "plausible.datanika.io" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Scanner: every window.plausible('EVENT', ...) call in the UI code must
+# reference an event name from ANALYTICS_EVENTS. Prevents typos from silently
+# sending junk events to Growth's dashboard.
+# ---------------------------------------------------------------------------
+
+_UI_ROOT = Path(analytics_module.__file__).resolve().parent.parent / "ui"
+_PLAUSIBLE_CALL_RE = re.compile(r"""window\.plausible\(\s*['"]([^'"]+)['"]""")
+
+
+class TestInlineScriptEventCatalogSync:
+    def test_every_plausible_call_uses_a_known_event_name(self):
+        """Scan every .py file under datanika/ui/ for window.plausible(...)
+        calls and assert the event name is in ANALYTICS_EVENTS. Catches
+        typos like 'template_selected' → 'tempalte_selected' immediately.
+        """
+        found_names: set[str] = set()
+        for py_file in _UI_ROOT.rglob("*.py"):
+            # analytics.py is the *definition* of the catalog — its docstring
+            # mentions example event names like 'NAME' that the regex would
+            # otherwise pick up as real consumers. Skip it.
+            if py_file.name == "analytics.py":
+                continue
+            text = py_file.read_text(encoding="utf-8")
+            for match in _PLAUSIBLE_CALL_RE.finditer(text):
+                found_names.add(match.group(1))
+
+        # Sanity: if the scanner finds zero, either the instrumentation
+        # isn't wired yet (before this PR) or the regex is broken. After
+        # this PR lands there should be at least one plausible() call.
+        assert found_names, (
+            "No window.plausible(...) calls found in datanika/ui/*.py — "
+            "instrumentation may have been removed by mistake"
+        )
+
+        unknown = found_names - ANALYTICS_EVENTS
+        assert not unknown, (
+            f"Unknown plausible event names used in UI code: {sorted(unknown)}. "
+            f"Either add them to ANALYTICS_EVENTS in datanika/ui/analytics.py "
+            f"or fix the typo. Known names: {sorted(ANALYTICS_EVENTS)}"
+        )


### PR DESCRIPTION
## Summary

Single PR since PR #90:

- **#94** Instrument Pipeline Templates funnel with Plausible events (closes #92). Dormant-by-default: the tracking script only renders when \`DATANIKA_ANALYTICS_DOMAIN\` and \`DATANIKA_ANALYTICS_SCRIPT_SRC\` env vars are set on the app container. Infra will flip the env vars post-deploy to activate tracking for \`app.datanika.io\`.

## Merge strategy
Using **\`--merge\`** (not \`--rebase\`) per Engineering's runbook recommendation. Prevents dev/master SHA divergence that required the PR #115 workaround last time.

## Post-deploy verification (I will run these)
- [ ] Containers up and healthy on Hetzner
- [ ] \`datanika/ui/analytics.py\` module exists in the container
- [ ] \`/\` HTML contains no Plausible script tag yet (env vars unset = dormant)
- [ ] After env flip: \`/\` HTML contains \`<script data-domain="app.datanika.io" src="https://plausible.datanika.io/js/script.js">\`