### PR TITLE
[Infra] Post-deploy smoke gate for app.datanika.io (closes #125)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/smoke-check.sh
+++ b/.github/smoke-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Post-deploy smoke gate. Fails loud on any broken URL.
+#
+# Usage: smoke-check.sh BASE_URL URL_LIST_FILE
+#
+# URL list format (pipe-separated, one per line, # for comments):
+#   path|content-type-substring|body-substring-or-empty
+#
+# Checks per row: HTTP 200, non-empty body, content-type contains substring,
+# body contains literal substring (skipped if empty). Sequential, 10s/URL,
+# no retries. See plans/growth/SMOKE_URLS.md for the curated list rationale.
+
+set -uo pipefail
+
+BASE_URL="${1:?usage: smoke-check.sh BASE_URL URL_LIST_FILE}"
+LIST_FILE="${2:?usage: smoke-check.sh BASE_URL URL_LIST_FILE}"
+
+if [[ ! -f "$LIST_FILE" ]]; then
+  echo "ERROR: URL list file not found: $LIST_FILE" >&2
+  exit 2
+fi
+
+FAIL=0
+CHECKED=0
+
+while IFS='|' read -r path ctype body || [[ -n "$path" ]]; do
+  # Skip blanks and comments
+  trimmed="${path#"${path%%[![:space:]]*}"}"
+  [[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
+
+  url="${BASE_URL}${path}"
+  CHECKED=$((CHECKED + 1))
+  printf "%-60s " "$url"
+
+  headers=$(mktemp)
+  body_file=$(mktemp)
+
+  code=$(curl -sS --max-time 10 --compressed \
+    -o "$body_file" -D "$headers" -w "%{http_code}" \
+    "$url" 2>/dev/null || echo "000")
+
+  size=$(wc -c < "$body_file" | tr -d ' ')
+  got_ctype=$(grep -i '^content-type:' "$headers" | head -1 | tr -d '\r\n' || true)
+
+  reason=""
+  if [[ "$code" != "200" ]]; then
+    reason="status=$code"
+  elif [[ "$size" -eq 0 ]]; then
+    reason="empty-body"
+  elif [[ -n "${ctype// }" ]] && ! echo "$got_ctype" | grep -qi -- "$ctype"; then
+    reason="content-type mismatch: want '$ctype' got '${got_ctype#content-type: }'"
+  elif [[ -n "${body// }" ]] && ! grep -qF -- "$body" "$body_file"; then
+    reason="body missing substring: '$body'"
+  fi
+
+  if [[ -z "$reason" ]]; then
+    echo "OK  ($code, ${size}b)"
+  else
+    echo "FAIL  $reason"
+    FAIL=$((FAIL + 1))
+  fi
+
+  rm -f "$headers" "$body_file"
+done < "$LIST_FILE"
+
+echo
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "Smoke gate FAILED: $FAIL of $CHECKED URL(s) broken"
+  exit 1
+fi
+echo "Smoke gate passed: $CHECKED URL(s) OK"

--- a/.github/smoke-urls-core.txt
+++ b/.github/smoke-urls-core.txt
@@ -1,0 +1,18 @@
+# Post-deploy smoke gate URL list for app.datanika.io (core).
+# Format: path|content-type-substring|body-substring-or-empty
+# Source of truth: plans/growth/SMOKE_URLS.md (Growth-owned).
+# Sync from there on change; ping Infra in core#125 on edits.
+#
+# /llms.txt will FAIL the gate until core#124 lands and promotes to prod.
+# This is intentional — the entire point of this gate is that a 404 on
+# /llms.txt blocks the deploy instead of lingering in prod for a day.
+#
+# /healthz was considered per the plan as an operational probe but is
+# NOT included here: Reflex's SPA catch-all serves 200 + HTML shell for
+# any unregistered route, so /healthz would be a false-positive generator
+# until Engineering adds a real route with a distinguishing body. The
+# container-level Docker health check is sufficient for now.
+/llms.txt|text/plain|app.datanika.io/api/v1/openapi.json
+/api/v1/agent-guide.md|text/markdown|
+/api/v1/meta/agent-tiers|application/json|tiers
+/api/v1/openapi.json|application/json|openapi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,17 @@ jobs:
             --data-urlencode "chat_id=1201995" \
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
+
+  # Post-deploy smoke gate. Fails loud if any curated URL 404s, returns an
+  # empty body, or serves the wrong content-type/body substring. See
+  # plans/growth/SMOKE_URLS.md (Growth-owned SoT) for the curation rationale.
+  # Non-empty body check is the critical guard — core#124 returned
+  # 404 Content-Length: 0, which a status-only check would have missed.
+  smoke:
+    needs: deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Smoke gate — app.datanika.io
+        run: bash .github/smoke-check.sh https://app.datanika.io .github/smoke-urls-core.txt


### PR DESCRIPTION
## Summary
Adds a post-deploy smoke gate to `ci.yml`: after the `deploy` job finishes (master push only), a new `smoke` job curls 4 curated app.datanika.io URLs and fails the workflow if any returns non-200, empty body, wrong content-type, or missing body substring.

**Why it matters**: `/llms.txt` 404'd in prod for a day (core#124) because vitest + sitemap don't check cross-host promises. The non-empty-body check is deliberate — a 404 with Content-Length:0 (core#124's actual failure mode) and a 200 with Content-Length:0 (reverse-proxy swallow) both have to fail.

## Draft — blocks on core#124
Local run right now shows the gate correctly catching the regression:
\`\`\`
https://app.datanika.io/llms.txt                             FAIL  status=404
https://app.datanika.io/api/v1/agent-guide.md                OK  (200, 4044b)
https://app.datanika.io/api/v1/meta/agent-tiers              OK  (200, 5350b)
https://app.datanika.io/api/v1/openapi.json                  OK  (200, 78570b)
Smoke gate FAILED: 1 of 4 URL(s) broken
\`\`\`
This PR cannot merge until core#124 lands, promotes to master, and the next deploy actually serves /llms.txt. Holding as draft; I'll flip to ready + merge once core#124 is live on app.datanika.io.

## Files
- `.github/smoke-check.sh` — reusable bash+curl checker, identical to landing#147's copy
- `.github/smoke-urls-core.txt` — 4 rows synced from `plans/growth/SMOKE_URLS.md`
- `.github/workflows/ci.yml` — new `smoke` job, \`needs: deploy\`, master-only
- `.gitattributes` — `*.sh eol=lf` so the shebang survives Windows checkouts

## `/healthz` deliberately excluded
Plan said to add `/healthz` as an operational probe in the core workflow (not in SMOKE_URLS.md). I verified the path on app.datanika.io — Reflex's SPA catch-all serves \`200 + HTML shell\` for it, same as any unregistered route. A smoke row against /healthz would always pass as a false positive until Engineering registers a real health route with a distinguishing body substring. Docker-level healthcheck on the \`datanika-app\` container is sufficient until then. Filing as a follow-up on core side if we want a real HTTP health probe.

## Test plan
- [ ] CI green on this PR itself (this only runs on push, so the gate won't fire on the PR)
- [ ] core#124 merges + promotes to master
- [ ] Flip this PR ready-for-review, merge to dev, promote to master
- [ ] Watch the first master deploy — `smoke` job runs after `deploy`, all 4 URLs must be OK

## Out of scope
- Rollback-on-failure automation (deliberately deferred per PLAN)
- Staging smoke gate (`deploy-staging` fires on dev push, could reuse the same script against https://staging-app.datanika.io — follow-up)
- Auth-gated routes (Playwright E2E territory)

Closes #125