### PR TITLE
[QA] Scaffold staging smoke suite + CI integration (refs #133)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,42 @@ jobs:
 
             echo "Staging deploy complete"
             docker image prune -f
+
+  smoke-staging:
+    needs: [deploy-staging]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Run smoke probes
+        id: smoke
+        run: pytest scripts/smoke/ -v --tb=short
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          SHORT_SHA=${COMMIT_SHA:0:7}
+          FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+          TEXT=$(printf '\xf0\x9f\x9a\xa8 *Staging smoke failed*\n\n*Commit:* `%s`\n*Message:* %s\n*Run:* %s' \
+            "$SHORT_SHA" "$FIRST_LINE" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=1201995" \
+            --data-urlencode "text=${TEXT}" \
+            --data-urlencode "parse_mode=Markdown"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,13 +138,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -1,0 +1,52 @@
+# Smoke Suite — Staging + Landing
+
+Owner: QA. Tracks [core#107](https://github.com/datanika-io/datanika-core/issues/107) → Phase 2 and [core#133](https://github.com/datanika-io/datanika-core/issues/133).
+
+Post-deploy probes that a handful of public-facing endpoints return HTTP 200 with the expected shape. Fails the CI workflow (and pages via Telegram) if any probe is red.
+
+## Scope
+
+- **Core** — ran against `https://staging-app.datanika.io/` in CI, against any `DATANIKA_SMOKE_CORE_URL` target locally. Exercises the SPA root, `/login`, `/llms.txt`, `/api/v1/openapi.json`, `/api/v1/agent-guide.md`, `/api/v1/meta/agent-tiers`.
+- **Landing** — ran against `https://datanika.io/` (prod — there is no landing staging). Exercises `/`, `/pricing/`, `/docs/`, `/sitemap-index.xml`.
+
+Intentionally out of scope for v1:
+
+- `/healthz` and `/readyz`. Reflex catches all routes and serves the SPA fallback with HTTP 200, so these are false-positive green. Would need real Starlette routes added by Engineering before they're smoke-useful. Tracked in core#107 comments.
+- Authed API endpoints (`/api/v1/meta/connection-types`, `/api/v1/meta/dlt-config-schema`, etc.). They 401 without an API key. Need a fixture token baked into staging bootstrap or a smoke-scoped key. Deferred.
+- Latency SLO hard-fails. v1 records elapsed time per probe and prints it in pytest output; no hard threshold. Tighten once we have two weeks of baseline data.
+- Smoke against prod. Phase 1 stays planned but un-shipped until Phase 2 has been green for ~two weeks.
+
+## Running locally
+
+```bash
+# Against staging (default)
+uv run pytest scripts/smoke/ -v
+
+# Against a different core target
+DATANIKA_SMOKE_CORE_URL=https://app.datanika.io/ \
+  uv run pytest scripts/smoke/test_core_smoke.py -v
+
+# Skip the landing suite entirely
+uv run pytest scripts/smoke/test_core_smoke.py -v
+```
+
+The suite is **not** picked up by `uv run pytest` with no args because `pyproject.toml` scopes `testpaths = ["tests"]` — you have to pass `scripts/smoke/` explicitly. That's intentional: smoke shouldn't run on every PR, only after deploy.
+
+## CI
+
+The `smoke-staging` job in `.github/workflows/ci.yml` runs after `deploy-staging` succeeds (`needs: [deploy-staging]`), only on `push` to `dev`. If any probe fails, the job fails and the pre-existing Grafana Telegram alert channel (`@DatanikaBot`, chat `1201995`) pages via the same pattern landing#145 set up for landing deploys.
+
+The smoke job runs entirely from the GHA runner — it doesn't SSH into Hetzner. Just HTTP from GitHub's network to Cloudflare → Aweb/Hetzner. This is deliberate: we want smoke to exercise the same network path real users hit.
+
+## Adding new probes
+
+1. Add the target endpoint to `test_core_smoke.py` or `test_landing_smoke.py` as a new `test_<descriptive_name>` function.
+2. Hit the endpoint via the `core_client` / `landing_client` fixture.
+3. Assert `response.status_code == 200` and a **specific shape claim** (not just "is not empty"). Shape claims are what catch deploys that return 200-with-wrong-payload.
+4. Latency: fixture records `response.elapsed`; print it via pytest's `-v` capture. No hard threshold in v1.
+
+## Known issues surfaced by building this
+
+- **landing sitemap path is `/sitemap-index.xml`, not `/sitemap.xml`.** PLAN_QA.md §P0 #2 listed the wrong path. Astro's sitemap integration publishes an index at `/sitemap-index.xml` with referenced children (`/sitemap-0.xml`, etc.). `/sitemap.xml` returns 404.
+- **core `/healthz` and `/readyz` silently 200.** Reflex handles any unknown path with the SPA fallback. Any dashboard or external monitor pointing at `/healthz` is effectively no-op'd. Worth a separate ticket to Engineering for real health routes.
+- **All `/api/v1/meta/*` endpoints except `/agent-tiers` require auth.** `/llms.txt`, `/agent-guide.md`, `/openapi.json`, `/agent-tiers` are public; the rest 401 without a token. Documentation in `agent-tiers` claims Tier 5 (Machine-Readable Discovery) is auth-less — that's true for the 4 listed endpoints, but `/meta/connection-types`, `/meta/dlt-config-schema`, `/meta/dbt-tests`, `/meta/materializations` are NOT Tier 5 per the JSON and do require auth. Minor doc ambiguity, not a bug.

--- a/scripts/smoke/conftest.py
+++ b/scripts/smoke/conftest.py
@@ -1,0 +1,53 @@
+"""Smoke suite fixtures.
+
+Scoped to `scripts/smoke/` only — not picked up by the main test suite
+(`pyproject.toml` pins `testpaths = ["tests"]`). Run explicitly via
+``uv run pytest scripts/smoke/``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+CORE_DEFAULT = "https://staging-app.datanika.io"
+LANDING_DEFAULT = "https://datanika.io"
+TIMEOUT_SECONDS = 15.0
+
+
+def _normalize(url: str) -> str:
+    return url.rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def core_base_url() -> str:
+    return _normalize(os.environ.get("DATANIKA_SMOKE_CORE_URL", CORE_DEFAULT))
+
+
+@pytest.fixture(scope="session")
+def landing_base_url() -> str:
+    return _normalize(os.environ.get("DATANIKA_SMOKE_LANDING_URL", LANDING_DEFAULT))
+
+
+@pytest.fixture(scope="session")
+def core_client(core_base_url: str):
+    with httpx.Client(
+        base_url=core_base_url,
+        timeout=TIMEOUT_SECONDS,
+        follow_redirects=True,
+        headers={"User-Agent": "datanika-qa-smoke/1"},
+    ) as client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def landing_client(landing_base_url: str):
+    with httpx.Client(
+        base_url=landing_base_url,
+        timeout=TIMEOUT_SECONDS,
+        follow_redirects=True,
+        headers={"User-Agent": "datanika-qa-smoke/1"},
+    ) as client:
+        yield client

--- a/scripts/smoke/test_core_smoke.py
+++ b/scripts/smoke/test_core_smoke.py
@@ -1,0 +1,122 @@
+"""Post-deploy probes for the core Reflex app at `staging-app.datanika.io`.
+
+Every probe asserts a **specific shape claim**, not just "HTTP 200 and
+non-empty body". The point of smoke is to catch deploys that serve
+200-with-wrong-payload (missing env var, stale cached HTML, plugin
+unloaded). A 200-with-nothing-asserted is worse than no check at all —
+it gives false comfort.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+
+def _log_latency(response: httpx.Response) -> None:
+    """Print elapsed time so pytest -v shows it.
+
+    No hard threshold in v1 per core#133 scope. Collect a baseline from
+    two weeks of green runs before tightening.
+    """
+    ms = response.elapsed.total_seconds() * 1000
+    print(f"    elapsed={ms:.0f}ms url={response.request.url}")
+
+
+def test_spa_root_loads(core_client: httpx.Client) -> None:
+    r = core_client.get("/")
+    _log_latency(r)
+    assert r.status_code == 200
+    # SPA shell is Reflex → React Router. Assert a marker that proves
+    # the hydrated document shipped, not just Cloudflare's error page.
+    body = r.text
+    assert "reactRouter" in body or "Datanika" in body, (
+        f"SPA root body did not contain expected markers; first 300 chars:\n{body[:300]}"
+    )
+
+
+def test_login_page_loads(core_client: httpx.Client) -> None:
+    r = core_client.get("/login")
+    _log_latency(r)
+    assert r.status_code == 200
+    # Same SPA shell, but assert at least one of the markers survives
+    # the client-side route to /login.
+    body = r.text
+    assert "reactRouter" in body or "Datanika" in body, (
+        "Login page body did not contain expected markers"
+    )
+
+
+def test_llms_txt_public(core_client: httpx.Client) -> None:
+    r = core_client.get("/llms.txt")
+    _log_latency(r)
+    assert r.status_code == 200
+    ctype = r.headers.get("content-type", "")
+    assert ctype.startswith("text/"), f"/llms.txt returned unexpected content-type: {ctype}"
+    body = r.text
+    # Known-stable substring from the live content. If someone trims
+    # the file so aggressively that "Tenant Isolation" drops, that's
+    # worth a smoke failure — the agent-guide doc has been ~stable for
+    # weeks and shouldn't shrink without notice.
+    assert "Tenant Isolation" in body, "/llms.txt missing 'Tenant Isolation' section"
+
+
+def test_openapi_json_public(core_client: httpx.Client) -> None:
+    r = core_client.get("/api/v1/openapi.json")
+    _log_latency(r)
+    assert r.status_code == 200
+    try:
+        payload = r.json()
+    except json.JSONDecodeError as e:
+        pytest.fail(f"/api/v1/openapi.json was not JSON: {e}; first 300 chars: {r.text[:300]}")
+    assert "openapi" in payload, "openapi.json missing top-level 'openapi' key"
+    assert "paths" in payload, "openapi.json missing 'paths' key"
+    # Sanity: at least one public meta path should be documented.
+    assert any(p.startswith("/api/v1/") for p in payload["paths"]), (
+        "openapi.json 'paths' is empty or doesn't include any /api/v1 routes"
+    )
+
+
+def test_agent_guide_md_public(core_client: httpx.Client) -> None:
+    r = core_client.get("/api/v1/agent-guide.md")
+    _log_latency(r)
+    assert r.status_code == 200
+    body = r.text
+    assert len(body) > 500, f"agent-guide.md body is suspiciously short ({len(body)} chars)"
+    # The guide should reference the golden path — if that section drops,
+    # we broke the SoT generator.
+    assert "golden" in body.lower() or "golden path" in body.lower(), (
+        "agent-guide.md missing 'golden path' section"
+    )
+
+
+def test_agent_tiers_shape(core_client: httpx.Client) -> None:
+    """Tier SoT — pinned to the current 5-tier / 7-capability layout.
+
+    If Product adds or removes a tier, this test goes red first and
+    forces a conscious update. That's the contract — `agent-tiers` is
+    the SoT for landing's build-time agent page (closes #108) and for
+    the /llms.txt generator.
+    """
+    r = core_client.get("/api/v1/meta/agent-tiers")
+    _log_latency(r)
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload.get("tier_count") == 5, (
+        f"tier_count changed from 5 to {payload.get('tier_count')} — "
+        "update the smoke test AND landing's build-time snapshot in the same PR"
+    )
+    assert payload.get("capability_count") == 7, (
+        f"capability_count changed from 7 to {payload.get('capability_count')} — "
+        "update the smoke test AND landing's build-time snapshot in the same PR"
+    )
+    assert isinstance(payload.get("tiers"), list), "tiers should be a list"
+    assert len(payload["tiers"]) == 5, "tiers list length doesn't match tier_count"
+    # Every tier must have a number, name, summary, and capabilities list.
+    for tier in payload["tiers"]:
+        assert "number" in tier
+        assert "name" in tier
+        assert "summary" in tier
+        assert isinstance(tier.get("capabilities"), list)

--- a/scripts/smoke/test_landing_smoke.py
+++ b/scripts/smoke/test_landing_smoke.py
@@ -1,0 +1,75 @@
+"""Post-deploy probes for the marketing site at `datanika.io`.
+
+Runs against prod because there is no landing staging (landing deploys
+straight from `main` to Aweb via `landing#137` workflow). Probes are
+HTTP-only and hit the same Cloudflare → Aweb path real users do.
+
+Like the core suite, every probe asserts a specific shape claim, not
+just "HTTP 200 and non-empty body". The failure modes we're trying to
+catch are: Astro build served stale, sitemap integration broken, pricing
+page rewritten without one of the three plans, docs overview missing.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def _log_latency(response: httpx.Response) -> None:
+    ms = response.elapsed.total_seconds() * 1000
+    print(f"    elapsed={ms:.0f}ms url={response.request.url}")
+
+
+def test_root_loads(landing_client: httpx.Client) -> None:
+    r = landing_client.get("/")
+    _log_latency(r)
+    assert r.status_code == 200
+    ctype = r.headers.get("content-type", "")
+    assert ctype.startswith("text/html"), f"root returned unexpected content-type: {ctype}"
+    body = r.text
+    # Title is stable and has been the same for months. If it changes,
+    # Growth rewrote the hero — surface that as a smoke failure so we
+    # update the assertion consciously rather than silently drift.
+    assert "<title>Datanika" in body, "root missing '<title>Datanika' — hero title changed?"
+
+
+def test_pricing_page_has_all_plans(landing_client: httpx.Client) -> None:
+    """Pricing SoT — Free / Pro / Enterprise must all appear.
+
+    If Growth renames a tier (say 'Pro' → 'Team'), this goes red and
+    forces a conscious update paired with the core `agent-tiers` snapshot.
+    """
+    r = landing_client.get("/pricing/")
+    _log_latency(r)
+    assert r.status_code == 200
+    body = r.text
+    for plan in ("Free", "Pro", "Enterprise"):
+        assert plan in body, f"pricing page missing plan '{plan}'"
+
+
+def test_docs_overview_loads(landing_client: httpx.Client) -> None:
+    r = landing_client.get("/docs/")
+    _log_latency(r)
+    assert r.status_code == 200
+    body = r.text
+    # Docs overview is the canonical entry for /docs — title should say
+    # so. If this drops, the Starlight/Astro docs build is broken.
+    assert "Datanika Docs" in body, "/docs/ missing 'Datanika Docs' in body"
+
+
+def test_sitemap_index_served(landing_client: httpx.Client) -> None:
+    """Astro's sitemap integration publishes `/sitemap-index.xml`, NOT
+    `/sitemap.xml`. Probe the right path — the index should reference
+    at least one child sitemap file.
+    """
+    r = landing_client.get("/sitemap-index.xml")
+    _log_latency(r)
+    assert r.status_code == 200
+    ctype = r.headers.get("content-type", "")
+    assert "xml" in ctype, f"/sitemap-index.xml returned unexpected content-type: {ctype}"
+    body = r.text
+    assert "<sitemapindex" in body, "/sitemap-index.xml missing <sitemapindex> root element"
+    assert "sitemap-0.xml" in body, (
+        "/sitemap-index.xml doesn't reference sitemap-0.xml — "
+        "Astro sitemap integration may be misconfigured"
+    )


### PR DESCRIPTION
Closes #133 (umbrella: #107 Phase 2)

## Summary

Post-deploy probes for `staging-app.datanika.io` and `datanika.io`, wired into CI after `deploy-staging` with an inline Telegram alert on failure.

- **Core probes (6)** in `scripts/smoke/test_core_smoke.py`:
  - `/` and `/login` — assert SPA shell shipped (not Cloudflare error page)
  - `/llms.txt` — assert `Tenant Isolation` section present
  - `/api/v1/openapi.json` — assert JSON shape (`openapi`, `paths`, ≥1 `/api/v1/` route)
  - `/api/v1/agent-guide.md` — assert body length + golden-path marker
  - `/api/v1/meta/agent-tiers` — **pins `tier_count == 5` / `capability_count == 7`** as the SoT contract with landing's build-time snapshot
- **Landing probes (4)** in `scripts/smoke/test_landing_smoke.py`:
  - `/` — title marker
  - `/pricing/` — all three plans (Free/Pro/Enterprise) present
  - `/docs/` — Starlight/Astro docs overview marker
  - `/sitemap-index.xml` — `<sitemapindex>` + `sitemap-0.xml` child reference

Every probe asserts a **specific shape claim**, not just "HTTP 200 and non-empty". The point is to catch deploys that 200-with-wrong-payload (missing env var, stale cached HTML, plugin unloaded). A 200-with-nothing-asserted is worse than no check at all.

## Scoping

- `scripts/smoke/` is **excluded** from the main test suite because `pyproject.toml` pins `testpaths = ["tests"]`. Devs running `uv run pytest` with no args don't trip it; you have to pass `scripts/smoke/` explicitly.
- The suite is **not** triggered on every PR — only after `deploy-staging` succeeds on push to `dev`.
- CI runs entirely from the GHA runner (no SSH into Hetzner). It exercises the real Cloudflare → Aweb/Hetzner path, same hop real users hit.

## CI wiring

New `smoke-staging` job in `.github/workflows/ci.yml`:

```yaml
smoke-staging:
  needs: [deploy-staging]
  if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
```

Telegram alert step matches the pattern landing#145 set up: hardcoded chat `1201995`, existing `TELEGRAM_BOT_TOKEN` secret, inline `if: failure()`, no separate job, no success notification.

## Intentionally out of scope for v1 (see `scripts/smoke/README.md`)

- `/healthz` and `/readyz` — Reflex catches these via the SPA fallback and 200s. Would need real Starlette health routes from Engineering. Surfacing this as a separate Engineering follow-up.
- Authed `/api/v1/meta/*` endpoints (connection-types, dlt-config-schema, etc.) — 401 without a token. Need a smoke-scoped fixture token baked into staging bootstrap.
- Latency SLO hard-fails — record elapsed ms, no threshold. Tighten after ~2 weeks of green baseline data per core#133 scope.
- Smoke against prod — Phase 1, deferred until Phase 2 has been green for ~2 weeks.

## Known issues surfaced by building this

- **landing sitemap path is `/sitemap-index.xml`, not `/sitemap.xml`.** PLAN_QA.md §P0 #2 listed the wrong path. Astro's sitemap integration publishes an index referencing children (`/sitemap-0.xml`, etc.). `/sitemap.xml` returns 404.
- **core `/healthz` and `/readyz` silently 200.** Any external monitor pointing at these is effectively no-op'd. Worth an Engineering ticket for real health routes.

## Test plan

- [x] `uv run pytest scripts/smoke/ -v` — **10/10 passed in 2.91s** against live staging + prod
- [x] `uv run pytest tests/` — **1772 passed** on the branch
- [x] `ruff check` + `ruff format --check` — clean (277 files formatted)
- [x] `uv run pytest` with no args does NOT pick up `scripts/smoke/` (verified `testpaths` scoping)
- [ ] After merge to `dev`: watch the first `smoke-staging` CI run for green status
- [ ] After merge: close #133 manually (§8 auto-close gotcha — feature PRs to `dev` don't fire `Closes #N`)

## Atomicity note

This PR is self-contained — no dependency on any other in-flight work. Can merge independently of core#112 (Playwright scaffold) and core#114 (quota atomic pair).