### PR TITLE
[Engineering] Surface typed UserServiceError in signup + log catch-all (#128)

### DIFF
--- a/datanika/ui/state/auth_state.py
+++ b/datanika/ui/state/auth_state.py
@@ -1,5 +1,6 @@
 """Authentication state — login, signup, logout, org switching."""
 
+import logging
 import re
 
 import reflex as rx
@@ -9,8 +10,10 @@ from datanika.config import settings
 from datanika.hooks import collect_events
 from datanika.services.auth import AuthService
 from datanika.services.captcha_service import CaptchaService
-from datanika.services.user_service import UserService
+from datanika.services.user_service import UserService, UserServiceError
 from datanika.ui.state.base_state import get_sync_session
+
+logger = logging.getLogger(__name__)
 
 # Option C auth bridge: valid template slug pattern + max length. Cold-traffic
 # visitors who click "Try this template" on a public /templates/<slug> landing
@@ -266,7 +269,19 @@ class AuthState(rx.State):
                             session.commit()
                     except Exception:
                         pass  # Invitation acceptance is best-effort
+        except UserServiceError as exc:
+            # Typed validation errors from user_service carry curated,
+            # user-facing messages ("Email already exists", "Name is
+            # required", etc.). Surface them verbatim so users can
+            # recover instead of bouncing off a generic toast. #128.
+            self.auth_error = str(exc)
+            return
         except Exception:
+            # Real failure of an unexpected kind — DB connection loss,
+            # CAPTCHA-service timeout, OAuth upstream exception, etc.
+            # Log the full traceback so ops can see root causes in
+            # container logs; show a generic message to the user. #128.
+            logger.exception("Unexpected signup failure")
             self.auth_error = "Signup failed. Please try again."
             return
         # Let plugins contribute Reflex events on signup success (issue

--- a/tests/test_ui/test_auth_state.py
+++ b/tests/test_ui/test_auth_state.py
@@ -164,3 +164,148 @@ class TestAuthStateFormFields:
             "uniqueness strategy, update password-signup in auth_state.py "
             "to match, and update #127."
         )
