### PR TITLE
Promote dev → master: Phase 2 Google Ads signup conversion tracking

### DIFF
--- a/datanika/config.py
+++ b/datanika/config.py
@@ -43,6 +43,21 @@ class Settings(BaseSettings):
     analytics_domain: str = ""
     analytics_script_src: str = ""
 
+    # Google Ads conversion tracking — issue #96 Phase 2. Both settings
+    # are dormant-by-default. When google_ads_tag_id is empty, no gtag
+    # script tags are emitted in the Reflex app head. When
+    # google_ads_conversion_label_signup is empty, auth_state.signup
+    # doesn't fire an rx.call_script — so local dev + tests work with no
+    # config, and production only activates after Infra sets both in
+    # .env.docker on Hetzner.
+    #
+    # The tag ID (AW-18081528527) is the same account used by the landing
+    # site gtag config — a public property, safe to commit as a default.
+    # Left empty here so tests don't accidentally emit live gtag scripts;
+    # production reads it from .env.docker.
+    google_ads_tag_id: str = ""
+    google_ads_conversion_label_signup: str = ""
+
     # dbt
     dbt_projects_dir: str = "./dbt_projects"
 

--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -3,7 +3,7 @@ import reflex as rx
 from datanika.config import settings as _settings
 from datanika.logging_config import setup_logging
 from datanika.scheduler import scheduler_integration
-from datanika.ui.analytics import plausible_head_component
+from datanika.ui.analytics import google_ads_head_components, plausible_head_component
 from datanika.ui.pages.audit_logs import audit_logs_page
 from datanika.ui.pages.auth_complete import auth_complete_page
 from datanika.ui.pages.connections import connections_page
@@ -42,16 +42,21 @@ from datanika.ui.state.upload_state import UploadState
 
 setup_logging(debug=_settings.debug)
 
-# Analytics head tag is conditional — gated on settings.analytics_domain +
-# settings.analytics_script_src (issue #92). Returns None when disabled,
-# in which case the inline event scripts in the UI become no-ops on the
-# client because window.plausible is undefined.
+# Analytics head tags are both conditional and dormant-by-default:
+# - Plausible (issue #92): gated on settings.analytics_domain +
+#   settings.analytics_script_src. Returns None when disabled; inline
+#   window.plausible(...) calls in UI pages become no-ops on the client
+#   because the global is undefined.
+# - Google Ads (issue #96): gated on settings.google_ads_tag_id. Returns
+#   an empty list when disabled; conversion events fired via
+#   rx.call_script also no-op because they guard on `window.gtag &&`.
 _head_components: list[rx.Component] = [
     rx.el.link(rel="icon", href="/favicon.ico", type="image/x-icon"),
 ]
 _plausible = plausible_head_component()
 if _plausible is not None:
     _head_components.append(_plausible)
+_head_components.extend(google_ads_head_components())
 
 app = rx.App(head_components=_head_components)
 

--- a/datanika/ui/analytics.py
+++ b/datanika/ui/analytics.py
@@ -1,34 +1,44 @@
-"""Plausible analytics instrumentation for the Reflex app (issue #92).
+"""Analytics instrumentation for the Reflex app.
 
-Two public surfaces:
+Two providers, both dormant-by-default (empty config = no script tags,
+inline event calls become JS no-ops via ``&&`` guards):
 
