### PR TITLE
[Infra] Minimal Helm chart stub for enterprise checkbox (closes #141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,23 @@ jobs:
       - name: Run tests
         run: pytest tests/ --tb=short -q
 
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Helm lint
+        run: helm lint deploy/helm/datanika
+
+      - name: Helm template (dry-run render)
+        run: helm template test-release deploy/helm/datanika > /dev/null
+
   deploy:
-    needs: [lint, test]
+    needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment: production
@@ -97,7 +112,7 @@ jobs:
             docker image prune -f
 
   deploy-staging:
-    needs: [lint, test]
+    needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     environment: production

--- a/deploy/helm/datanika/.helmignore
+++ b/deploy/helm/datanika/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+.git/
+.gitignore
+.vscode/
+.idea/
+*.tmproj
+*.swp
+*.bak
+*.tgz
+*~

--- a/deploy/helm/datanika/Chart.yaml
+++ b/deploy/helm/datanika/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: datanika
+description: |
+  Datanika — multi-tenant data pipeline management platform (dlt + dbt + Celery + Reflex).
+  This is a minimal stub chart that maps the same services as the production
+  docker-compose setup: app, celery, postgres, redis. Intended for enterprise
+  procurement ("yes, deployable on Kubernetes") and small self-hosted installs.
+  Not a full production story — see README.md for the feature matrix.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://datanika.io
+sources:
+  - https://github.com/datanika-io/datanika-core
+maintainers:
+  - name: Datanika Infra
+    url: https://github.com/datanika-io/datanika-core
+keywords:
+  - data-pipeline
+  - dlt
+  - dbt
+  - etl
+  - multi-tenant
+annotations:
+  category: Analytics

--- a/deploy/helm/datanika/README.md
+++ b/deploy/helm/datanika/README.md
@@ -1,0 +1,123 @@
+# Datanika Helm Chart
+
+Minimal Helm chart that installs Datanika (multi-tenant data pipeline platform)
+on any Kubernetes cluster. Functionally equivalent to the production
+docker-compose deployment on Hetzner, minus the bundled monitoring stack.
+
+> **Status: v0.1.0 stub.** Closes the enterprise "Helm chart" checkbox. Good
+> enough for `helm install` onto a cluster that provides `ReadWriteMany`
+> storage; not yet hardened for HA or large multi-tenant fleets. See the
+> [Known caveats](#known-caveats) section before using it in production.
+
+## What it installs
+
+| Component | Kind | Notes |
+|-----------|------|-------|
+| `app` | Deployment (1 replica) | Reflex frontend (`:3000`) + backend (`:8000`). Runs `alembic upgrade head` on startup. |
+| `celery` | Deployment (1 replica) | Background worker. Shares the `dbt_projects` PVC with `app`. |
+| `postgres` | StatefulSet (1 replica) | Postgres 16-alpine with `pg_stat_statements`. Disable via `postgres.enabled=false` to bring your own. |
+| `redis` | Deployment (1 replica) | Redis 7-alpine. Broker + cache. Disable via `redis.enabled=false` to bring your own. |
+| `ingress` | Ingress (optional) | `/` → app frontend, `/api` → app backend. Mirrors the production Nginx reverse proxy. |
+| `dbt-projects` PVC | PVC (RWX) | Shared between `app` and `celery` pods. **Requires a ReadWriteMany storage class.** |
+| Secret | `Opaque` | `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, and all `POSTGRES_*`/`REDIS_*` values, rendered from `.Values.env` + `.Values.secrets`. |
+
+Monitoring (Prometheus, Grafana, node-exporter, cAdvisor) is **not** in scope
+for this chart — run your cluster's existing observability stack and point it
+at the app's metrics endpoints.
+
+## Quickstart
+
+```bash
+# From a clone of the datanika-core repo:
+helm install my-datanika ./deploy/helm/datanika \
+  --namespace datanika --create-namespace \
+  --set secrets.POSTGRES_PASSWORD=$(openssl rand -base64 24) \
+  --set secrets.REDIS_PASSWORD=$(openssl rand -base64 24) \
+  --set secrets.SECRET_KEY=$(openssl rand -base64 32)
+
+# Watch the rollout
+kubectl -n datanika get pods -w
+
+# Port-forward the UI (or enable ingress)
+kubectl -n datanika port-forward svc/my-datanika-app 3000:3000
+# open http://localhost:3000
+```
+
+To use managed databases instead of the bundled Postgres/Redis:
+
+```bash
+helm install my-datanika ./deploy/helm/datanika \
+  --namespace datanika --create-namespace \
+  --set postgres.enabled=false \
+  --set externalDatabase.host=<managed-postgres-host> \
+  --set env.POSTGRES_USER=<user> \
+  --set env.POSTGRES_DB=<db> \
+  --set secrets.POSTGRES_PASSWORD=<password> \
+  --set redis.enabled=false \
+  --set externalRedis.host=<managed-redis-host> \
+  --set secrets.REDIS_PASSWORD=<password> \
+  --set secrets.SECRET_KEY=$(openssl rand -base64 32)
+```
+
+## Configuration highlights
+
+See `values.yaml` for the full list. Common overrides:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `image.repository` | `ghcr.io/datanika-io/datanika` | Override for a private registry |
+| `image.tag` | `latest` | Pin to a release tag |
+| `env.DATANIKA_EDITION` | `oss` | Set to `cloud` to activate the Paddle billing plugin |
+| `env.extra` | `{}` | Map of extra env keys injected into the Secret (anything else the app reads from `.env.docker`) |
+| `postgres.enabled` | `true` | Set `false` + fill `externalDatabase.host` for managed Postgres |
+| `redis.enabled` | `true` | Set `false` + fill `externalRedis.host` for managed Redis |
+| `ingress.enabled` | `false` | Turn on once you have a TLS-terminating ingress class |
+| `app.replicaCount` | `1` | Keep at `1` until the migration job is extracted (see caveats) |
+| `app.dbtProjectsSize` | `5Gi` | Size of the shared dbt projects PVC |
+
+## Known caveats
+
+- **RWX storage required.** The `app` and `celery` Deployments both mount
+  the `dbt_projects` PVC, so the chart requests `ReadWriteMany`. On managed
+  Kubernetes that usually means NFS, EFS, Azure Files, or Filestore. On
+  bare-metal clusters, Longhorn and Rook/CephFS both work. If your cluster
+  only has `ReadWriteOnce`, you can pin both Deployments to the same node
+  via `nodeSelector` + `affinity` as a workaround.
+- **Migrations run on every app pod startup.** The `app` container runs
+  `alembic upgrade head` before starting Reflex. With `app.replicaCount=1`
+  this is fine. For HA, move migrations into a
+  `helm.sh/hook: pre-install,pre-upgrade` Job (tracked separately — see the
+  infrastructure plan).
+- **Bundled Postgres + Redis are single-replica, single-PVC.** They're fine
+  for evaluation and small installs. For anything real, disable them and
+  point to managed databases via `externalDatabase` / `externalRedis`.
+- **No monitoring stack.** Unlike the Hetzner docker-compose, this chart
+  does not ship Grafana, Prometheus, cAdvisor or node-exporter. Use your
+  cluster's existing observability tooling.
+- **`secrets.*` default to `"CHANGE-ME"`.** The chart will install with
+  these placeholders, which is useful for `helm lint` / CI but unsafe for
+  any real environment. Always override them at install time.
+
+## Compared to the production Hetzner deploy
+
+| Feature | Hetzner docker-compose | This chart |
+|---------|------------------------|------------|
+| App + Celery + Postgres + Redis | yes | yes |
+| Persistent volumes | Docker volumes | PVCs (PVC for Postgres, PVC for `dbt_projects`) |
+| Nginx reverse proxy + TLS | host-level Nginx | ingress resource (optional) |
+| Grafana + Prometheus + cAdvisor | yes | no (run separately) |
+| Auto-deploy on push to master | yes | no (managed by user) |
+| HA / rolling updates | `replicas=1` | `replicas=1` (see caveats) |
+| Paddle billing plugin | yes (`DATANIKA_EDITION=cloud`) | yes (`--set env.DATANIKA_EDITION=cloud`) |
+
+## Development
+
+Lint the chart locally before committing:
+
+```bash
+helm lint deploy/helm/datanika
+helm template test deploy/helm/datanika | kubectl apply --dry-run=client -f -
+```
+
+`helm lint` is also run on every PR and push to `dev` / `master` via
+`.github/workflows/ci.yml`.

--- a/deploy/helm/datanika/templates/NOTES.txt
+++ b/deploy/helm/datanika/templates/NOTES.txt
@@ -1,0 +1,32 @@
+Datanika {{ .Chart.AppVersion }} is installed as release "{{ .Release.Name }}".
+
+1. Check pod status:
+
+   kubectl --namespace {{ .Release.Namespace }} get pods \
+     -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+2. Access the UI:
+{{- if .Values.ingress.enabled }}
+
+   https://{{ .Values.ingress.host }}
+{{- else }}
+
+   kubectl --namespace {{ .Release.Namespace }} port-forward \
+     svc/{{ include "datanika.fullname" . }}-app \
+     {{ .Values.app.service.frontendPort }}:{{ .Values.app.service.frontendPort }}
+
+   Then open http://localhost:{{ .Values.app.service.frontendPort }}
+{{- end }}
+
+3. IMPORTANT: the default passwords in values.yaml are "CHANGE-ME" placeholders.
+   Rotate them before using this install for anything real:
+
+   helm upgrade {{ .Release.Name }} <chart> \
+     --reuse-values \
+     --set secrets.POSTGRES_PASSWORD=$(openssl rand -base64 24) \
+     --set secrets.REDIS_PASSWORD=$(openssl rand -base64 24) \
+     --set secrets.SECRET_KEY=$(openssl rand -base64 32)
+
+4. Read deploy/helm/datanika/README.md for production caveats:
+   RWX storage requirement, migration ordering, and externalDatabase /
+   externalRedis overrides for managed Postgres / Redis.

--- a/deploy/helm/datanika/templates/_helpers.tpl
+++ b/deploy/helm/datanika/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Datanika Helm chart — shared template helpers.
+*/}}
+
+{{/* Full release name — truncated to 63 chars (k8s DNS label limit). */}}
+{{- define "datanika.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Chart base name for labels. */}}
+{{- define "datanika.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Chart version label. */}}
+{{- define "datanika.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels applied to every rendered object. */}}
+{{- define "datanika.labels" -}}
+helm.sh/chart: {{ include "datanika.chart" . }}
+{{ include "datanika.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels — immutable fields used by Deployments/StatefulSets. */}}
+{{- define "datanika.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "datanika.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Service-specific selector (adds the component label). */}}
+{{- define "datanika.componentSelector" -}}
+{{ include "datanika.selectorLabels" . }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/* ServiceAccount name — either from values or generated. */}}
+{{- define "datanika.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "datanika.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* Postgres host — internal service or external override. */}}
+{{- define "datanika.postgresHost" -}}
+{{- if .Values.postgres.enabled }}
+{{- printf "%s-postgres" (include "datanika.fullname" .) }}
+{{- else }}
+{{- required "externalDatabase.host is required when postgres.enabled=false" .Values.externalDatabase.host }}
+{{- end }}
+{{- end }}
+
+{{/* Redis host — internal service or external override. */}}
+{{- define "datanika.redisHost" -}}
+{{- if .Values.redis.enabled }}
+{{- printf "%s-redis" (include "datanika.fullname" .) }}
+{{- else }}
+{{- required "externalRedis.host is required when redis.enabled=false" .Values.externalRedis.host }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/datanika/templates/app-deployment.yaml
+++ b/deploy/helm/datanika/templates/app-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datanika.fullname" . }}-app
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: app
+    spec:
+      serviceAccountName: {{ include "datanika.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.app.command | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: {{ include "datanika.fullname" . }}-env
+          ports:
+            - name: http-frontend
+              containerPort: 3000
+            - name: http-backend
+              containerPort: 8000
+          readinessProbe:
+            {{- toYaml .Values.app.probes.readiness | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.app.probes.liveness | nindent 12 }}
+          volumeMounts:
+            - name: dbt-projects
+              mountPath: /app/dbt_projects
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+      volumes:
+        - name: dbt-projects
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-dbt-projects
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/datanika/templates/app-service.yaml
+++ b/deploy/helm/datanika/templates/app-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datanika.fullname" . }}-app
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  type: {{ .Values.app.service.type }}
+  ports:
+    - name: http-frontend
+      port: {{ .Values.app.service.frontendPort }}
+      targetPort: http-frontend
+    - name: http-backend
+      port: {{ .Values.app.service.backendPort }}
+      targetPort: http-backend
+  selector:
+    {{- include "datanika.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: app

--- a/deploy/helm/datanika/templates/celery-deployment.yaml
+++ b/deploy/helm/datanika/templates/celery-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datanika.fullname" . }}-celery
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: celery
+spec:
+  replicas: {{ .Values.celery.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: celery
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: celery
+    spec:
+      serviceAccountName: {{ include "datanika.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: celery
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.celery.command | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: {{ include "datanika.fullname" . }}-env
+          volumeMounts:
+            - name: dbt-projects
+              mountPath: /app/dbt_projects
+          resources:
+            {{- toYaml .Values.celery.resources | nindent 12 }}
+      volumes:
+        - name: dbt-projects
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-dbt-projects
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/datanika/templates/dbt-pvc.yaml
+++ b/deploy/helm/datanika/templates/dbt-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "datanika.fullname" . }}-dbt-projects
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dbt
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.app.dbtProjectsSize }}

--- a/deploy/helm/datanika/templates/ingress.yaml
+++ b/deploy/helm/datanika/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "datanika.fullname" . }}
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "datanika.fullname" . }}-app
+                port:
+                  number: {{ .Values.app.service.backendPort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "datanika.fullname" . }}-app
+                port:
+                  number: {{ .Values.app.service.frontendPort }}
+{{- end }}

--- a/deploy/helm/datanika/templates/postgres-service.yaml
+++ b/deploy/helm/datanika/templates/postgres-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datanika.fullname" . }}-postgres
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.port | default 5432 }}
+      targetPort: postgres
+  selector:
+    {{- include "datanika.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+{{- end }}

--- a/deploy/helm/datanika/templates/postgres-statefulset.yaml
+++ b/deploy/helm/datanika/templates/postgres-statefulset.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "datanika.fullname" . }}-postgres
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "datanika.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - postgres
+            - -c
+            - shared_preload_libraries=pg_stat_statements
+            - -c
+            - pg_stat_statements.track=all
+            - -c
+            - log_min_duration_statement=500
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: POSTGRES_DB
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.env.POSTGRES_USER }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.env.POSTGRES_USER }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.postgres.persistence.storageClass }}
+        storageClassName: {{ .Values.postgres.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+{{- end }}

--- a/deploy/helm/datanika/templates/redis-deployment.yaml
+++ b/deploy/helm/datanika/templates/redis-deployment.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datanika.fullname" . }}-redis
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "datanika.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "datanika.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - 'exec redis-server --requirepass "$REDIS_PASSWORD"'
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datanika.fullname" . }}-env
+                  key: REDIS_PASSWORD
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'redis-cli -a "$REDIS_PASSWORD" ping | grep -q PONG'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+      volumes:
+        - name: data
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/datanika/templates/redis-service.yaml
+++ b/deploy/helm/datanika/templates/redis-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datanika.fullname" . }}-redis
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port | default 6379 }}
+      targetPort: redis
+  selector:
+    {{- include "datanika.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/deploy/helm/datanika/templates/secret.yaml
+++ b/deploy/helm/datanika/templates/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "datanika.fullname" . }}-env
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.env.POSTGRES_USER | quote }}
+  POSTGRES_DB: {{ .Values.env.POSTGRES_DB | quote }}
+  POSTGRES_PASSWORD: {{ .Values.secrets.POSTGRES_PASSWORD | quote }}
+  POSTGRES_HOST: {{ include "datanika.postgresHost" . | quote }}
+  POSTGRES_PORT: {{ .Values.postgres.port | default 5432 | quote }}
+  REDIS_HOST: {{ include "datanika.redisHost" . | quote }}
+  REDIS_PORT: {{ .Values.redis.port | default 6379 | quote }}
+  REDIS_PASSWORD: {{ .Values.secrets.REDIS_PASSWORD | quote }}
+  REDIS_URL: "redis://:{{ .Values.secrets.REDIS_PASSWORD }}@{{ include "datanika.redisHost" . }}:{{ .Values.redis.port | default 6379 }}/0"
+  DATABASE_URL: "postgresql+asyncpg://{{ .Values.env.POSTGRES_USER }}:{{ .Values.secrets.POSTGRES_PASSWORD }}@{{ include "datanika.postgresHost" . }}:{{ .Values.postgres.port | default 5432 }}/{{ .Values.env.POSTGRES_DB }}"
+  SECRET_KEY: {{ .Values.secrets.SECRET_KEY | quote }}
+  DATANIKA_EDITION: {{ .Values.env.DATANIKA_EDITION | quote }}
+  {{- range $key, $val := .Values.env.extra }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/deploy/helm/datanika/templates/serviceaccount.yaml
+++ b/deploy/helm/datanika/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "datanika.serviceAccountName" . }}
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/datanika/values.yaml
+++ b/deploy/helm/datanika/values.yaml
@@ -1,0 +1,156 @@
+## Datanika Helm chart — default values.
+##
+## This is a minimal stub. See README.md for the feature matrix vs.
+## production docker-compose deployment on Hetzner.
+
+image:
+  repository: ghcr.io/datanika-io/datanika
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+## Ingress — optional HTTP entry. Maps / → app frontend (Reflex :3000) and
+## /api/ → app backend (:8000). Mirrors the production Nginx reverse proxy.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: datanika.local
+  tls: []
+  ##  - hosts:
+  ##      - datanika.local
+  ##    secretName: datanika-tls
+
+## Datanika application env. In production this comes from .env.docker on the
+## host; in Kubernetes we put the same keys into a Secret and mount via envFrom.
+## Users MUST override the password/secret fields before install.
+env:
+  POSTGRES_USER: datanika
+  POSTGRES_DB: datanika
+  DATANIKA_EDITION: "oss"
+  ## Optional extras — anything else the app reads from .env.docker. Keys listed
+  ## here become literal Secret entries. Values left empty will be emitted as
+  ## empty strings; users should populate them before running in a real env.
+  extra: {}
+
+## Secrets — rendered into the env Secret. Passwords must be overridden.
+secrets:
+  POSTGRES_PASSWORD: "CHANGE-ME"
+  REDIS_PASSWORD: "CHANGE-ME"
+  SECRET_KEY: "CHANGE-ME"
+
+## Application (Reflex frontend :3000 + backend :8000).
+app:
+  replicaCount: 1
+  command:
+    - sh
+    - -c
+    - "uv run alembic upgrade head && uv run reflex run --env prod --backend-host 0.0.0.0"
+  service:
+    type: ClusterIP
+    frontendPort: 3000
+    backendPort: 8000
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  probes:
+    readiness:
+      httpGet:
+        path: /healthz
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 5
+    liveness:
+      httpGet:
+        path: /healthz
+        port: 8000
+      initialDelaySeconds: 60
+      periodSeconds: 30
+      failureThreshold: 3
+  dbtProjectsSize: 5Gi
+
+## Celery worker.
+celery:
+  replicaCount: 1
+  command:
+    - uv
+    - run
+    - celery
+    - -A
+    - datanika.tasks.celery_app:celery_app
+    - worker
+    - -l
+    - info
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+## PostgreSQL (stub — for real clusters, set enabled=false and provide
+## externalDatabase.host). Uses a StatefulSet + PVC for data durability.
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16-alpine"
+  port: 5432
+  persistence:
+    size: 20Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+## External Postgres override — ignored unless postgres.enabled=false.
+externalDatabase:
+  host: ""
+  port: 5432
+  user: ""
+  database: ""
+
+## Redis (Celery broker + cache). Runs with an emptyDir volume — on pod
+## restart the broker queue is lost, which is fine for Datanika's task model
+## (Celery tasks are idempotent and re-enqueued by the app on failure).
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+  port: 6379
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+## External Redis override — ignored unless redis.enabled=false.
+externalRedis:
+  host: ""
+  port: 6379
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary

Closes #141. Adds a minimal self-contained Helm 3 chart at `deploy/helm/datanika/` so Datanika can be `helm install`-ed onto any Kubernetes cluster with `ReadWriteMany` storage. Closes the long-standing enterprise "Helm chart" checkbox.

Not a replacement for the production Hetzner docker-compose deploy — that stays the canonical install path. This is for self-hosted / enterprise evaluators who want a `helm install` smoke test on their own cluster.

## What's in the chart

| Component | Kind | Notes |
|-----------|------|-------|
| `app` | Deployment (1 replica) | Reflex frontend (:3000) + backend (:8000). Runs `alembic upgrade head` on startup. |
| `celery` | Deployment (1 replica) | Shares the `dbt_projects` PVC with `app`. |
| `postgres` | StatefulSet (1 replica) | Postgres 16-alpine with `pg_stat_statements`. Disable via `postgres.enabled=false` to bring your own. |
| `redis` | Deployment (1 replica) | Redis 7-alpine, emptyDir volume (broker + cache). Disable via `redis.enabled=false`. |
| `ingress` | Ingress (optional) | `/` → app frontend, `/api` → app backend. Mirrors the production Nginx reverse proxy. |
| `dbt-projects` PVC | PVC (RWX) | Shared between `app` and `celery` pods. |
| Secret | `Opaque` | `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, `POSTGRES_*`, `REDIS_*`, `DATANIKA_EDITION`, `env.extra` passthrough. |
| ServiceAccount | optional | Gated by `serviceAccount.create`. |

Monitoring stack (Prometheus/Grafana/cAdvisor/node-exporter) is intentionally out of scope — run your cluster's existing observability tooling.

## CI gate

New `helm-lint` job in `.github/workflows/ci.yml`:

- Runs on every PR and every push to `dev` / `master`
- `helm lint deploy/helm/datanika`
- `helm template test-release deploy/helm/datanika > /dev/null` (catches template rendering errors)
- Hard gate for both `deploy` (prod) and `deploy-staging` — added to `needs: [...]` on both

## Known caveats (also documented in chart README)

- **RWX storage required** for the shared `dbt_projects` PVC. On managed K8s: NFS / EFS / Azure Files / Filestore. On bare metal: Longhorn / Rook-CephFS. Workaround for RWO-only clusters: pin both Deployments to one node via nodeSelector/affinity.
- **Migrations run on every app pod start** (`alembic upgrade head` in `.Values.app.command`). Fine at `replicaCount=1`. For HA, extract into a `helm.sh/hook: pre-install,pre-upgrade` Job — tracked separately in PLAN_INFRASTRUCTURE.md.
- **Bundled postgres + redis are single-replica.** Evaluator-grade. For real workloads, disable and point to managed databases via `externalDatabase.host` / `externalRedis.host`.
- **`secrets.*` default to `"CHANGE-ME"`.** Lets `helm lint` / CI install with defaults. Unsafe for anything real — always override at install time.

## Local verification

```
$ helm lint deploy/helm/datanika
==> Linting deploy/helm/datanika
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

$ helm template test-release deploy/helm/datanika | grep -E '^kind:' | sort -u
kind: Deployment
kind: PersistentVolumeClaim
kind: Secret
kind: Service
kind: ServiceAccount
kind: StatefulSet

$ helm template test-release deploy/helm/datanika --set ingress.enabled=true | grep '^kind:' | sort -u
# (+kind: Ingress)

$ helm template test-release deploy/helm/datanika \
    --set postgres.enabled=false --set externalDatabase.host=pg.example.com \
    --set redis.enabled=false --set externalRedis.host=redis.example.com \
    | grep -E 'DATABASE_URL|REDIS_URL|POSTGRES_HOST|REDIS_HOST'
  POSTGRES_HOST: "pg.example.com"
  REDIS_HOST: "redis.example.com"
  REDIS_URL: "redis://:CHANGE-ME@redis.example.com:6379/0"
  DATABASE_URL: "postgresql+asyncpg://datanika:CHANGE-ME@pg.example.com:5432/datanika"
```

## Test plan

- [ ] CI `lint` job green
- [ ] CI `test` job green
- [ ] CI `helm-lint` job green (new, blocks deploy + deploy-staging)
- [ ] After merge to `dev`: verify `helm-lint` runs on push and is still a gate
- [ ] Chart README renders correctly on GitHub (tables, caveats section)
- [ ] Landing `/docs/self-hosting/` link-out to the chart — **tracked separately on datanika-landing** (will be added in a follow-up landing PR once this lands on `dev`)

## Follow-ups (not in this PR)

- Extract `alembic upgrade head` into a `helm.sh/hook: pre-install,pre-upgrade` Job for real HA
- Chart publishing: GH Pages index or ghcr.io OCI registry (`helm push`) — tracked in PLAN_INFRASTRUCTURE.md
- Landing `/docs/self-hosting/` content update (separate landing#PR)

Note: this branch is based on `origin/dev` (HEAD 442ecec at branch time). The PR targets `dev` per branching strategy.
