### PR TITLE
[QA] Port TestNoAnalyticsLeakIntoCore into core CI

### DIFF
--- a/tests/test_no_analytics_leak.py
+++ b/tests/test_no_analytics_leak.py
@@ -1,0 +1,45 @@
+"""Open-core regression guard.
+
+The cloud plugin (private repo) owns all Plausible / Google Ads
+instrumentation. Self-hosters cloning the open-source core must see
+zero SaaS-specific references in the datanika/ package tree.
+
+Originally defined in datanika-cloud/tests/test_analytics.py as
+TestNoAnalyticsLeakIntoCore — ported to core CI so a core PR that
+reintroduces analytics trips the test here, not only when a cloud PR
+happens to run.
+
+Regression for datanika-io/datanika-core issue #99.
+"""
+
+from pathlib import Path
+
+FORBIDDEN_STRINGS = [
+    "plausible_head_component",
+    "google_ads_head_components",
+    "google_ads_conversion_event_js",
+    "analytics_domain",
+    "analytics_script_src",
+    "google_ads_tag_id",
+    "google_ads_conversion_label_signup",
+    "AW-18081528527",
+    "plausible.datanika.io",
+]
+
+
+class TestNoAnalyticsLeakIntoCore:
+    def test_no_plausible_or_gtag_references_in_core(self):
+        import datanika as core_module
+
+        core_root = Path(core_module.__file__).resolve().parent
+        offenders: list[tuple[Path, str]] = []
+        for py_file in core_root.rglob("*.py"):
+            text = py_file.read_text(encoding="utf-8")
+            for needle in FORBIDDEN_STRINGS:
+                if needle in text:
+                    offenders.append((py_file.relative_to(core_root), needle))
+        assert not offenders, (
+            "Open-core refactor regression (issue #99): the following "
+            "SaaS-specific references leaked back into core:\n"
+            + "\n".join(f"  {p} -> {n}" for p, n in offenders)
+        )


### PR DESCRIPTION
Closes #108.

Ports the existing open-core regression guard from `datanika-cloud/tests/test_analytics.py::TestNoAnalyticsLeakIntoCore` into core itself so a core PR that reintroduces Plausible / Google Ads references trips the test here, not only when an unrelated cloud PR happens to run.

## What
- New `tests/test_no_analytics_leak.py`, standalone (no `datanika_cloud` imports).
- Walks `datanika/**/*.py` and asserts none of the 9 forbidden strings appear: `plausible_head_component`, `google_ads_head_components`, `google_ads_conversion_event_js`, `analytics_domain`, `analytics_script_src`, `google_ads_tag_id`, `google_ads_conversion_label_signup`, `AW-18081528527`, `plausible.datanika.io`.
- Picked up automatically by `testpaths = ["tests"]` — no `.github/workflows/ci.yml` edit needed.

## Verified
- `precheck.sh`: ruff clean, ruff format clean, **1737 passed** (~106s).
- Green against `origin/dev` HEAD (1cbfdf8).

## Not in scope
- Removing the cloud-side copy. Leaving the cloud test in place too — belt and suspenders for the open-core boundary; no cost to duplication.

Regression context: core issue #99 (open-core refactor).