-1. ``plausible_head_component()`` — emits the Plausible ``<script>`` tag
-   into ``rx.App(head_components=[...])`` when both ``analytics_domain``
-   and ``analytics_script_src`` are configured. Returns ``None`` otherwise
-   so ``datanika.py`` can splice it into the head list conditionally.
+**Plausible** (issue #92, shipped PR #94):
+- ``plausible_head_component()`` — returns an ``rx.script`` loading
+  Plausible's JS when both ``analytics_domain`` and ``analytics_script_src``
+  are configured, ``None`` otherwise.
+- ``ANALYTICS_EVENTS`` — canonical set of Plausible custom event names.
+  A scanner test enforces every ``window.plausible('NAME', ...)`` call
+  in ``datanika/ui/`` references a name in this set.
 
-2. ``ANALYTICS_EVENTS`` — the canonical set of custom event names we fire
-   from inline ``rx.script`` blocks in the UI pages. A test scanner in
-   ``tests/test_ui/test_analytics.py`` walks every ``.py`` file under
-   ``datanika/ui/`` looking for ``window.plausible('NAME', ...)`` calls
-   and asserts ``NAME`` is in this set — that's how we catch typos before
-   they silently break a Growth dashboard.
+**Google Ads** (issue #96, Phase 2 conversion tracking):
+- ``google_ads_head_components()`` — returns a list of ``rx.script``
+  components (gtag.js loader + init) when ``google_ads_tag_id`` is set,
+  empty list otherwise.
+- ``google_ads_conversion_event_js(label)`` — pure function returning a
+  JS one-liner that fires ``gtag('event', 'conversion', {...})`` for the
+  given conversion label. Returns empty string when the label or tag ID
+  is unset. Callers pass the result to ``rx.call_script`` inside an
+  event handler (e.g. signup success in ``auth_state.signup``).
 
 Design notes:
 
-- Analytics is **gated off by default**. Both settings default to empty.
-  This lets the instrumentation code ship before Infra creates the
-  ``app.datanika.io`` site in Plausible CE — the inline event scripts
-  guard ``window.plausible && window.plausible(...)`` so they're no-ops
-  when the global isn't defined.
-- The Plausible script tag uses the standard (non-manual) form so SPA
-  pageviews are auto-tracked. Manual pageview firing is a follow-up if
-  we find Reflex's router doesn't trigger the history events Plausible
-  listens for.
-- We intentionally do NOT wrap event firing in Python. JavaScript emits
-  the events directly via inline ``rx.script`` blocks at the call sites,
-  because event firing must happen synchronously on the client before
-  navigation. A server round-trip would race the browser's link follow.
+- **Gated off by default**. All settings default to empty. This lets
+  instrumentation code ship before Infra wires the prod env vars.
+  Plausible inline events guard on ``window.plausible &&``; Google Ads
+  conversion events guard on ``window.gtag &&``. Both are silent no-ops
+  when the corresponding global isn't defined.
+- **Plausible** uses the standard non-manual script form so SPA
+  pageviews are auto-tracked.
+- **Google Ads** loads gtag.js asynchronously + an inline init script
+  that calls ``gtag('config', <TAG_ID>)``. Matches the exact snippet
+  Google Ads provides in the Tag setup UI, so the rendered HTML is
+  bit-identical to what the Google Ads debugger expects.
+- **Event firing**: for Plausible we use inline ``rx.script`` blocks at
+  the call site (synchronous, beats browser navigation). For Google Ads
+  signup conversion we use ``rx.call_script`` returned from the signup
+  event handler alongside ``rx.redirect("/")`` — Reflex processes the
+  event list in order, so the JS fires before the redirect.
 """
 
 from __future__ import annotations
@@ -77,4 +87,99 @@ def plausible_head_component() -> rx.Component | None:
         src=src,
         defer=True,
         custom_attrs={"data-domain": domain},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Google Ads (issue #96 — Phase 2 conversion tracking)
+# ---------------------------------------------------------------------------
+
+
+def google_ads_head_components() -> list[rx.Component]:
+    """Return the gtag.js loader + init script tags, or an empty list.
+
+    Dormant-by-default: when ``settings.google_ads_tag_id`` is empty,
+    returns ``[]`` so callers can simply ``extend`` the head components
+    list without null checks. When set, returns two script components:
+
+    1. The async gtag.js loader pointing at googletagmanager.com with
+       the configured tag ID.
+    2. The standard inline init snippet that creates ``window.dataLayer``
+       and calls ``gtag('js', new Date())`` + ``gtag('config', <TAG_ID>)``.
+
+    The two scripts together match the exact HTML snippet Google Ads
+    shows in the *Tag setup → Install the tag yourself* dialog. Keeping
+    it bit-identical means Google's conversion debugger recognizes it
+    without extra configuration.
+
+    The conversion label is NOT read here — that lives on a per-event
+    basis via ``google_ads_conversion_event_js()``. This function only
+    emits the base tag, which is a prerequisite for any conversion event
+    to fire.
+    """
+    tag_id = settings.google_ads_tag_id.strip()
+    if not tag_id:
+        return []
+
+    loader = rx.script(
+        src=f"https://www.googletagmanager.com/gtag/js?id={tag_id}",
+        custom_attrs={"async": "true"},
+    )
+    init = rx.script(
+        "window.dataLayer = window.dataLayer || [];"
+        "function gtag(){dataLayer.push(arguments);}"
+        "gtag('js', new Date());"
+        f"gtag('config', '{tag_id}');"
+    )
+    return [loader, init]
+
+
+def google_ads_conversion_event_js(label: str) -> str:
+    """Return a JS one-liner that fires a Google Ads conversion event.
+
+    Pure function: no side effects, no Reflex imports. Takes the
+    conversion label (e.g. ``"EHgmCLWVmpscEM_1-K1D"``) and returns a
+    JS string like::
+
+        window.gtag && window.gtag('event', 'conversion', {
+          'send_to': 'AW-18081528527/EHgmCLWVmpscEM_1-K1D',
+          'value': 1.0,
+          'currency': 'EUR'
+        });
+
+    The ``window.gtag &&`` prefix makes this a silent no-op when gtag.js
+    hasn't loaded — which happens in two cases:
+    1. ``settings.google_ads_tag_id`` is empty (no head components
+       emitted, so the gtag global never exists)
+    2. The user clicks signup before gtag.js finishes loading (rare but
+       possible on slow networks)
+
+    Returns an empty string when either ``label`` is empty OR
+    ``settings.google_ads_tag_id`` is empty. Callers should check for
+    the empty string and skip emitting ``rx.call_script`` entirely in
+    that case — firing an empty script is wasteful WebSocket traffic.
+
+    Why a pure function (not an rx.Component): conversion events fire
+    from event handlers via ``rx.call_script``, not from the rendered
+    DOM. The Reflex runtime expects a JS string payload, not a
+    component. This also makes the function trivially unit-testable
+    without spinning up a Reflex app.
+    """
+    if not label:
+        return ""
+    tag_id = settings.google_ads_tag_id.strip()
+    if not tag_id:
+        return ""
+    # Currency is hardcoded EUR because the Datanika pricing page lists
+    # all tiers in EUR and the Google Ads account is billed in EUR. If
+    # we ever localize pricing, this should read from a new setting.
+    # Value is a placeholder 1.0 — we don't have a per-signup dollar
+    # value at this point in the funnel; Google's bidding can still
+    # optimize against conversion *count* regardless of value.
+    return (
+        "window.gtag && window.gtag('event', 'conversion', {"
+        f"'send_to': '{tag_id}/{label}', "
+        "'value': 1.0, "
+        "'currency': 'EUR'"
+        "});"
     )

--- a/datanika/ui/state/auth_state.py
+++ b/datanika/ui/state/auth_state.py
@@ -9,6 +9,7 @@ from datanika.config import settings
 from datanika.services.auth import AuthService
 from datanika.services.captcha_service import CaptchaService
 from datanika.services.user_service import UserService
+from datanika.ui.analytics import google_ads_conversion_event_js
 from datanika.ui.state.base_state import get_sync_session
 
 
@@ -237,6 +238,17 @@ class AuthState(rx.State):
         except Exception:
             self.auth_error = "Signup failed. Please try again."
             return
+        # Fire the Google Ads "Account signup completed" conversion event
+        # (issue #96 Phase 2). Dormant-by-default: returns "" when either
+        # google_ads_tag_id or google_ads_conversion_label_signup is empty,
+        # in which case we skip rx.call_script entirely and just redirect.
+        # When set, the JS guards on `window.gtag &&` so it's still a
+        # no-op if the gtag loader hasn't emitted in the page head (belt
+        # + suspenders — both config flags must be set AND gtag.js must
+        # have loaded for an actual conversion to fire).
+        conversion_js = google_ads_conversion_event_js(settings.google_ads_conversion_label_signup)
+        if conversion_js:
+            return [rx.call_script(conversion_js), rx.redirect("/")]
         return rx.redirect("/")
 
     def logout(self):

--- a/tests/test_ui/test_analytics.py
+++ b/tests/test_ui/test_analytics.py
@@ -20,6 +20,8 @@ import datanika.ui.analytics as analytics_module
 from datanika.config import settings
 from datanika.ui.analytics import (
     ANALYTICS_EVENTS,
+    google_ads_conversion_event_js,
+    google_ads_head_components,
     plausible_head_component,
 )
 
@@ -32,6 +34,16 @@ def reset_analytics_settings():
     yield
     settings.analytics_domain = original_domain
     settings.analytics_script_src = original_src
+
+
+@pytest.fixture
+def reset_google_ads_settings():
+    """Snapshot + restore Google Ads settings around each test."""
+    original_tag_id = settings.google_ads_tag_id
+    original_label = settings.google_ads_conversion_label_signup
+    yield
+    settings.google_ads_tag_id = original_tag_id
+    settings.google_ads_conversion_label_signup = original_label
 
 
 class TestAnalyticsEvents:
@@ -94,6 +106,101 @@ class TestPlausibleHeadComponent:
         # The rendered string should mention the configured domain and src.
         assert "app.datanika.io" in rendered
         assert "plausible.datanika.io" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Google Ads head components: gtag.js loader + init script, dormant-by-default
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleAdsHeadComponents:
+    def test_returns_empty_list_when_tag_id_empty(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = ""
+        settings.google_ads_conversion_label_signup = "EHgmCLWVmpscEM_1-K1D"
+        assert google_ads_head_components() == []
+
+    def test_returns_empty_list_when_both_empty(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = ""
+        settings.google_ads_conversion_label_signup = ""
+        assert google_ads_head_components() == []
+
+    def test_returns_components_when_tag_id_set(self, reset_google_ads_settings):
+        # Only tag_id is required to emit the gtag loader — the conversion
+        # label is only needed to fire the signup event. We intentionally
+        # allow tag_id alone so the gtag global can load even before the
+        # conversion label is wired (e.g. during staged rollout).
+        settings.google_ads_tag_id = "AW-18081528527"
+        settings.google_ads_conversion_label_signup = ""
+        components = google_ads_head_components()
+        assert isinstance(components, list)
+        assert len(components) >= 1
+
+    def test_components_carry_tag_id(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        settings.google_ads_conversion_label_signup = "EHgmCLWVmpscEM_1-K1D"
+        rendered = "".join(str(c) for c in google_ads_head_components())
+        assert "AW-18081528527" in rendered
+
+    def test_components_reference_googletagmanager_loader(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        rendered = "".join(str(c) for c in google_ads_head_components())
+        assert "googletagmanager.com/gtag/js" in rendered
+
+    def test_components_include_gtag_config_call(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        rendered = "".join(str(c) for c in google_ads_head_components())
+        # The init script should call gtag('config', 'AW-...').
+        assert "gtag(" in rendered or "gtag (" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Google Ads conversion event JS builder — pure function, easy to unit test
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleAdsConversionEventJs:
+    def test_returns_empty_string_when_label_empty(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        assert google_ads_conversion_event_js("") == ""
+
+    def test_returns_empty_string_when_tag_id_empty(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = ""
+        assert google_ads_conversion_event_js("EHgmCLWVmpscEM_1-K1D") == ""
+
+    def test_contains_window_gtag_guard(self, reset_google_ads_settings):
+        # The JS must guard on window.gtag so it's a silent no-op when
+        # gtag.js hasn't loaded (staged rollout, local dev, etc).
+        settings.google_ads_tag_id = "AW-18081528527"
+        js = google_ads_conversion_event_js("EHgmCLWVmpscEM_1-K1D")
+        assert "window.gtag" in js
+        assert "&&" in js
+
+    def test_contains_conversion_event_name(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        js = google_ads_conversion_event_js("EHgmCLWVmpscEM_1-K1D")
+        assert "'conversion'" in js or '"conversion"' in js
+
+    def test_send_to_uses_tag_id_and_label(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        js = google_ads_conversion_event_js("EHgmCLWVmpscEM_1-K1D")
+        assert "AW-18081528527/EHgmCLWVmpscEM_1-K1D" in js
+
+    def test_sets_value_and_currency(self, reset_google_ads_settings):
+        settings.google_ads_tag_id = "AW-18081528527"
+        js = google_ads_conversion_event_js("EHgmCLWVmpscEM_1-K1D")
+        assert "'value'" in js or '"value"' in js
+        assert "1.0" in js
+        assert "'currency'" in js or '"currency"' in js
+        assert "EUR" in js
+
+    def test_no_python_format_leaks(self, reset_google_ads_settings):
+        # Regression: make sure the JS doesn't contain unrendered {placeholder}
+        # tokens from an accidental raw f-string template.
+        settings.google_ads_tag_id = "AW-18081528527"
+        js = google_ads_conversion_event_js("EHgmCLWVmpscEM_1-K1D")
+        assert "{label}" not in js
+        assert "{tag_id}" not in js
+        assert "{send_to}" not in js
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui/test_auth_state.py
+++ b/tests/test_ui/test_auth_state.py
@@ -72,3 +72,63 @@ class TestAuthStateFormFields:
         sig = inspect.signature(fn)
         params = list(sig.parameters.keys())
         assert "form_data" in params
+
+    def test_signup_imports_google_ads_conversion_helper(self):
+        """Regression for #96: auth_state must import the conversion-event
+        helper so the signup success path can fire it. A future refactor
+        that drops this import silently breaks Google Ads attribution.
+        """
+        import datanika.ui.state.auth_state as auth_state_module
+
+        assert hasattr(auth_state_module, "google_ads_conversion_event_js"), (
+            "auth_state.py must import google_ads_conversion_event_js from "
+            "datanika.ui.analytics so signup() can fire the Phase 2 "
+            "conversion event. See issue #96."
+        )
+
+    def test_signup_source_references_call_script_and_conversion_helper(self):
+        """Source scan: signup() must reference both rx.call_script and the
+        conversion helper. Catches regressions that drop the event fire
+        while keeping the import intact (e.g. "oops, removed one call").
+        """
+        import inspect
+
+        import datanika.ui.state.auth_state as auth_state_module
+
+        source = inspect.getsource(auth_state_module.AuthState.signup.fn)
+        assert "google_ads_conversion_event_js" in source, (
+            "signup() no longer calls google_ads_conversion_event_js — "
+            "the Phase 2 conversion event will not fire"
+        )
+        assert "call_script" in source, (
+            "signup() no longer returns rx.call_script — the conversion "
+            "event JS will not be sent to the client"
+        )
+
+
+class TestConfigHasGoogleAdsSettings:
+    """Regression for #96: settings fields must exist so the dormant
+    check in google_ads_conversion_event_js() doesn't AttributeError.
+    """
+
+    def test_google_ads_tag_id_exists(self):
+        from datanika.config import settings
+
+        assert hasattr(settings, "google_ads_tag_id")
+        assert isinstance(settings.google_ads_tag_id, str)
+
+    def test_google_ads_conversion_label_signup_exists(self):
+        from datanika.config import settings
+
+        assert hasattr(settings, "google_ads_conversion_label_signup")
+        assert isinstance(settings.google_ads_conversion_label_signup, str)
+
+    def test_defaults_are_empty_strings(self):
+        # Dormant-by-default contract: the test environment must not
+        # accidentally emit live gtag scripts. Empty string is the
+        # dormant signal in both analytics.py helpers.
+        from datanika.config import Settings
+
+        fresh = Settings()
+        assert fresh.google_ads_tag_id == ""
+        assert fresh.google_ads_conversion_label_signup == ""


### PR DESCRIPTION
## Summary

Single PR:
- **#97** Phase 2: Google Ads conversion tracking on signup completion — dormant-by-default via env vars. Extends \`datanika/ui/analytics.py\` (additive, no conflicts with Product's PR #94), adds \`google_ads_tag_id\` + \`google_ads_conversion_label_signup\` to Pydantic Settings, wires gtag.js head component into \`datanika.py\`, fires a \`conversion\` event on successful password signup via \`rx.call_script\` before redirect. Closes #96.

## Merge strategy
\`gh pr merge --merge\` per the adopted promotion policy in \`plans/infra/RUNBOOK_DEV_TO_MASTER.md\`.

## Post-deploy env vars (from core PR #97 coordination section)

After merge + CD completes, Infra will append to \`/opt/datanika/datanika/.env.docker\`:
\`\`\`
GOOGLE_ADS_TAG_ID=AW-18081528527
GOOGLE_ADS_CONVERSION_LABEL_SIGNUP=EHgmCLWVmpscEM_1-K1D
\`\`\`
Values parsed from \`D:/Projects/Datanika/secrets/google-ads-api.env\`. Then \`docker compose up -d --build app\` to pick up new env. Verify via \`docker exec datanika-app env | grep GOOGLE_ADS\`.

## Post-deploy verification (Infra will run these)
- [ ] Containers up and healthy
- [ ] \`docker exec datanika-app env | grep GOOGLE_ADS\` shows both vars
- [ ] \`datanika-app\` logs don't emit any \`google_ads_conversion_event_js\` format-string errors
- [ ] After Growth verifies: Phase 2 conversions transition from "No recent conversions" to "Recording conversions" in Google Ads UI (user/Growth task, not Infra)

## Out of scope
- OAuth signup tracking (Phase 3, per PR body)
- Flipping *Start free click* → *Account signup completed* in Google Ads bidding (human-only, tracked in \`plans/PLAN_HUMAN_LOCKERS.md\`, do not flip until ≥10 Phase 2 events accumulate)