### PR TITLE
[Engineering] Add REDIS_PASSWORD to .env.example (closes #122)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ DATABASE_URL=postgresql+asyncpg://datanika:change-me-to-a-strong-password@localh
 DATABASE_URL_SYNC=postgresql://datanika:change-me-to-a-strong-password@localhost:5432/datanika
 
 # Redis
+# REDIS_PASSWORD is required by docker-compose.yml (strict interpolation).
+# Must be set before running `docker compose up -d redis` — the compose
+# command will refuse to start without it.
+REDIS_PASSWORD=change-me-to-a-strong-password
 REDIS_URL=redis://localhost:6379/0
 
 # Auth


### PR DESCRIPTION
docker-compose.yml line 54 uses strict interpolation `${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env.docker}` but .env.example never included the key. Fresh clones hit `required variable REDIS_PASSWORD is missing` on `docker compose up -d redis`.

One-line template fix + comment pointing future copiers at the strict-interpolation guard. Discovered during smoke-testing of #109 e2e-seed against local docker-compose.

Closes #122.