### PR TITLE
[Engineering] Bump smoke test capability_count assertion to 8

### DIFF
--- a/scripts/smoke/test_core_smoke.py
+++ b/scripts/smoke/test_core_smoke.py
@@ -93,7 +93,7 @@ def test_agent_guide_md_public(core_client: httpx.Client) -> None:
 
 
 def test_agent_tiers_shape(core_client: httpx.Client) -> None:
-    """Tier SoT — pinned to the current 5-tier / 7-capability layout.
+    """Tier SoT — pinned to the current 5-tier / 8-capability layout.
 
     If Product adds or removes a tier, this test goes red first and
     forces a conscious update. That's the contract — `agent-tiers` is
@@ -108,8 +108,8 @@ def test_agent_tiers_shape(core_client: httpx.Client) -> None:
         f"tier_count changed from 5 to {payload.get('tier_count')} — "
         "update the smoke test AND landing's build-time snapshot in the same PR"
     )
-    assert payload.get("capability_count") == 7, (
-        f"capability_count changed from 7 to {payload.get('capability_count')} — "
+    assert payload.get("capability_count") == 8, (
+        f"capability_count changed from 8 to {payload.get('capability_count')} — "
         "update the smoke test AND landing's build-time snapshot in the same PR"
     )
     assert isinstance(payload.get("tiers"), list), "tiers should be a list"


### PR DESCRIPTION
## Summary

- Bumps [scripts/smoke/test_core_smoke.py:111](scripts/smoke/test_core_smoke.py#L111) from `capability_count == 7` to `== 8`
- Updates the drift-message numbers on lines 112-113
- Updates the docstring from "7-capability layout" to "8-capability layout"

Closes #159.

## Why

The SoT in `datanika/services/agent_tiers.py` was moved to 8 capabilities when #150 (closing #131) added the `Bulk Import` capability under Tier 2 (`POST /api/v1/import`). `tests/test_services/test_agent_tiers.py::test_current_capability_count_is_eight` already pins `capability_count() == 8`, so unit tests are green — only the smoke harness (which hits the live API) was stale.

## Cross-repo pair

Paired with **datanika-landing#180** which refreshes the build-time fallback snapshot (`src/data/agent-tiers.fallback.json`) in the same shape. Both need to land together so the prod smoke run against the live API stays green.

## Test plan

- [x] Core precheck green (1864 passing)
- [x] Existing `test_current_capability_count_is_eight` unit test is unaffected (smoke script is not under `tests/`)
- [ ] Post-promotion: smoke run against `app.datanika.io/api/v1/meta/agent-tiers` returns `capability_count: 8` once core#150 + this PR promote together