+
+
+class TestSignupExceptionHandling:
+    """#128 — ``signup()`` must surface typed ``UserServiceError`` messages
+    verbatim and log the catch-all path for observability.
+
+    Before this fix every signup failure (duplicate email, slug exists,
+    validation, DB drop, OAuth timeout) was replaced with the generic
+    string "Signup failed. Please try again." — users had no recovery
+    path and ops had no signal.
+    """
+
+    def test_user_service_error_imported(self):
+        import datanika.ui.state.auth_state as auth_state_module
+
+        assert hasattr(auth_state_module, "UserServiceError"), (
+            "auth_state.py must import UserServiceError so the typed "
+            "except branch can distinguish curated user-facing errors "
+            "from unexpected failures. See #128."
+        )
+
+    def test_module_logger_defined(self):
+        import datanika.ui.state.auth_state as auth_state_module
+
+        assert hasattr(auth_state_module, "logger"), (
+            "auth_state.py must define a module-level `logger` so the "
+            "catch-all except branch can emit traceable root causes. #128."
+        )
+
+    def test_signup_has_typed_user_service_error_branch(self):
+        import inspect
+
+        import datanika.ui.state.auth_state as auth_state_module
+
+        source = inspect.getsource(auth_state_module.AuthState.signup.fn)
+        assert "except UserServiceError" in source, (
+            "signup() must have a typed `except UserServiceError` branch "
+            "that surfaces the exception message verbatim. See #128."
+        )
+        assert "self.auth_error = str(exc)" in source, (
+            "The UserServiceError branch must set auth_error = str(exc), "
+            "not a hardcoded string. #128."
+        )
+
+    def test_signup_catch_all_logs_exception(self):
+        import inspect
+
+        import datanika.ui.state.auth_state as auth_state_module
+
+        source = inspect.getsource(auth_state_module.AuthState.signup.fn)
+        assert "logger.exception" in source, (
+            "signup()'s catch-all `except Exception` branch must call "
+            "logger.exception(...) so root causes land in container logs. "
+            "See #128."
+        )
+
+    def test_runtime_user_service_error_surfaces_message(self):
+        """End-to-end: a UserServiceError raised by the service layer
+        reaches the user as its real message, not the generic toast.
+
+        Uses ``SimpleNamespace`` as the state duck-type because Reflex's
+        ``rx.State.__setattr__`` requires full state init (dirty_vars,
+        parent state) that's expensive to stand up in a unit test — and
+        irrelevant here since the error path only touches ``self.auth_error``.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.user_service import UserServiceError
+        from datanika.ui.state.auth_state import AuthState
+
+        fake_svc = MagicMock()
+        fake_svc.register_user.side_effect = UserServiceError("Email already exists")
+
+        state = SimpleNamespace(
+            auth_error="",
+            _get_user_service=lambda: fake_svc,
+        )
+
+        with (
+            patch("datanika.ui.state.auth_state.CaptchaService") as mock_captcha_cls,
+            patch("datanika.ui.state.auth_state.get_sync_session") as mock_session,
+        ):
+            mock_captcha_cls.return_value.verify.return_value = True
+            mock_session.return_value.__enter__.return_value = MagicMock()
+            mock_session.return_value.__exit__.return_value = False
+
+            result = AuthState.signup.fn(
+                state,
+                {
+                    "email": "alice@example.com",
+                    "password": "pw12345678",
+                    "full_name": "Alice",
+                    "captcha_token": "tok",
+                },
+            )
+
+        assert state.auth_error == "Email already exists"
+        assert result is None  # early return on error path
+
+    def test_runtime_unexpected_exception_logs_and_shows_generic_toast(self, caplog):
+        """End-to-end: a non-UserServiceError exception keeps the generic
+        user-facing message AND writes a log entry with the real cause."""
+        import logging
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        from datanika.ui.state.auth_state import AuthState
+
+        fake_svc = MagicMock()
+        fake_svc.register_user.side_effect = RuntimeError("DB connection lost")
+
+        state = SimpleNamespace(
+            auth_error="",
+            _get_user_service=lambda: fake_svc,
+        )
+
+        with (
+            patch("datanika.ui.state.auth_state.CaptchaService") as mock_captcha_cls,
+            patch("datanika.ui.state.auth_state.get_sync_session") as mock_session,
+            caplog.at_level(logging.ERROR, logger="datanika.ui.state.auth_state"),
+        ):
+            mock_captcha_cls.return_value.verify.return_value = True
+            mock_session.return_value.__enter__.return_value = MagicMock()
+            mock_session.return_value.__exit__.return_value = False
+
+            AuthState.signup.fn(
+                state,
+                {
+                    "email": "alice@example.com",
+                    "password": "pw12345678",
+                    "full_name": "Alice",
+                    "captcha_token": "tok",
+                },
+            )
+
+        assert state.auth_error == "Signup failed. Please try again."
+        assert any(
+            "DB connection lost" in rec.message
+            or (rec.exc_info and "DB connection lost" in str(rec.exc_info[1]))
+            for rec in caplog.records
+        ), (
+            "The catch-all branch must log the exception so ops can see "
+            "root causes in container logs. #128."
+        )


### PR DESCRIPTION
## Summary
- Add a typed `except UserServiceError as exc: self.auth_error = str(exc)` branch in `AuthState.signup()` so curated user-facing messages ("Email already exists", "Name is required") surface verbatim instead of being replaced by the generic "Signup failed. Please try again." toast.
- Emit `logger.exception("Unexpected signup failure")` in the catch-all so real failures (DB loss, CAPTCHA timeout, OAuth timeout) land in container logs with full tracebacks — ops had zero signal before.
- 6 regression tests in `TestSignupExceptionHandling`: 4 source-level scans pin the branch shape, 2 runtime tests verify end-to-end that (a) a `UserServiceError` surfaces verbatim, and (b) a `RuntimeError` is logged and the user gets the generic message.

## Background
Filed by QA during the 2026-04-14 SQLite/CSV walkthrough. The most common trigger (duplicate org slug on same-`full_name` signups) was fixed by #130/#127, so #128 is P1, not P0. Still worth shipping — any future `UserServiceError` variant will surface correctly from day one.

## Test plan
- [x] `uv run pytest tests/test_ui/test_auth_state.py -v` — 18 passed
- [x] `bash plans/precheck.sh .` — 1778 passed, all checks passed

Closes #128.