### PR TITLE
AuthState: propagate ?template=<slug> across signup redirect (Option C)

### DIFF
--- a/datanika/ui/state/auth_state.py
+++ b/datanika/ui/state/auth_state.py
@@ -12,6 +12,16 @@ from datanika.services.user_service import UserService
 from datanika.ui.analytics import google_ads_conversion_event_js
 from datanika.ui.state.base_state import get_sync_session
 
+# Option C auth bridge: valid template slug pattern + max length. Cold-traffic
+# visitors who click "Try this template" on a public /templates/<slug> landing
+# page must have the slug preserved across the signup wall so the post-auth
+# redirect can land on /connections?template=<slug>. The slug is compared
+# against this pattern (not against the in-app template registry) to keep the
+# auth layer decoupled from ConnectionState; unknown-but-well-formed slugs are
+# silently ignored downstream by ConnectionState.load_template_from_query.
+# Rejecting malformed or over-long slugs avoids an open-redirect vector.
+_TEMPLATE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
 
 class UserInfo(BaseModel):
     id: int = 0
@@ -62,6 +72,24 @@ class AuthState(rx.State):
     def _get_user_service(self) -> UserService:
         auth = AuthService(settings.secret_key)
         return UserService(auth)
+
+    def _post_auth_redirect_target(self) -> str:
+        """Return the path to redirect to after a successful login/signup.
+
+        When the URL carries a well-formed ``?template=<slug>`` query
+        parameter (from a public ``datanika.io/templates/<slug>`` landing
+        page CTA), redirect to ``/connections?template=<slug>`` so
+        ``ConnectionState.load_template_from_query`` prefills the form.
+        Otherwise fall back to the dashboard root.
+
+        Slugs are validated against ``_TEMPLATE_SLUG_RE`` to avoid an
+        open-redirect vector. Unknown-but-well-formed slugs pass through;
+        ConnectionState silently ignores them downstream.
+        """
+        slug = self.router.page.params.get("template", "")
+        if not slug or not _TEMPLATE_SLUG_RE.match(slug):
+            return "/"
+        return f"/connections?template={slug}"
 
     def _load_current_role(self, user_id: int, org_id: int):
         """Load the user's role for the given org from the membership table."""
@@ -167,7 +195,7 @@ class AuthState(rx.State):
                 self.current_org = o
                 break
         self._load_current_role(user_id, org_id)
-        return rx.redirect("/")
+        return rx.redirect(self._post_auth_redirect_target())
 
     def signup(self, form_data: dict):
         self.auth_error = ""
@@ -247,9 +275,10 @@ class AuthState(rx.State):
         # + suspenders — both config flags must be set AND gtag.js must
         # have loaded for an actual conversion to fire).
         conversion_js = google_ads_conversion_event_js(settings.google_ads_conversion_label_signup)
+        redirect_target = self._post_auth_redirect_target()
         if conversion_js:
-            return [rx.call_script(conversion_js), rx.redirect("/")]
-        return rx.redirect("/")
+            return [rx.call_script(conversion_js), rx.redirect(redirect_target)]
+        return rx.redirect(redirect_target)
 
     def logout(self):
         # Audit logout before clearing state
@@ -345,7 +374,7 @@ class AuthState(rx.State):
                     self.current_org = o
                     break
         self._load_current_role(user_id, org_id)
-        return rx.redirect("/")
+        return rx.redirect(self._post_auth_redirect_target())
 
     async def check_auth(self):
         if not self.access_token:

--- a/tests/test_ui/test_auth_state_template_bridge.py
+++ b/tests/test_ui/test_auth_state_template_bridge.py
@@ -1,0 +1,117 @@
+"""Option C auth bridge: ?template=<slug> must survive the signup wall.
+
+When a cold-traffic visitor clicks "Try this template" on a public landing
+page at ``datanika.io/templates/<slug>`` and signs up, the post-auth
+redirect must land on ``/connections?template=<slug>`` so
+``ConnectionState.load_template_from_query`` (shipped in PR #81) can
+prefill the connection form.
+
+See plans/product/SPEC_PUBLIC_TEMPLATE_LANDING.md "The auth bridge" section
+and datanika-io/datanika-landing#125.
+"""
+
+import inspect
+
+import datanika.ui.state.auth_state as auth_state_module
+from datanika.ui.state.auth_state import AuthState
+
+
+class _FakePage:
+    def __init__(self, params: dict):
+        self.params = params
+
+
+class _FakeRouter:
+    def __init__(self, params: dict):
+        self.page = _FakePage(params)
+
+
+def _make_state(query_params: dict) -> AuthState:
+    """Build an AuthState instance with a mocked router for unit tests.
+
+    Reflex state classes subclass ``rx.State`` and override ``__setattr__``
+    with parent-state delegation we don't care about. Bypass it with
+    ``object.__setattr__`` — the helper under test only reads
+    ``self.router.page.params``, nothing else.
+    """
+    state = AuthState.__new__(AuthState)
+    object.__setattr__(state, "router", _FakeRouter(query_params))
+    return state
+
+
+class TestPostAuthRedirectTarget:
+    """The shared helper that each auth entry point consults."""
+
+    def test_returns_connections_with_template_when_param_present(self):
+        state = _make_state({"template": "stripe-to-postgres"})
+        assert state._post_auth_redirect_target() == "/connections?template=stripe-to-postgres"
+
+    def test_returns_root_when_param_absent(self):
+        state = _make_state({})
+        assert state._post_auth_redirect_target() == "/"
+
+    def test_returns_root_when_param_is_empty_string(self):
+        state = _make_state({"template": ""})
+        assert state._post_auth_redirect_target() == "/"
+
+    def test_template_slug_is_urlencoded(self):
+        """A slug with only [a-z0-9-] characters needs no escaping, but the
+        helper must not break if Python's urlencode introduces one.
+        """
+        state = _make_state({"template": "postgres-to-bigquery"})
+        target = state._post_auth_redirect_target()
+        assert target == "/connections?template=postgres-to-bigquery"
+
+    def test_unknown_characters_in_slug_are_rejected(self):
+        """Only slugs matching the public template pattern should survive.
+        An attacker-controlled value like 'foo?injected=1' or 'foo bar' must
+        not produce an open-redirect vector. Reject by returning the root.
+        """
+        state = _make_state({"template": "foo bar/baz?x=1"})
+        assert state._post_auth_redirect_target() == "/"
+
+    def test_slug_length_limit(self):
+        """Overlong slugs are rejected to avoid amplification."""
+        state = _make_state({"template": "a" * 200})
+        assert state._post_auth_redirect_target() == "/"
+
+
+class TestAuthStateSourceWiring:
+    """Source-inspection regression tests — matches the PR #96 pattern in
+    tests/test_ui/test_auth_state.py. Catches a future refactor that
+    drops the helper call from one of the three auth entry points.
+    """
+
+    def test_signup_source_calls_post_auth_redirect_target(self):
+        source = inspect.getsource(auth_state_module.AuthState.signup.fn)
+        assert "_post_auth_redirect_target" in source, (
+            "signup() no longer consults _post_auth_redirect_target — "
+            "cold-traffic ?template=<slug> will be dropped at the signup wall. "
+            "See plans/product/SPEC_PUBLIC_TEMPLATE_LANDING.md auth bridge."
+        )
+
+    def test_login_source_calls_post_auth_redirect_target(self):
+        source = inspect.getsource(auth_state_module.AuthState.login.fn)
+        assert "_post_auth_redirect_target" in source, (
+            "login() no longer consults _post_auth_redirect_target — "
+            "a returning visitor with a bookmarked ?template=<slug> URL will "
+            "be redirected to / and lose their template intent."
+        )
+
+    def test_handle_oauth_complete_source_calls_post_auth_redirect_target(self):
+        source = inspect.getsource(auth_state_module.AuthState.handle_oauth_complete.fn)
+        assert "_post_auth_redirect_target" in source, (
+            "handle_oauth_complete() no longer consults "
+            "_post_auth_redirect_target — OAuth/SSO signups from template "
+            "landing pages will drop the template intent."
+        )
+
+    def test_signup_preserves_google_ads_conversion_event_when_templating(self):
+        """Regression guard: the Option C change must not delete the Phase 2
+        Google Ads conversion event path from PR #96. Both the conversion
+        call_script and the template redirect must coexist in signup().
+        """
+        source = inspect.getsource(auth_state_module.AuthState.signup.fn)
+        assert "google_ads_conversion_event_js" in source
+        assert "call_script" in source
+        assert "_post_auth_redirect_target" in source


