### PR TITLE
[Engineering P0] Suffix signup org_slug with user.id (closes #127)

### DIFF
--- a/datanika/ui/state/auth_state.py
+++ b/datanika/ui/state/auth_state.py
@@ -213,7 +213,10 @@ class AuthState(rx.State):
             with get_sync_session() as session:
                 user = svc.register_user(session, email, password, full_name)
                 org_name = f"{full_name}'s Org"
-                org_slug = _slugify(full_name)
+                # Suffix with user.id so two users with the same full_name
+                # don't collide on the org slug unique constraint. Mirrors
+                # the pattern in user_service.find_or_create_oauth_user. #127.
+                org_slug = f"{_slugify(full_name)}-{user.id}"
                 org = svc.create_org(session, org_name, org_slug, user.id)
                 # Capture id before commit expires ORM attributes
                 org_id = org.id

--- a/tests/test_ui/test_auth_state.py
+++ b/tests/test_ui/test_auth_state.py
@@ -117,3 +117,50 @@ class TestAuthStateFormFields:
             "signup() must emit the 'user.signup_completed' event so "
             "cloud plugin handlers can fire on successful signup"
         )
+
+    def test_signup_org_slug_includes_user_id_suffix(self):
+        """Regression for #127: two users with the same full_name must
+        produce distinct org slugs. The password-signup path used to
+        call ``_slugify(full_name)`` with no suffix, so a second user
+        named ``John Smith`` hit ``Slug already exists`` on create_org
+        (then swallowed into the generic toast per #128). The fix
+        mirrors ``user_service.find_or_create_oauth_user:308`` which
+        suffixes with ``{user.id}`` — making the slug globally unique
+        by construction (user ids are autoincrement).
+        """
+        import inspect
+        import re
+
+        import datanika.ui.state.auth_state as auth_state_module
+
+        source = inspect.getsource(auth_state_module.AuthState.signup.fn)
+
+        # The slug construction must reference both _slugify(full_name)
+        # and user.id on the same line. A loose substring check would
+        # pass on any future refactor that moves them apart.
+        pattern = re.compile(r"org_slug\s*=\s*f[\"'][^\"']*\{_slugify\(full_name\)\}-\{user\.id\}")
+        assert pattern.search(source), (
+            "Expected signup() to build org_slug as "
+            '`f"{_slugify(full_name)}-{user.id}"` — #127 regression. '
+            "Without the user.id suffix two users with the same full_name "
+            "collide on the organizations.slug unique constraint and the "
+            "second signup fails."
+        )
+
+    def test_signup_slug_pattern_matches_oauth_path(self):
+        """Both signup paths must use the same uniqueness strategy —
+        otherwise, password-signup and OAuth-signup diverge and the next
+        refactor picks whichever is in sight. #127.
+        """
+        import inspect
+
+        from datanika.services import user_service
+
+        oauth_source = inspect.getsource(user_service.UserService.find_or_create_oauth_user)
+        # The OAuth path builds: slug=f"{slug}-{user.id}"
+        assert 'f"{slug}-{user.id}"' in oauth_source, (
+            "find_or_create_oauth_user no longer uses the "
+            'f"{slug}-{user.id}" pattern — if you changed the OAuth '
+            "uniqueness strategy, update password-signup in auth_state.py "
+            "to match, and update #127."
+        )


### PR DESCRIPTION
## Fix

`auth_state.signup()` built the org slug as `_slugify(full_name)` with no uniqueness suffix. Two users signing up with the same `full_name` (e.g. "John Smith") both produced `org_slug="john-smith"` — the second `create_org` call failed with `Slug already exists` and got swallowed by the generic `except Exception` block into "Signup failed. Please try again." (that separate recovery-path bug is filed as #128, not in scope here).

Two-line fix: mirror the OAuth signup path in `user_service.find_or_create_oauth_user:308` which already suffixes with `{user.id}`. User IDs are autoincrement, so the slug is globally unique by construction — no retry loop needed.

```python
user = svc.register_user(session, email, password, full_name)
org_name = f"{full_name}'s Org"
org_slug = f"{_slugify(full_name)}-{user.id}"  # was: _slugify(full_name)
org = svc.create_org(session, org_name, org_slug, user.id)
```

## Severity

P0 — multi-tenancy denial-of-signup. Probability of collision scales with the birthday paradox on popular names; "John Smith" / "Maria Garcia" / etc. reliably fail in the wild. QA hit it during the SQLite/CSV connector walkthrough.

## Regression tests (+2)

In `tests/test_ui/test_auth_state.py::TestAuthStateFormFields`:

- `test_signup_org_slug_includes_user_id_suffix` — regex against the live source pins the exact `f"{_slugify(full_name)}-{user.id}"` pattern. A future refactor that drops the suffix (or splits the two interpolations across lines) fails the test.
- `test_signup_slug_pattern_matches_oauth_path` — pins the OAuth-side pattern too. The two signup paths can't silently diverge again.

1,758 passing (was 1,756).

## Not in scope

- **#128** — generic-toast exception-swallowing. Separate issue, P1, filed but not fixed here. Once #128 ships, failures surface specific error messages even when they're not slug collisions.
- **landing#149** — connector-guide wording ("modal" vs inline form). Product owns. Filed.

## Cross-team

- **QA**: once merged + promoted, please repeat the SQLite/CSV walkthrough with a duplicate `full_name` to confirm both signups land in distinct orgs.

## Test plan

- [x] 2 new regression tests pass
- [x] Full core suite green (1,758)
- [x] Ruff clean
- [ ] QA smoke-test: duplicate-name signup against real Postgres

Closes #127.