### PR TITLE
[Engineering P0] Materialise /llms.txt to assets/ so frontend serves it (closes #124)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .web
 .states
 assets/external/
+# Generated at app startup by services/agent_docs.py::write_llms_txt_asset()
+# from the agent_tiers.py SoT. Committing risks drift. See issue #124.
+assets/llms.txt
 *.db
 *.py[cod]
 # Byte-compiled / optimized / DLL files

--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -239,11 +239,17 @@ from datanika.services.openapi import openapi_routes  # noqa: E402
 for _route in openapi_routes:
     app._api.routes.append(_route)
 
-# Mount agent discovery docs (/llms.txt, /api/v1/agent-guide.md)
-from datanika.services.agent_docs import agent_doc_routes  # noqa: E402
+# Mount agent discovery docs (/llms.txt, /api/v1/agent-guide.md).
+# Also materialise /llms.txt into the Reflex assets dir so the frontend
+# (nginx → :3000) serves it at the root URL published in our docs.
+# See the module docstring in services/agent_docs.py for why this is
+# needed on top of the Starlette route registration. Issue #124.
+from datanika.services.agent_docs import agent_doc_routes, write_llms_txt_asset  # noqa: E402
 
 for _route in agent_doc_routes:
     app._api.routes.append(_route)
+
+write_llms_txt_asset()
 
 # Mount Prometheus metrics endpoint and middleware
 from datanika.services.metrics import PrometheusMiddleware, metrics_routes  # noqa: E402

--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -9,7 +9,20 @@ templates and serves them via Starlette routes. **Do not hardcode any
 tier counts, capability lists, error codes, or golden-path steps in
 this file** — derive them from `agent_tiers` so a single edit there
 updates every surface.
+
+Delivery note (issue #124): `/llms.txt` is at the site root, not under
+the `/api/v1/*` backend prefix. Nginx routes `/` to the Reflex frontend
+(port 3000) and `/api/*` / `/_event` to Starlette (port 8000), so a
+Starlette route registered at `/llms.txt` never receives the request
+in production — the frontend 404s first. To match the published URL
+(`https://app.datanika.io/llms.txt`, referenced from landing / blog /
+comparison pages) we also materialise the rendered text into the
+Reflex `assets/` directory at app startup, which Reflex's frontend
+serves at root. The Starlette route is kept for tests + API clients
+that hit the backend directly.
 """
+
+from pathlib import Path
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
@@ -174,6 +187,28 @@ agent_doc_routes = [
 ]
 
 
+# Default path to the Reflex assets directory, relative to the project
+# root (the directory Reflex is run from). Reflex serves contents of
+# this directory at the site root, so writing `assets/llms.txt` makes
+# it reachable at `https://app.datanika.io/llms.txt` through nginx.
+DEFAULT_ASSETS_DIR = Path(__file__).resolve().parents[2] / "assets"
+
+
+def write_llms_txt_asset(assets_dir: Path = DEFAULT_ASSETS_DIR) -> Path:
+    """Materialise LLMS_TXT into the Reflex assets directory.
+
+    Called from ``datanika.datanika`` at app bootstrap. Idempotent —
+    safe to call on every startup. The file is gitignored so it stays
+    in sync with the SoT (``agent_tiers.py``) automatically.
+
+    Returns the path the file was written to, for logging/testing.
+    """
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    target = assets_dir / "llms.txt"
+    target.write_text(LLMS_TXT, encoding="utf-8")
+    return target
+
+
 __all__ = [
     "LLMS_TXT",
     "AGENT_GUIDE_MD",
@@ -183,4 +218,6 @@ __all__ = [
     "llms_txt",
     "tier_count",
     "capability_count",
+    "write_llms_txt_asset",
+    "DEFAULT_ASSETS_DIR",
 ]

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -1,10 +1,18 @@
-"""Tests for /llms.txt, /api/v1/agent-guide.md, /api/v1/meta/agent-tiers (#64, #85)."""
+"""Tests for /llms.txt, /api/v1/agent-guide.md, /api/v1/meta/agent-tiers (#64, #85, #124)."""
+
+from pathlib import Path
 
 import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from datanika.services.agent_docs import AGENT_GUIDE_MD, LLMS_TXT, agent_doc_routes
+from datanika.services.agent_docs import (
+    AGENT_GUIDE_MD,
+    DEFAULT_ASSETS_DIR,
+    LLMS_TXT,
+    agent_doc_routes,
+    write_llms_txt_asset,
+)
 from datanika.services.agent_tiers import (
     all_capabilities,
     capability_count,
@@ -194,3 +202,60 @@ class TestSoTWiring:
             # endpoint substring is the stable part to assert on.
             endpoint = step.split("`")[1] if "`" in step else step
             assert endpoint in AGENT_GUIDE_MD, f"Golden path step {endpoint!r} missing"
+
+
+class TestLlmsTxtStaticAsset:
+    """Regression for issue #124.
+
+    `/llms.txt` is referenced from published landing content, blog
+    posts, and four comparison pages. It must be reachable at
+    `https://app.datanika.io/llms.txt` — which means it has to be
+    served by the Reflex frontend (port 3000), not the Starlette
+    backend, because nginx routes the root to the frontend. We
+    materialise the rendered LLMS_TXT into the Reflex assets dir at
+    app startup; these tests pin that contract so the fix can't drift.
+    """
+
+    def test_write_llms_txt_asset_creates_file(self, tmp_path):
+        target = write_llms_txt_asset(assets_dir=tmp_path)
+        assert target.exists()
+        assert target == tmp_path / "llms.txt"
+
+    def test_asset_content_matches_module_constant(self, tmp_path):
+        target = write_llms_txt_asset(assets_dir=tmp_path)
+        assert target.read_text(encoding="utf-8") == LLMS_TXT
+
+    def test_asset_is_non_empty_and_has_openapi_url(self, tmp_path):
+        target = write_llms_txt_asset(assets_dir=tmp_path)
+        content = target.read_text(encoding="utf-8")
+        assert len(content) > 500
+        assert "openapi.json" in content
+
+    def test_asset_is_idempotent(self, tmp_path):
+        """Calling twice leaves the same file, same content."""
+        first = write_llms_txt_asset(assets_dir=tmp_path)
+        second = write_llms_txt_asset(assets_dir=tmp_path)
+        assert first == second
+        assert first.read_text(encoding="utf-8") == LLMS_TXT
+
+    def test_default_assets_dir_is_project_root_assets(self):
+        """The default must resolve to the repo's assets/ directory,
+        next to datanika/, not to a subdir inside datanika/services/."""
+        assert DEFAULT_ASSETS_DIR.name == "assets"
+        assert DEFAULT_ASSETS_DIR.parent.name in ("datanika-core-engineering", "datanika")
+
+    def test_app_bootstrap_writes_the_asset(self):
+        """datanika.datanika imports and calls write_llms_txt_asset()
+        so the file exists after app startup. This is a source-level
+        assertion — a runtime check would require booting the full
+        Reflex app, which is out of scope for unit tests."""
+        src = Path(__file__).resolve().parents[2] / "datanika" / "datanika.py"
+        text = src.read_text(encoding="utf-8")
+        assert "write_llms_txt_asset" in text, (
+            "datanika/datanika.py must import and call write_llms_txt_asset() "
+            "at app bootstrap — see issue #124."
+        )
+        assert "write_llms_txt_asset()" in text, (
+            "datanika/datanika.py imports write_llms_txt_asset but never "
+            "calls it — the asset won't be materialised on startup."
+        )

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -239,10 +239,12 @@ class TestLlmsTxtStaticAsset:
         assert first.read_text(encoding="utf-8") == LLMS_TXT
 
     def test_default_assets_dir_is_project_root_assets(self):
-        """The default must resolve to the repo's assets/ directory,
-        next to datanika/, not to a subdir inside datanika/services/."""
+        """The default must resolve to a sibling `assets/` directory
+        next to the `datanika/` package, not a subdir inside it."""
         assert DEFAULT_ASSETS_DIR.name == "assets"
-        assert DEFAULT_ASSETS_DIR.parent.name in ("datanika-core-engineering", "datanika")
+        assert DEFAULT_ASSETS_DIR.is_absolute()
+        # The package dir `datanika/` must live alongside, not above.
+        assert (DEFAULT_ASSETS_DIR.parent / "datanika").is_dir()
 
     def test_app_bootstrap_writes_the_asset(self):
         """datanika.datanika imports and calls write_llms_txt_asset()


### PR DESCRIPTION
## Root cause

Nginx routes `/` to the Reflex frontend (port 3000) and `/api/*` + `/_event` to Starlette (port 8000). The Starlette route for `/llms.txt` registered in `datanika.py:242` has **never actually received a request in production** — the frontend 404s at the nginx edge before the backend sees it. Sibling routes `/api/v1/agent-guide.md` and `/api/v1/meta/agent-tiers` work because they're under the `/api/v1/*` backend prefix.

This is **not** a regression from the 2026-04-13 open-core refactor. The route registration block is byte-identical to commit `16aa8b4` that first shipped Tier 5. It's been broken in prod since day one. The existing test suite only built a standalone Starlette app and hit it via TestClient, so the real delivery path was never exercised.

Growth flagged it (issue #124) because `/llms.txt` is referenced from:
- 4 comparison pages (`/compare/{airbyte,fivetran,hevo,stitch}`)
- `/ai-agents` (button + copy)
- `/docs/ai-agents`
- The AI-Agent Native blog post
- `Features.astro` on the homepage

Any prospect or AI agent following our own marketing hits a 404.

## Fix (Option 1 — keep the published URL)

Write `LLMS_TXT` into `datanika-core/assets/llms.txt` at app bootstrap. Reflex serves `assets/` at the site root, so the frontend now responds to `GET /llms.txt` with the rendered file instead of 404. Same URL everyone linked to, same SoT (`agent_tiers.py`) driving the content.

- **`services/agent_docs.py`** — new `write_llms_txt_asset()` + `DEFAULT_ASSETS_DIR`. Module docstring documents the why-this-is-needed so the next agent doesn't try to "just add the Starlette route, it's already there".
- **`datanika.py`** — calls `write_llms_txt_asset()` right after the Starlette route registration block (kept for tests + API-prefix callers).
- **`.gitignore`** — `assets/llms.txt` is generated, not checked in. Prevents drift between the committed text and the `agent_tiers.py` SoT.

## Regression tests (+6)

`TestLlmsTxtStaticAsset` in `tests/test_services/test_agent_docs.py`:
- `test_write_llms_txt_asset_creates_file`
- `test_asset_content_matches_module_constant`
- `test_asset_is_non_empty_and_has_openapi_url`
- `test_asset_is_idempotent`
- `test_default_assets_dir_is_project_root_assets`
- `test_app_bootstrap_writes_the_asset` — source-level assertion on `datanika.py`, since a runtime check would require booting the full Reflex app

**1,756 passing** (was 1,750). Ruff clean.

## Cross-team

- **Growth**: published URL unchanged, content unchanged. Re-verify the 4 comparison pages + `/ai-agents` + blog post after the Infra promotion.
- **QA**: please add `GET /llms.txt` to the `PLAN_QA.md` P0 pre-promotion smoke probe list. A 200 check would have caught this day one.
- **Infra**: standard `dev → master` promotion. No config changes, no new env vars, no nginx changes.

## Test plan

- [x] 6 new tests pass
- [x] ruff check + format clean
- [x] Full core suite green (1,756)
- [x] Local verification: `assets/llms.txt` written and matches `LLMS_TXT` byte-for-byte
- [ ] Post-promotion: `curl -sI https://app.datanika.io/llms.txt` → 200, content-type text/plain
- [ ] Growth confirms the 4 comparison pages + homepage Features card render truthfully again