### PR DESCRIPTION
Closes #100. Core-side half of [Option C](plans/product/SPEC_PUBLIC_TEMPLATE_LANDING.md). Landing half at datanika-io/datanika-landing#125.

## Summary

- New helper \`AuthState._post_auth_redirect_target()\` reads \`?template=<slug>\` from \`self.router.page.params\`. When the slug is well-formed, returns \`/connections?template=<slug>\`; otherwise returns \`/\`.
- Called from \`AuthState.signup()\`, \`AuthState.login()\`, and \`AuthState.handle_oauth_complete()\` before each \`rx.redirect\`.
- Slug pattern: \`^[a-z0-9][a-z0-9-]{0,63}$\` — blocks open-redirect vectors (slashes, query separators, whitespace) and caps length. Unknown-but-well-formed slugs pass through unchanged; \`ConnectionState.load_template_from_query\` (PR #81) silently ignores anything not in the in-app template registry.
- Preserves the PR #96 Google Ads conversion-event path on signup (\`call_script\` + \`google_ads_conversion_event_js\` still coexist).

## Why this shape

Extracted a helper rather than duplicating the query-param logic across three call sites. Source-inspection tests (same pattern as PR #96's regression guard) catch a future refactor that drops the helper call from any of the three auth entry points.

The helper returns a **string**, not an \`EventSpec\`, so it's unit-testable without instantiating a full Reflex state tree. Tests mock \`self.router.page.params\` via \`object.__setattr__\` to bypass Reflex's parent-state delegation in \`__setattr__\`.

## Tests

- \`tests/test_ui/test_auth_state_template_bridge.py\` — 10 new tests:
  - Happy path: well-formed slug → \`/connections?template=<slug>\`
  - Negatives: missing param → \`/\`; empty param → \`/\`
  - Security: \`foo bar/baz?x=1\` → \`/\`; 200-char slug → \`/\`
  - Source-wiring regression: \`signup\` / \`login\` / \`handle_oauth_complete\` all reference \`_post_auth_redirect_target\`
  - Regression: PR #96 Google Ads conversion event path still fires on signup alongside the new redirect
- \`tests/test_ui/test_auth_state.py\` — 16 existing tests still green (no behavioral drift in auth shape)
- \`bash plans/precheck.sh\` — ruff + ruff format + **1745/1745 pytest pass**

## Test plan

- [x] Unit tests for the helper and wiring (10 new tests, all green)
- [x] Full core suite (1745 pass)
- [x] Ruff lint + format
- [ ] **After Infra promotes both #125 and this PR**: manual smoke on \`app.datanika.io\` — visit \`/templates/stripe-to-postgres\` on the landing, click Try this template, sign up, confirm redirect to \`/connections?template=stripe-to-postgres\` with the form prefilled (ConnectionState.load_template_from_query already handles the receiving end from PR #81).

## Out of scope

- The optional \`template_signup_completed\` Plausible event from the spec — defer until Infra wires the core-side Plausible envs from PR #94.
- Any change to \`ConnectionState.load_template_from_query\` — already correct per PR #81.
- Public landing pages themselves — shipped in datanika-io/datanika-landing#125.

## Cross-team coordination

- **Landing PR #125** — this PR has no hard dependency; the CTAs on the landing work with or without the core change. But the **cold-traffic signup funnel** only closes end-to-end when both ship together. Infra should include both in the same promotion to dev→master.
- **Infra reminder** (still in \`plans/PLAN_HUMAN_LOCKERS.md\`): when wiring PR #94 Plausible envs, use \`DATANIKA_ANALYTICS_DOMAIN=datanika.io\`, not \`app.datanika.io\`, so the cross-subdomain funnel stitches.