### PR TITLE
Add x-stability tags + API versioning policy (#137)

### DIFF
--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -261,6 +261,34 @@ SCHEMAS = {
         },
         required=["name", "channel_type"],
     ),
+    # --- Catalog ---
+    "CatalogEntry": _obj(
+        {
+            "id": {"type": "integer"},
+            "entry_type": {
+                "type": "string",
+                "enum": ["source_table", "dbt_model"],
+            },
+            "origin_type": {
+                "type": "string",
+                "enum": ["upload", "transformation", "pipeline"],
+            },
+            "origin_id": {"type": "integer"},
+            "table_name": {"type": "string"},
+            "schema_name": {"type": "string"},
+            "dataset_name": {"type": "string"},
+            "connection_id": {"type": "integer", "nullable": True},
+            "description": {"type": "string", "nullable": True},
+            "columns": {
+                "type": "array",
+                "items": {"type": "object"},
+                "nullable": True,
+            },
+            "dbt_config": {"type": "object", "nullable": True},
+            "created_at": _TS,
+            "updated_at": _TS,
+        }
+    ),
     # --- Tier 2 Agent Compatibility: compile + preview ---
     "CompileResult": _obj(
         {
@@ -563,6 +591,24 @@ _RUNS_PARAMS = [
 
 
 # ---------------------------------------------------------------------------
+# Stability annotations — docs/api_versioning.md, #137
+# ---------------------------------------------------------------------------
+
+
+def _annotate_stability(paths: dict) -> None:
+    """Tag every operation with ``x-stability`` (stable | beta | experimental).
+
+    Catalog endpoints are beta; everything else is stable. The tags show
+    up in Swagger UI and are consumed by enterprise procurement checklists.
+    """
+    for path_key, methods in paths.items():
+        stability = "beta" if path_key.startswith("/api/v1/catalog") else "stable"
+        for op in methods.values():
+            if isinstance(op, dict) and "tags" in op:
+                op["x-stability"] = stability
+
+
+# ---------------------------------------------------------------------------
 # Full spec
 # ---------------------------------------------------------------------------
 
@@ -691,6 +737,19 @@ def build_openapi_spec() -> dict:
         "delete": _delete_op(nt, "Delete notification channel"),
     }
 
+    # Catalog (beta — schema may change as we add lineage)
+    paths["/api/v1/catalog"] = {
+        "get": _list_op("Catalog", "CatalogEntry", "List catalog entries"),
+    }
+    paths["/api/v1/catalog/{id}"] = {
+        "get": _get_op("Catalog", "CatalogEntry", "Get catalog entry"),
+    }
+
+    # Annotate every operation with x-stability per the API versioning
+    # policy (docs/api_versioning.md, #137). Enterprise procurement
+    # requires a machine-readable stability signal in the OpenAPI spec.
+    _annotate_stability(paths)
+
     return {
         "openapi": "3.0.3",
         "info": {
@@ -718,6 +777,7 @@ def build_openapi_spec() -> dict:
             {"name": "Schedules"},
             {"name": "Runs"},
             {"name": "Notifications"},
+            {"name": "Catalog"},
         ],
         "paths": paths,
     }

--- a/docs/api_versioning.md
+++ b/docs/api_versioning.md
@@ -1,0 +1,78 @@
+# API Versioning Policy
+
+All Datanika REST endpoints live under `/api/v1/`. This document defines
+the rules for evolving that surface without breaking integrations.
+
+## Breaking-Change Rules
+
+A **breaking change** is any modification that can cause a working
+client to fail. The following are breaking:
+
+| Category | Examples |
+|----------|----------|
+| Removal | Deleting an endpoint, field, or enum value |
+| Rename | Changing an endpoint path, field name, or query param |
+| Type change | Changing a field from `string` to `integer`, or from nullable to non-nullable |
+| Semantic change | Altering the meaning of a status code or error code |
+| Auth tightening | Requiring a new scope or elevating the required role |
+
+The following are **non-breaking** and may ship without notice:
+
+- Adding a new endpoint, field, query parameter, or enum value
+- Adding a new optional request-body property
+- Widening a constraint (e.g., raising a `maximum`)
+- Adding new error codes alongside existing ones
+- Relaxing auth requirements
+
+## Deprecation Lifecycle
+
+1. **Announce** — the endpoint or field is marked `deprecated: true` in
+   the OpenAPI spec and a `Sunset` HTTP header is added to responses.
+   The minimum notice period is **12 months** from the announcement date.
+2. **Warn** — during the notice period the endpoint continues to work.
+   Responses include `Deprecation: true` and `Sunset: <date>` headers.
+   Release notes and changelog entries call out the deprecation.
+3. **Remove** — after the sunset date the endpoint may return
+   `410 Gone`. The schema entry is removed from the OpenAPI spec.
+
+For critical security fixes, the minimum notice period may be shortened
+to **30 days** with explicit communication to affected users.
+
+## Stability Tiers
+
+Every operation in the OpenAPI spec carries an `x-stability` extension
+so consumers (and enterprise procurement checklists) can assess risk
+at a glance.
+
+| Tier | Meaning | Commitment |
+|------|---------|------------|
+| **stable** | Production-ready, fully supported | 12-month deprecation notice before breaking changes |
+| **beta** | Functionally complete, schema may evolve | 3-month notice before breaking changes; additive changes ship freely |
+| **experimental** | Early access, may change or be removed at any time | No notice required; not recommended for production integrations |
+
+### Current Assignments
+
+| Endpoints | Tier |
+|-----------|------|
+| `/api/v1/connections`, `/api/v1/uploads`, `/api/v1/pipelines`, `/api/v1/transformations`, `/api/v1/schedules` (CRUD + trigger) | stable |
+| `/api/v1/runs`, `/api/v1/notifications/channels` | stable |
+| `/api/v1/transformations/{id}/compile`, `/api/v1/transformations/{id}/preview` | stable |
+| `/api/v1/catalog`, `/api/v1/catalog/{id}` | beta |
+
+### Promotion Path
+
+`experimental` -> `beta` -> `stable`. Promotion happens via a PR that
+updates the `x-stability` value in `datanika/services/openapi.py` and
+adds a changelog entry. Demotion (e.g., `stable` -> `beta`) is treated
+as a breaking change and follows the deprecation lifecycle above.
+
+## Version Lifecycle
+
+| Phase | Description |
+|-------|-------------|
+| **Active** | `/api/v1/` — current and only version. Receives features and fixes. |
+| **Deprecated** | When `/api/v2/` is introduced, v1 enters a 12-month sunset window. |
+| **Retired** | After the sunset date, v1 endpoints return `410 Gone`. |
+
+There are no plans to introduce `/api/v2/` at this time. When that
+happens, this document will be updated with a concrete timeline.

--- a/tests/test_services/test_openapi.py
+++ b/tests/test_services/test_openapi.py
@@ -257,6 +257,69 @@ class TestTier3InlinedSchemas:
         assert stripe["properties"]["api_key"]["format"] == "password"
 
 
+class TestStabilityTags:
+    """#137 — every operation in the OpenAPI spec must carry an
+    ``x-stability`` extension so enterprise buyers can distinguish
+    stable, beta, and experimental endpoints at a glance.
+    """
+
+    def test_all_operations_have_x_stability(self):
+        spec = build_openapi_spec()
+        for path_key, methods in spec["paths"].items():
+            for method, op in methods.items():
+                if not isinstance(op, dict) or "tags" not in op:
+                    continue
+                assert "x-stability" in op, (
+                    f"{method.upper()} {path_key} is missing x-stability tag. "
+                    "See docs/api_versioning.md and #137."
+                )
+                assert op["x-stability"] in ("stable", "beta", "experimental"), (
+                    f"{method.upper()} {path_key} has invalid x-stability "
+                    f"value {op['x-stability']!r}"
+                )
+
+    def test_crud_endpoints_are_stable(self):
+        spec = build_openapi_spec()
+        for resource in ("connections", "uploads", "pipelines", "transformations", "schedules"):
+            path = f"/api/v1/{resource}"
+            for method, op in spec["paths"][path].items():
+                if isinstance(op, dict) and "tags" in op:
+                    assert op["x-stability"] == "stable", (
+                        f"{method.upper()} {path} should be stable"
+                    )
+
+    def test_catalog_endpoints_are_beta(self):
+        spec = build_openapi_spec()
+        for path_key, methods in spec["paths"].items():
+            if not path_key.startswith("/api/v1/catalog"):
+                continue
+            for method, op in methods.items():
+                if isinstance(op, dict) and "tags" in op:
+                    assert op["x-stability"] == "beta", (
+                        f"{method.upper()} {path_key} should be beta"
+                    )
+
+    def test_at_least_three_stable_endpoints(self):
+        spec = build_openapi_spec()
+        stable_count = sum(
+            1
+            for methods in spec["paths"].values()
+            for op in methods.values()
+            if isinstance(op, dict) and op.get("x-stability") == "stable"
+        )
+        assert stable_count >= 3, f"Only {stable_count} stable endpoints found"
+
+    def test_at_least_one_beta_endpoint(self):
+        spec = build_openapi_spec()
+        beta_count = sum(
+            1
+            for methods in spec["paths"].values()
+            for op in methods.values()
+            if isinstance(op, dict) and op.get("x-stability") == "beta"
+        )
+        assert beta_count >= 1, "No beta endpoints found — catalog should be beta"
+
+
 class TestOpenAPIEndpoints:
     def test_openapi_json_returns_200(self, client):
         resp = client.get("/api/v1/openapi.json")


### PR DESCRIPTION
## Summary
- Every OpenAPI operation now carries an `x-stability` extension (`stable` | `beta` | `experimental`) for enterprise procurement. Catalog endpoints are `beta`; all others are `stable`.
- Added `CatalogEntry` schema to the OpenAPI spec and `Catalog` tag.
- Added `docs/api_versioning.md`: breaking-change rules, 12-month deprecation notice, stability tier definitions, version lifecycle.
- 5 new tests in `TestStabilityTags` (30 total in `test_openapi.py`). 1828 passing.

Closes #137.

## Test plan
- [x] `TestStabilityTags::test_all_operations_have_x_stability` — every op has the tag
- [x] `TestStabilityTags::test_crud_endpoints_are_stable` — CRUD paths are stable
- [x] `TestStabilityTags::test_catalog_endpoints_are_beta` — catalog is beta
- [x] `TestStabilityTags::test_at_least_three_stable_endpoints` — minimum stable count
- [x] `TestStabilityTags::test_at_least_one_beta_endpoint` — at least one beta
- [x] Full suite: 1828 passed, ruff clean