### PR TITLE
[Engineering] E5 doc debt paydown + ruff format drift — core

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,7 +86,7 @@ Sources -> dlt (extract + load into user-chosen schema)
 | **Package Manager** | uv |
 | **Linting** | Ruff |
 | **i18n** | 9 languages (en, ru, el, de, fr, es, zh, ar, sr) with runtime switching |
-| **Testing** | pytest + pytest-asyncio, SQLite in-memory, 1,700+ tests across unit / security / E2E |
+| **Testing** | pytest + pytest-asyncio, SQLite in-memory, 1,800+ tests across unit / security / E2E |
 | **Monitoring** | Prometheus (metrics collection), Grafana (dashboards), Node Exporter (host metrics), cAdvisor (container metrics) |
 
 ## Database Design
@@ -364,6 +364,16 @@ Tier 3/4 endpoints return a new typed `error_code` field alongside the human mes
 
 `transformation_compile.py` runs `dbt compile` via `dbtRunner().invoke()`, wraps the resulting SQL in `SELECT * FROM (...) LIMIT N`, and re-validates via `is_select_only()` before executing against the warehouse. Defense in depth: a compromised or buggy dbt compile output cannot reach DDL/DML. The read-only guard uses regex word boundaries (not a full SQL parser) for lightness while still rejecting DDL, DML, multi-statement, and CTE-with-mutation payloads.
 
+### API stability tiers
+
+Every operation in the OpenAPI spec carries an `x-stability` extension (`stable` / `beta` / `experimental`) injected at build time by `_annotate_stability()` in `datanika/services/openapi.py`. Agents can branch on the tier to decide whether to rely on a field. Stability semantics, deprecation windows, and the removal policy are frozen in [`docs/api_versioning.md`](docs/api_versioning.md) — tier promotions require a doc update and a PR-level review.
+
+### MCP server (`datanika-mcp/`)
+
+`datanika-mcp/` is a first-class [Model Context Protocol](https://modelcontextprotocol.io/) server that wraps the REST API behind 25 tools (16 read-only + 9 write) covering connections, uploads, transformations, pipelines, runs, templates, and catalog browsing. It is a thin HTTP client — there is no parallel business logic. The server ships as its own uv package installable via `uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp"` so agents (Claude Desktop, Claude Code) can speak to any Datanika instance without shelling out to the UI.
+
+Write-facing tools (create / update / delete / run) are gated behind `--allow-write`; the default posture is read-only so "connect Claude Desktop to production" does not accidentally mutate pipelines. All 25 tools are decorated with `@mcp.tool()` in `datanika-mcp/src/datanika_mcp/server.py`; the HTTP shim lives in `client.py`. Tests in `tests/test_mcp/test_mcp_server.py` assert the tool surface matches the API and that `--allow-write` correctly filters mutating tools.
+
 ## Notification Center
 
 Datanika has two notification surfaces that share the same `notifications` table:
@@ -442,6 +452,8 @@ All services are defined in `docker-compose.yml` (requires `source .env.docker` 
 | **Soft delete** | Records preserved for audit, never hard-removed |
 | **Input validation** | Identifier regex, path traversal prevention in dbt file writes |
 
+Vulnerability disclosure policy, supported versions, and the security contact live in [`SECURITY.md`](SECURITY.md) at the repo root.
+
 ## Testing Strategy
 
 - **Framework**: pytest + pytest-asyncio with `asyncio_mode = "auto"`
@@ -449,7 +461,7 @@ All services are defined in `docker-compose.yml` (requires `source .env.docker` 
 - **Layout**: Test files mirror source — `datanika/services/foo.py` → `tests/test_services/test_foo.py`
 - **TDD**: Failing test first, then implementation, then refactor
 - **Bug fixes**: Every fix requires a regression test
-- **Test count**: 1,700+ across unit / service / UI / migration / security suites (see `pytest tests/ --collect-only -q` for the live number)
+- **Test count**: 1,800+ across unit / service / UI / migration / security suites (see `pytest tests/ --collect-only -q` for the live number)
 - **Test directories**: `test_models/`, `test_services/`, `test_tasks/`, `test_ui/`, `test_i18n/`, `test_migrations/`, `test_security/`, plus top-level `test_hooks.py`, `test_hooks_integration.py`, `test_plugin_registry.py`, `test_app_plugin_init.py`
 - **Security tests**: coverage for injection, path traversal, auth attacks, input validation, tenant isolation
 - **E2E tests**: `datanika-examples/tests/` running against real Docker databases (Postgres, MySQL, MSSQL, MongoDB seed scripts + Compose)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ uv run reflex run                     # starts on :3000 + :8000
 - [x] In-app notification center with Slack, Telegram, Email, Webhook channels
 - [x] SSO (SAML/OIDC) for Enterprise
 - [x] Usage-based billing (cloud plugin)
-- [x] 1,700+ tests across unit, security, and E2E (SQLite in-memory for speed)
+- [x] 1,800+ tests across unit, security, and E2E (SQLite in-memory for speed)
 - [ ] Kubernetes Helm chart
 - [ ] Data lineage visualization
 

--- a/datanika/services/agent_tiers.py
+++ b/datanika/services/agent_tiers.py
@@ -111,9 +111,7 @@ TIERS: tuple[Tier, ...] = (
                     "import format. Validates everything first — if any "
                     "errors are found, nothing is created."
                 ),
-                endpoints=(
-                    "POST /api/v1/import",
-                ),
+                endpoints=("POST /api/v1/import",),
             ),
         ),
     ),

