### PR TITLE
[Engineering] Pass predicted_runs to run.before_execute (quota Path A)

### DIFF
--- a/datanika/services/pipeline_service.py
+++ b/datanika/services/pipeline_service.py
@@ -127,3 +127,32 @@ class PipelineService:
             suffix = "+" if m.get("downstream") else ""
             parts.append(f"{prefix}{name}{suffix}")
         return " ".join(parts)
+
+    @staticmethod
+    def predict_run_count(pipeline: Pipeline) -> int | None:
+        """Predict how many dbt nodes a pipeline run will execute.
+
+        Returns an int when the count is cheaply knowable from the
+        static pipeline config, or ``None`` when a real dbt graph
+        walk would be needed (fan-out flags or a custom selector).
+
+        Callers pass the result as ``predicted_runs`` to the
+        ``run.before_execute`` hook. ``None`` puts the run on Path B
+        (allow-then-block fallback) per
+        ``datanika-cloud/docs/billing_contract.md``.
+
+        Rules (cheap predictor, no dbt invocation):
+        - If ``custom_selector`` is set: return ``None`` (selector
+          could expand to anything).
+        - If any model entry has ``upstream=True`` or
+          ``downstream=True``: return ``None`` (fan-out).
+        - Otherwise: return ``len(pipeline.models)``, which is the
+          exact count dbt will run for a flat ``--select a b c`` list.
+        """
+        if pipeline.custom_selector and pipeline.custom_selector.strip():
+            return None
+        models = pipeline.models or []
+        for m in models:
+            if m.get("upstream") or m.get("downstream"):
+                return None
+        return len(models)

