### PR TITLE
[Infra] Bump GH Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -36,13 +36,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
Node 20 runners become hard errors in GitHub Actions on 2026-06-02. Bump every action used in \`ci.yml\` to the latest major that runs on Node 24.

| Action | Was | Now |
|---|---|---|
| \`actions/checkout\` | v4 | v6 |
| \`astral-sh/setup-uv\` | v5 | v8 |
| \`actions/setup-python\` | v5 | v6 |

\`appleboy/ssh-action@v1\` is a Docker-based action and isn't affected by the Node runner deprecation — left alone.

## Why trust the major jumps
None of the options used by this workflow (\`with: version: "latest"\`, \`with: python-version: "3.12"\`) changed shape between the old and new majors. CI will surface any runtime breakage; if anything trips I'll pin to an older major and adjust.

## Test plan
- [ ] CI lint job green
- [ ] CI test job green

Part of PLAN_INFRASTRUCTURE.md deferred item "Node.js 20 → 24 action bumps". Landing and cloud bumps shipping in parallel PRs.