### PR TITLE
Promote dev → master: bulk import, MCP, E2E harness, Helm chart, drift B fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,10 +176,11 @@ jobs:
     needs: [deploy-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -208,7 +209,7 @@ jobs:
           DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
           DATANIKA_E2E_SEED_CMD: >-
             ssh root@${{ secrets.HETZNER_HOST }}
-            'docker exec datanika-staging-app uv run python -m datanika.scripts.e2e_seed'
+            'E2E_SEED_ALLOW_ANY_HOST=1 docker exec datanika-staging-app uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
 
       - name: Upload Playwright report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,70 @@ jobs:
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
 
+  e2e-staging:
+    needs: [deploy-staging]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install chromium --with-deps
+
+      - name: Configure SSH for seed
+        env:
+          SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+      - name: Run E2E tests against staging
+        working-directory: e2e
+        env:
+          CI: "true"
+          DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
+          DATANIKA_E2E_SEED_CMD: >-
+            ssh root@${{ secrets.HETZNER_HOST }}
+            'docker exec datanika-staging-app uv run python -m datanika.scripts.e2e_seed'
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          SHORT_SHA=${COMMIT_SHA:0:7}
+          FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+          TEXT=$(printf '\xf0\x9f\x9a\xa8 *Staging E2E failed*\n\n*Commit:* `%s`\n*Message:* %s\n*Run:* %s' \
+            "$SHORT_SHA" "$FIRST_LINE" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=1201995" \
+            --data-urlencode "text=${TEXT}" \
+            --data-urlencode "parse_mode=Markdown"
+
   # Post-deploy smoke gate. Fails loud if any curated URL 404s, returns an
   # empty body, or serves the wrong content-type/body substring. See
   # plans/growth/SMOKE_URLS.md (Growth-owned SoT) for the curation rationale.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,23 @@ jobs:
       - name: Run tests
         run: pytest tests/ --tb=short -q
 
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Helm lint
+        run: helm lint deploy/helm/datanika
+
+      - name: Helm template (dry-run render)
+        run: helm template test-release deploy/helm/datanika > /dev/null
+
   deploy:
-    needs: [lint, test]
+    needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment: production
@@ -97,7 +112,7 @@ jobs:
             docker image prune -f
 
   deploy-staging:
-    needs: [lint, test]
+    needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     environment: production

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,7 +86,7 @@ Sources -> dlt (extract + load into user-chosen schema)
 | **Package Manager** | uv |
 | **Linting** | Ruff |
 | **i18n** | 9 languages (en, ru, el, de, fr, es, zh, ar, sr) with runtime switching |
-| **Testing** | pytest + pytest-asyncio, SQLite in-memory, 1,700+ tests across unit / security / E2E |
+| **Testing** | pytest + pytest-asyncio, SQLite in-memory, 1,800+ tests across unit / security / E2E |
 | **Monitoring** | Prometheus (metrics collection), Grafana (dashboards), Node Exporter (host metrics), cAdvisor (container metrics) |
 
 ## Database Design
@@ -364,6 +364,16 @@ Tier 3/4 endpoints return a new typed `error_code` field alongside the human mes
 
 `transformation_compile.py` runs `dbt compile` via `dbtRunner().invoke()`, wraps the resulting SQL in `SELECT * FROM (...) LIMIT N`, and re-validates via `is_select_only()` before executing against the warehouse. Defense in depth: a compromised or buggy dbt compile output cannot reach DDL/DML. The read-only guard uses regex word boundaries (not a full SQL parser) for lightness while still rejecting DDL, DML, multi-statement, and CTE-with-mutation payloads.
 
+### API stability tiers
+
+Every operation in the OpenAPI spec carries an `x-stability` extension (`stable` / `beta` / `experimental`) injected at build time by `_annotate_stability()` in `datanika/services/openapi.py`. Agents can branch on the tier to decide whether to rely on a field. Stability semantics, deprecation windows, and the removal policy are frozen in [`docs/api_versioning.md`](docs/api_versioning.md) — tier promotions require a doc update and a PR-level review.
+
+### MCP server (`datanika-mcp/`)
+
+`datanika-mcp/` is a first-class [Model Context Protocol](https://modelcontextprotocol.io/) server that wraps the REST API behind 25 tools (16 read-only + 9 write) covering connections, uploads, transformations, pipelines, runs, templates, and catalog browsing. It is a thin HTTP client — there is no parallel business logic. The server ships as its own uv package installable via `uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp"` so agents (Claude Desktop, Claude Code) can speak to any Datanika instance without shelling out to the UI.
+
+Write-facing tools (create / update / delete / run) are gated behind `--allow-write`; the default posture is read-only so "connect Claude Desktop to production" does not accidentally mutate pipelines. All 25 tools are decorated with `@mcp.tool()` in `datanika-mcp/src/datanika_mcp/server.py`; the HTTP shim lives in `client.py`. Tests in `tests/test_mcp/test_mcp_server.py` assert the tool surface matches the API and that `--allow-write` correctly filters mutating tools.
+
 ## Notification Center
 
 Datanika has two notification surfaces that share the same `notifications` table:
@@ -442,6 +452,8 @@ All services are defined in `docker-compose.yml` (requires `source .env.docker` 
 | **Soft delete** | Records preserved for audit, never hard-removed |
 | **Input validation** | Identifier regex, path traversal prevention in dbt file writes |
 
+Vulnerability disclosure policy, supported versions, and the security contact live in [`SECURITY.md`](SECURITY.md) at the repo root.
+
 ## Testing Strategy
 
 - **Framework**: pytest + pytest-asyncio with `asyncio_mode = "auto"`
@@ -449,7 +461,7 @@ All services are defined in `docker-compose.yml` (requires `source .env.docker` 
 - **Layout**: Test files mirror source — `datanika/services/foo.py` → `tests/test_services/test_foo.py`
 - **TDD**: Failing test first, then implementation, then refactor
 - **Bug fixes**: Every fix requires a regression test
-- **Test count**: 1,700+ across unit / service / UI / migration / security suites (see `pytest tests/ --collect-only -q` for the live number)
+- **Test count**: 1,800+ across unit / service / UI / migration / security suites (see `pytest tests/ --collect-only -q` for the live number)
 - **Test directories**: `test_models/`, `test_services/`, `test_tasks/`, `test_ui/`, `test_i18n/`, `test_migrations/`, `test_security/`, plus top-level `test_hooks.py`, `test_hooks_integration.py`, `test_plugin_registry.py`, `test_app_plugin_init.py`
 - **Security tests**: coverage for injection, path traversal, auth attacks, input validation, tenant isolation
 - **E2E tests**: `datanika-examples/tests/` running against real Docker databases (Postgres, MySQL, MSSQL, MongoDB seed scripts + Compose)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ uv run reflex run                     # starts on :3000 + :8000
 - [x] 32 connectors (databases, SaaS APIs, files, streaming)
 - [x] dbt transformations, tests, snapshots, packages
 - [x] REST API v1 with OpenAPI/Swagger and typed per-connector inline schemas
-- [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel)
+- [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel, MCP server)
 - [x] Pipeline templates (one-click setup)
 - [x] In-app notification center with Slack, Telegram, Email, Webhook channels
 - [x] SSO (SAML/OIDC) for Enterprise
@@ -98,6 +98,26 @@ uv run reflex run                     # starts on :3000 + :8000
 - [x] 1,700+ tests across unit, security, and E2E (SQLite in-memory for speed)
 - [ ] Kubernetes Helm chart
 - [ ] Data lineage visualization
+
+---
+
+## AI Agent Integration
+
+Datanika ships a first-class [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude Desktop, Claude Code, etc.) can browse connections, preview data, compile transformations, and manage pipelines natively.
+
+```bash
+# Install and run (read-only by default)
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" \
+    datanika-mcp --url https://app.datanika.io --api-key YOUR_KEY
+```
+
+See [`datanika-mcp/README.md`](datanika-mcp/README.md) for Claude Desktop config snippets, the full tool list, and the `--allow-write` flag.
+
+Additional agent resources:
+- [`/llms.txt`](https://app.datanika.io/llms.txt) — discovery document
+- [`/api/v1/openapi.json`](https://app.datanika.io/api/v1/openapi.json) — OpenAPI spec with typed inline schemas
+- [`/api/v1/meta/agent-tiers`](https://app.datanika.io/api/v1/meta/agent-tiers) — 5-tier capability stack (JSON)
+- [`docs/api_versioning.md`](docs/api_versioning.md) — stability tiers and deprecation policy
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ uv run reflex run                     # starts on :3000 + :8000
 - [x] In-app notification center with Slack, Telegram, Email, Webhook channels
 - [x] SSO (SAML/OIDC) for Enterprise
 - [x] Usage-based billing (cloud plugin)
-- [x] 1,700+ tests across unit, security, and E2E (SQLite in-memory for speed)
+- [x] 1,800+ tests across unit, security, and E2E (SQLite in-memory for speed)
 - [ ] Kubernetes Helm chart
 - [ ] Data lineage visualization
 

--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -1,0 +1,128 @@
+# Datanika MCP Server
+
+MCP server for [Datanika](https://datanika.io) — browse connections, preview data, compile and validate dbt transformations, monitor runs, and manage pipelines from Claude Desktop.
+
+**Read-only by default.** Pass `--allow-write` to enable creating resources and triggering pipeline runs.
+
+## Install
+
+```bash
+# From PyPI (when published)
+uvx datanika-mcp --help
+
+# From git
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" datanika-mcp --help
+```
+
+## Claude Desktop Configuration
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
+
+### Read-only (recommended)
+
+```json
+{
+  "mcpServers": {
+    "datanika": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp",
+        "--url", "https://app.datanika.io",
+        "--api-key", "YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+### With write access
+
+```json
+{
+  "mcpServers": {
+    "datanika": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp",
+        "--url", "https://app.datanika.io",
+        "--api-key", "YOUR_API_KEY",
+        "--allow-write"
+      ]
+    }
+  }
+}
+```
+
+### Environment variables
+
+You can also configure via environment variables:
+
+```json
+{
+  "mcpServers": {
+    "datanika": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp"
+      ],
+      "env": {
+        "DATANIKA_URL": "https://app.datanika.io",
+        "DATANIKA_API_KEY": "YOUR_API_KEY",
+        "DATANIKA_ALLOW_WRITE": "true"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Always available (read-only)
+
+| Tool | Description |
+|------|-------------|
+| `get_agent_tiers` | Get the 5-tier agent capability stack |
+| `get_connection_types` | List supported connection types with config schemas |
+| `list_connections` | List all connections in the org |
+| `get_connection` | Get connection details by ID |
+| `introspect_connection` | List schemas/tables of a source connection |
+| `preview_connection` | Preview first N rows of a table |
+| `query_connection` | Execute a read-only SQL query |
+| `compile_transformation` | Compile a dbt transformation (no execution) |
+| `preview_transformation` | Compile + execute, return preview rows |
+| `list_uploads` | List all uploads |
+| `list_pipelines` | List all pipelines |
+| `list_transformations` | List all transformations |
+| `list_runs` | List runs with optional filters |
+| `get_run` | Get run details by ID |
+| `get_run_logs` | Get run logs |
+| `list_catalog` | List catalog entries (source tables + dbt models) |
+| `get_catalog_entry` | Get catalog entry details |
+
+### Requires `--allow-write`
+
+| Tool | Description |
+|------|-------------|
+| `create_connection` | Create a new data connection |
+| `create_upload` | Create a new upload (extract + load) |
+| `create_pipeline` | Create a new pipeline (dbt orchestration) |
+| `create_transformation` | Create a new dbt SQL transformation |
+| `bulk_import` | Bulk-create resources from JSON v2 format |
+| `trigger_upload` | Trigger an upload run |
+| `trigger_pipeline` | Trigger a pipeline run |
+| `trigger_transformation` | Trigger a transformation run |
+
+## Self-hosted
+
+Point `--url` at your instance:
+
+```bash
+datanika-mcp --url http://localhost:3000 --api-key etf_your_key
+```
+
+## License
+
+AGPL-3.0 — same as the core Datanika platform.

--- a/datanika-mcp/pyproject.toml
+++ b/datanika-mcp/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "datanika-mcp"
+version = "0.1.0"
+description = "MCP server for Datanika — browse connections, preview data, and manage pipelines from Claude Desktop"
+requires-python = ">=3.12"
+license = "AGPL-3.0-or-later"
+readme = "README.md"
+dependencies = [
+    "mcp>=1.0.0",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+datanika-mcp = "datanika_mcp.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/datanika_mcp"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "UP", "B", "SIM"]

--- a/datanika-mcp/src/datanika_mcp/__init__.py
+++ b/datanika-mcp/src/datanika_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Datanika MCP server — browse connections, preview data, manage pipelines."""
+
+__version__ = "0.1.0"

--- a/datanika-mcp/src/datanika_mcp/client.py
+++ b/datanika-mcp/src/datanika_mcp/client.py
@@ -1,0 +1,210 @@
+"""Thin httpx wrapper for the Datanika REST API v1."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class DatanikaClient:
+    """Authenticated HTTP client for the Datanika REST API.
+
+    All methods return the parsed JSON body (dict/list) or raise
+    ``httpx.HTTPStatusError`` on 4xx/5xx.
+    """
+
+    def __init__(self, base_url: str, api_key: str, timeout: float = 30.0) -> None:
+        self._base = base_url.rstrip("/")
+        self._http = httpx.Client(
+            base_url=self._base,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
+        )
+
+    def close(self) -> None:
+        self._http.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get(self, path: str, **params) -> dict:
+        resp = self._http.get(path, params=params or None)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _post(self, path: str, json: dict | None = None) -> dict:
+        resp = self._http.post(path, json=json)
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Read-only — Tier 1: Discover & Introspect
+    # ------------------------------------------------------------------
+
+    def get_agent_tiers(self) -> dict:
+        return self._get("/api/v1/meta/agent-tiers")
+
+    def get_connection_types(self) -> dict:
+        return self._get("/api/v1/meta/connection-types")
+
+    def list_connections(self) -> dict:
+        return self._get("/api/v1/connections")
+
+    def get_connection(self, connection_id: int) -> dict:
+        return self._get(f"/api/v1/connections/{connection_id}")
+
+    def introspect_connection(self, connection_id: int, schema: str | None = None) -> dict:
+        body = {}
+        if schema:
+            body["schema"] = schema
+        return self._post(f"/api/v1/connections/{connection_id}/introspect", json=body)
+
+    def preview_connection(
+        self, connection_id: int, table: str, schema: str | None = None, limit: int = 100
+    ) -> dict:
+        body: dict = {"table": table, "limit": limit}
+        if schema:
+            body["schema"] = schema
+        return self._post(f"/api/v1/connections/{connection_id}/preview", json=body)
+
+    def query_connection(self, connection_id: int, query: str) -> dict:
+        return self._post(f"/api/v1/connections/{connection_id}/query", json={"query": query})
+
+    # ------------------------------------------------------------------
+    # Read-only — Tier 3: Validate
+    # ------------------------------------------------------------------
+
+    def compile_transformation(self, transformation_id: int) -> dict:
+        return self._post(f"/api/v1/transformations/{transformation_id}/compile")
+
+    def preview_transformation(self, transformation_id: int, limit: int = 100) -> dict:
+        return self._post(
+            f"/api/v1/transformations/{transformation_id}/preview",
+            json={"limit": limit},
+        )
+
+    # ------------------------------------------------------------------
+    # Read-only — Tier 4: Control (read half)
+    # ------------------------------------------------------------------
+
+    def list_uploads(self) -> dict:
+        return self._get("/api/v1/uploads")
+
+    def list_pipelines(self) -> dict:
+        return self._get("/api/v1/pipelines")
+
+    def list_transformations(self) -> dict:
+        return self._get("/api/v1/transformations")
+
+    def list_runs(
+        self,
+        target_type: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> dict:
+        params: dict = {"limit": limit}
+        if target_type:
+            params["target_type"] = target_type
+        if status:
+            params["status"] = status
+        return self._get("/api/v1/runs", **params)
+
+    def get_run(self, run_id: int) -> dict:
+        return self._get(f"/api/v1/runs/{run_id}")
+
+    def get_run_logs(self, run_id: int) -> dict:
+        return self._get(f"/api/v1/runs/{run_id}/logs")
+
+    def list_catalog(self) -> dict:
+        return self._get("/api/v1/catalog")
+
+    def get_catalog_entry(self, entry_id: int) -> dict:
+        return self._get(f"/api/v1/catalog/{entry_id}")
+
+    # ------------------------------------------------------------------
+    # Write — Tier 2: Build (requires --allow-write)
+    # ------------------------------------------------------------------
+
+    def create_connection(self, name: str, connection_type: str, config: dict) -> dict:
+        return self._post(
+            "/api/v1/connections",
+            json={"name": name, "connection_type": connection_type, "config": config},
+        )
+
+    def create_upload(
+        self,
+        name: str,
+        source_connection_id: int,
+        destination_connection_id: int,
+        dlt_config: dict | None = None,
+        description: str | None = None,
+    ) -> dict:
+        body: dict = {
+            "name": name,
+            "source_connection_id": source_connection_id,
+            "destination_connection_id": destination_connection_id,
+        }
+        if dlt_config:
+            body["dlt_config"] = dlt_config
+        if description:
+            body["description"] = description
+        return self._post("/api/v1/uploads", json=body)
+
+    def create_pipeline(
+        self,
+        name: str,
+        destination_connection_id: int,
+        command: str = "run",
+        description: str | None = None,
+    ) -> dict:
+        body: dict = {
+            "name": name,
+            "destination_connection_id": destination_connection_id,
+            "command": command,
+        }
+        if description:
+            body["description"] = description
+        return self._post("/api/v1/pipelines", json=body)
+
+    def create_transformation(
+        self,
+        name: str,
+        sql_body: str,
+        materialization: str = "view",
+        description: str | None = None,
+        schema_name: str = "staging",
+    ) -> dict:
+        body: dict = {
+            "name": name,
+            "sql_body": sql_body,
+            "materialization": materialization,
+            "schema_name": schema_name,
+        }
+        if description:
+            body["description"] = description
+        return self._post("/api/v1/transformations", json=body)
+
+    def bulk_import(self, payload: dict) -> dict:
+        return self._post("/api/v1/import", json=payload)
+
+    # ------------------------------------------------------------------
+    # Write — Tier 4: Execute (requires --allow-write)
+    # ------------------------------------------------------------------
+
+    def trigger_upload(self, upload_id: int, wait: bool = False) -> dict:
+        path = f"/api/v1/uploads/{upload_id}/run"
+        if wait:
+            path += "?wait=true"
+        return self._post(path)
+
+    def trigger_pipeline(self, pipeline_id: int, wait: bool = False) -> dict:
+        path = f"/api/v1/pipelines/{pipeline_id}/run"
+        if wait:
+            path += "?wait=true"
+        return self._post(path)
+
+    def trigger_transformation(self, transformation_id: int, wait: bool = False) -> dict:
+        path = f"/api/v1/transformations/{transformation_id}/run"
+        if wait:
+            path += "?wait=true"
+        return self._post(path)

--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -1,0 +1,435 @@
+"""Datanika MCP server — exposes the Datanika REST API as MCP tools.
+
+Read-only by default. Pass ``--allow-write`` to enable mutation tools
+(create resources, trigger pipeline runs).
+
+Usage::
+
+    # Read-only (safe default)
+    datanika-mcp --url https://app.datanika.io --api-key etf_...
+
+    # With write access
+    datanika-mcp --url https://app.datanika.io --api-key etf_... --allow-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from mcp.server.fastmcp import FastMCP
+
+from datanika_mcp.client import DatanikaClient
+
+# ---------------------------------------------------------------------------
+# Globals populated at startup
+# ---------------------------------------------------------------------------
+
+_client: DatanikaClient | None = None
+_allow_write: bool = False
+
+mcp = FastMCP(
+    "Datanika",
+    instructions=(
+        "Browse data connections, preview tables, compile and validate "
+        "dbt transformations, monitor pipeline runs, and (with --allow-write) "
+        "create resources and trigger runs in Datanika."
+    ),
+)
+
+
+def _get_client() -> DatanikaClient:
+    if _client is None:
+        raise RuntimeError("DatanikaClient not initialized — call main() first")
+    return _client
+
+
+def _require_write(action: str) -> None:
+    if not _allow_write:
+        raise RuntimeError(
+            f"Write access required for '{action}'. "
+            "Restart the server with --allow-write to enable mutations."
+        )
+
+
+# ===================================================================
+# Read-only tools — always available
+# ===================================================================
+
+
+# --- Tier 1: Discover & Introspect ---
+
+
+@mcp.tool()
+def get_agent_tiers() -> str:
+    """Get the 5-tier agent capability stack — describes what the API can do."""
+    return json.dumps(_get_client().get_agent_tiers(), indent=2)
+
+
+@mcp.tool()
+def get_connection_types() -> str:
+    """List all supported connection types with their config schemas."""
+    return json.dumps(_get_client().get_connection_types(), indent=2)
+
+
+@mcp.tool()
+def list_connections() -> str:
+    """List all connections in the organization."""
+    return json.dumps(_get_client().list_connections(), indent=2)
+
+
+@mcp.tool()
+def get_connection(connection_id: int) -> str:
+    """Get details of a specific connection by ID."""
+    return json.dumps(_get_client().get_connection(connection_id), indent=2)
+
+
+@mcp.tool()
+def introspect_connection(connection_id: int, schema: str | None = None) -> str:
+    """List schemas and tables of a source connection.
+
+    Args:
+        connection_id: The connection to introspect.
+        schema: Optional schema name to filter tables.
+    """
+    return json.dumps(_get_client().introspect_connection(connection_id, schema), indent=2)
+
+
+@mcp.tool()
+def preview_connection(
+    connection_id: int, table: str, schema: str | None = None, limit: int = 100
+) -> str:
+    """Preview the first N rows of a table from a source connection.
+
+    Args:
+        connection_id: The connection to query.
+        table: Table name to preview.
+        schema: Optional schema name.
+        limit: Max rows to return (default 100).
+    """
+    return json.dumps(
+        _get_client().preview_connection(connection_id, table, schema, limit),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def query_connection(connection_id: int, query: str) -> str:
+    """Execute a read-only SQL query against a source connection.
+
+    Args:
+        connection_id: The connection to query.
+        query: A single SELECT statement (no mutations allowed).
+    """
+    return json.dumps(_get_client().query_connection(connection_id, query), indent=2)
+
+
+# --- Tier 3: Validate ---
+
+
+@mcp.tool()
+def compile_transformation(transformation_id: int) -> str:
+    """Compile a dbt transformation — resolves Jinja, ref(), source(). No execution.
+
+    Args:
+        transformation_id: The transformation to compile.
+    """
+    return json.dumps(_get_client().compile_transformation(transformation_id), indent=2)
+
+
+@mcp.tool()
+def preview_transformation(transformation_id: int, limit: int = 100) -> str:
+    """Compile and execute a transformation, returning preview rows.
+
+    Args:
+        transformation_id: The transformation to preview.
+        limit: Max rows to return (default 100, max 1000).
+    """
+    return json.dumps(_get_client().preview_transformation(transformation_id, limit), indent=2)
+
+
+# --- Tier 4: Control (read half) ---
+
+
+@mcp.tool()
+def list_uploads() -> str:
+    """List all uploads (extract + load jobs) in the organization."""
+    return json.dumps(_get_client().list_uploads(), indent=2)
+
+
+@mcp.tool()
+def list_pipelines() -> str:
+    """List all pipelines (dbt transform orchestration) in the organization."""
+    return json.dumps(_get_client().list_pipelines(), indent=2)
+
+
+@mcp.tool()
+def list_transformations() -> str:
+    """List all dbt transformations in the organization."""
+    return json.dumps(_get_client().list_transformations(), indent=2)
+
+
+@mcp.tool()
+def list_runs(target_type: str | None = None, status: str | None = None, limit: int = 50) -> str:
+    """List pipeline/upload/transformation runs with optional filters.
+
+    Args:
+        target_type: Filter by type — 'upload', 'pipeline', or 'transformation'.
+        status: Filter by status — 'pending', 'running', 'success', 'failed', 'cancelled'.
+        limit: Max results (default 50, max 200).
+    """
+    return json.dumps(_get_client().list_runs(target_type, status, limit), indent=2)
+
+
+@mcp.tool()
+def get_run(run_id: int) -> str:
+    """Get details of a specific run by ID.
+
+    Args:
+        run_id: The run ID to look up.
+    """
+    return json.dumps(_get_client().get_run(run_id), indent=2)
+
+
+@mcp.tool()
+def get_run_logs(run_id: int) -> str:
+    """Get the logs of a specific run.
+
+    Args:
+        run_id: The run ID whose logs to fetch.
+    """
+    return json.dumps(_get_client().get_run_logs(run_id), indent=2)
+
+
+@mcp.tool()
+def list_catalog() -> str:
+    """List all catalog entries (source tables and dbt models)."""
+    return json.dumps(_get_client().list_catalog(), indent=2)
+
+
+@mcp.tool()
+def get_catalog_entry(entry_id: int) -> str:
+    """Get details of a specific catalog entry.
+
+    Args:
+        entry_id: The catalog entry ID.
+    """
+    return json.dumps(_get_client().get_catalog_entry(entry_id), indent=2)
+
+
+# ===================================================================
+# Write tools — only available with --allow-write
+# ===================================================================
+
+
+# --- Tier 2: Build ---
+
+
+@mcp.tool()
+def create_connection(name: str, connection_type: str, config: dict) -> str:
+    """Create a new data connection.
+
+    Requires --allow-write.
+
+    Args:
+        name: Human-readable name for the connection.
+        connection_type: One of the supported types (e.g. 'postgres', 'mysql', 'stripe').
+        config: Connection-specific configuration (host, port, credentials, etc.).
+    """
+    _require_write("create_connection")
+    return json.dumps(_get_client().create_connection(name, connection_type, config), indent=2)
+
+
+@mcp.tool()
+def create_upload(
+    name: str,
+    source_connection_id: int,
+    destination_connection_id: int,
+    dlt_config: dict | None = None,
+    description: str | None = None,
+) -> str:
+    """Create a new upload (extract + load job).
+
+    Requires --allow-write.
+
+    Args:
+        name: Upload name.
+        source_connection_id: ID of the source connection.
+        destination_connection_id: ID of the destination connection.
+        dlt_config: Optional dlt extraction config (load_mode, table_name, etc.).
+        description: Optional description.
+    """
+    _require_write("create_upload")
+    return json.dumps(
+        _get_client().create_upload(
+            name, source_connection_id, destination_connection_id, dlt_config, description
+        ),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def create_pipeline(
+    name: str,
+    destination_connection_id: int,
+    command: str = "run",
+    description: str | None = None,
+) -> str:
+    """Create a new pipeline (dbt transform orchestration).
+
+    Requires --allow-write.
+
+    Args:
+        name: Pipeline name.
+        destination_connection_id: ID of the destination connection.
+        command: dbt command — 'run', 'build', 'test', 'seed', 'snapshot', 'compile'.
+        description: Optional description.
+    """
+    _require_write("create_pipeline")
+    return json.dumps(
+        _get_client().create_pipeline(name, destination_connection_id, command, description),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def create_transformation(
+    name: str,
+    sql_body: str,
+    materialization: str = "view",
+    description: str | None = None,
+    schema_name: str = "staging",
+) -> str:
+    """Create a new dbt SQL transformation.
+
+    Requires --allow-write.
+
+    Args:
+        name: Model name (letters, digits, underscores, hyphens; must start with letter or _).
+        sql_body: dbt-compatible SQL (supports ref(), source(), Jinja).
+        materialization: 'view', 'table', 'incremental', 'ephemeral', or 'snapshot'.
+        description: Optional description.
+        schema_name: Target schema (default 'staging').
+    """
+    _require_write("create_transformation")
+    return json.dumps(
+        _get_client().create_transformation(
+            name, sql_body, materialization, description, schema_name
+        ),
+        indent=2,
+    )
+
+
+@mcp.tool()
+def bulk_import(payload: dict) -> str:
+    """Bulk-import connections, uploads, pipelines, and transformations in one call.
+
+    Requires --allow-write. Uses the JSON v2 import format.
+    Validates everything first — if any errors, nothing is created.
+
+    Args:
+        payload: JSON v2 import payload with version, connections, uploads,
+                 pipelines, transformations sections. See AI_IMPORT_GUIDE.md.
+    """
+    _require_write("bulk_import")
+    return json.dumps(_get_client().bulk_import(payload), indent=2)
+
+
+# --- Tier 4: Execute ---
+
+
+@mcp.tool()
+def trigger_upload(upload_id: int, wait: bool = False) -> str:
+    """Trigger an upload run.
+
+    Requires --allow-write.
+
+    Args:
+        upload_id: The upload to run.
+        wait: If true, block until the run completes (up to 120s).
+    """
+    _require_write("trigger_upload")
+    return json.dumps(_get_client().trigger_upload(upload_id, wait), indent=2)
+
+
+@mcp.tool()
+def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
+    """Trigger a pipeline run (dbt build/run/test).
+
+    Requires --allow-write.
+
+    Args:
+        pipeline_id: The pipeline to run.
+        wait: If true, block until the run completes (up to 120s).
+    """
+    _require_write("trigger_pipeline")
+    return json.dumps(_get_client().trigger_pipeline(pipeline_id, wait), indent=2)
+
+
+@mcp.tool()
+def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
+    """Trigger a transformation run.
+
+    Requires --allow-write.
+
+    Args:
+        transformation_id: The transformation to run.
+        wait: If true, block until the run completes (up to 120s).
+    """
+    _require_write("trigger_transformation")
+    return json.dumps(_get_client().trigger_transformation(transformation_id, wait), indent=2)
+
+
+# ===================================================================
+# Entry point
+# ===================================================================
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="datanika-mcp",
+        description="Datanika MCP server — data pipeline tools for Claude Desktop",
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("DATANIKA_URL", "https://app.datanika.io"),
+        help="Datanika instance URL (default: $DATANIKA_URL or https://app.datanika.io)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("DATANIKA_API_KEY"),
+        help="API key (default: $DATANIKA_API_KEY)",
+    )
+    parser.add_argument(
+        "--allow-write",
+        action="store_true",
+        default=os.environ.get("DATANIKA_ALLOW_WRITE", "").lower() in ("1", "true"),
+        help="Enable write tools (create resources, trigger runs)",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 0.1.0",
+    )
+
+    args = parser.parse_args()
+
+    if not args.api_key:
+        print("Error: --api-key or $DATANIKA_API_KEY is required", file=sys.stderr)
+        sys.exit(1)
+
+    global _client, _allow_write
+    _client = DatanikaClient(args.url, args.api_key)
+    _allow_write = args.allow_write
+
+    mode = "read-write" if _allow_write else "read-only"
+    print(f"Datanika MCP server starting ({mode})...", file=sys.stderr)
+    print(f"  URL: {args.url}", file=sys.stderr)
+
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/datanika/services/agent_tiers.py
+++ b/datanika/services/agent_tiers.py
@@ -111,9 +111,7 @@ TIERS: tuple[Tier, ...] = (
                     "import format. Validates everything first — if any "
                     "errors are found, nothing is created."
                 ),
-                endpoints=(
-                    "POST /api/v1/import",
-                ),
+                endpoints=("POST /api/v1/import",),
             ),
         ),
     ),

--- a/datanika/services/agent_tiers.py
+++ b/datanika/services/agent_tiers.py
@@ -84,7 +84,8 @@ TIERS: tuple[Tier, ...] = (
         summary=(
             "Full CRUD for every resource the agent needs to assemble a "
             "pipeline: connections, uploads, pipelines, transformations, "
-            "schedules, notification channels."
+            "schedules, notification channels. Bulk import creates all "
+            "resources in a single call."
         ),
         capabilities=(
             Capability(
@@ -100,6 +101,18 @@ TIERS: tuple[Tier, ...] = (
                     "POST /api/v1/transformations",
                     "POST /api/v1/schedules",
                     "POST /api/v1/notifications/channels",
+                ),
+            ),
+            Capability(
+                name="Bulk Import",
+                description=(
+                    "Create connections, uploads, pipelines, and "
+                    "transformations in a single call using the JSON v2 "
+                    "import format. Validates everything first — if any "
+                    "errors are found, nothing is created."
+                ),
+                endpoints=(
+                    "POST /api/v1/import",
                 ),
             ),
         ),

--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -1143,6 +1143,270 @@ async def delete_notification_channel(request, api_key, session):
 
 
 # ---------------------------------------------------------------------------
+# Bulk import — POST /api/v1/import (#131)
+# ---------------------------------------------------------------------------
+
+
+def _validate_import_payload(data: dict, existing_conn_names: dict[str, int]) -> list[dict]:
+    """Validate the entire import payload and return a list of error dicts.
+
+    ``existing_conn_names`` maps connection name → id for connections
+    already present in the org.
+    """
+    errors: list[dict] = []
+
+    # --- connections ---
+    conn_names_in_payload: set[str] = set()
+    for i, c in enumerate(data.get("connections", [])):
+        name = c.get("name")
+        if not name or not str(name).strip():
+            errors.append(
+                {"code": "MISSING_FIELD", "message": f"connections[{i}]: name is required"}
+            )
+            continue
+        ct = c.get("connection_type")
+        if not ct:
+            errors.append(
+                {
+                    "code": "MISSING_FIELD",
+                    "message": f"connections[{i}]: connection_type is required",
+                }
+            )
+        else:
+            try:
+                ConnectionType(ct)
+            except ValueError:
+                errors.append(
+                    {
+                        "code": "INVALID_CONNECTION_TYPE",
+                        "message": f"connections[{i}]: invalid connection_type '{ct}'",
+                    }
+                )
+        if not isinstance(c.get("config"), dict):
+            errors.append(
+                {
+                    "code": "MISSING_FIELD",
+                    "message": f"connections[{i}]: config (object) is required",
+                }
+            )
+        if name in conn_names_in_payload:
+            errors.append(
+                {"code": "DUPLICATE_NAME", "message": f"connections[{i}]: duplicate name '{name}'"}
+            )
+        else:
+            conn_names_in_payload.add(name)
+
+    # Build a combined name set for cross-reference checks
+    all_conn_names = set(existing_conn_names.keys()) | conn_names_in_payload
+
+    # --- uploads ---
+    upload_names: set[str] = set()
+    for i, u in enumerate(data.get("uploads", [])):
+        name = u.get("name")
+        if not name or not str(name).strip():
+            errors.append({"code": "MISSING_FIELD", "message": f"uploads[{i}]: name is required"})
+        elif name in upload_names:
+            errors.append(
+                {"code": "DUPLICATE_NAME", "message": f"uploads[{i}]: duplicate name '{name}'"}
+            )
+        else:
+            upload_names.add(name)
+        for ref_field in ("source_connection_name", "destination_connection_name"):
+            ref = u.get(ref_field)
+            if not ref:
+                errors.append(
+                    {"code": "MISSING_FIELD", "message": f"uploads[{i}]: {ref_field} is required"}
+                )
+            elif ref not in all_conn_names:
+                errors.append(
+                    {
+                        "code": "UNKNOWN_CONNECTION_REF",
+                        "message": f"uploads[{i}]: {ref_field} '{ref}' not found",
+                    }
+                )
+
+    # --- pipelines ---
+    pipeline_names: set[str] = set()
+    for i, p in enumerate(data.get("pipelines", [])):
+        name = p.get("name")
+        if not name or not str(name).strip():
+            errors.append({"code": "MISSING_FIELD", "message": f"pipelines[{i}]: name is required"})
+        elif name in pipeline_names:
+            errors.append(
+                {"code": "DUPLICATE_NAME", "message": f"pipelines[{i}]: duplicate name '{name}'"}
+            )
+        else:
+            pipeline_names.add(name)
+        ref = p.get("destination_connection_name")
+        if not ref:
+            errors.append(
+                {
+                    "code": "MISSING_FIELD",
+                    "message": f"pipelines[{i}]: destination_connection_name is required",
+                }
+            )
+        elif ref not in all_conn_names:
+            errors.append(
+                {
+                    "code": "UNKNOWN_CONNECTION_REF",
+                    "message": f"pipelines[{i}]: destination_connection_name '{ref}' not found",
+                }
+            )
+        cmd = p.get("command")
+        if cmd:
+            try:
+                DbtCommand(cmd)
+            except ValueError:
+                errors.append(
+                    {
+                        "code": "INVALID_ENUM_VALUE",
+                        "message": f"pipelines[{i}]: invalid command '{cmd}'",
+                    }
+                )
+
+    # --- transformations ---
+    transform_names: set[str] = set()
+    for i, t in enumerate(data.get("transformations", [])):
+        name = t.get("name")
+        if not name or not str(name).strip():
+            errors.append(
+                {"code": "MISSING_FIELD", "message": f"transformations[{i}]: name is required"}
+            )
+        elif name in transform_names:
+            errors.append(
+                {
+                    "code": "DUPLICATE_NAME",
+                    "message": f"transformations[{i}]: duplicate name '{name}'",
+                }
+            )
+        else:
+            transform_names.add(name)
+        if not t.get("sql_body"):
+            errors.append(
+                {"code": "MISSING_FIELD", "message": f"transformations[{i}]: sql_body is required"}
+            )
+        mat = t.get("materialization")
+        if mat:
+            try:
+                Materialization(mat)
+            except ValueError:
+                errors.append(
+                    {
+                        "code": "INVALID_ENUM_VALUE",
+                        "message": f"transformations[{i}]: invalid materialization '{mat}'",
+                    }
+                )
+
+    return errors
+
+
+@api_endpoint(required_scope=None)
+async def bulk_import(request, api_key, session):
+    """POST /api/v1/import — create connections, uploads, pipelines,
+    and transformations from a single JSON payload.
+
+    Validates the entire payload first; if any errors are found, nothing
+    is created (atomic). Uses the same JSON v2 format as AI_IMPORT_GUIDE.md.
+    """
+    data = await _body(request)
+
+    # --- version check ---
+    version = data.get("version")
+    if version != 2:
+        return _error(400, "version 2 is required")
+
+    # --- build existing connection name→id map ---
+    existing_conns = _get_conn_svc().list_connections(session, api_key.org_id)
+    existing_conn_names: dict[str, int] = {c.name: c.id for c in existing_conns}
+
+    # --- validate everything before creating anything ---
+    errors = _validate_import_payload(data, existing_conn_names)
+    if errors:
+        return JSONResponse({"errors": errors}, status_code=400)
+
+    created: dict[str, list[int]] = {
+        "connections": [],
+        "uploads": [],
+        "pipelines": [],
+        "transformations": [],
+    }
+
+    # --- Phase 1: create connections ---
+    # Maps connection name → id (payload + existing)
+    conn_name_to_id: dict[str, int] = dict(existing_conn_names)
+    for c in data.get("connections", []):
+        conn = _get_conn_svc().create_connection(
+            session,
+            api_key.org_id,
+            name=c["name"],
+            connection_type=ConnectionType(c["connection_type"]),
+            config=c["config"],
+        )
+        session.flush()
+        conn_name_to_id[c["name"]] = conn.id
+        created["connections"].append(conn.id)
+
+    # --- Phase 2: create uploads ---
+    for u in data.get("uploads", []):
+        upload = _get_upload_svc().create_upload(
+            session,
+            api_key.org_id,
+            name=u["name"],
+            description=u.get("description"),
+            source_connection_id=conn_name_to_id[u["source_connection_name"]],
+            destination_connection_id=conn_name_to_id[u["destination_connection_name"]],
+            dlt_config=u.get("dlt_config", {}),
+        )
+        session.flush()
+        created["uploads"].append(upload.id)
+
+    # --- Phase 3: create pipelines ---
+    for p in data.get("pipelines", []):
+        command = DbtCommand.RUN
+        if p.get("command"):
+            command = DbtCommand(p["command"])
+        pipeline = _pipeline_svc.create_pipeline(
+            session,
+            api_key.org_id,
+            name=p["name"],
+            description=p.get("description"),
+            destination_connection_id=conn_name_to_id[p["destination_connection_name"]],
+            command=command,
+            full_refresh=p.get("full_refresh", False),
+            models=p.get("models"),
+            custom_selector=p.get("custom_selector"),
+        )
+        session.flush()
+        created["pipelines"].append(pipeline.id)
+
+    # --- Phase 4: create transformations ---
+    for t in data.get("transformations", []):
+        mat = Materialization.VIEW
+        if t.get("materialization"):
+            mat = Materialization(t["materialization"])
+        dest_conn_id = None
+        if t.get("destination_connection_name"):
+            dest_conn_id = conn_name_to_id.get(t["destination_connection_name"])
+        transformation = _transform_svc.create_transformation(
+            session,
+            api_key.org_id,
+            name=t["name"],
+            sql_body=t["sql_body"],
+            materialization=mat,
+            description=t.get("description"),
+            schema_name=t.get("schema_name", "staging"),
+            tests_config=t.get("tests_config"),
+            destination_connection_id=dest_conn_id,
+            tags=t.get("tags"),
+            incremental_config=t.get("incremental_config"),
+        )
+        session.flush()
+        created["transformations"].append(transformation.id)
+
+    return JSONResponse({"created": created}, status_code=201)
+
+
+# ---------------------------------------------------------------------------
 # Route table
 # ---------------------------------------------------------------------------
 
@@ -1225,6 +1489,8 @@ api_v1_routes = [
     Route("/api/v1/notifications/{id:int}/read", mark_notification_read, methods=["PATCH"]),
     Route("/api/v1/notifications/read-all", mark_all_notifications_read, methods=["POST"]),
     Route("/api/v1/notifications/{id:int}", dismiss_notification, methods=["DELETE"]),
+    # Bulk import
+    Route("/api/v1/import", bulk_import, methods=["POST"]),
     # Notification channels
     Route("/api/v1/notifications/channels", list_notification_channels, methods=["GET"]),
     Route("/api/v1/notifications/channels/{id:int}", get_notification_channel, methods=["GET"]),

--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -398,8 +398,7 @@ SCHEMAS = {
                 "type": "array",
                 "items": {"type": "object"},
                 "description": (
-                    "Uploads to create. Use connection_name references, "
-                    "not connection_id."
+                    "Uploads to create. Use connection_name references, not connection_id."
                 ),
             },
             "pipelines": {

--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -385,6 +385,64 @@ SCHEMAS = {
         },
         required=["error"],
     ),
+    # --- Bulk import ---
+    "ImportRequest": _obj(
+        {
+            "version": {"type": "integer", "enum": [2]},
+            "connections": {
+                "type": "array",
+                "items": _ref("ConnectionCreate"),
+                "description": "Connections to create (optional).",
+            },
+            "uploads": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": (
+                    "Uploads to create. Use connection_name references, "
+                    "not connection_id."
+                ),
+            },
+            "pipelines": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": (
+                    "Pipelines to create. Use destination_connection_name, "
+                    "not destination_connection_id."
+                ),
+            },
+            "transformations": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Transformations to create.",
+            },
+        },
+        required=["version"],
+    ),
+    "ImportResult": _obj(
+        {
+            "created": _obj(
+                {
+                    "connections": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "uploads": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "pipelines": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                    "transformations": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                }
+            ),
+        },
+        required=["created"],
+    ),
 }
 
 # Inline per-type Connection.config and per-mode Upload.dlt_config schemas
@@ -737,6 +795,36 @@ def build_openapi_spec() -> dict:
         "delete": _delete_op(nt, "Delete notification channel"),
     }
 
+    # Bulk import (#131)
+    paths["/api/v1/import"] = {
+        "post": {
+            "tags": ["Import"],
+            "summary": "Bulk-import resources from a JSON config",
+            "description": (
+                "Create connections, uploads, pipelines, and transformations "
+                "in a single call. Validates the entire payload first; if any "
+                "errors are found, nothing is created (atomic). Uses the same "
+                "JSON v2 format as AI_IMPORT_GUIDE.md."
+            ),
+            "requestBody": {
+                "required": True,
+                "content": _json_content(_ref("ImportRequest")),
+            },
+            "responses": {
+                "201": {
+                    "description": "All resources created",
+                    "content": _json_content(_ref("ImportResult")),
+                },
+                "400": {
+                    "description": "Validation errors — nothing created",
+                    "content": _err_content,
+                },
+                "401": _401,
+                "429": _429,
+            },
+        },
+    }
+
     # Catalog (beta — schema may change as we add lineage)
     paths["/api/v1/catalog"] = {
         "get": _list_op("Catalog", "CatalogEntry", "List catalog entries"),
@@ -777,6 +865,7 @@ def build_openapi_spec() -> dict:
             {"name": "Schedules"},
             {"name": "Runs"},
             {"name": "Notifications"},
+            {"name": "Import"},
             {"name": "Catalog"},
         ],
         "paths": paths,

--- a/deploy/helm/datanika/.helmignore
+++ b/deploy/helm/datanika/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+.git/
+.gitignore
+.vscode/
+.idea/
+*.tmproj
+*.swp
+*.bak
+*.tgz
+*~

--- a/deploy/helm/datanika/Chart.yaml
+++ b/deploy/helm/datanika/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: datanika
+description: |
+  Datanika — multi-tenant data pipeline management platform (dlt + dbt + Celery + Reflex).
+  This is a minimal stub chart that maps the same services as the production
+  docker-compose setup: app, celery, postgres, redis. Intended for enterprise
+  procurement ("yes, deployable on Kubernetes") and small self-hosted installs.
+  Not a full production story — see README.md for the feature matrix.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://datanika.io
+sources:
+  - https://github.com/datanika-io/datanika-core
+maintainers:
+  - name: Datanika Infra
+    url: https://github.com/datanika-io/datanika-core
+keywords:
+  - data-pipeline
+  - dlt
+  - dbt
+  - etl
+  - multi-tenant
+annotations:
+  category: Analytics

--- a/deploy/helm/datanika/README.md
+++ b/deploy/helm/datanika/README.md
@@ -1,0 +1,123 @@
+# Datanika Helm Chart
+
+Minimal Helm chart that installs Datanika (multi-tenant data pipeline platform)
+on any Kubernetes cluster. Functionally equivalent to the production
+docker-compose deployment on Hetzner, minus the bundled monitoring stack.
+
+> **Status: v0.1.0 stub.** Closes the enterprise "Helm chart" checkbox. Good
+> enough for `helm install` onto a cluster that provides `ReadWriteMany`
+> storage; not yet hardened for HA or large multi-tenant fleets. See the
+> [Known caveats](#known-caveats) section before using it in production.
+
+## What it installs
+
+| Component | Kind | Notes |
+|-----------|------|-------|
+| `app` | Deployment (1 replica) | Reflex frontend (`:3000`) + backend (`:8000`). Runs `alembic upgrade head` on startup. |
+| `celery` | Deployment (1 replica) | Background worker. Shares the `dbt_projects` PVC with `app`. |
+| `postgres` | StatefulSet (1 replica) | Postgres 16-alpine with `pg_stat_statements`. Disable via `postgres.enabled=false` to bring your own. |
+| `redis` | Deployment (1 replica) | Redis 7-alpine. Broker + cache. Disable via `redis.enabled=false` to bring your own. |
+| `ingress` | Ingress (optional) | `/` → app frontend, `/api` → app backend. Mirrors the production Nginx reverse proxy. |
+| `dbt-projects` PVC | PVC (RWX) | Shared between `app` and `celery` pods. **Requires a ReadWriteMany storage class.** |
+| Secret | `Opaque` | `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, and all `POSTGRES_*`/`REDIS_*` values, rendered from `.Values.env` + `.Values.secrets`. |
+
+Monitoring (Prometheus, Grafana, node-exporter, cAdvisor) is **not** in scope
+for this chart — run your cluster's existing observability stack and point it
+at the app's metrics endpoints.
+
+## Quickstart
+
+```bash
+# From a clone of the datanika-core repo:
+helm install my-datanika ./deploy/helm/datanika \
+  --namespace datanika --create-namespace \
+  --set secrets.POSTGRES_PASSWORD=$(openssl rand -base64 24) \
+  --set secrets.REDIS_PASSWORD=$(openssl rand -base64 24) \
+  --set secrets.SECRET_KEY=$(openssl rand -base64 32)
+
+# Watch the rollout
+kubectl -n datanika get pods -w
+
+# Port-forward the UI (or enable ingress)
+kubectl -n datanika port-forward svc/my-datanika-app 3000:3000
+# open http://localhost:3000
+```
+
+To use managed databases instead of the bundled Postgres/Redis:
+
+```bash
+helm install my-datanika ./deploy/helm/datanika \
+  --namespace datanika --create-namespace \
+  --set postgres.enabled=false \
+  --set externalDatabase.host=<managed-postgres-host> \
+  --set env.POSTGRES_USER=<user> \
+  --set env.POSTGRES_DB=<db> \
+  --set secrets.POSTGRES_PASSWORD=<password> \
+  --set redis.enabled=false \
+  --set externalRedis.host=<managed-redis-host> \
+  --set secrets.REDIS_PASSWORD=<password> \
+  --set secrets.SECRET_KEY=$(openssl rand -base64 32)
+```
+
+## Configuration highlights
+
+See `values.yaml` for the full list. Common overrides:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `image.repository` | `ghcr.io/datanika-io/datanika` | Override for a private registry |
+| `image.tag` | `latest` | Pin to a release tag |
+| `env.DATANIKA_EDITION` | `oss` | Set to `cloud` to activate the Paddle billing plugin |
+| `env.extra` | `{}` | Map of extra env keys injected into the Secret (anything else the app reads from `.env.docker`) |
+| `postgres.enabled` | `true` | Set `false` + fill `externalDatabase.host` for managed Postgres |
+| `redis.enabled` | `true` | Set `false` + fill `externalRedis.host` for managed Redis |
+| `ingress.enabled` | `false` | Turn on once you have a TLS-terminating ingress class |
+| `app.replicaCount` | `1` | Keep at `1` until the migration job is extracted (see caveats) |
+| `app.dbtProjectsSize` | `5Gi` | Size of the shared dbt projects PVC |
+
+## Known caveats
+
+- **RWX storage required.** The `app` and `celery` Deployments both mount
+  the `dbt_projects` PVC, so the chart requests `ReadWriteMany`. On managed
+  Kubernetes that usually means NFS, EFS, Azure Files, or Filestore. On
+  bare-metal clusters, Longhorn and Rook/CephFS both work. If your cluster
+  only has `ReadWriteOnce`, you can pin both Deployments to the same node
+  via `nodeSelector` + `affinity` as a workaround.
+- **Migrations run on every app pod startup.** The `app` container runs
+  `alembic upgrade head` before starting Reflex. With `app.replicaCount=1`
+  this is fine. For HA, move migrations into a
+  `helm.sh/hook: pre-install,pre-upgrade` Job (tracked separately — see the
+  infrastructure plan).
+- **Bundled Postgres + Redis are single-replica, single-PVC.** They're fine
+  for evaluation and small installs. For anything real, disable them and
+  point to managed databases via `externalDatabase` / `externalRedis`.
+- **No monitoring stack.** Unlike the Hetzner docker-compose, this chart
+  does not ship Grafana, Prometheus, cAdvisor or node-exporter. Use your
+  cluster's existing observability tooling.
+- **`secrets.*` default to `"CHANGE-ME"`.** The chart will install with
+  these placeholders, which is useful for `helm lint` / CI but unsafe for
+  any real environment. Always override them at install time.
+
+## Compared to the production Hetzner deploy
+
+| Feature | Hetzner docker-compose | This chart |
+|---------|------------------------|------------|
+| App + Celery + Postgres + Redis | yes | yes |
+| Persistent volumes | Docker volumes | PVCs (PVC for Postgres, PVC for `dbt_projects`) |
+| Nginx reverse proxy + TLS | host-level Nginx | ingress resource (optional) |
+| Grafana + Prometheus + cAdvisor | yes | no (run separately) |
+| Auto-deploy on push to master | yes | no (managed by user) |
+| HA / rolling updates | `replicas=1` | `replicas=1` (see caveats) |
+| Paddle billing plugin | yes (`DATANIKA_EDITION=cloud`) | yes (`--set env.DATANIKA_EDITION=cloud`) |
+
+## Development
+
+Lint the chart locally before committing:
+
+```bash
+helm lint deploy/helm/datanika
+helm template test deploy/helm/datanika | kubectl apply --dry-run=client -f -
+```
+
+`helm lint` is also run on every PR and push to `dev` / `master` via
+`.github/workflows/ci.yml`.

--- a/deploy/helm/datanika/templates/NOTES.txt
+++ b/deploy/helm/datanika/templates/NOTES.txt
@@ -1,0 +1,32 @@
+Datanika {{ .Chart.AppVersion }} is installed as release "{{ .Release.Name }}".
+
+1. Check pod status:
+
+   kubectl --namespace {{ .Release.Namespace }} get pods \
+     -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+2. Access the UI:
+{{- if .Values.ingress.enabled }}
+
+   https://{{ .Values.ingress.host }}
+{{- else }}
+
+   kubectl --namespace {{ .Release.Namespace }} port-forward \
+     svc/{{ include "datanika.fullname" . }}-app \
+     {{ .Values.app.service.frontendPort }}:{{ .Values.app.service.frontendPort }}
+
+   Then open http://localhost:{{ .Values.app.service.frontendPort }}
+{{- end }}
+
+3. IMPORTANT: the default passwords in values.yaml are "CHANGE-ME" placeholders.
+   Rotate them before using this install for anything real:
+
+   helm upgrade {{ .Release.Name }} <chart> \
+     --reuse-values \
+     --set secrets.POSTGRES_PASSWORD=$(openssl rand -base64 24) \
+     --set secrets.REDIS_PASSWORD=$(openssl rand -base64 24) \
+     --set secrets.SECRET_KEY=$(openssl rand -base64 32)
+
+4. Read deploy/helm/datanika/README.md for production caveats:
+   RWX storage requirement, migration ordering, and externalDatabase /
+   externalRedis overrides for managed Postgres / Redis.

--- a/deploy/helm/datanika/templates/_helpers.tpl
+++ b/deploy/helm/datanika/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Datanika Helm chart — shared template helpers.
+*/}}
+
+{{/* Full release name — truncated to 63 chars (k8s DNS label limit). */}}
+{{- define "datanika.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Chart base name for labels. */}}
+{{- define "datanika.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Chart version label. */}}
+{{- define "datanika.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels applied to every rendered object. */}}
+{{- define "datanika.labels" -}}
+helm.sh/chart: {{ include "datanika.chart" . }}
+{{ include "datanika.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels — immutable fields used by Deployments/StatefulSets. */}}
+{{- define "datanika.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "datanika.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Service-specific selector (adds the component label). */}}
+{{- define "datanika.componentSelector" -}}
+{{ include "datanika.selectorLabels" . }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/* ServiceAccount name — either from values or generated. */}}
+{{- define "datanika.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "datanika.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* Postgres host — internal service or external override. */}}
+{{- define "datanika.postgresHost" -}}
+{{- if .Values.postgres.enabled }}
+{{- printf "%s-postgres" (include "datanika.fullname" .) }}
+{{- else }}
+{{- required "externalDatabase.host is required when postgres.enabled=false" .Values.externalDatabase.host }}
+{{- end }}
+{{- end }}
+
+{{/* Redis host — internal service or external override. */}}
+{{- define "datanika.redisHost" -}}
+{{- if .Values.redis.enabled }}
+{{- printf "%s-redis" (include "datanika.fullname" .) }}
+{{- else }}
+{{- required "externalRedis.host is required when redis.enabled=false" .Values.externalRedis.host }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/datanika/templates/app-deployment.yaml
+++ b/deploy/helm/datanika/templates/app-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datanika.fullname" . }}-app
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: app
+    spec:
+      serviceAccountName: {{ include "datanika.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.app.command | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: {{ include "datanika.fullname" . }}-env
+          ports:
+            - name: http-frontend
+              containerPort: 3000
+            - name: http-backend
+              containerPort: 8000
+          readinessProbe:
+            {{- toYaml .Values.app.probes.readiness | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.app.probes.liveness | nindent 12 }}
+          volumeMounts:
+            - name: dbt-projects
+              mountPath: /app/dbt_projects
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+      volumes:
+        - name: dbt-projects
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-dbt-projects
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/datanika/templates/app-service.yaml
+++ b/deploy/helm/datanika/templates/app-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datanika.fullname" . }}-app
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  type: {{ .Values.app.service.type }}
+  ports:
+    - name: http-frontend
+      port: {{ .Values.app.service.frontendPort }}
+      targetPort: http-frontend
+    - name: http-backend
+      port: {{ .Values.app.service.backendPort }}
+      targetPort: http-backend
+  selector:
+    {{- include "datanika.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: app

--- a/deploy/helm/datanika/templates/celery-deployment.yaml
+++ b/deploy/helm/datanika/templates/celery-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datanika.fullname" . }}-celery
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: celery
+spec:
+  replicas: {{ .Values.celery.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: celery
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: celery
+    spec:
+      serviceAccountName: {{ include "datanika.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: celery
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.celery.command | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: {{ include "datanika.fullname" . }}-env
+          volumeMounts:
+            - name: dbt-projects
+              mountPath: /app/dbt_projects
+          resources:
+            {{- toYaml .Values.celery.resources | nindent 12 }}
+      volumes:
+        - name: dbt-projects
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-dbt-projects
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/datanika/templates/dbt-pvc.yaml
+++ b/deploy/helm/datanika/templates/dbt-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "datanika.fullname" . }}-dbt-projects
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dbt
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.app.dbtProjectsSize }}

--- a/deploy/helm/datanika/templates/ingress.yaml
+++ b/deploy/helm/datanika/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "datanika.fullname" . }}
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "datanika.fullname" . }}-app
+                port:
+                  number: {{ .Values.app.service.backendPort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "datanika.fullname" . }}-app
+                port:
+                  number: {{ .Values.app.service.frontendPort }}
+{{- end }}

--- a/deploy/helm/datanika/templates/postgres-service.yaml
+++ b/deploy/helm/datanika/templates/postgres-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datanika.fullname" . }}-postgres
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.port | default 5432 }}
+      targetPort: postgres
+  selector:
+    {{- include "datanika.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+{{- end }}

--- a/deploy/helm/datanika/templates/postgres-statefulset.yaml
+++ b/deploy/helm/datanika/templates/postgres-statefulset.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "datanika.fullname" . }}-postgres
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "datanika.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - postgres
+            - -c
+            - shared_preload_libraries=pg_stat_statements
+            - -c
+            - pg_stat_statements.track=all
+            - -c
+            - log_min_duration_statement=500
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: POSTGRES_DB
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.env.POSTGRES_USER }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.env.POSTGRES_USER }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.postgres.persistence.storageClass }}
+        storageClassName: {{ .Values.postgres.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+{{- end }}

--- a/deploy/helm/datanika/templates/redis-deployment.yaml
+++ b/deploy/helm/datanika/templates/redis-deployment.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datanika.fullname" . }}-redis
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - 'exec redis-server --requirepass "$REDIS_PASSWORD"'
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: REDIS_PASSWORD
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'redis-cli -a "$REDIS_PASSWORD" ping | grep -q PONG'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+      volumes:
+        - name: data
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/datanika/templates/redis-service.yaml
+++ b/deploy/helm/datanika/templates/redis-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datanika.fullname" . }}-redis
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port | default 6379 }}
+      targetPort: redis
+  selector:
+    {{- include "datanika.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/deploy/helm/datanika/templates/secret.yaml
+++ b/deploy/helm/datanika/templates/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "datanika.fullname" . }}-env
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.env.POSTGRES_USER | quote }}
+  POSTGRES_DB: {{ .Values.env.POSTGRES_DB | quote }}
+  POSTGRES_PASSWORD: {{ .Values.secrets.POSTGRES_PASSWORD | quote }}
+  POSTGRES_HOST: {{ include "datanika.postgresHost" . | quote }}
+  POSTGRES_PORT: {{ .Values.postgres.port | default 5432 | quote }}
+  REDIS_HOST: {{ include "datanika.redisHost" . | quote }}
+  REDIS_PORT: {{ .Values.redis.port | default 6379 | quote }}
+  REDIS_PASSWORD: {{ .Values.secrets.REDIS_PASSWORD | quote }}
+  REDIS_URL: "redis://:{{ .Values.secrets.REDIS_PASSWORD }}@{{ include "datanika.redisHost" . }}:{{ .Values.redis.port | default 6379 }}/0"
+  DATABASE_URL: "postgresql+asyncpg://{{ .Values.env.POSTGRES_USER }}:{{ .Values.secrets.POSTGRES_PASSWORD }}@{{ include "datanika.postgresHost" . }}:{{ .Values.postgres.port | default 5432 }}/{{ .Values.env.POSTGRES_DB }}"
+  SECRET_KEY: {{ .Values.secrets.SECRET_KEY | quote }}
+  DATANIKA_EDITION: {{ .Values.env.DATANIKA_EDITION | quote }}
+  {{- range $key, $val := .Values.env.extra }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/deploy/helm/datanika/templates/serviceaccount.yaml
+++ b/deploy/helm/datanika/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "datanika.serviceAccountName" . }}
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/datanika/values.yaml
+++ b/deploy/helm/datanika/values.yaml
@@ -1,0 +1,156 @@
+## Datanika Helm chart — default values.
+##
+## This is a minimal stub. See README.md for the feature matrix vs.
+## production docker-compose deployment on Hetzner.
+
+image:
+  repository: ghcr.io/datanika-io/datanika
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+## Ingress — optional HTTP entry. Maps / → app frontend (Reflex :3000) and
+## /api/ → app backend (:8000). Mirrors the production Nginx reverse proxy.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: datanika.local
+  tls: []
+  ##  - hosts:
+  ##      - datanika.local
+  ##    secretName: datanika-tls
+
+## Datanika application env. In production this comes from .env.docker on the
+## host; in Kubernetes we put the same keys into a Secret and mount via envFrom.
+## Users MUST override the password/secret fields before install.
+env:
+  POSTGRES_USER: datanika
+  POSTGRES_DB: datanika
+  DATANIKA_EDITION: "oss"
+  ## Optional extras — anything else the app reads from .env.docker. Keys listed
+  ## here become literal Secret entries. Values left empty will be emitted as
+  ## empty strings; users should populate them before running in a real env.
+  extra: {}
+
+## Secrets — rendered into the env Secret. Passwords must be overridden.
+secrets:
+  POSTGRES_PASSWORD: "CHANGE-ME"
+  REDIS_PASSWORD: "CHANGE-ME"
+  SECRET_KEY: "CHANGE-ME"
+
+## Application (Reflex frontend :3000 + backend :8000).
+app:
+  replicaCount: 1
+  command:
+    - sh
+    - -c
+    - "uv run alembic upgrade head && uv run reflex run --env prod --backend-host 0.0.0.0"
+  service:
+    type: ClusterIP
+    frontendPort: 3000
+    backendPort: 8000
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  probes:
+    readiness:
+      httpGet:
+        path: /healthz
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 5
+    liveness:
+      httpGet:
+        path: /healthz
+        port: 8000
+      initialDelaySeconds: 60
+      periodSeconds: 30
+      failureThreshold: 3
+  dbtProjectsSize: 5Gi
+
+## Celery worker.
+celery:
+  replicaCount: 1
+  command:
+    - uv
+    - run
+    - celery
+    - -A
+    - datanika.tasks.celery_app:celery_app
+    - worker
+    - -l
+    - info
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+## PostgreSQL (stub — for real clusters, set enabled=false and provide
+## externalDatabase.host). Uses a StatefulSet + PVC for data durability.
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16-alpine"
+  port: 5432
+  persistence:
+    size: 20Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+## External Postgres override — ignored unless postgres.enabled=false.
+externalDatabase:
+  host: ""
+  port: 5432
+  user: ""
+  database: ""
+
+## Redis (Celery broker + cache). Runs with an emptyDir volume — on pod
+## restart the broker queue is lost, which is fine for Datanika's task model
+## (Celery tasks are idempotent and re-enqueued by the app on failure).
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+  port: 6379
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+## External Redis override — ignored unless redis.enabled=false.
+externalRedis:
+  host: ""
+  port: 6379
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "datanika-e2e",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datanika-e2e",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@playwright/test": "^1.47.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "pytest-cov>=6.0",
     "ruff>=0.9",
     "httpx>=0.28",
+    "mcp>=1.0.0",
 ]
 
 [build-system]

--- a/scripts/smoke/test_core_smoke.py
+++ b/scripts/smoke/test_core_smoke.py
@@ -93,7 +93,7 @@ def test_agent_guide_md_public(core_client: httpx.Client) -> None:
 
 
 def test_agent_tiers_shape(core_client: httpx.Client) -> None:
-    """Tier SoT — pinned to the current 5-tier / 7-capability layout.
+    """Tier SoT — pinned to the current 5-tier / 8-capability layout.
 
     If Product adds or removes a tier, this test goes red first and
     forces a conscious update. That's the contract — `agent-tiers` is
@@ -108,8 +108,8 @@ def test_agent_tiers_shape(core_client: httpx.Client) -> None:
         f"tier_count changed from 5 to {payload.get('tier_count')} — "
         "update the smoke test AND landing's build-time snapshot in the same PR"
     )
-    assert payload.get("capability_count") == 7, (
-        f"capability_count changed from 7 to {payload.get('capability_count')} — "
+    assert payload.get("capability_count") == 8, (
+        f"capability_count changed from 8 to {payload.get('capability_count')} — "
         "update the smoke test AND landing's build-time snapshot in the same PR"
     )
     assert isinstance(payload.get("tiers"), list), "tiers should be a list"

--- a/tests/test_mcp/test_mcp_server.py
+++ b/tests/test_mcp/test_mcp_server.py
@@ -1,0 +1,238 @@
+"""Tests for the Datanika MCP server (#140).
+
+These tests verify tool registration, the write-guard, and the CLI
+argument parser without requiring a live Datanika instance.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _add_mcp_to_path():
+    """Make ``datanika_mcp`` importable from the MCP sub-package."""
+    import pathlib
+
+    mcp_src = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+    if mcp_src not in sys.path:
+        sys.path.insert(0, mcp_src)
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistration:
+    """All expected tools must be registered on the FastMCP instance."""
+
+    def test_read_only_tools_registered(self):
+        from datanika_mcp.server import mcp as server
+
+        tool_names = {t.name for t in server._tool_manager.list_tools()}
+        read_tools = {
+            "get_agent_tiers",
+            "get_connection_types",
+            "list_connections",
+            "get_connection",
+            "introspect_connection",
+            "preview_connection",
+            "query_connection",
+            "compile_transformation",
+            "preview_transformation",
+            "list_uploads",
+            "list_pipelines",
+            "list_transformations",
+            "list_runs",
+            "get_run",
+            "get_run_logs",
+            "list_catalog",
+            "get_catalog_entry",
+        }
+        assert read_tools.issubset(tool_names), f"Missing read tools: {read_tools - tool_names}"
+
+    def test_write_tools_registered(self):
+        from datanika_mcp.server import mcp as server
+
+        tool_names = {t.name for t in server._tool_manager.list_tools()}
+        write_tools = {
+            "create_connection",
+            "create_upload",
+            "create_pipeline",
+            "create_transformation",
+            "bulk_import",
+            "trigger_upload",
+            "trigger_pipeline",
+            "trigger_transformation",
+        }
+        assert write_tools.issubset(tool_names), f"Missing write tools: {write_tools - tool_names}"
+
+    def test_total_tool_count(self):
+        from datanika_mcp.server import mcp as server
+
+        tools = server._tool_manager.list_tools()
+        assert len(tools) == 25  # 17 read + 8 write
+
+
+# ---------------------------------------------------------------------------
+# Write guard
+# ---------------------------------------------------------------------------
+
+
+class TestWriteGuard:
+    def test_write_blocked_by_default(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = False
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv._require_write("create_connection")
+
+    def test_write_allowed_when_enabled(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        srv._require_write("create_connection")  # should not raise
+
+    def test_create_connection_calls_require_write(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = False
+        srv._client = MagicMock()
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv.create_connection("test", "postgres", {"host": "localhost"})
+
+    def test_trigger_pipeline_calls_require_write(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = False
+        srv._client = MagicMock()
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv.trigger_pipeline(1, wait=False)
+
+
+# ---------------------------------------------------------------------------
+# Read tools call client correctly
+# ---------------------------------------------------------------------------
+
+
+class TestReadToolsCallClient:
+    def test_list_connections_calls_client(self):
+        import datanika_mcp.server as srv
+
+        mock_client = MagicMock()
+        mock_client.list_connections.return_value = {"items": []}
+        srv._client = mock_client
+
+        result = srv.list_connections()
+        mock_client.list_connections.assert_called_once()
+        assert '"items"' in result
+
+    def test_get_run_logs_calls_client(self):
+        import datanika_mcp.server as srv
+
+        mock_client = MagicMock()
+        mock_client.get_run_logs.return_value = {"run_id": 42, "logs": "ok"}
+        srv._client = mock_client
+
+        result = srv.get_run_logs(42)
+        mock_client.get_run_logs.assert_called_once_with(42)
+        assert "42" in result
+
+    def test_compile_transformation_calls_client(self):
+        import datanika_mcp.server as srv
+
+        mock_client = MagicMock()
+        mock_client.compile_transformation.return_value = {
+            "compiled_sql": "SELECT 1",
+            "node": "model.t.stg_orders",
+        }
+        srv._client = mock_client
+
+        result = srv.compile_transformation(5)
+        mock_client.compile_transformation.assert_called_once_with(5)
+        assert "SELECT 1" in result
+
+
+# ---------------------------------------------------------------------------
+# Write tools call client when allowed
+# ---------------------------------------------------------------------------
+
+
+class TestWriteToolsCallClient:
+    def test_create_connection_calls_client(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        mock_client = MagicMock()
+        mock_client.create_connection.return_value = {"id": 1, "name": "test"}
+        srv._client = mock_client
+
+        result = srv.create_connection("test", "postgres", {"host": "localhost"})
+        mock_client.create_connection.assert_called_once_with(
+            "test", "postgres", {"host": "localhost"}
+        )
+        assert '"id": 1' in result
+
+    def test_bulk_import_calls_client(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        mock_client = MagicMock()
+        mock_client.bulk_import.return_value = {"created": {"connections": [1]}}
+        srv._client = mock_client
+
+        payload = {"version": 2, "connections": [{"name": "a"}]}
+        result = srv.bulk_import(payload)
+        mock_client.bulk_import.assert_called_once_with(payload)
+        assert "connections" in result
+
+    def test_trigger_upload_with_wait(self):
+        import datanika_mcp.server as srv
+
+        srv._allow_write = True
+        mock_client = MagicMock()
+        mock_client.trigger_upload.return_value = {"run_id": 10, "status": "success"}
+        srv._client = mock_client
+
+        result = srv.trigger_upload(3, wait=True)
+        mock_client.trigger_upload.assert_called_once_with(3, True)
+        assert "success" in result
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_missing_api_key_exits(self):
+        """Server should exit with error if no API key is provided."""
+        import datanika_mcp.server as srv
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("sys.argv", ["datanika-mcp"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            # Remove any env vars that might provide the key
+            import os
+
+            os.environ.pop("DATANIKA_API_KEY", None)
+            os.environ.pop("DATANIKA_URL", None)
+            os.environ.pop("DATANIKA_ALLOW_WRITE", None)
+            srv.main()
+
+        assert exc_info.value.code == 1
+
+    def test_version_flag(self):
+        import datanika_mcp.server as srv
+
+        with (
+            patch("sys.argv", ["datanika-mcp", "--version"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            srv.main()
+
+        assert exc_info.value.code == 0

--- a/tests/test_services/test_agent_tiers.py
+++ b/tests/test_services/test_agent_tiers.py
@@ -81,20 +81,14 @@ class TestCapabilityCount:
         manual_total = sum(len(t.capabilities) for t in TIERS)
         assert capability_count() == manual_total
 
-    def test_current_capability_count_is_six(self):
-        # 5 tiers, but the current capability decomposition is 6:
-        # Discover, Introspect, Build, Validate, Execute, Control,
-        # plus the Tier 5 docs capability — wait, that's 7. Recount.
+    def test_current_capability_count_is_eight(self):
         # Tier 1: Discover + Introspect = 2
-        # Tier 2: Build = 1
+        # Tier 2: Build + Bulk Import = 2
         # Tier 3: Validate = 1
         # Tier 4: Execute + Control = 2
         # Tier 5: Discover Docs = 1
-        # Total = 7
-        # If you change this, the LLMS_TXT capability list changes too,
-        # and any landing-site copy that quotes a number will need to
-        # be updated. Better: have the landing site fetch the JSON.
-        assert capability_count() == 7
+        # Total = 8
+        assert capability_count() == 8
 
 
 class TestKnownCapabilityNames:

--- a/tests/test_services/test_import_endpoint.py
+++ b/tests/test_services/test_import_endpoint.py
@@ -163,9 +163,7 @@ def _full_payload():
 class TestImportEndpointHappyPath:
     def test_full_import_creates_all_resources(self, client, fake_api_key, rate_limit_ok):
         with _patch_auth(fake_api_key, rate_limit_ok):
-            resp = client.post(
-                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
-            )
+            resp = client.post("/api/v1/import", json=_full_payload(), headers=_auth_headers())
             assert resp.status_code == 201, resp.json()
             data = resp.json()
             assert "created" in data
@@ -255,9 +253,7 @@ class TestImportEndpointHappyPath:
 
     def test_response_contains_created_ids(self, client, fake_api_key, rate_limit_ok):
         with _patch_auth(fake_api_key, rate_limit_ok):
-            resp = client.post(
-                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
-            )
+            resp = client.post("/api/v1/import", json=_full_payload(), headers=_auth_headers())
             data = resp.json()
             for section in ("connections", "uploads", "pipelines", "transformations"):
                 for item_id in data["created"][section]:
@@ -309,9 +305,7 @@ class TestImportValidation:
                 "/api/v1/import",
                 json={
                     "version": 2,
-                    "connections": [
-                        {"name": "Bad", "connection_type": "no_such_db", "config": {}}
-                    ],
+                    "connections": [{"name": "Bad", "connection_type": "no_such_db", "config": {}}],
                 },
                 headers=_auth_headers(),
             )

--- a/tests/test_services/test_import_endpoint.py
+++ b/tests/test_services/test_import_endpoint.py
@@ -1,0 +1,475 @@
+"""Tests for POST /api/v1/import — bulk resource creation (#131)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import datanika.models.invitation  # noqa: F401
+import datanika.models.notification_channel  # noqa: F401
+import datanika.models.sso_config  # noqa: F401
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+
+@pytest.fixture
+def fake_api_key():
+    key = MagicMock()
+    key.id = 1
+    key.org_id = 10
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def app():
+    return Starlette(routes=api_v1_routes)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def _auth_headers():
+    return {"Authorization": "Bearer etf_testkey"}
+
+
+def _patch_auth(fake_api_key, rate_limit_ok):
+    import contextlib
+
+    from cryptography.fernet import Fernet
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from datanika.models.base import Base
+    from datanika.services.connection_service import ConnectionService
+    from datanika.services.encryption import EncryptionService
+    from datanika.services.pipeline_service import PipelineService
+    from datanika.services.schedule_service import ScheduleService
+    from datanika.services.transformation_service import TransformationService
+    from datanika.services.upload_service import UploadService
+
+    @contextlib.contextmanager
+    def _ctx():
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=__import__("sqlalchemy.pool", fromlist=["StaticPool"]).StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session = SASession(engine)
+
+        enc = EncryptionService(Fernet.generate_key().decode())
+        conn_svc = ConnectionService(enc)
+        upload_svc = UploadService(conn_svc)
+        pipeline_svc = PipelineService()
+        transform_svc = TransformationService()
+        schedule_svc = ScheduleService(upload_svc, transform_svc, pipeline_service=pipeline_svc)
+
+        @contextlib.contextmanager
+        def fake_session():
+            yield session
+
+        import datanika.services.api_v1_routes as routes_mod
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session", fake_session),
+            patch.object(routes_mod, "_get_conn_svc", return_value=conn_svc),
+            patch.object(routes_mod, "_get_upload_svc", return_value=upload_svc),
+            patch.object(routes_mod, "_get_schedule_svc", return_value=schedule_svc),
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+
+            yield session
+
+        session.close()
+        engine.dispose()
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — common payloads
+# ---------------------------------------------------------------------------
+
+_PG_CONN = {
+    "name": "My PG",
+    "connection_type": "postgres",
+    "config": {"host": "localhost", "port": 5432, "user": "u", "password": "p", "database": "db"},
+}
+
+_MYSQL_CONN = {
+    "name": "My MySQL",
+    "connection_type": "mysql",
+    "config": {"host": "mysql.local", "port": 3306, "user": "u", "password": "p", "database": "db"},
+}
+
+
+def _full_payload():
+    """Return a valid version-2 import payload with all sections."""
+    return {
+        "version": 2,
+        "connections": [_PG_CONN, _MYSQL_CONN],
+        "uploads": [
+            {
+                "name": "Load orders",
+                "source_connection_name": "My MySQL",
+                "destination_connection_name": "My PG",
+                "dlt_config": {"load_mode": "single_table", "table_name": "orders"},
+            }
+        ],
+        "pipelines": [
+            {
+                "name": "Build analytics",
+                "destination_connection_name": "My PG",
+                "command": "build",
+            }
+        ],
+        "transformations": [
+            {
+                "name": "stg_orders",
+                "sql_body": "SELECT * FROM {{ source('raw', 'orders') }}",
+                "materialization": "view",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestImportEndpointHappyPath:
+    def test_full_import_creates_all_resources(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
+            )
+            assert resp.status_code == 201, resp.json()
+            data = resp.json()
+            assert "created" in data
+            assert len(data["created"]["connections"]) == 2
+            assert len(data["created"]["uploads"]) == 1
+            assert len(data["created"]["pipelines"]) == 1
+            assert len(data["created"]["transformations"]) == 1
+
+    def test_connections_only(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 2, "connections": [_PG_CONN]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            assert len(data["created"]["connections"]) == 1
+            assert data["created"]["uploads"] == []
+            assert data["created"]["pipelines"] == []
+            assert data["created"]["transformations"] == []
+
+    def test_uploads_referencing_existing_connections(self, client, fake_api_key, rate_limit_ok):
+        """Uploads can reference connections already in the org, not just in the payload."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            # Pre-create connections via the normal endpoint
+            client.post(
+                "/api/v1/connections",
+                json=_PG_CONN,
+                headers=_auth_headers(),
+            )
+            client.post(
+                "/api/v1/connections",
+                json=_MYSQL_CONN,
+                headers=_auth_headers(),
+            )
+
+            # Import an upload referencing those existing connections
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "uploads": [
+                        {
+                            "name": "Load orders",
+                            "source_connection_name": "My MySQL",
+                            "destination_connection_name": "My PG",
+                            "dlt_config": {"load_mode": "single_table", "table_name": "t"},
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            assert len(resp.json()["created"]["uploads"]) == 1
+
+    def test_transformations_only(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "transformations": [
+                        {
+                            "name": "stg_users",
+                            "sql_body": "SELECT * FROM users",
+                            "materialization": "view",
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            assert len(resp.json()["created"]["transformations"]) == 1
+
+    def test_empty_sections_are_fine(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 2},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            for key in ("connections", "uploads", "pipelines", "transformations"):
+                assert data["created"][key] == []
+
+    def test_response_contains_created_ids(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
+            )
+            data = resp.json()
+            for section in ("connections", "uploads", "pipelines", "transformations"):
+                for item_id in data["created"][section]:
+                    assert isinstance(item_id, int)
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestImportValidation:
+    def test_missing_version_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"connections": [_PG_CONN]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+    def test_wrong_version_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 1, "connections": [_PG_CONN]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+    def test_connection_missing_name(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [
+                        {"connection_type": "postgres", "config": {"host": "localhost"}}
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            assert "errors" in resp.json()
+
+    def test_connection_invalid_type(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [
+                        {"name": "Bad", "connection_type": "no_such_db", "config": {}}
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("INVALID_CONNECTION_TYPE" in str(e) for e in errors)
+
+    def test_duplicate_connection_names(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            conn = {**_PG_CONN}
+            resp = client.post(
+                "/api/v1/import",
+                json={"version": 2, "connections": [conn, conn]},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("DUPLICATE_NAME" in str(e) for e in errors)
+
+    def test_upload_unknown_connection_ref(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "uploads": [
+                        {
+                            "name": "Bad ref",
+                            "source_connection_name": "Does Not Exist",
+                            "destination_connection_name": "Also Missing",
+                            "dlt_config": {},
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("UNKNOWN_CONNECTION_REF" in str(e) for e in errors)
+
+    def test_pipeline_unknown_connection_ref(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "pipelines": [
+                        {
+                            "name": "Bad pipeline",
+                            "destination_connection_name": "Nope",
+                            "command": "run",
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert any("UNKNOWN_CONNECTION_REF" in str(e) for e in errors)
+
+    def test_transformation_missing_sql_body(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "transformations": [{"name": "bad"}],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+    def test_multiple_errors_returned_at_once(self, client, fake_api_key, rate_limit_ok):
+        """All validation errors collected, not just the first one."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [
+                        {"connection_type": "postgres", "config": {}},  # missing name
+                        {"name": "Bad", "connection_type": "no_such", "config": {}},
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+            errors = resp.json()["errors"]
+            assert len(errors) >= 2
+
+    def test_nothing_created_on_validation_failure(self, client, fake_api_key, rate_limit_ok):
+        """If validation fails, no resources are created (atomic)."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            # Send a payload with a valid connection but an invalid upload
+            resp = client.post(
+                "/api/v1/import",
+                json={
+                    "version": 2,
+                    "connections": [_PG_CONN],
+                    "uploads": [
+                        {
+                            "name": "Bad",
+                            "source_connection_name": "Nonexistent",
+                            "destination_connection_name": "My PG",
+                            "dlt_config": {},
+                        }
+                    ],
+                },
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 400
+
+            # Verify the connection was NOT created
+            resp2 = client.get("/api/v1/connections", headers=_auth_headers())
+            assert resp2.status_code == 200
+            assert resp2.json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Auth & routing
+# ---------------------------------------------------------------------------
+
+
+class TestImportAuth:
+    def test_no_auth_returns_401(self, client):
+        resp = client.post("/api/v1/import", json={"version": 2})
+        assert resp.status_code == 401
+
+    def test_empty_body_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post("/api/v1/import", json={}, headers=_auth_headers())
+            assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI spec
+# ---------------------------------------------------------------------------
+
+
+class TestImportOpenAPISpec:
+    def test_import_path_in_spec(self):
+        from datanika.services.openapi import build_openapi_spec
+
+        spec = build_openapi_spec()
+        assert "/api/v1/import" in spec["paths"]
+        assert "post" in spec["paths"]["/api/v1/import"]
+
+    def test_import_is_stable(self):
+        from datanika.services.openapi import build_openapi_spec
+
+        spec = build_openapi_spec()
+        post_op = spec["paths"]["/api/v1/import"]["post"]
+        assert post_op.get("x-stability") == "stable"
+
+    def test_import_schemas_exist(self):
+        from datanika.services.openapi import build_openapi_spec
+
+        spec = build_openapi_spec()
+        schemas = spec["components"]["schemas"]
+        assert "ImportRequest" in schemas
+        assert "ImportResult" in schemas

--- a/uv.lock
+++ b/uv.lock
@@ -962,6 +962,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -978,18 +979,19 @@ requires-dist = [
     { name = "cryptography", specifier = ">=44.0" },
     { name = "dbt-bigquery", specifier = ">=1.7,<1.8" },
     { name = "dbt-clickhouse", specifier = ">=1.7,<1.8" },
-    { name = "dbt-core", specifier = ">=1.7,<1.8" },
+    { name = "dbt-core", specifier = ">=1.7.19,<1.8" },
     { name = "dbt-duckdb", specifier = ">=1.7,<1.8" },
     { name = "dbt-mysql", specifier = ">=1.7,<1.8" },
     { name = "dbt-postgres", specifier = ">=1.7,<1.8" },
     { name = "dbt-redshift", specifier = ">=1.7,<1.8" },
     { name = "dbt-snowflake", specifier = ">=1.7,<1.8" },
     { name = "dbt-sqlserver", specifier = ">=1.7,<1.8" },
-    { name = "dlt", extras = ["postgres", "snowflake", "bigquery", "mssql", "clickhouse", "duckdb", "databricks", "synapse"], specifier = ">=1.5" },
+    { name = "dlt", extras = ["postgres", "snowflake", "bigquery", "mssql", "clickhouse", "duckdb", "databricks", "synapse"], specifier = ">=1.21,<2" },
     { name = "duckdb", specifier = ">=1.0" },
     { name = "google-auth", specifier = ">=2.0" },
     { name = "gspread", specifier = ">=6.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1992,6 +1994,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2380,6 +2391,31 @@ wheels = [
 [package.optional-dependencies]
 msgpack = [
     { name = "msgpack" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]
@@ -4264,6 +4300,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4361,6 +4410,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Atomic dev→master promotion for 2026-04-15 PM sweep (**re-promotion** after the earlier halt on drifts A/B/C — all three now fixed). 9 commits, 6 feature PRs, paired with landing dev→main (agent-tiers snapshot) — **both must ship together** so the /api/v1/meta/agent-tiers shape matches on both ends.

## Features

| PR | Area | What |
|----|------|------|
| #150 (#131) | Engineering | `POST /api/v1/import` bulk resource creation |
| #153 (#140) | Engineering | Datanika MCP server — AI-agent native distribution |
| #152 + 2 follow-ups | QA | Playwright E2E harness wired into CI (lint+test+helm-lint gated, runs against staging on push to dev). Drift A fix (package-lock) on 86b3966. |
| #160 | Engineering | Smoke test \`test_agent_tiers_shape\`: bump \`capability_count\` assertion 7 → 8 (drift B fix, core side) |
| #156 | Engineering | E5 doc debt paydown — README/DESIGN refresh + ruff format drift |
| #158 | Infra | Minimal Helm chart stub (\`deploy/helm/datanika/\`) + CI \`helm-lint\` gate |

## Paired landing PR

datanika-landing dev→main carries **#180 agent-tiers fallback snapshot refresh to 8 capabilities** (drift B landing side) + **#176 /api/versioning mirror**. The two must hit prod together so browsers don't see a stale 7-cap snapshot while the API returns 8.

## CD expected

- Master push triggers \`deploy\` → Hetzner SSH → \`docker compose up -d --build app celery\` → healthcheck gate (120s timeout)
- Post-deploy \`smoke\` job runs \`.github/smoke-check.sh https://app.datanika.io .github/smoke-urls-core.txt\`

## Drift C fix (2026-04-15 PM)

TELEGRAM_BOT_TOKEN was missing from GHA repo secrets across all 3 repos — GHA→Telegram alert path dark since CI shipped. Token was pulled from Hetzner \`.env.docker\` and mirrored to \`datanika-core\`, \`datanika-landing\`, \`datanika-cloud\` via \`gh secret set\`. First live validation happened on the previous push-to-dev run (24467455683) where both smoke-staging and e2e-staging failures fired their Telegram alert steps successfully.

## Verification on push-to-dev run [24469056697](https://github.com/datanika-io/datanika-core/actions/runs/24469056697)

- ✓ lint, test, helm-lint (all required for deploy)
- ✓ deploy-staging (Hetzner staging live at 75569d1)
- ✓ **smoke-staging** (drift B fix validated — capability_count=8 now passes)
- ✗ e2e-staging — 3 Playwright tests fail in \`loggedInPage\` fixture (\`locator.fill\` 60s timeout on \`/login\`). Pre-existing staging login flake, not drift-related. Tracked as QA follow-up; \`deploy\` gate requires \`[lint, test, helm-lint]\` only.

## Supersedes

The earlier halt comment on this PR is now resolved; drifts A/B/C all fixed, CI deploy gates all green.