--- a/datanika/services/openapi.py
+++ b/datanika/services/openapi.py
@@ -398,8 +398,7 @@ SCHEMAS = {
                 "type": "array",
                 "items": {"type": "object"},
                 "description": (
-                    "Uploads to create. Use connection_name references, "
-                    "not connection_id."
+                    "Uploads to create. Use connection_name references, not connection_id."
                 ),
             },
             "pipelines": {

--- a/tests/test_services/test_import_endpoint.py
+++ b/tests/test_services/test_import_endpoint.py
@@ -163,9 +163,7 @@ def _full_payload():
 class TestImportEndpointHappyPath:
     def test_full_import_creates_all_resources(self, client, fake_api_key, rate_limit_ok):
         with _patch_auth(fake_api_key, rate_limit_ok):
-            resp = client.post(
-                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
-            )
+            resp = client.post("/api/v1/import", json=_full_payload(), headers=_auth_headers())
             assert resp.status_code == 201, resp.json()
             data = resp.json()
             assert "created" in data
@@ -255,9 +253,7 @@ class TestImportEndpointHappyPath:
 
     def test_response_contains_created_ids(self, client, fake_api_key, rate_limit_ok):
         with _patch_auth(fake_api_key, rate_limit_ok):
-            resp = client.post(
-                "/api/v1/import", json=_full_payload(), headers=_auth_headers()
-            )
+            resp = client.post("/api/v1/import", json=_full_payload(), headers=_auth_headers())
             data = resp.json()
             for section in ("connections", "uploads", "pipelines", "transformations"):
                 for item_id in data["created"][section]:
@@ -309,9 +305,7 @@ class TestImportValidation:
                 "/api/v1/import",
                 json={
                     "version": 2,
-                    "connections": [
-                        {"name": "Bad", "connection_type": "no_such_db", "config": {}}
-                    ],
+                    "connections": [{"name": "Bad", "connection_type": "no_such_db", "config": {}}],
                 },
                 headers=_auth_headers(),
             )


### PR DESCRIPTION
Closes #154.

## Summary

E5 doc-debt paydown for the core repo's reference docs, plus a small drive-by ruff-format drift fix needed to unblock precheck on dev.

## Docs changes

**README.md**
- Test count 1,700+ → 1,800+ (actual collected = 1864 on dev)

**DESIGN.md**
- Test counts at lines 89 and 452 bumped to 1,800+
- New subsection _API stability tiers_ under `## AI Agent Compatibility`, documenting the `x-stability` OpenAPI extension injected by `_annotate_stability()` in `datanika/services/openapi.py` and pointing at [`docs/api_versioning.md`](docs/api_versioning.md) (core#147)
- New subsection _MCP server (`datanika-mcp/`)_ documenting the 25-tool (16 read + 9 write) MCP server shipped in core#153, including the `--allow-write` gate, the `uvx --from "git+..."` install path, and the `tests/test_mcp/test_mcp_server.py` test location
- `## Security` section now links to [`SECURITY.md`](SECURITY.md) at the repo root (core#146)

## Drive-by: ruff format drift

Three files had pre-existing `ruff format --check` drift on origin/dev:
- `datanika/services/agent_tiers.py`
- `datanika/services/openapi.py`
- `tests/test_services/test_import_endpoint.py`

All diffs are trivial whitespace / line-length reflows auto-generated by `ruff format`. The precheck failure was blocking every Engineering push until someone ran the formatter. Folded into this PR rather than filing a one-liner follow-up, since any other agent hitting the same precheck failure would have had to do exactly this work before continuing.

## Venv drift (no code change)

`test_mcp/test_mcp_server.py` was failing with `ModuleNotFoundError: No module named 'mcp'`. `mcp>=1.0.0` is already declared as a dev dep in `pyproject.toml`; the main venv at `D:/Projects/Datanika/datanika/.venv` just hadn't been re-synced since core#153. Resolved locally via `uv pip install 'mcp>=1.0.0'` — no PR change required. Worth flagging for the Infra runbook: next promotion should re-sync the server venv too.

## Verification

- `bash plans/precheck.sh worktrees/datanika-core-engineering` → **1864 passed**, ruff check + format clean
- Every referenced file verified to exist in the worktree before committing:
  - `docs/api_versioning.md`
  - `SECURITY.md`
  - `datanika-mcp/src/datanika_mcp/server.py`
  - `tests/test_mcp/test_mcp_server.py`
- MCP tool count verified by grep: 25 `@mcp.tool()` decorators (16 read + 9 write) in `server.py`