### PR TITLE
[Engineering] Expose all 32 connection types in picker (closes #120)

### DIFF
--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -12,6 +12,54 @@ from datanika.ui.state.i18n_state import I18nState
 
 _t = I18nState.translations
 
+# Picker options for the connection-type dropdown. Must cover every
+# ConnectionType the backend dispatches on — see the coverage test at
+# tests/test_ui/test_connection_picker_coverage.py. Grouped by category
+# for UX (databases first, then warehouses, files, APIs, SaaS, analytics,
+# messaging), not alphabetically.
+PICKER_TYPES: list[str] = [
+    # Databases
+    "postgres",
+    "mysql",
+    "mssql",
+    "sqlite",
+    "redshift",
+    "synapse",
+    "clickhouse",
+    "duckdb",
+    "mongodb",
+    # Cloud warehouses
+    "bigquery",
+    "snowflake",
+    "databricks",
+    # File / blob
+    "s3",
+    "csv",
+    "json",
+    "parquet",
+    # Generic APIs
+    "rest_api",
+    "google_sheets",
+    # SaaS / CRM
+    "stripe",
+    "salesforce",
+    "hubspot",
+    "shopify",
+    "zendesk",
+    "airtable",
+    "notion",
+    # Dev tools
+    "github",
+    "jira",
+    "slack",
+    # Analytics / ads
+    "google_analytics",
+    "google_ads",
+    "facebook_ads",
+    # Messaging
+    "kafka",
+]
+
 
 def connection_form() -> rx.Component:
     return rx.card(
@@ -34,23 +82,7 @@ def connection_form() -> rx.Component:
                 width="100%",
             ),
             searchable_select(
-                [
-                    "postgres",
-                    "mysql",
-                    "mssql",
-                    "sqlite",
-                    "rest_api",
-                    "bigquery",
-                    "snowflake",
-                    "redshift",
-                    "clickhouse",
-                    "mongodb",
-                    "s3",
-                    "csv",
-                    "json",
-                    "parquet",
-                    "google_sheets",
-                ],
+                PICKER_TYPES,
                 value=ConnectionState.form_type,
                 on_change=ConnectionState.set_form_type,
                 placeholder=_t["connections.ph_type"],

--- a/tests/test_ui/test_connection_picker_coverage.py
+++ b/tests/test_ui/test_connection_picker_coverage.py
@@ -1,0 +1,45 @@
+"""Regression test: the connection-type picker must expose every
+ConnectionType the backend knows about.
+
+Context: core#120 shipped with the picker list hardcoded to 15 of 32
+types. Seven connector setup guides were stranded because users
+following them hit a UI that didn't list the connector at all. This
+test makes that drift impossible — if the enum grows and the picker
+list doesn't, CI fails here.
+"""
+
+from datanika.models.connection import ConnectionType
+from datanika.ui.pages.connections import PICKER_TYPES
+
+
+def test_picker_covers_every_connection_type():
+    """Every ConnectionType enum value must appear in the picker list."""
+    enum_values = {t.value for t in ConnectionType}
+    picker_values = set(PICKER_TYPES)
+
+    missing_from_picker = enum_values - picker_values
+    assert not missing_from_picker, (
+        f"The connection picker is missing {len(missing_from_picker)} "
+        f"type(s) the backend supports: {sorted(missing_from_picker)}. "
+        f"Add them to PICKER_TYPES in datanika/ui/pages/connections.py."
+    )
+
+
+def test_picker_has_no_unknown_types():
+    """Every picker entry must be a real ConnectionType — no typos."""
+    enum_values = {t.value for t in ConnectionType}
+    picker_values = set(PICKER_TYPES)
+
+    unknown_in_picker = picker_values - enum_values
+    assert not unknown_in_picker, (
+        f"The picker lists types the backend does not support: "
+        f"{sorted(unknown_in_picker)}. Typo? Or remove them from PICKER_TYPES."
+    )
+
+
+def test_picker_has_no_duplicates():
+    """Catches copy-paste mistakes when adding types."""
+    assert len(PICKER_TYPES) == len(set(PICKER_TYPES)), (
+        f"PICKER_TYPES contains duplicates: "
+        f"{[t for t in PICKER_TYPES if PICKER_TYPES.count(t) > 1]}"
+    )


### PR DESCRIPTION
## Summary

Product flagged on #120 that the connections picker was stranded at 15/32 types — 7 shipped connector setup guides (stripe, salesforce, databricks, kafka, google-analytics, duckdb, github) lead users to a UI that doesn't list their connector. Dispatch, enum, and i18n all support 32 already; only the picker was drifting.

## Change

`datanika/ui/pages/connections.py`:
- New `PICKER_TYPES` module constant, grouped by category (databases → warehouses → files → APIs → SaaS/CRM → dev tools → analytics → messaging) for UX.
- All 32 `ConnectionType` enum values present.
- `searchable_select()` call now takes `PICKER_TYPES` instead of an inline list.

## Regression test

`tests/test_ui/test_connection_picker_coverage.py` — 3 asserts:
1. Every `ConnectionType` enum value appears in `PICKER_TYPES` (drift guard — adding a type to the enum without the picker now fails CI).
2. Every `PICKER_TYPES` entry is a real enum value (typo guard).
3. No duplicates in `PICKER_TYPES`.

This was Product's explicit suggestion in the issue: "A `tests/test_ui/test_connection_picker_coverage.py` regression test asserting `set(picker_list) == set(types_with_dispatch_branch)` would make this a compile-time failure next time."

## Tests

1,750 passing (+3). Full precheck green.

## Unblocks

- datanika-landing#139 (Product's DuckDB draft)
- Held Product branch `143-json-parquet-github-guides`
- QA's walkthrough queue for all 7 affected guides

Closes #120.

## Test plan

- [x] 3 new coverage tests pass
- [x] ruff check + format clean
- [x] Full core suite green (1,750)
- [ ] Smoke: QA confirms the picker now shows stripe/salesforce/duckdb/etc. after merge + promotion