### PR TITLE
Add POST /api/v1/import bulk resource creation (#131)

### DIFF
--- a/datanika/services/agent_tiers.py
+++ b/datanika/services/agent_tiers.py
@@ -84,7 +84,8 @@ TIERS: tuple[Tier, ...] = (
         summary=(
             "Full CRUD for every resource the agent needs to assemble a "
             "pipeline: connections, uploads, pipelines, transformations, "
-            "schedules, notification channels."
+            "schedules, notification channels. Bulk import creates all "
+            "resources in a single call."
         ),
         capabilities=(
             Capability(
@@ -100,6 +101,18 @@ TIERS: tuple[Tier, ...] = (
                     "POST /api/v1/transformations",
                     "POST /api/v1/schedules",
                     "POST /api/v1/notifications/channels",
+                ),
+            ),
+            Capability(
+                name="Bulk Import",
+                description=(
+                    "Create connections, uploads, pipelines, and "
+                    "transformations in a single call using the JSON v2 "
+                    "import format. Validates everything first — if any "
+                    "errors are found, nothing is created."
+                ),
+                endpoints=(
+                    "POST /api/v1/import",
                 ),
             ),
         ),

--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -1143,6 +1143,270 @@ async def delete_notification_channel(request, api_key, session):
 
 
 # ---------------------------------------------------------------------------
+# Bulk import — POST /api/v1/import (#131)
+# ---------------------------------------------------------------------------
+
+
+def _validate_import_payload(data: dict, existing_conn_names: dict[str, int]) -> list[dict]:
+    """Validate the entire import payload and return a list of error dicts.
+
+    ``existing_conn_names`` maps connection name → id for connections
+    already present in the org.
+    """
+    errors: list[dict] = []
+
+    # --- connections ---
+    conn_names_in_payload: set[str] = set()
+    for i, c in enumerate(data.get("connections", [])):
+        name = c.get("name")
+        if not name or not str(name).strip():
+            errors.append(
+                {"code": "MISSING_FIELD", "message": f"connections[{i}]: name is required"}
+            )
+            continue
+        ct = c.get("connection_type")
+        if not ct:
+            errors.append(
+                {
+                    "code": "MISSING_FIELD",
+                    "message": f"connections[{i}]: connection_type is required",
+                }
+            )
+        else:
+            try:
+                ConnectionType(ct)
+            except ValueError:
+                errors.append(
+                    {
+                        "code": "INVALID_CONNECTION_TYPE",
+                        "message": f"connections[{i}]: invalid connection_type '{ct}'",
+                    }
+                )
+        if not isinstance(c.get("config"), dict):
+            errors.append(
+                {
+                    "code": "MISSING_FIELD",
+                    "message": f"connections[{i}]: config (object) is required",
+                }
+            )
+        if name in conn_names_in_payload:
+            errors.append(
+                {"code": "DUPLICATE_NAME", "message": f"connections[{i}]: duplicate name '{name}'"}
+            )
+        else:
+            conn_names_in_payload.add(name)
+
+    # Build a combined name set for cross-reference checks
+    all_conn_names = set(existing_conn_names.keys()) | conn_names_in_payload
+
+    # --- uploads ---
+    upload_names: set[str] = set()
+    for i, u in enumerate(data.get("uploads", [])):
+        name = u.get("name")
+        if not name or not str(name).strip():
+            errors.append({"code": "MISSING_FIELD", "message": f"uploads[{i}]: name is required"})
+        elif name in upload_names:
+            errors.append(
+                {"code": "DUPLICATE_NAME", "message": f"uploads[{i}]: duplicate name '{name}'"}
+            )
+        else:
+            upload_names.add(name)
+        for ref_field in ("source_connection_name", "destination_connection_name"):
+            ref = u.get(ref_field)
+            if not ref:
+                errors.append(
+                    {"code": "MISSING_FIELD", "message": f"uploads[{i}]: {ref_field} is required"}
+                )
+            elif ref not in all_conn_names:
+                errors.append(
+                    {
+                        "code": "UNKNOWN_CONNECTION_REF",
+                        "message": f"uploads[{i}]: {ref_field} '{ref}' not found",
+                    }
+                )
+
+    # --- pipelines ---
+    pipeline_names: set[str] = set()
+    for i, p in enumerate(data.get("pipelines", [])):
+        name = p.get("name")
+        if not name or not str(name).strip():
+            errors.append({"code": "MISSING_FIELD", "message": f"pipelines[{i}]: name is required"})
+        elif name in pipeline_names:
+            errors.append(
+                {"code": "DUPLICATE_NAME", "message": f"pipelines[{i}]: duplicate name '{name}'"}
+            )
+        else:
+            pipeline_names.add(name)
+        ref = p.get("destination_connection_name")
+        if not ref:
+            errors.append(
+                {
+                    "code": "MISSING_FIELD",
+                    "message": f"pipelines[{i}]: destination_connection_name is required",
+                }
+            )
+        elif ref not in all_conn_names:
+            errors.append(
+                {
+                    "code": "UNKNOWN_CONNECTION_REF",
+                    "message": f"pipelines[{i}]: destination_connection_name '{ref}' not found",
+                }
+            )
+        cmd = p.get("command")
+        if cmd:
+            try:
+                DbtCommand(cmd)
+            except ValueError:
+                errors.append(
+                    {
+                        "code": "INVALID_ENUM_VALUE",
+                        "message": f"pipelines[{i}]: invalid command '{cmd}'",
+                    }
+                )
+
+    # --- transformations ---
+    transform_names: set[str] = set()
+    for i, t in enumerate(data.get("transformations", [])):
+        name = t.get("name")
+        if not name or not str(name).strip():
+            errors.append(
+                {"code": "MISSING_FIELD", "message": f"transformations[{i}]: name is required"}
+            )
+        elif name in transform_names:
+            errors.append(
+                {
+                    "code": "DUPLICATE_NAME",
+                    "message": f"transformations[{i}]: duplicate name '{name}'",
+                }
+            )
+        else:
+            transform_names.add(name)
+        if not t.get("sql_body"):
+            errors.append(
+                {"code": "MISSING_FIELD", "message": f"transformations[{i}]: sql_body is required"}
+            )
+        mat = t.get("materialization")
+        if mat:
+            try:
+                Materialization(mat)
+            except ValueError:
+                errors.append(
+                    {
+                        "code": "INVALID_ENUM_VALUE",
+                        "message": f"transformations[{i}]: invalid materialization '{mat}'",
+                    }
+                )
+
+    return errors
+
+
+@api_endpoint(required_scope=None)
+async def bulk_import(request, api_key, session):
+    """POST /api/v1/import — create connections, uploads, pipelines,
+    and transformations from a single JSON payload.
+
+    Validates the entire payload first; if any errors are found, nothing
+    is created (atomic). Uses the same JSON v2 format as AI_IMPORT_GUIDE.md.
+    """
+    data = await _body(request)
+
+    # --- version check ---
+    version = data.get("version")
+    if version != 2:
+        return _error(400, "version 2 is required")
+
+    # --- build existing connection name→id map ---
+    existing_conns = _get_conn_svc().list_connections(session, api_key.org_id)
+    existing_conn_names: dict[str, int] = {c.name: c.id for c in existing_conns}
+
+    # --- validate everything before creating anything ---
+    errors = _validate_import_payload(data, existing_conn_names)
+    if errors:
+        return JSONResponse({"errors": errors}, status_code=400)
+
+    created: dict[str, list[int]] = {
+        "connections": [],
+        "uploads": [],
+        "pipelines": [],
+        "transformations": [],
+    }
+
+    # --- Phase 1: create connections ---
+    # Maps connection name → id (payload + existing)
+    conn_name_to_id: dict[str, int] = dict(existing_conn_names)
+    for c in data.get("connections", []):
+        conn = _get_conn_svc().create_connection(
+            session,
+            api_key.org_id,
+            name=c["name"],
+            connection_type=ConnectionType(c["connection_type"]),
+            config=c["config"],
+        )
+        session.flush()
+        conn_name_to_id[c["name"]] = conn.id
+        created["connections"].append(conn.id)
+
+    # --- Phase 2: create uploads ---
+    for u in data.get("uploads", []):
+        upload = _get_upload_svc().create_upload(
+            session,
+            api_key.org_id,
+            name=u["name"],
+            description=u.get("description"),
+            source_connection_id=conn_name_to_id[u["source_connection_name"]],
+            destination_connection_id=conn_name_to_id[u["destination_connection_name"]],
+            dlt_config=u.get("dlt_config", {}),
+        )
+        session.flush()
+        created["uploads"].append(upload.id)
+
+    # --- Phase 3: create pipelines ---
+    for p in data.get("pipelines", []):
+        command = DbtCommand.RUN
+        if p.get("command"):
+            command = DbtCommand(p["command"])
+        pipeline = _pipeline_svc.create_pipeline(
+            session,
+            api_key.org_id,
+            name=p["name"],
+            description=p.get("description"),
+            destination_connection_id=conn_name_to_id[p["destination_connection_name"]],
+            command=command,
+            full_refresh=p.get("full_refresh", False),
+            models=p.get("models"),
+            custom_selector=p.get("custom_selector"),
+        )
+        session.flush()
+        created["pipelines"].append(pipeline.id)
+
+    # --- Phase 4: create transformations ---
+    for t in data.get("transformations", []):
+        mat = Materialization.VIEW
+        if t.get("materialization"):
+            mat = Materialization(t["materialization"])
+        dest_conn_id = None
+        if t.get("destination_connection_name"):
+            dest_conn_id = conn_name_to_id.get(t["destination_connection_name"])
+        transformation = _transform_svc.create_transformation(
+            session,
+            api_key.org_id,
+            name=t["name"],
+            sql_body=t["sql_body"],
+            materialization=mat,
+            description=t.get("description"),
+            schema_name=t.get("schema_name", "staging"),
+            tests_config=t.get("tests_config"),
+            destination_connection_id=dest_conn_id,
+            tags=t.get("tags"),
+            incremental_config=t.get("incremental_config"),
+        )
+        session.flush()
+        created["transformations"].append(transformation.id)
+
+    return JSONResponse({"created": created}, status_code=201)
+
+
+# ---------------------------------------------------------------------------
 # Route table
 # ---------------------------------------------------------------------------
 
@@ -1225,6 +1489,8 @@ api_v1_routes = [
     Route("/api/v1/notifications/{id:int}/read", mark_notification_read, methods=["PATCH"]),
     Route("/api/v1/notifications/read-all", mark_all_notifications_read, methods=["POST"]),
     Route("/api/v1/notifications/{id:int}", dismiss_notification, methods=["DELETE"]),
+    # Bulk import
+    Route("/api/v1/import", bulk_import, methods=["POST"]),
     # Notification channels
     Route("/api/v1/notifications/channels", list_notification_channels, methods=["GET"]),
     Route("/api/v1/notifications/channels/{id:int}", get_notification_channel, methods=["GET"]),

--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -385,6 +385,64 @@ SCHEMAS = {
         },
         required=["error"],
     ),
+    # --- Bulk import ---
+    "ImportRequest": _obj(
+        {
+            "version": {"type": "integer", "enum": [2]},
+            "connections": {
+                "type": "array",
+                "items": _ref("ConnectionCreate"),
+                "description": "Connections to create (optional).",
+            },
+            "uploads": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": (
+                    "Uploads to create. Use connection_name references, "
+                    "not connection_id."
+                ),
+            },
+            "pipelines": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": (
+                    "Pipelines to create. Use destination_connection_name, "
+                    "not destination_connection_id."
+                ),
+            },
+            "transformations": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Transformations to create.",
+            },
+        },
+        required=["version"],
+    ),
+    "ImportResult": _obj(
+        {
+            "created": _obj(
+                {
+                    "connections": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "uploads": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "pipelines": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "transformations": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                }
+            ),
+        },
+        required=["created"],
+    ),
 }
 
 # Inline per-type Connection.config and per-mode Upload.dlt_config schemas
