### PR TITLE
Add Datanika MCP server — AI-agent native distribution (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ uv run reflex run                     # starts on :3000 + :8000
 - [x] 32 connectors (databases, SaaS APIs, files, streaming)
 - [x] dbt transformations, tests, snapshots, packages
 - [x] REST API v1 with OpenAPI/Swagger and typed per-connector inline schemas
-- [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel)
+- [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel, MCP server)
 - [x] Pipeline templates (one-click setup)
 - [x] In-app notification center with Slack, Telegram, Email, Webhook channels
 - [x] SSO (SAML/OIDC) for Enterprise
@@ -98,6 +98,26 @@ uv run reflex run                     # starts on :3000 + :8000
 - [x] 1,700+ tests across unit, security, and E2E (SQLite in-memory for speed)
 - [ ] Kubernetes Helm chart
 - [ ] Data lineage visualization
+
+---
+
+## AI Agent Integration
+
+Datanika ships a first-class [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude Desktop, Claude Code, etc.) can browse connections, preview data, compile transformations, and manage pipelines natively.
+
+```bash
+# Install and run (read-only by default)
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" \
+    datanika-mcp --url https://app.datanika.io --api-key YOUR_KEY
+```
+
+See [`datanika-mcp/README.md`](datanika-mcp/README.md) for Claude Desktop config snippets, the full tool list, and the `--allow-write` flag.
+
+Additional agent resources:
+- [`/llms.txt`](https://app.datanika.io/llms.txt) — discovery document
+- [`/api/v1/openapi.json`](https://app.datanika.io/api/v1/openapi.json) — OpenAPI spec with typed inline schemas
+- [`/api/v1/meta/agent-tiers`](https://app.datanika.io/api/v1/meta/agent-tiers) — 5-tier capability stack (JSON)
+- [`docs/api_versioning.md`](docs/api_versioning.md) — stability tiers and deprecation policy
 
 ---
 

--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -1,0 +1,128 @@
+# Datanika MCP Server
+
+MCP server for [Datanika](https://datanika.io) — browse connections, preview data, compile and validate dbt transformations, monitor runs, and manage pipelines from Claude Desktop.
+
+**Read-only by default.** Pass `--allow-write` to enable creating resources and triggering pipeline runs.
+
+## Install
+
+```bash
+# From PyPI (when published)
+uvx datanika-mcp --help
+
+# From git
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" datanika-mcp --help
+```
+
+## Claude Desktop Configuration
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
+
+### Read-only (recommended)
+
+```json
+{
+  "mcpServers": {
+    "datanika": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp",
+        "--url", "https://app.datanika.io",
+        "--api-key", "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+### With write access
+
+```json
+{
+  "mcpServers": {
+    "datanika": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp",
+        "--url", "https://app.datanika.io",
+        "--api-key", "YOUR_API_KEY",
+        "--allow-write"
+      ]
+    }
+  }
+}
+```
+
+### Environment variables
+
+You can also configure via environment variables:
+
+```json
+{
+  "mcpServers": {
+    "datanika": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp"
+      ],
+      "env": {
+        "DATANIKA_URL": "https://app.datanika.io",
+        "DATANIKA_API_KEY": "YOUR_API_KEY",
+        "DATANIKA_ALLOW_WRITE": "true"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Always available (read-only)
+
+| Tool | Description |
+|------|-------------|
+| `get_agent_tiers` | Get the 5-tier agent capability stack |
+| `get_connection_types` | List supported connection types with config schemas |
+| `list_connections` | List all connections in the org |
+| `get_connection` | Get connection details by ID |
+| `introspect_connection` | List schemas/tables of a source connection |
+| `preview_connection` | Preview first N rows of a table |
+| `query_connection` | Execute a read-only SQL query |
+| `compile_transformation` | Compile a dbt transformation (no execution) |
+| `preview_transformation` | Compile + execute, return preview rows |
+| `list_uploads` | List all uploads |
+| `list_pipelines` | List all pipelines |
+| `list_transformations` | List all transformations |
+| `list_runs` | List runs with optional filters |
+| `get_run` | Get run details by ID |
+| `get_run_logs` | Get run logs |
+| `list_catalog` | List catalog entries (source tables + dbt models) |
+| `get_catalog_entry` | Get catalog entry details |
+
+### Requires `--allow-write`
+
+| Tool | Description |
+|------|-------------|
+| `create_connection` | Create a new data connection |
+| `create_upload` | Create a new upload (extract + load) |
+| `create_pipeline` | Create a new pipeline (dbt orchestration) |
+| `create_transformation` | Create a new dbt SQL transformation |
+| `bulk_import` | Bulk-create resources from JSON v2 format |
+| `trigger_upload` | Trigger an upload run |
+| `trigger_pipeline` | Trigger a pipeline run |
+| `trigger_transformation` | Trigger a transformation run |
+
+## Self-hosted
+
+Point `--url` at your instance:
+
+```bash
+datanika-mcp --url http://localhost:3000 --api-key etf_your_key
+```
+
+## License
+
+AGPL-3.0 — same as the core Datanika platform.

--- a/datanika-mcp/pyproject.toml
+++ b/datanika-mcp/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "datanika-mcp"
+version = "0.1.0"
+description = "MCP server for Datanika — browse connections, preview data, and manage pipelines from Claude Desktop"
+requires-python = ">=3.12"
+license = "AGPL-3.0-or-later"
+readme = "README.md"
+dependencies = [
+    "mcp>=1.0.0",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+datanika-mcp = "datanika_mcp.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/datanika_mcp"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "UP", "B", "SIM"]

--- a/datanika-mcp/src/datanika_mcp/__init__.py
+++ b/datanika-mcp/src/datanika_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Datanika MCP server — browse connections, preview data, manage pipelines."""
+
+__version__ = "0.1.0"

--- a/datanika-mcp/src/datanika_mcp/client.py
+++ b/datanika-mcp/src/datanika_mcp/client.py
@@ -1,0 +1,210 @@
+"""Thin httpx wrapper for the Datanika REST API v1."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class DatanikaClient:
+    """Authenticated HTTP client for the Datanika REST API.
+
+    All methods return the parsed JSON body (dict/list) or raise
+    ``httpx.HTTPStatusError`` on 4xx/5xx.
+    """
+
+    def __init__(self, base_url: str, api_key: str, timeout: float = 30.0) -> None:
+        self._base = base_url.rstrip("/")
+        self._http = httpx.Client(
+            base_url=self._base,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
+        )
+
+    def close(self) -> None:
+        self._http.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get(self, path: str, **params) -> dict:
+        resp = self._http.get(path, params=params or None)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _post(self, path: str, json: dict | None = None) -> dict:
+        resp = self._http.post(path, json=json)
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Read-only — Tier 1: Discover & Introspect
+    # ------------------------------------------------------------------
+
+    def get_agent_tiers(self) -> dict:
+        return self._get("/api/v1/meta/agent-tiers")
+
+    def get_connection_types(self) -> dict:
+        return self._get("/api/v1/meta/connection-types")
+
+    def list_connections(self) -> dict:
+        return self._get("/api/v1/connections")
+
+    def get_connection(self, connection_id: int) -> dict:
+        return self._get(f"/api/v1/connections/{connection_id}")
+
+    def introspect_connection(self, connection_id: int, schema: str | None = None) -> dict:
+        body = {}
+        if schema:
+            body["schema"] = schema
+        return self._post(f"/api/v1/connections/{connection_id}/introspect", json=body)
+
+    def preview_connection(
+        self, connection_id: int, table: str, schema: str | None = None, limit: int = 100
+    ) -> dict:
+        body: dict = {"table": table, "limit": limit}
+        if schema:
+            body["schema"] = schema
+        return self._post(f"/api/v1/connections/{connection_id}/preview", json=body)
+
+    def query_connection(self, connection_id: int, query: str) -> dict:
+        return self._post(f"/api/v1/connections/{connection_id}/query", json={"query": query})
+
+    # ------------------------------------------------------------------
+    # Read-only — Tier 3: Validate
+    # ------------------------------------------------------------------
+
+    def compile_transformation(self, transformation_id: int) -> dict:
+        return self._post(f"/api/v1/transformations/{transformation_id}/compile")
+
+    def preview_transformation(self, transformation_id: int, limit: int = 100) -> dict:
+        return self._post(
+            f"/api/v1/transformations/{transformation_id}/preview",
+            json={"limit": limit},
+        )
+
+    # ------------------------------------------------------------------
+    # Read-only — Tier 4: Control (read half)
+    # ------------------------------------------------------------------
+
+    def list_uploads(self) -> dict:
+        return self._get("/api/v1/uploads")
+
+    def list_pipelines(self) -> dict:
+        return self._get("/api/v1/pipelines")
+
+    def list_transformations(self) -> dict:
+        return self._get("/api/v1/transformations")
+
+    def list_runs(
+        self,
+        target_type: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> dict:
+        params: dict = {"limit": limit}
+        if target_type:
+            params["target_type"] = target_type
+        if status:
+            params["status"] = status
+        return self._get("/api/v1/runs", **params)
+
+    def get_run(self, run_id: int) -> dict:
+        return self._get(f"/api/v1/runs/{run_id}")
+
+    def get_run_logs(self, run_id: int) -> dict:
+        return self._get(f"/api/v1/runs/{run_id}/logs")
+
+    def list_catalog(self) -> dict:
+        return self._get("/api/v1/catalog")
+
+    def get_catalog_entry(self, entry_id: int) -> dict:
+        return self._get(f"/api/v1/catalog/{entry_id}")
+
+    # ------------------------------------------------------------------
+    # Write — Tier 2: Build (requires --allow-write)
+    # ------------------------------------------------------------------
+
+    def create_connection(self, name: str, connection_type: str, config: dict) -> dict:
+        return self._post(
+            "/api/v1/connections",
+            json={"name": name, "connection_type": connection_type, "config": config},
+        )
+
+    def create_upload(
+        self,
+        name: str,
+        source_connection_id: int,
+        destination_connection_id: int,
+        dlt_config: dict | None = None,
+        description: str | None = None,
+    ) -> dict:
+        body: dict = {
+            "name": name,
+            "source_connection_id": source_connection_id,
+            "destination_connection_id": destination_connection_id,
+        }
+        if dlt_config:
+            body["dlt_config"] = dlt_config
+        if description:
+            body["description"] = description
+        return self._post("/api/v1/uploads", json=body)
+
+    def create_pipeline(
+        self,
+        name: str,
+        destination_connection_id: int,
+        command: str = "run",
+        description: str | None = None,
+    ) -> dict:
+        body: dict = {
+            "name": name,
+            "destination_connection_id": destination_connection_id,
+            "command": command,
+        }
+        if description:
+            body["description"] = description
+        return self._post("/api/v1/pipelines", json=body)
+
+    def create_transformation(
+        self,
+        name: str,
+        sql_body: str,
+        materialization: str = "view",
+        description: str | None = None,
+        schema_name: str = "staging",
+    ) -> dict:
+        body: dict = {
+            "name": name,
+            "sql_body": sql_body,
+            "materialization": materialization,
+            "schema_name": schema_name,
+        }
+        if description:
+            body["description"] = description
+        return self._post("/api/v1/transformations", json=body)
+
+    def bulk_import(self, payload: dict) -> dict:
+        return self._post("/api/v1/import", json=payload)
+
+    # ------------------------------------------------------------------
+    # Write — Tier 4: Execute (requires --allow-write)
+    # ------------------------------------------------------------------
+
+    def trigger_upload(self, upload_id: int, wait: bool = False) -> dict:
+        path = f"/api/v1/uploads/{upload_id}/run"
+        if wait:
+            path += "?wait=true"
+        return self._post(path)
+
+    def trigger_pipeline(self, pipeline_id: int, wait: bool = False) -> dict:
+        path = f"/api/v1/pipelines/{pipeline_id}/run"
+        if wait:
+            path += "?wait=true"
+        return self._post(path)
+
+    def trigger_transformation(self, transformation_id: int, wait: bool = False) -> dict:
+        path = f"/api/v1/transformations/{transformation_id}/run"
+        if wait:
+            path += "?wait=true"
+        return self._post(path)

--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -1,0 +1,435 @@
+"""Datanika MCP server — exposes the Datanika REST API as MCP tools.
+
+Read-only by default. Pass ``--allow-write`` to enable mutation tools
+(create resources, trigger pipeline runs).
+
+Usage::
+
+    # Read-only (safe default)
+    datanika-mcp --url https://app.datanika.io --api-key etf_...
+
+    # With write access
+    datanika-mcp --url https://app.datanika.io --api-key etf_... --allow-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from mcp.server.fastmcp import FastMCP
+
+from datanika_mcp.client import DatanikaClient
+
+# ---------------------------------------------------------------------------
+# Globals populated at startup
+# ---------------------------------------------------------------------------
+
+_client: DatanikaClient | None = None
+_allow_write: bool = False
+
+mcp = FastMCP(
+    "Datanika",
+    instructions=(
+        "Browse data connections, preview tables, compile and validate "
+        "dbt transformations, monitor pipeline runs, and (with --allow-write) "
+        "create resources and trigger runs in Datanika."
+    ),
+)
+
+
+def _get_client() -> DatanikaClient:
+    if _client is None:
+        raise RuntimeError("DatanikaClient not initialized — call main() first")
+    return _client
+
+
+def _require_write(action: str) -> None:
+    if not _allow_write:
+        raise RuntimeError(
+            f"Write access required for '{action}'. "
+            "Restart the server with --allow-write to enable mutations."
+        )
+
+
+# ===================================================================
+# Read-only tools — always available
+# ===================================================================
+
+
+# --- Tier 1: Discover & Introspect ---
+
+
+@mcp.tool()
+def get_agent_tiers() -> str:
+    """Get the 5-tier agent capability stack — describes what the API can do."""
+    return json.dumps(_get_client().get_agent_tiers(), indent=2)
+
+
+@mcp.tool()
+def get_connection_types() -> str:
+    """List all supported connection types with their config schemas."""
+    return json.dumps(_get_client().get_connection_types(), indent=2)
+
+
+@mcp.tool()
+def list_connections() -> str:
+    """List all connections in the organization."""
+    return json.dumps(_get_client().list_connections(), indent=2)
+
+
+@mcp.tool()
+def get_connection(connection_id: int) -> str:
+    """Get details of a specific connection by ID."""
+    return json.dumps(_get_client().get_connection(connection_id), indent=2)
+
+
+@mcp.tool()
+def introspect_connection(connection_id: int, schema: str | None = None) -> str:
+    """List schemas and tables of a source connection.
+
+    Args:
+        connection_id: The connection to introspect.
+        schema: Optional schema name to filter tables.
+    """
+    return json.dumps(_get_client().introspect_connection(connection_id, schema), indent=2)
+
+
+@mcp.tool()
+def preview_connection(
+    connection_id: int, table: str, schema: str | None = None, limit: int = 100
+) -> str:
+    """Preview the first N rows of a table from a source connection.
+
+    Args:
+        connection_id: The connection to query.
+        table: Table name to preview.
+        schema: Optional schema name.
+        limit: Max rows to return (default 100).
+    """
+    return json.dumps(
+        _get_client().preview_connection(connection_id, table, schema, limit),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def query_connection(connection_id: int, query: str) -> str:
+    """Execute a read-only SQL query against a source connection.
+
+    Args:
+        connection_id: The connection to query.
+        query: A single SELECT statement (no mutations allowed).
+    """
+    return json.dumps(_get_client().query_connection(connection_id, query), indent=2)
+
+
+# --- Tier 3: Validate ---
+
+
+@mcp.tool()
+def compile_transformation(transformation_id: int) -> str:
+    """Compile a dbt transformation — resolves Jinja, ref(), source(). No execution.
+
+    Args:
+        transformation_id: The transformation to compile.
+    """
+    return json.dumps(_get_client().compile_transformation(transformation_id), indent=2)
+
+
+@mcp.tool()
+def preview_transformation(transformation_id: int, limit: int = 100) -> str:
+    """Compile and execute a transformation, returning preview rows.
+
+    Args:
+        transformation_id: The transformation to preview.
+        limit: Max rows to return (default 100, max 1000).
+    """
+    return json.dumps(_get_client().preview_transformation(transformation_id, limit), indent=2)
+
+
+# --- Tier 4: Control (read half) ---
+
+
+@mcp.tool()
+def list_uploads() -> str:
+    """List all uploads (extract + load jobs) in the organization."""
+    return json.dumps(_get_client().list_uploads(), indent=2)
+
+
+@mcp.tool()
+def list_pipelines() -> str:
+    """List all pipelines (dbt transform orchestration) in the organization."""
+    return json.dumps(_get_client().list_pipelines(), indent=2)
+
+
+@mcp.tool()
+def list_transformations() -> str:
+    """List all dbt transformations in the organization."""
+    return json.dumps(_get_client().list_transformations(), indent=2)
+
+
+@mcp.tool()
+def list_runs(target_type: str | None = None, status: str | None = None, limit: int = 50) -> str:
+    """List pipeline/upload/transformation runs with optional filters.
+
+    Args:
+        target_type: Filter by type — 'upload', 'pipeline', or 'transformation'.
+        status: Filter by status — 'pending', 'running', 'success', 'failed', 'cancelled'.
+        limit: Max results (default 50, max 200).
+    """
+    return json.dumps(_get_client().list_runs(target_type, status, limit), indent=2)
+
+
+@mcp.tool()
+def get_run(run_id: int) -> str:
+    """Get details of a specific run by ID.
+
+    Args:
+        run_id: The run ID to look up.
+    """
+    return json.dumps(_get_client().get_run(run_id), indent=2)
+
+
+@mcp.tool()
+def get_run_logs(run_id: int) -> str:
+    """Get the logs of a specific run.
+
+    Args:
+        run_id: The run ID whose logs to fetch.
+    """
+    return json.dumps(_get_client().get_run_logs(run_id), indent=2)
+
+
+@mcp.tool()
+def list_catalog() -> str:
+    """List all catalog entries (source tables and dbt models)."""
+    return json.dumps(_get_client().list_catalog(), indent=2)
+
+
+@mcp.tool()
+def get_catalog_entry(entry_id: int) -> str:
+    """Get details of a specific catalog entry.
+
+    Args:
+        entry_id: The catalog entry ID.
+    """
+    return json.dumps(_get_client().get_catalog_entry(entry_id), indent=2)
+
+
+# ===================================================================
+# Write tools — only available with --allow-write
+# ===================================================================
+
+
+# --- Tier 2: Build ---
+
+
+@mcp.tool()
+def create_connection(name: str, connection_type: str, config: dict) -> str:
+    """Create a new data connection.
+
+    Requires --allow-write.
+
+    Args:
+        name: Human-readable name for the connection.
+        connection_type: One of the supported types (e.g. 'postgres', 'mysql', 'stripe').
+        config: Connection-specific configuration (host, port, credentials, etc.).
+    """
+    _require_write("create_connection")
+    return json.dumps(_get_client().create_connection(name, connection_type, config), indent=2)
+
+
+@mcp.tool()
+def create_upload(
+    name: str,
+    source_connection_id: int,
+    destination_connection_id: int,
+    dlt_config: dict | None = None,
+    description: str | None = None,
+) -> str:
+    """Create a new upload (extract + load job).
+
+    Requires --allow-write.
+
+    Args:
+        name: Upload name.
+        source_connection_id: ID of the source connection.
+        destination_connection_id: ID of the destination connection.
+        dlt_config: Optional dlt extraction config (load_mode, table_name, etc.).
+        description: Optional description.
+    """
+    _require_write("create_upload")
+    return json.dumps(
+        _get_client().create_upload(
+            name, source_connection_id, destination_connection_id, dlt_config, description
+        ),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def create_pipeline(
+    name: str,
+    destination_connection_id: int,
+    command: str = "run",
+    description: str | None = None,
+) -> str:
+    """Create a new pipeline (dbt transform orchestration).
+
+    Requires --allow-write.
+
+    Args:
+        name: Pipeline name.
+        destination_connection_id: ID of the destination connection.
+        command: dbt command — 'run', 'build', 'test', 'seed', 'snapshot', 'compile'.
+        description: Optional description.
+    """
+    _require_write("create_pipeline")
+    return json.dumps(
+        _get_client().create_pipeline(name, destination_connection_id, command, description),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def create_transformation(
+    name: str,
+    sql_body: str,
+    materialization: str = "view",
+    description: str | None = None,
+    schema_name: str = "staging",
+) -> str:
+    """Create a new dbt SQL transformation.
+
+    Requires --allow-write.
+
+    Args:
+        name: Model name (letters, digits, underscores, hyphens; must start with letter or _).
+        sql_body: dbt-compatible SQL (supports ref(), source(), Jinja).
+        materialization: 'view', 'table', 'incremental', 'ephemeral', or 'snapshot'.
+        description: Optional description.
+        schema_name: Target schema (default 'staging').
+    """
+    _require_write("create_transformation")
+    return json.dumps(
+        _get_client().create_transformation(
+            name, sql_body, materialization, description, schema_name
+        ),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def bulk_import(payload: dict) -> str:
+    """Bulk-import connections, uploads, pipelines, and transformations in one call.
+
+    Requires --allow-write. Uses the JSON v2 import format.
+    Validates everything first — if any errors, nothing is created.
+
+    Args:
+        payload: JSON v2 import payload with version, connections, uploads,
+                 pipelines, transformations sections. See AI_IMPORT_GUIDE.md.
+    """
+    _require_write("bulk_import")
+    return json.dumps(_get_client().bulk_import(payload), indent=2)
+
+
+# --- Tier 4: Execute ---
+
+
+@mcp.tool()
+def trigger_upload(upload_id: int, wait: bool = False) -> str:
+    """Trigger an upload run.
+
+    Requires --allow-write.
+
+    Args:
+        upload_id: The upload to run.
+        wait: If true, block until the run completes (up to 120s).
+    """
+    _require_write("trigger_upload")
+    return json.dumps(_get_client().trigger_upload(upload_id, wait), indent=2)
+
+
+@mcp.tool()
+def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
+    """Trigger a pipeline run (dbt build/run/test).
+
+    Requires --allow-write.
+
+    Args:
+        pipeline_id: The pipeline to run.
+        wait: If true, block until the run completes (up to 120s).
+    """
+    _require_write("trigger_pipeline")
+    return json.dumps(_get_client().trigger_pipeline(pipeline_id, wait), indent=2)
+
+
+@mcp.tool()
+def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
+    """Trigger a transformation run.
+
+    Requires --allow-write.
+
+    Args:
+        transformation_id: The transformation to run.
+        wait: If true, block until the run completes (up to 120s).
+    """
+    _require_write("trigger_transformation")
+    return json.dumps(_get_client().trigger_transformation(transformation_id, wait), indent=2)
+
+
+# ===================================================================
+# Entry point
+# ===================================================================
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="datanika-mcp",
+        description="Datanika MCP server — data pipeline tools for Claude Desktop",
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("DATANIKA_URL", "https://app.datanika.io"),
+        help="Datanika instance URL (default: $DATANIKA_URL or https://app.datanika.io)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("DATANIKA_API_KEY"),
+        help="API key (default: $DATANIKA_API_KEY)",
+    )
+    parser.add_argument(
+        "--allow-write",
+        action="store_true",
+        default=os.environ.get("DATANIKA_ALLOW_WRITE", "").lower() in ("1", "true"),
+        help="Enable write tools (create resources, trigger runs)",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 0.1.0",
+    )
+
+    args = parser.parse_args()
+
+    if not args.api_key:
+        print("Error: --api-key or $DATANIKA_API_KEY is required", file=sys.stderr)
+        sys.exit(1)
+
+    global _client, _allow_write
+    _client = DatanikaClient(args.url, args.api_key)
+    _allow_write = args.allow_write
+
+    mode = "read-write" if _allow_write else "read-only"
+    print(f"Datanika MCP server starting ({mode})...", file=sys.stderr)
+    print(f"  URL: {args.url}", file=sys.stderr)
+
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "pytest-cov>=6.0",
     "ruff>=0.9",
     "httpx>=0.28",
+    "mcp>=1.0.0",
 ]
 
 [build-system]

--- a/tests/test_mcp/test_mcp_server.py
+++ b/tests/test_mcp/test_mcp_server.py
@@ -1,0 +1,238 @@
+"""Tests for the Datanika MCP server (#140).
+
+These tests verify tool registration, the write-guard, and the CLI
+argument parser without requiring a live Datanika instance.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _add_mcp_to_path():
+    """Make ``datanika_mcp`` importable from the MCP sub-package."""
+    import pathlib
+
+    mcp_src = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+    if mcp_src not in sys.path:
+        sys.path.insert(0, mcp_src)
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistration:
+    """All expected tools must be registered on the FastMCP instance."""
+
+    def test_read_only_tools_registered(self):
+        from datanika_mcp.server import mcp as server
+
+        tool_names = {t.name for t in server._tool_manager.list_tools()}
+        read_tools = {
+            "get_agent_tiers",
+            "get_connection_types",
+            "list_connections",
+            "get_connection",
+            "introspect_connection",
+            "preview_connection",
+            "query_connection",
+            "compile_transformation",
+            "preview_transformation",
+            "list_uploads",
+            "list_pipelines",
+            "list_transformations",
+            "list_runs",
+            "get_run",
+            "get_run_logs",
+            "list_catalog",
+            "get_catalog_entry",
+        }
+        assert read_tools.issubset(tool_names), f"Missing read tools: {read_tools - tool_names}"
+
+    def test_write_tools_registered(self):
+        from datanika_mcp.server import mcp as server
+
+        tool_names = {t.name for t in server._tool_manager.list_tools()}
+        write_tools = {
+            "create_connection",
+            "create_upload",
+            "create_pipeline",
+            "create_transformation",
+            "bulk_import",
+            "trigger_upload",
+            "trigger_pipeline",
+            "trigger_transformation",
+        }
+        assert write_tools.issubset(tool_names), f"Missing write tools: {write_tools - tool_names}"
+
+    def test_total_tool_count(self):
+        from datanika_mcp.server import mcp as server
+
+        tools = server._tool_manager.list_tools()
+        assert len(tools) == 25  # 17 read + 8 write
+
+
+# ---------------------------------------------------------------------------
+# Write guard
+# ---------------------------------------------------------------------------
+
+
+class TestWriteGuard:
+    def test_write_blocked_by_default(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = False
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv._require_write("create_connection")
+
+    def test_write_allowed_when_enabled(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        srv._require_write("create_connection")  # should not raise
+
+    def test_create_connection_calls_require_write(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = False
+        srv._client = MagicMock()
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv.create_connection("test", "postgres", {"host": "localhost"})
+
+    def test_trigger_pipeline_calls_require_write(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = False
+        srv._client = MagicMock()
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv.trigger_pipeline(1, wait=False)
+
+
+# ---------------------------------------------------------------------------
+# Read tools call client correctly
+# ---------------------------------------------------------------------------
+
+
+class TestReadToolsCallClient:
+    def test_list_connections_calls_client(self):
+        import datanika_mcp.server as srv
+
+        mock_client = MagicMock()
+        mock_client.list_connections.return_value = {"items": []}
+        srv._client = mock_client
+
+        result = srv.list_connections()
+        mock_client.list_connections.assert_called_once()
+        assert '"items"' in result
+
+    def test_get_run_logs_calls_client(self):
+        import datanika_mcp.server as srv
+
+        mock_client = MagicMock()
+        mock_client.get_run_logs.return_value = {"run_id": 42, "logs": "ok"}
+        srv._client = mock_client
+
+        result = srv.get_run_logs(42)
+        mock_client.get_run_logs.assert_called_once_with(42)
+        assert "42" in result
+
+    def test_compile_transformation_calls_client(self):
+        import datanika_mcp.server as srv
+
+        mock_client = MagicMock()
+        mock_client.compile_transformation.return_value = {
+            "compiled_sql": "SELECT 1",
+            "node": "model.t.stg_orders",
+        }
+        srv._client = mock_client
+
+        result = srv.compile_transformation(5)
+        mock_client.compile_transformation.assert_called_once_with(5)
+        assert "SELECT 1" in result
+
+
+# ---------------------------------------------------------------------------
+# Write tools call client when allowed
+# ---------------------------------------------------------------------------
+
+
+class TestWriteToolsCallClient:
+    def test_create_connection_calls_client(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        mock_client = MagicMock()
+        mock_client.create_connection.return_value = {"id": 1, "name": "test"}
+        srv._client = mock_client
+
+        result = srv.create_connection("test", "postgres", {"host": "localhost"})
+        mock_client.create_connection.assert_called_once_with(
+            "test", "postgres", {"host": "localhost"}
+        )
+        assert '"id": 1' in result
+
+    def test_bulk_import_calls_client(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        mock_client = MagicMock()
+        mock_client.bulk_import.return_value = {"created": {"connections": [1]}}
+        srv._client = mock_client
+
+        payload = {"version": 2, "connections": [{"name": "a"}]}
+        result = srv.bulk_import(payload)
+        mock_client.bulk_import.assert_called_once_with(payload)
+        assert "connections" in result
+
+    def test_trigger_upload_with_wait(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        mock_client = MagicMock()
+        mock_client.trigger_upload.return_value = {"run_id": 10, "status": "success"}
+        srv._client = mock_client
+
+        result = srv.trigger_upload(3, wait=True)
+        mock_client.trigger_upload.assert_called_once_with(3, True)
+        assert "success" in result
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_missing_api_key_exits(self):
+        """Server should exit with error if no API key is provided."""
+        import datanika_mcp.server as srv
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("sys.argv", ["datanika-mcp"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            # Remove any env vars that might provide the key
+            import os
+
+            os.environ.pop("DATANIKA_API_KEY", None)
+            os.environ.pop("DATANIKA_URL", None)
+            os.environ.pop("DATANIKA_ALLOW_WRITE", None)
+            srv.main()
+
+        assert exc_info.value.code == 1
+
+    def test_version_flag(self):
+        import datanika_mcp.server as srv
+
+        with (
+            patch("sys.argv", ["datanika-mcp", "--version"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            srv.main()
+
+        assert exc_info.value.code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -962,6 +962,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -978,18 +979,19 @@ requires-dist = [
     { name = "cryptography", specifier = ">=44.0" },
     { name = "dbt-bigquery", specifier = ">=1.7,<1.8" },
     { name = "dbt-clickhouse", specifier = ">=1.7,<1.8" },
-    { name = "dbt-core", specifier = ">=1.7,<1.8" },
+    { name = "dbt-core", specifier = ">=1.7.19,<1.8" },
     { name = "dbt-duckdb", specifier = ">=1.7,<1.8" },
     { name = "dbt-mysql", specifier = ">=1.7,<1.8" },
     { name = "dbt-postgres", specifier = ">=1.7,<1.8" },
     { name = "dbt-redshift", specifier = ">=1.7,<1.8" },
     { name = "dbt-snowflake", specifier = ">=1.7,<1.8" },
     { name = "dbt-sqlserver", specifier = ">=1.7,<1.8" },
-    { name = "dlt", extras = ["postgres", "snowflake", "bigquery", "mssql", "clickhouse", "duckdb", "databricks", "synapse"], specifier = ">=1.5" },
+    { name = "dlt", extras = ["postgres", "snowflake", "bigquery", "mssql", "clickhouse", "duckdb", "databricks", "synapse"], specifier = ">=1.21,<2" },
     { name = "duckdb", specifier = ">=1.0" },
     { name = "google-auth", specifier = ">=2.0" },
     { name = "gspread", specifier = ">=6.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1992,6 +1994,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2380,6 +2391,31 @@ wheels = [
 [package.optional-dependencies]
 msgpack = [
     { name = "msgpack" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]
@@ -4264,6 +4300,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4361,6 +4410,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `datanika-mcp/` package: MCP server exposing Datanika REST API as native tools for Claude Desktop
- **Read-only by default** (17 tools): discover connection types, list/introspect/preview connections, compile/preview transformations, list runs, browse catalog
- **`--allow-write`** opt-in (8 tools): create connections/uploads/pipelines/transformations, bulk import, trigger runs
- Configurable via CLI args (`--url`, `--api-key`, `--allow-write`) or env vars (`DATANIKA_URL`, `DATANIKA_API_KEY`, `DATANIKA_ALLOW_WRITE`)
- Installable via `uvx --from "git+...#subdirectory=datanika-mcp" datanika-mcp`
- Claude Desktop config snippets in `datanika-mcp/README.md`
- README.md updated with AI Agent Integration section
- `mcp>=1.0.0` added to dev dependencies for testing
- 15 new tests (tool registration, write guard, client delegation, CLI), 1864 total passing

Closes #140.

## Test plan
- [x] `TestToolRegistration` — 17 read tools + 8 write tools registered (25 total)
- [x] `TestWriteGuard` — write blocked by default, allowed when enabled, specific tools guard correctly
- [x] `TestReadToolsCallClient` — list_connections, get_run_logs, compile_transformation delegate to client
- [x] `TestWriteToolsCallClient` — create_connection, bulk_import, trigger_upload delegate when write enabled
- [x] `TestCLI` — missing API key exits with error, --version works
- [x] Full suite: 1864 passed, ruff clean