### PR TITLE
[Engineering] Wire template_first_run_triggered Plausible event (#93)

### DIFF
--- a/datanika/migrations/versions/y4u1v2w3x5z6_add_source_template_slug_to_connections.py
+++ b/datanika/migrations/versions/y4u1v2w3x5z6_add_source_template_slug_to_connections.py
@@ -1,0 +1,36 @@
+"""Add source_template_slug and template_first_run_fired_at to connections
+
+Revision ID: y4u1v2w3x5z6
+Revises: x3t0u1v2w4q5
+Create Date: 2026-04-14 12:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "y4u1v2w3x5z6"
+down_revision: str | None = "x3t0u1v2w4q5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "connections",
+        sa.Column("source_template_slug", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "connections",
+        sa.Column(
+            "template_first_run_fired_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("connections", "template_first_run_fired_at")
+    op.drop_column("connections", "source_template_slug")

--- a/datanika/models/connection.py
+++ b/datanika/models/connection.py
@@ -1,6 +1,7 @@
 import enum
+from datetime import datetime
 
-from sqlalchemy import Enum, String, Text
+from sqlalchemy import DateTime, Enum, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import JSON
 
@@ -61,3 +62,9 @@ class Connection(Base, TenantMixin, TimestampMixin):
     )
     config_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
     freshness_config: Mapped[dict | None] = mapped_column(JSON, nullable=True, default=None)
+    source_template_slug: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, default=None
+    )
+    template_first_run_fired_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -201,22 +201,49 @@ class ConnectionService:
         name: str,
         connection_type: ConnectionType,
         config: dict,
+        source_template_slug: str | None = None,
     ) -> Connection:
         from datanika.hooks import emit
 
         emit("connection.before_create", session=session, org_id=org_id)
         validate_connection_name(name)
         direction = infer_direction(connection_type)
+        # Normalise "" → None so analytics queries can filter on a single
+        # NULL check. ConnectionState.selected_template_slug defaults to ""
+        # when a user creates a connection outside the template flow. #93.
         conn = Connection(
             org_id=org_id,
             name=name,
             connection_type=connection_type,
             direction=direction,
             config_encrypted=self._encryption.encrypt(config),
+            source_template_slug=source_template_slug or None,
         )
         session.add(conn)
         session.flush()
         return conn
+
+    def consume_template_first_run(self, session: Session, org_id: int, conn_id: int) -> str | None:
+        """Return the template slug on the connection's first eligible run,
+        then mark it so subsequent calls return None. Idempotent.
+
+        Feeds the ``template_first_run_triggered`` Plausible event (#93).
+        The caller (``PipelineState.run_pipeline`` / ``UploadState.run_upload``)
+        emits an ``rx.call_script`` when this returns a slug, and nothing
+        when it returns None — so a connection fires the funnel step 3
+        event exactly once over its lifetime, regardless of how many
+        runs it sees.
+        """
+        from datetime import UTC, datetime
+
+        conn = self.get_connection(session, org_id, conn_id)
+        if conn is None or not conn.source_template_slug:
+            return None
+        if conn.template_first_run_fired_at is not None:
+            return None
+        conn.template_first_run_fired_at = datetime.now(UTC)
+        session.flush()
+        return conn.source_template_slug
 
     def get_connection(self, session: Session, org_id: int, conn_id: int) -> Connection | None:
         stmt = select(Connection).where(

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -883,12 +883,17 @@ class ConnectionState(BaseState):
                         new_values={"name": self.form_name, "connection_type": self.form_type},
                     )
                 else:
+                    # Pass the template slug through so the Plausible
+                    # funnel step 3 (``template_first_run_triggered``)
+                    # can attribute this connection's first run back to
+                    # the template the user started from. #93.
                     conn = svc.create_connection(
                         session,
                         org_id,
                         self.form_name,
                         ConnectionType(self.form_type),
                         config,
+                        source_template_slug=self.selected_template_slug or None,
                     )
                     self._audit(
                         session,
@@ -903,6 +908,9 @@ class ConnectionState(BaseState):
         except Exception as e:
             self._set_error(e, "Failed to save connection")
             return
+        # Slug was persisted on the Connection row; detach from UI state so
+        # a subsequent non-template create doesn't inherit it. #93.
+        self.selected_template_slug = ""
         self._reset_form_fields()
         await self.load_connections()
 

--- a/datanika/ui/state/pipeline_state.py
+++ b/datanika/ui/state/pipeline_state.py
@@ -412,7 +412,10 @@ class PipelineState(BaseState):
         org_id = auth_state.current_org.id
         user_id = auth_state.current_user.id
         exec_svc = ExecutionService()
+        pipeline_svc = PipelineService()
+        template_slug: str | None = None
         with get_sync_session() as session:
+            pipeline = pipeline_svc.get_pipeline(session, org_id, pipeline_id)
             run = exec_svc.create_run(session, org_id, NodeType.PIPELINE, pipeline_id)
             self._audit(
                 session,
@@ -423,8 +426,28 @@ class PipelineState(BaseState):
                 resource_id=pipeline_id,
                 new_values={"target_type": "pipeline", "target_id": pipeline_id},
             )
+            # Check the pipeline's destination connection for a template
+            # origin. First eligible run emits the ``template_first_run_triggered``
+            # Plausible event (funnel step 3). Idempotent via
+            # ``template_first_run_fired_at``. #93.
+            if pipeline is not None:
+                encryption = EncryptionService(settings.credential_encryption_key)
+                conn_svc = ConnectionService(encryption)
+                template_slug = conn_svc.consume_template_first_run(
+                    session, org_id, pipeline.destination_connection_id
+                )
             session.commit()
             run_id = run.id
         run_pipeline_task.delay(run_id=run_id, org_id=org_id)
         self.error_message = ""
         yield rx.toast("Run triggered", position="top-right")
+        if template_slug:
+            # Inline Plausible event — ``window.plausible`` is guarded so
+            # open-source self-hosted installs without the tracker loaded
+            # no-op cleanly instead of throwing. #93.
+            import json
+
+            yield rx.call_script(
+                "if(window.plausible){window.plausible('template_first_run_triggered',"
+                f"{{props:{{slug:{json.dumps(template_slug)}}}}})}}"
+            )

--- a/datanika/ui/state/upload_state.py
+++ b/datanika/ui/state/upload_state.py
@@ -560,7 +560,12 @@ class UploadState(BaseState):
         org_id = auth_state.current_org.id
         user_id = auth_state.current_user.id
         exec_svc = ExecutionService()
+        encryption = EncryptionService(settings.credential_encryption_key)
+        conn_svc = ConnectionService(encryption)
+        upload_svc = UploadService(conn_svc)
+        template_slug: str | None = None
         with get_sync_session() as session:
+            upload = upload_svc.get_upload(session, org_id, upload_id)
             run = exec_svc.create_run(session, org_id, NodeType.UPLOAD, upload_id)
             self._audit(
                 session,
@@ -571,8 +576,24 @@ class UploadState(BaseState):
                 resource_id=upload_id,
                 new_values={"target_type": "upload", "target_id": upload_id},
             )
+            # Check both ends of the upload — the template flow could have
+            # created either the source or the destination. First eligible
+            # connection fires ``template_first_run_triggered``; subsequent
+            # runs see fired_at set and return None. #93.
+            if upload is not None:
+                for conn_id in (upload.source_connection_id, upload.destination_connection_id):
+                    template_slug = conn_svc.consume_template_first_run(session, org_id, conn_id)
+                    if template_slug:
+                        break
             session.commit()
             run_id = run.id
         run_upload_task.delay(run_id=run_id, org_id=org_id)
         self.error_message = ""
         yield rx.toast("Run triggered", position="top-right")
+        if template_slug:
+            import json
+
+            yield rx.call_script(
+                "if(window.plausible){window.plausible('template_first_run_triggered',"
+                f"{{props:{{slug:{json.dumps(template_slug)}}}}})}}"
+            )

--- a/tests/test_services/test_connection_service.py
+++ b/tests/test_services/test_connection_service.py
@@ -764,3 +764,90 @@ class TestIsSelectOnly:
 
     def test_strips_block_comments(self):
         assert ConnectionService.is_select_only("/* hi */ SELECT 1")
+
+
+class TestSourceTemplateSlug:
+    """#93 — ``connections.source_template_slug`` records the Pipeline
+    Template a connection was created from, so the Plausible funnel
+    (``template_selected`` → ``template_prefill_applied`` →
+    ``template_first_run_triggered``) can attribute activation to the
+    right template across sessions.
+    """
+
+    def test_default_source_template_slug_is_none(self, svc, db_session, org):
+        conn = svc.create_connection(db_session, org.id, "Plain", ConnectionType.POSTGRES, {})
+        assert conn.source_template_slug is None
+
+    def test_stores_source_template_slug(self, svc, db_session, org):
+        conn = svc.create_connection(
+            db_session,
+            org.id,
+            "Shopify",
+            ConnectionType.SHOPIFY,
+            {},
+            source_template_slug="shopify-to-postgres",
+        )
+        assert conn.source_template_slug == "shopify-to-postgres"
+
+    def test_empty_slug_normalises_to_none(self, svc, db_session, org):
+        # ``ConnectionState.selected_template_slug`` defaults to "" so the
+        # service must treat the empty string the same as NULL — otherwise
+        # analytics queries for "template-sourced connections" would need
+        # a secondary `!= ""` filter and every non-template connection
+        # would show up as a phantom template-origin row.
+        conn = svc.create_connection(
+            db_session, org.id, "X", ConnectionType.MYSQL, {}, source_template_slug=""
+        )
+        assert conn.source_template_slug is None
+
+
+class TestConsumeTemplateFirstRun:
+    """#93 — ``consume_template_first_run`` is the idempotency latch. The
+    first call for a template-sourced connection returns the slug and
+    stamps ``template_first_run_fired_at``; every subsequent call
+    returns None. The Plausible event must fire exactly once per
+    connection lifetime.
+    """
+
+    def _create(self, svc, db_session, org, slug=None):
+        return svc.create_connection(
+            db_session,
+            org.id,
+            "Conn",
+            ConnectionType.POSTGRES,
+            {"host": "localhost"},
+            source_template_slug=slug,
+        )
+
+    def test_returns_slug_on_first_call(self, svc, db_session, org):
+        conn = self._create(svc, db_session, org, slug="shopify-to-pg")
+        assert svc.consume_template_first_run(db_session, org.id, conn.id) == "shopify-to-pg"
+
+    def test_sets_fired_at_on_first_call(self, svc, db_session, org):
+        conn = self._create(svc, db_session, org, slug="x")
+        assert conn.template_first_run_fired_at is None
+        svc.consume_template_first_run(db_session, org.id, conn.id)
+        db_session.refresh(conn)
+        assert conn.template_first_run_fired_at is not None
+
+    def test_returns_none_on_second_call(self, svc, db_session, org):
+        conn = self._create(svc, db_session, org, slug="x")
+        first = svc.consume_template_first_run(db_session, org.id, conn.id)
+        second = svc.consume_template_first_run(db_session, org.id, conn.id)
+        assert first == "x"
+        assert second is None
+
+    def test_returns_none_when_no_slug(self, svc, db_session, org):
+        conn = self._create(svc, db_session, org, slug=None)
+        assert svc.consume_template_first_run(db_session, org.id, conn.id) is None
+
+    def test_returns_none_for_missing_connection(self, svc, db_session, org):
+        assert svc.consume_template_first_run(db_session, org.id, 999_999) is None
+
+    def test_scoped_to_org(self, svc, db_session, org, other_org):
+        """A connection in another org is invisible. MUST NOT fire for the
+        wrong tenant, AND must remain eligible from the right tenant.
+        """
+        conn = self._create(svc, db_session, org, slug="x")
+        assert svc.consume_template_first_run(db_session, other_org.id, conn.id) is None
+        assert svc.consume_template_first_run(db_session, org.id, conn.id) == "x"

--- a/tests/test_ui/test_run_dispatch.py
+++ b/tests/test_ui/test_run_dispatch.py
@@ -40,11 +40,33 @@ class TestUploadRunDispatchesCeleryTask:
         mock_exec_svc = MagicMock()
         mock_exec_svc.create_run.return_value = mock_run
 
+        # #93 — run_upload now instantiates Encryption/Connection/Upload
+        # services to consume the template first-run latch. Mock them so
+        # the template path no-ops and Celery dispatch is the only signal
+        # this test asserts on.
+        mock_conn_svc = MagicMock()
+        mock_conn_svc.consume_template_first_run.return_value = None
+
+        mock_upload = MagicMock()
+        mock_upload.source_connection_id = 101
+        mock_upload.destination_connection_id = 202
+        mock_upload_svc = MagicMock()
+        mock_upload_svc.get_upload.return_value = mock_upload
+
         with (
             patch("datanika.ui.state.upload_state.get_sync_session") as mock_get_session,
             patch(
                 "datanika.ui.state.upload_state.ExecutionService",
                 return_value=mock_exec_svc,
+            ),
+            patch("datanika.ui.state.upload_state.EncryptionService"),
+            patch(
+                "datanika.ui.state.upload_state.ConnectionService",
+                return_value=mock_conn_svc,
+            ),
+            patch(
+                "datanika.ui.state.upload_state.UploadService",
+                return_value=mock_upload_svc,
             ),
             patch("datanika.ui.state.upload_state.run_upload_task") as mock_task,
             patch("datanika.ui.state.base_state.BaseState._audit"),

--- a/tests/test_ui/test_template_first_run_event.py
+++ b/tests/test_ui/test_template_first_run_event.py
@@ -1,0 +1,144 @@
+"""#93 — Source-scan regression tests for the ``template_first_run_triggered``
+Plausible event wiring.
+
+The actual consume-and-emit logic is covered by service-level tests in
+``tests/test_services/test_connection_service.py``
+(``TestConsumeTemplateFirstRun``). This module pins the *wiring* —
+that ``ConnectionState.save_connection`` passes the template slug into
+``create_connection``, and that ``PipelineState.run_pipeline`` /
+``UploadState.run_upload`` call ``consume_template_first_run`` and emit
+``rx.call_script`` with the ``template_first_run_triggered`` event.
+A runtime test would need to stand up Reflex state init + mock the
+execution/pipeline/upload services — more machinery than signal. If a
+future refactor moves this logic to a different call site these
+source-scan tests fail loudly.
+"""
+
+import inspect
+
+
+class TestConnectionStateSaveConnectionPassesTemplateSlug:
+    def test_save_connection_passes_selected_template_slug_to_create(self):
+        import datanika.ui.state.connection_state as cs
+
+        source = inspect.getsource(cs.ConnectionState.save_connection.fn)
+        assert "source_template_slug=self.selected_template_slug" in source, (
+            "ConnectionState.save_connection must pass "
+            "`source_template_slug=self.selected_template_slug or None` "
+            "to ConnectionService.create_connection so the template "
+            "origin is persisted on the Connection row. #93."
+        )
+
+    def test_save_connection_clears_slug_after_save(self):
+        import datanika.ui.state.connection_state as cs
+
+        source = inspect.getsource(cs.ConnectionState.save_connection.fn)
+        assert 'self.selected_template_slug = ""' in source, (
+            "ConnectionState.save_connection must clear "
+            "`selected_template_slug` after a successful save so a "
+            "subsequent non-template create doesn't inherit the slug "
+            "from the previous template flow. #93."
+        )
+
+
+class TestPipelineStateRunPipelineEmitsEvent:
+    def test_consumes_template_first_run_on_destination_connection(self):
+        import datanika.ui.state.pipeline_state as ps
+
+        source = inspect.getsource(ps.PipelineState.run_pipeline.fn)
+        assert "consume_template_first_run" in source, (
+            "PipelineState.run_pipeline must call "
+            "ConnectionService.consume_template_first_run on the "
+            "pipeline's destination_connection_id to check and latch "
+            "the funnel step 3 event. #93."
+        )
+        assert "destination_connection_id" in source, (
+            "PipelineState.run_pipeline must read the pipeline's "
+            "destination_connection_id when consuming the template "
+            "first-run latch. #93."
+        )
+
+    def test_yields_rx_call_script_for_template_first_run_triggered(self):
+        import datanika.ui.state.pipeline_state as ps
+
+        source = inspect.getsource(ps.PipelineState.run_pipeline.fn)
+        assert "rx.call_script" in source, (
+            "PipelineState.run_pipeline must yield an rx.call_script "
+            "with the Plausible event when the consume helper returns "
+            "a slug. #93."
+        )
+        assert "template_first_run_triggered" in source, (
+            "The call_script must emit the `template_first_run_triggered` "
+            "Plausible event name (funnel step 3). #93."
+        )
+
+    def test_guards_window_plausible_undefined(self):
+        import datanika.ui.state.pipeline_state as ps
+
+        source = inspect.getsource(ps.PipelineState.run_pipeline.fn)
+        assert "window.plausible" in source, "The call_script must reference window.plausible. #93."
+        assert "if(window.plausible)" in source or "if (window.plausible)" in source, (
+            "The call_script must guard window.plausible with an `if` "
+            "so self-hosted installs without the tracker loaded no-op "
+            "cleanly instead of throwing ReferenceError. #93."
+        )
+
+
+class TestUploadStateRunUploadEmitsEvent:
+    def test_consumes_template_first_run_on_both_connections(self):
+        import datanika.ui.state.upload_state as us
+
+        source = inspect.getsource(us.UploadState.run_upload.fn)
+        assert "consume_template_first_run" in source, (
+            "UploadState.run_upload must call ConnectionService.consume_template_first_run. #93."
+        )
+        # Both ends — an upload's template flow could live on either side.
+        assert "source_connection_id" in source, (
+            "UploadState.run_upload must check upload.source_connection_id "
+            "for a template origin. #93."
+        )
+        assert "destination_connection_id" in source, (
+            "UploadState.run_upload must check upload.destination_connection_id "
+            "for a template origin. #93."
+        )
+
+    def test_yields_rx_call_script_for_template_first_run_triggered(self):
+        import datanika.ui.state.upload_state as us
+
+        source = inspect.getsource(us.UploadState.run_upload.fn)
+        assert "rx.call_script" in source, (
+            "UploadState.run_upload must yield an rx.call_script when "
+            "the consume helper returns a slug. #93."
+        )
+        assert "template_first_run_triggered" in source, (
+            "The call_script must emit the `template_first_run_triggered` "
+            "Plausible event name. #93."
+        )
+
+    def test_guards_window_plausible_undefined(self):
+        import datanika.ui.state.upload_state as us
+
+        source = inspect.getsource(us.UploadState.run_upload.fn)
+        assert "if(window.plausible)" in source or "if (window.plausible)" in source, (
+            "The call_script must guard window.plausible with an `if` "
+            "so self-hosted installs without the tracker loaded no-op "
+            "cleanly. #93."
+        )
+
+
+class TestConnectionServiceSignatureHasTemplateSlugKwarg:
+    """Guard against a future refactor that drops the kwarg — the UI
+    passes it as a keyword argument, so any signature change that
+    silently removes it would break the wiring without a test failure
+    at the call site."""
+
+    def test_create_connection_accepts_source_template_slug_kwarg(self):
+        from datanika.services.connection_service import ConnectionService
+
+        sig = inspect.signature(ConnectionService.create_connection)
+        assert "source_template_slug" in sig.parameters, (
+            "ConnectionService.create_connection must accept a "
+            "`source_template_slug` keyword argument. #93."
+        )
+        # Default must be None so callers that don't care don't need to pass it.
+        assert sig.parameters["source_template_slug"].default is None


### PR DESCRIPTION
## Summary

Closes the Pipeline Templates funnel step 3 (`template_first_run_triggered`). When a user triggers the first run on a connection created via a template, a Plausible event fires with the template slug — letting Growth measure `template_selected` → `template_prefill_applied` → `template_first_run_triggered` end-to-end.

**Option A** from the issue: schema column, not localStorage bridge.

### What changed

- **Migration** `y4u1v2w3x5z6`: adds `connections.source_template_slug` (`String(128)`, nullable) + `connections.template_first_run_fired_at` (`DateTime(tz)`, nullable — idempotency latch)
- **Model**: two new `Mapped` fields on `Connection`
- **ConnectionService**: `create_connection` accepts `source_template_slug` kwarg (normalises `""` → `None`); new `consume_template_first_run(session, org_id, conn_id)` helper returns slug on first eligible call, `None` thereafter
- **ConnectionState.save_connection**: passes `self.selected_template_slug` through to `create_connection`; clears slug after save
- **PipelineState.run_pipeline**: consumes on `pipeline.destination_connection_id`; yields `rx.call_script(window.plausible(...))` when slug present
- **UploadState.run_upload**: consumes on both `source_connection_id` and `destination_connection_id`; same emit pattern
- **`window.plausible` guard**: `if(window.plausible){...}` so self-hosted installs without the tracker no-op cleanly

### Tests

- 9 service-level tests: `TestSourceTemplateSlug` (3) + `TestConsumeTemplateFirstRun` (6: first call returns slug, sets fired_at, idempotent second call, no-slug, missing connection, org-scoped)
- 9 source-scan regression tests in `test_template_first_run_event.py`: wiring assertions for ConnectionState, PipelineState, UploadState (passes slug, clears after save, consumes on correct connection_ids, yields rx.call_script, guards window.plausible)
- Updated `test_run_dispatch.py` to mock the new ConnectionService/UploadService instantiation in `run_upload`
- **1796 total passing** (18 new), ruff clean

Closes #93.

## Test plan

- [ ] `pytest tests/test_services/test_connection_service.py::TestSourceTemplateSlug` — column write + empty-string normalisation
- [ ] `pytest tests/test_services/test_connection_service.py::TestConsumeTemplateFirstRun` — idempotency, org scoping
- [ ] `pytest tests/test_ui/test_template_first_run_event.py` — wiring source-scan
- [ ] `alembic upgrade head` — migration applies cleanly
- [ ] Manual: create connection via template flow → verify `source_template_slug` populated
- [ ] Manual: run pipeline on template connection → check Plausible for `template_first_run_triggered` event
- [ ] Manual: second run on same connection → no duplicate event

🤖 Generated with [Claude Code](https://claude.com/claude-code)