--- a/datanika/tasks/pipeline_tasks.py
+++ b/datanika/tasks/pipeline_tasks.py
@@ -166,19 +166,29 @@ def run_pipeline(
         encryption = EncryptionService(settings.credential_encryption_key)
 
     try:
-        # Check run quota before starting (cloud plugin may block)
+        # Check run quota before starting (cloud plugin may block).
+        # Load the pipeline first so we can pass a cheap prediction
+        # (Path A in datanika-cloud/docs/billing_contract.md). Falls
+        # back to Path B (predicted_runs=None) for fan-out / custom
+        # selectors where the static model list under-counts.
         from datanika.hooks import emit as _emit_hook
-
-        _emit_hook("run.before_execute", session=session, org_id=org_id)
-
-        execution_service.start_run(session, run_id)
-        if own_session:
-            session.commit()
 
         run = session.get(Run, run_id)
         pipeline = session.execute(
             select(Pipeline).where(Pipeline.id == run.target_id, Pipeline.org_id == org_id)
         ).scalar_one()
+
+        predicted = PipelineService.predict_run_count(pipeline)
+        _emit_hook(
+            "run.before_execute",
+            session=session,
+            org_id=org_id,
+            predicted_runs=predicted,
+        )
+
+        execution_service.start_run(session, run_id)
+        if own_session:
+            session.commit()
 
         dst_conn = session.get(Connection, pipeline.destination_connection_id)
         dst_config = encryption.decrypt(dst_conn.config_encrypted)

--- a/datanika/tasks/transformation_tasks.py
+++ b/datanika/tasks/transformation_tasks.py
@@ -96,10 +96,12 @@ def run_transformation(
         session = get_sync_session()
 
     try:
-        # Check run quota before starting (cloud plugin may block)
+        # Check run quota before starting (cloud plugin may block).
+        # Standalone transformations are Path A with predicted_runs=1,
+        # per datanika-cloud/docs/billing_contract.md.
         from datanika.hooks import emit
 
-        emit("run.before_execute", session=session, org_id=org_id)
+        emit("run.before_execute", session=session, org_id=org_id, predicted_runs=1)
 
         execution_service.start_run(session, run_id)
         if own_session:

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -109,10 +109,13 @@ def run_upload(
         encryption = EncryptionService(settings.credential_encryption_key)
 
     try:
-        # Check run quota before starting (cloud plugin may block)
+        # Check run quota before starting (cloud plugin may block).
+        # Uploads are Path A with predicted_runs=1 — one submission
+        # counts as one run for both gating and metering, per
+        # datanika-cloud/docs/billing_contract.md.
         from datanika.hooks import emit
 
-        emit("run.before_execute", session=session, org_id=org_id)
+        emit("run.before_execute", session=session, org_id=org_id, predicted_runs=1)
 
         execution_service.start_run(session, run_id)
         if own_session:

--- a/tests/test_services/test_pipeline_service.py
+++ b/tests/test_services/test_pipeline_service.py
@@ -372,6 +372,110 @@ class TestBuildSelector:
         assert result is None
 
 
+class TestPredictRunCount:
+    """Path A prediction for the run.before_execute quota hook.
+
+    Returns an int when the count is cheaply knowable from the static
+    pipeline config, or None (→ Path B allow-then-block) when the
+    selector could fan out unpredictably. See
+    datanika-cloud/docs/billing_contract.md.
+    """
+
+    @staticmethod
+    def _make(models=None, custom_selector=None):
+        p = Pipeline(
+            org_id=1,
+            name="p",
+            destination_connection_id=1,
+            command=DbtCommand.BUILD,
+            full_refresh=False,
+            models=models or [],
+            custom_selector=custom_selector,
+        )
+        return p
+
+    def test_empty_models_returns_zero(self):
+        assert PipelineService.predict_run_count(self._make(models=[])) == 0
+
+    def test_flat_single_model(self):
+        assert PipelineService.predict_run_count(self._make(models=[{"name": "orders"}])) == 1
+
+    def test_flat_multiple_models(self):
+        assert (
+            PipelineService.predict_run_count(
+                self._make(
+                    models=[
+                        {"name": "orders"},
+                        {"name": "customers"},
+                        {"name": "products"},
+                    ]
+                )
+            )
+            == 3
+        )
+
+    def test_flat_models_with_false_flags(self):
+        """Explicit upstream=False / downstream=False should still be flat."""
+        assert (
+            PipelineService.predict_run_count(
+                self._make(
+                    models=[
+                        {"name": "orders", "upstream": False, "downstream": False},
+                        {"name": "customers", "upstream": False, "downstream": False},
+                    ]
+                )
+            )
+            == 2
+        )
+
+    def test_upstream_flag_triggers_fallback(self):
+        """+orders could expand to many nodes → Path B."""
+        assert (
+            PipelineService.predict_run_count(
+                self._make(models=[{"name": "orders", "upstream": True}])
+            )
+            is None
+        )
+
+    def test_downstream_flag_triggers_fallback(self):
+        assert (
+            PipelineService.predict_run_count(
+                self._make(models=[{"name": "orders", "downstream": True}])
+            )
+            is None
+        )
+
+    def test_mixed_flat_and_fanout_triggers_fallback(self):
+        assert (
+            PipelineService.predict_run_count(
+                self._make(
+                    models=[
+                        {"name": "a"},
+                        {"name": "b", "upstream": True},
+                    ]
+                )
+            )
+            is None
+        )
+
+    def test_custom_selector_triggers_fallback(self):
+        assert (
+            PipelineService.predict_run_count(
+                self._make(models=[{"name": "x"}], custom_selector="tag:nightly")
+            )
+            is None
+        )
+
+    def test_whitespace_only_custom_selector_does_not_trigger_fallback(self):
+        """Same rule as build_selector — whitespace custom_selector = no custom."""
+        assert (
+            PipelineService.predict_run_count(
+                self._make(models=[{"name": "x"}], custom_selector="   ")
+            )
+            == 1
+        )
+
+
 class TestValidateModels:
     def test_valid_models(self):
         PipelineService.validate_models(

--- a/tests/test_tasks/test_pipeline_tasks.py
+++ b/tests/test_tasks/test_pipeline_tasks.py
@@ -514,3 +514,106 @@ class TestPipelineCatalogSync:
         db_session.refresh(run)
         assert run.status == RunStatus.SUCCESS
         assert run.rows_loaded == 10
+
+
+class TestRunPipelinePredictedRuns:
+    """Verify run_pipeline passes predicted_runs to run.before_execute,
+    per datanika-cloud/docs/billing_contract.md Path A contract.
+
+    The cloud plugin subscribes to this hook with a handler that reads
+    the kwarg and gates on usage + predicted_runs. Core's job is to
+    compute the prediction and pass it; we test that forwarding here.
+    """
+
+    def test_flat_pipeline_passes_model_count(self, db_session, encryption, setup_pipeline):
+        """models=[a, b] (flat) → predicted_runs=2."""
+        org, conn, pipeline, transformations, run = setup_pipeline
+        captured = {}
+
+        def _capture(event, **kwargs):
+            if event == "run.before_execute":
+                captured["predicted_runs"] = kwargs.get("predicted_runs")
+
+        with (
+            _mock_dbt_project() as mock_dbt_cls,
+            patch("datanika.hooks.emit", side_effect=_capture),
+        ):
+            instance = mock_dbt_cls.return_value
+            instance.run_command.return_value = {
+                "success": True,
+                "rows_affected": 0,
+                "logs": "",
+                "raw_result": [],
+            }
+            run_pipeline(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+                encryption=encryption,
+            )
+
+        assert captured["predicted_runs"] == 2  # models=[src_order_items, src_users]
+
+    def test_custom_selector_pipeline_passes_none(self, db_session, encryption, setup_pipeline):
+        """custom_selector set → predicted_runs=None (Path B fallback)."""
+        org, conn, pipeline, transformations, run = setup_pipeline
+        pipeline.custom_selector = "tag:nightly"
+        db_session.flush()
+
+        captured = {}
+
+        def _capture(event, **kwargs):
+            if event == "run.before_execute":
+                captured["predicted_runs"] = kwargs.get("predicted_runs", "NOT_PASSED")
+
+        with (
+            _mock_dbt_project() as mock_dbt_cls,
+            patch("datanika.hooks.emit", side_effect=_capture),
+        ):
+            instance = mock_dbt_cls.return_value
+            instance.run_command.return_value = {
+                "success": True,
+                "rows_affected": 0,
+                "logs": "",
+                "raw_result": [],
+            }
+            run_pipeline(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+                encryption=encryption,
+            )
+
+        assert captured["predicted_runs"] is None
+
+    def test_upstream_fan_out_passes_none(self, db_session, encryption, setup_pipeline):
+        """Any upstream=True flag → predicted_runs=None."""
+        org, conn, pipeline, transformations, run = setup_pipeline
+        pipeline.models = [{"name": "src_order_items", "upstream": True}]
+        db_session.flush()
+
+        captured = {}
+
+        def _capture(event, **kwargs):
+            if event == "run.before_execute":
+                captured["predicted_runs"] = kwargs.get("predicted_runs", "NOT_PASSED")
+
+        with (
+            _mock_dbt_project() as mock_dbt_cls,
+            patch("datanika.hooks.emit", side_effect=_capture),
+        ):
+            instance = mock_dbt_cls.return_value
+            instance.run_command.return_value = {
+                "success": True,
+                "rows_affected": 0,
+                "logs": "",
+                "raw_result": [],
+            }
+            run_pipeline(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+                encryption=encryption,
+            )
+
+        assert captured["predicted_runs"] is None

--- a/tests/test_tasks/test_transformation_tasks.py
+++ b/tests/test_tasks/test_transformation_tasks.py
@@ -138,6 +138,34 @@ class TestRunTransformationTask:
 
         assert run_transformation_task.name == "datanika.run_transformation"
 
+    def test_passes_predicted_runs_one_to_hook(self, db_session, setup_transformation):
+        """Transformations emit run.before_execute with predicted_runs=1
+        per datanika-cloud/docs/billing_contract.md Path A contract."""
+        org, transformation, run = setup_transformation
+        captured = {}
+
+        def _capture(event, **kwargs):
+            if event == "run.before_execute":
+                captured["predicted_runs"] = kwargs.get("predicted_runs", "NOT_PASSED")
+
+        with (
+            _mock_dbt_project() as mock_dbt_cls,
+            patch("datanika.hooks.emit", side_effect=_capture),
+        ):
+            instance = mock_dbt_cls.return_value
+            instance.run_model.return_value = {
+                "success": True,
+                "rows_affected": 0,
+                "logs": "",
+            }
+            run_transformation(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+            )
+
+        assert captured["predicted_runs"] == 1
+
 
 class TestCatalogSyncAfterTransformation:
     def test_syncs_catalog_after_success(self, db_session, setup_transformation):

--- a/tests/test_tasks/test_upload_tasks.py
+++ b/tests/test_tasks/test_upload_tasks.py
@@ -304,6 +304,35 @@ class TestCatalogSyncAfterUpload:
         )
         mock_dbt_instance.write_source_yml_for_connection.assert_called_once()
 
+    def test_passes_predicted_runs_one_to_hook(self, db_session, setup_upload):
+        """Upload tasks must emit run.before_execute with predicted_runs=1
+        per datanika-cloud/docs/billing_contract.md Path A contract
+        (1 submission = 1 run)."""
+        org, upload, run, encryption = setup_upload
+        captured = {}
+
+        def _capture(event, **kwargs):
+            if event == "run.before_execute":
+                captured["predicted_runs"] = kwargs.get("predicted_runs", "NOT_PASSED")
+
+        with (
+            _mock_dlt_runner() as mock_runner_cls,
+            patch("datanika.hooks.emit", side_effect=_capture),
+        ):
+            instance = mock_runner_cls.return_value
+            instance.execute.return_value = {
+                "rows_loaded": 5,
+                "load_info": "ok",
+            }
+            run_upload(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+                encryption=encryption,
+            )
+
+        assert captured["predicted_runs"] == 1
+
     def test_catalog_sync_failure_does_not_fail_run(self, db_session, setup_upload):
         org, upload, run, encryption = setup_upload
         with (


### PR DESCRIPTION
## Summary

Companion to [datanika-cloud#18](https://github.com/datanika-io/datanika-cloud/pull/18) which rewrites the billing contract to hybrid predict-and-reject. Both PRs must land in the same Infra promotion window — core's emit sites now pass a kwarg the cloud hook needs to honor the stricter contract.

## What this PR does

Three task modules now compute a cheap prediction at submission time and pass it to `run.before_execute`:

| Task | Prediction | Path |
|---|---|---|
| `upload_tasks.run_upload` | `predicted_runs=1` (one submission = one run) | A |
| `transformation_tasks.run_transformation` | `predicted_runs=1` | A |
| `pipeline_tasks.run_pipeline` | `PipelineService.predict_run_count(pipeline)` → `len(models)` for flat selections, `None` for fan-out/custom | A when flat, B when fan-out |

### New `PipelineService.predict_run_count()`

Cheap predictor: reads `Pipeline.models` statically. Returns:
- `int` when the count is knowable without invoking dbt (no `custom_selector`, no `upstream`/`downstream` flags).
- `None` when the selector could fan out unpredictably → signals Path B fallback to the cloud gate.

No `dbt ls` / `dbt parse` invocation. We considered it and decided against it for this pivot — see the billing contract doc for the tradeoff (tenant project materialization cost vs. value of perfect prediction on fan-out cases, which are a minority).

### Hook signature compatibility

Core just adds a new kwarg to the emit call. Core's own `hooks.emit()` passes kwargs verbatim, and cloud's handler already uses `**_kwargs` — forward-compatible. If the cloud plugin isn't installed, the kwarg is harmless (nothing subscribed).

## Tests

`datanika-core`: **1,750 passing** (was 1,744 before this PR).

New tests:
- `TestPredictRunCount` (9 tests) — flat, multi-model, upstream, downstream, mixed, custom_selector, whitespace-only custom_selector.
- `TestRunPipelinePredictedRuns` (3 tests) — verifies the kwarg flows end-to-end through `run_pipeline` to the emit wrapper.
- `test_passes_predicted_runs_one_to_hook` on `test_upload_tasks.py` and `test_transformation_tasks.py`.

All existing task tests still green — `run.before_execute` on a pipeline that loads the `Run` row first (I had to reorder two lines in `pipeline_tasks.run_pipeline` to move the Pipeline load before the emit so we can compute the prediction).

## Blocked on

This PR and cloud#18 must land in the **same promotion**. Merge order:
1. cloud#18 → merge to cloud/dev
2. core#<this PR> → merge to core/dev
3. Single Infra promotion of both repos to master/main

Same pattern as the 2026-04-13 open-core refactor pair.

## Test plan

- [x] All new tests pass locally
- [x] `ruff check` clean
- [x] Full core suite green (1,750)
- [ ] QA: please smoke-test against the e2e-seed fixture from #109 once both PRs land — a Free-plan org at 499/500 should now be blocked on a pipeline with 2 models (previously it would allow one overshoot).

Closes #115.