@@ -737,6 +795,36 @@ def build_openapi_spec() -> dict:
         "delete": _delete_op(nt, "Delete notification channel"),
     }
 
+    # Bulk import (#131)
+    paths["/api/v1/import"] = {
+        "post": {
+            "tags": ["Import"],
+            "summary": "Bulk-import resources from a JSON config",
+            "description": (
+                "Create connections, uploads, pipelines, and transformations "
+                "in a single call. Validates the entire payload first; if any "
+                "errors are found, nothing is created (atomic). Uses the same "
+                "JSON v2 format as AI_IMPORT_GUIDE.md."
+            ),
+            "requestBody": {
+                "required": True,
+                "content": _json_content(_ref("ImportRequest")),
+            },
+            "responses": {
+                "201": {
+                    "description": "All resources created",
+                    "content": _json_content(_ref("ImportResult")),
+                },
+                "400": {
+                    "description": "Validation errors — nothing created",
+                    "content": _err_content,
+                },
+                "401": _401,
+                "429": _429,
+            },
+        },
+    }
+
     # Catalog (beta — schema may change as we add lineage)
     paths["/api/v1/catalog"] = {
         "get": _list_op("Catalog", "CatalogEntry", "List catalog entries"),
@@ -777,6 +865,7 @@ def build_openapi_spec() -> dict:
             {"name": "Schedules"},
             {"name": "Runs"},
             {"name": "Notifications"},
+            {"name": "Import"},
             {"name": "Catalog"},
         ],
         "paths": paths,

--- a/tests/test_services/test_agent_tiers.py
+++ b/tests/test_services/test_agent_tiers.py
@@ -81,20 +81,14 @@ class TestCapabilityCount:
         manual_total = sum(len(t.capabilities) for t in TIERS)
         assert capability_count() == manual_total
 
-    def test_current_capability_count_is_six(self):
-        # 5 tiers, but the current capability decomposition is 6:
-        # Discover, Introspect, Build, Validate, Execute, Control,
-        # plus the Tier 5 docs capability — wait, that's 7. Recount.
+    def test_current_capability_count_is_eight(self):
         # Tier 1: Discover + Introspect = 2
-        # Tier 2: Build = 1
+        # Tier 2: Build + Bulk Import = 2
         # Tier 3: Validate = 1
         # Tier 4: Execute + Control = 2
         # Tier 5: Discover Docs = 1
-        # Total = 7
-        # If you change this, the LLMS_TXT capability list changes too,
-        # and any landing-site copy that quotes a number will need to
-        # be updated. Better: have the landing site fetch the JSON.
-        assert capability_count() == 7
+        # Total = 8
+        assert capability_count() == 8
 
 
 class TestKnownCapabilityNames:

--- a/tests/test_services/test_import_endpoint.py
+++ b/tests/test_services/test_import_endpoint.py
@@ -1,0 +1,475 @@
+"""Tests for POST /api/v1/import — bulk resource creation (#131)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import datanika.models.invitation  # noqa: F401
+import datanika.models.notification_channel  # noqa: F401
+import datanika.models.sso_config  # noqa: F401
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+
+@pytest.fixture
+def fake_api_key():
+    key = MagicMock()
+    key.id = 1
+    key.org_id = 10
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def app():
+    return Starlette(routes=api_v1_routes)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def _auth_headers():
+    return {"Authorization": "Bearer etf_testkey"}
+
+
+def _patch_auth(fake_api_key, rate_limit_ok):
+    import contextlib
+
+    from cryptography.fernet import Fernet
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from datanika.models.base import Base
+    from datanika.services.connection_service import ConnectionService
+    from datanika.services.encryption import EncryptionService
+    from datanika.services.pipeline_service import PipelineService
+    from datanika.services.schedule_service import ScheduleService
+    from datanika.services.transformation_service import TransformationService
+    from datanika.services.upload_service import UploadService
+
+    @contextlib.contextmanager
+    def _ctx():
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=__import__("sqlalchemy.pool", fromlist=["StaticPool"]).StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session = SASession(engine)
+
+        enc = EncryptionService(Fernet.generate_key().decode())
+        conn_svc = ConnectionService(enc)
+        upload_svc = UploadService(conn_svc)
+        pipeline_svc = PipelineService()
+        transform_svc = TransformationService()
+        schedule_svc = ScheduleService(upload_svc, transform_svc, pipeline_service=pipeline_svc)
+
+        @contextlib.contextmanager
+        def fake_session():
+            yield session
+
+        import datanika.services.api_v1_routes as routes_mod
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session", fake_session),
+            patch.object(routes_mod, "_get_conn_svc", return_value=conn_svc),
+            patch.object(routes_mod, "_get_upload_svc", return_value=upload_svc),
+            patch.object(routes_mod, "_get_schedule_svc", return_value=schedule_svc),
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+
+            yield session
+
+        session.close()
+        engine.dispose()
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — common payloads
+# ---------------------------------------------------------------------------
+
+_PG_CONN = {
+    "name": "My PG",
+    "connection_type": "postgres",
+    "config": {"host": "localhost", "port": 5432, "user": "u", "password": "p", "database": "db"},
+}
+
+_MYSQL_CONN = {
+    "name": "My MySQL",
+    "connection_type": "mysql",
+    "config": {"host": "mysql.local", "port": 3306, "user": "u", "password": "p", "database": "db"},
+}
+
+
+def _full_payload():
+    """Return a valid version-2 import payload with all sections."""
+    return {
+        "version": 2,
+        "connections": [_PG_CONN, _MYSQL_CONN],
+        "uploads": [
+            {
+                "name": "Load orders",
+                "source_connection_name": "My MySQL",
+                "destination_connection_name": "My PG",
+                "dlt_config": {"load_mode": "single_table", "table_name": "orders"},
+            }
+        ],
+        "pipelines": [
+            {
+                "name": "Build analytics",
+                "destination_connection_name": "My PG",
+                "command": "build",
+            }
+        ],
+        "transformations": [
+            {
+                "name": "stg_orders",
+                "sql_body": "SELECT * FROM {{ source('raw', 'orders') }}",
+                "materialization": "view",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestImportEndpointHappyPath:
+    def test_full_import_creates_all_resources(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
+            )
+            assert resp.status_code == 201, resp.json()
+            data = resp.json()
+            assert "created" in data
+            assert len(data["created"]["connections"]) == 2
+            assert len(data["created"]["uploads"]) == 1
+            assert len(data["created"]["pipelines"]) == 1
+            assert len(data["created"]["transformations"]) == 1
+
+    def test_connections_only(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 2, "connections": [_PG_CONN]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            assert len(data["created"]["connections"]) == 1
+            assert data["created"]["uploads"] == []
+            assert data["created"]["pipelines"] == []
+            assert data["created"]["transformations"] == []
+
+    def test_uploads_referencing_existing_connections(self, client, fake_api_key, rate_limit_ok):
+        """Uploads can reference connections already in the org, not just in the payload."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            # Pre-create connections via the normal endpoint
+            client.post(
+                "/api/v1/connections",
+                json=_PG_CONN,
+                headers=_auth_headers(),
+            )
+            client.post(
+                "/api/v1/connections",
+                json=_MYSQL_CONN,
+                headers=_auth_headers(),
+            )
+
+            # Import an upload referencing those existing connections
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "uploads": [
+                        {
+                            "name": "Load orders",
+                            "source_connection_name": "My MySQL",
+                            "destination_connection_name": "My PG",
+                            "dlt_config": {"load_mode": "single_table", "table_name": "t"},
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            assert len(resp.json()["created"]["uploads"]) == 1
+
+    def test_transformations_only(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "transformations": [
+                        {
+                            "name": "stg_users",
+                            "sql_body": "SELECT * FROM users",
+                            "materialization": "view",
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            assert len(resp.json()["created"]["transformations"]) == 1
+
+    def test_empty_sections_are_fine(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 2},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            for key in ("connections", "uploads", "pipelines", "transformations"):
+                assert data["created"][key] == []
+
+    def test_response_contains_created_ids(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
+            )
+            data = resp.json()
+            for section in ("connections", "uploads", "pipelines", "transformations"):
+                for item_id in data["created"][section]:
+                    assert isinstance(item_id, int)
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestImportValidation:
+    def test_missing_version_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"connections": [_PG_CONN]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+    def test_wrong_version_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 1, "connections": [_PG_CONN]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+    def test_connection_missing_name(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [
+                        {"connection_type": "postgres", "config": {"host": "localhost"}}
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            assert "errors" in resp.json()
+
+    def test_connection_invalid_type(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [
+                        {"name": "Bad", "connection_type": "no_such_db", "config": {}}
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("INVALID_CONNECTION_TYPE" in str(e) for e in errors)
+
+    def test_duplicate_connection_names(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            conn = {**_PG_CONN}
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 2, "connections": [conn, conn]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("DUPLICATE_NAME" in str(e) for e in errors)
+
+    def test_upload_unknown_connection_ref(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "uploads": [
+                        {
+                            "name": "Bad ref",
+                            "source_connection_name": "Does Not Exist",
+                            "destination_connection_name": "Also Missing",
+                            "dlt_config": {},
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("UNKNOWN_CONNECTION_REF" in str(e) for e in errors)
+
+    def test_pipeline_unknown_connection_ref(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "pipelines": [
+                        {
+                            "name": "Bad pipeline",
+                            "destination_connection_name": "Nope",
+                            "command": "run",
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("UNKNOWN_CONNECTION_REF" in str(e) for e in errors)
+
+    def test_transformation_missing_sql_body(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "transformations": [{"name": "bad"}],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+    def test_multiple_errors_returned_at_once(self, client, fake_api_key, rate_limit_ok):
+        """All validation errors collected, not just the first one."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [
+                        {"connection_type": "postgres", "config": {}},  # missing name
+                        {"name": "Bad", "connection_type": "no_such", "config": {}},
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert len(errors) >= 2
+
+    def test_nothing_created_on_validation_failure(self, client, fake_api_key, rate_limit_ok):
+        """If validation fails, no resources are created (atomic)."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            # Send a payload with a valid connection but an invalid upload
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [_PG_CONN],
+                    "uploads": [
+                        {
+                            "name": "Bad",
+                            "source_connection_name": "Nonexistent",
+                            "destination_connection_name": "My PG",
+                            "dlt_config": {},
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+            # Verify the connection was NOT created
+            resp2 = client.get("/api/v1/connections", headers=_auth_headers())
+            assert resp2.status_code == 200
+            assert resp2.json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Auth & routing
+# ---------------------------------------------------------------------------
+
+
+class TestImportAuth:
+    def test_no_auth_returns_401(self, client):
+        resp = client.post("/api/v1/import", json={"version": 2})
+        assert resp.status_code == 401
+
+    def test_empty_body_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post("/api/v1/import", json={}, headers=_auth_headers())
+            assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI spec
+# ---------------------------------------------------------------------------
+
+
+class TestImportOpenAPISpec:
+    def test_import_path_in_spec(self):
+        from datanika.services.openapi import build_openapi_spec
+
+        spec = build_openapi_spec()
+        assert "/api/v1/import" in spec["paths"]
+        assert "post" in spec["paths"]["/api/v1/import"]
+
+    def test_import_is_stable(self):
+        from datanika.services.openapi import build_openapi_spec
+
+        spec = build_openapi_spec()
+        post_op = spec["paths"]["/api/v1/import"]["post"]
+        assert post_op.get("x-stability") == "stable"
+
+    def test_import_schemas_exist(self):
+        from datanika.services.openapi import build_openapi_spec
+
+        spec = build_openapi_spec()
+        schemas = spec["components"]["schemas"]
+        assert "ImportRequest" in schemas
+        assert "ImportResult" in schemas


### PR DESCRIPTION
## Summary
- **`POST /api/v1/import`** — bulk-create connections, uploads, pipelines, and transformations from a single JSON v2 payload (same format as `AI_IMPORT_GUIDE.md`)
- Validates everything first; if any errors are found, nothing is created (atomic). All errors returned at once so the caller can fix in one pass.
- Resolves `*_connection_name` references against both payload connections and existing org connections
- OpenAPI spec: `ImportRequest` + `ImportResult` schemas, `x-stability: stable`, `Import` tag
- Agent tiers: Tier 2 gains a "Bulk Import" capability (`POST /api/v1/import`)
- 21 new tests, 1849 total passing

Closes #131.

## Test plan
- [x] `TestImportEndpointHappyPath` — full import, connections-only, uploads referencing existing connections, transformations-only, empty sections, created IDs
- [x] `TestImportValidation` — missing version, wrong version, missing fields, invalid connection type, duplicate names, unknown connection refs, missing sql_body, multiple errors at once, atomicity (nothing created on validation failure)
- [x] `TestImportAuth` — 401 without auth, 400 on empty body
- [x] `TestImportOpenAPISpec` — path in spec, stability tag, schemas exist
- [x] Full suite: 1849 passed, ruff clean