### PR TITLE
[Infra] Clean literal backticks/angle brackets from Grafana alert annotations

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -213,7 +213,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "Container {{ $labels.name }} memory > 1.5GB"
+          summary: "Container {{ $labels.name }} memory over 1.5GB"
           description: "Container {{ $labels.name }} is using more than 1.5GB of memory."
 
   - orgId: 1
@@ -580,7 +580,7 @@ groups:
           team: revenue
         annotations:
           summary: "No Paddle webhooks processed in 35+ days"
-          description: "Latest subscriptions.updated_at is older than 840 hours (35 days) while active/trialing/past_due subscriptions exist. A full monthly billing cycle should have produced at least one subscription.updated or transaction.completed event. Check the webhook handler logs (`docker logs datanika-app | grep webhook`), Paddle dashboard → Notifications → Webhooks for delivery errors, and `PADDLE_WEBHOOK_SECRET` in .env.docker. Note: threshold is coarse because `subscriptions.renews_at` is not currently populated — once it is, switch this rule to a missed-renewal query with a 12h grace."
+          description: "Latest subscriptions.updated_at is older than 840 hours (35 days) while active/trialing/past_due subscriptions exist. A full monthly billing cycle should have produced at least one subscription.updated or transaction.completed event. Check the webhook handler logs on datanika-app for webhook errors, Paddle dashboard → Notifications → Webhooks for delivery errors, and the PADDLE_WEBHOOK_SECRET value in .env.docker. Note: threshold is coarse because subscriptions.renews_at is not currently populated — once it is, switch this rule to a missed-renewal query with a 12h grace."
 
       # --- Stuck past_due subscription ---
       # A subscription in past_due for > 72h should have transitioned to either
@@ -641,8 +641,8 @@ groups:
           severity: critical
           team: revenue
         annotations:
-          summary: "Subscription stuck in past_due > 72h"
-          description: "One or more subscriptions have been in past_due for longer than 72 hours. Paddle's dunning cycle should resolve within 72h — either a follow-up webhook was dropped or the handler failed on it. Inspect: `SELECT id, paddle_subscription_id, updated_at FROM subscriptions WHERE status = 'past_due' AND updated_at < NOW() - INTERVAL '72 hours';`. Cross-check the Paddle dashboard for the corresponding subscription state."
+          summary: "Subscription stuck in past_due for over 72h"
+          description: "One or more subscriptions have been in past_due for longer than 72 hours. Paddle's dunning cycle should resolve within 72h — either a follow-up webhook was dropped or the handler failed on it. Inspect: SELECT id, paddle_subscription_id, updated_at FROM subscriptions WHERE status = 'past_due' AND updated_at older than 72 hours. Cross-check the Paddle dashboard for the corresponding subscription state. Full query in monitoring/grafana/provisioning/alerting/alerts.yml."
 
       # --- MRR drop week-over-week ---
       # Business-anomaly detection. Compares today's MRR (sum of monthly-equiv
@@ -733,4 +733,4 @@ groups:
           team: revenue
         annotations:
           summary: "MRR dropped more than 10% week-over-week"
-          description: "Current MRR is more than 10% below the week-ago baseline. Check the Revenue Metrics dashboard (Datanika Cloud → Revenue Metrics) for which plan tier moved. Likely causes: batch of cancellations landed, high-ARPU customer downgraded, or the MRR query is reading a stale snapshot. Compare the current_mrr vs last_week_mrr CTEs in `monitoring/grafana/provisioning/alerting/alerts.yml`."
+          description: "Current MRR is more than 10% below the week-ago baseline. Check the Revenue Metrics dashboard (Datanika Cloud → Revenue Metrics) for which plan tier moved. Likely causes: batch of cancellations landed, high-ARPU customer downgraded, or the MRR query is reading a stale snapshot. Compare the current_mrr vs last_week_mrr CTEs in the alerts.yml file."


### PR DESCRIPTION
## Summary

Grafana alerting templates re-evaluate annotation strings before dispatch to notifiers. Literal backticks, \`<\`, \`>\` collide with Telegram's Markdown escape pass + Go-template re-eval, producing silently-malformed alerts (or in the worst case, alerts that fail to render and go to devnull).

The 2026-04-15 AM synthetic-fire exercise surfaced the pattern. This PR cleans the remaining occurrences in annotation blocks (\`summary:\` / \`description:\`). Alert expressions (\`expr:\`) and comments keep their SQL/syntax untouched — they're not re-evaluated.

## Spots cleaned (this + prior-stash work)

| Line | Field | Before | After |
|------|-------|--------|-------|
| 216 | \`summary\` | \`memory > 1.5GB\` | \`memory over 1.5GB\` |
| 644 | \`summary\` | \`past_due > 72h\` | \`past_due for over 72h\` |
| 645 | \`description\` | Backtick-wrapped SQL with \`<\` | Plain-text SQL hint, no angle brackets |
| 583 | \`description\` | 3 backtick spans (docker logs cmd, \`PADDLE_WEBHOOK_SECRET\`, \`subscriptions.renews_at\`) | Plain prose |
| 736 | \`description\` | Backtick-wrapped file path | Plain-text reference (\`the alerts.yml file\`) |

## Verification

- \`yaml.safe_load\` parses cleanly; 5 alert groups intact.
- Scanner on \`annotations:\` blocks reports **0 remaining hits** for \`[\`\`<>]\`.

## Related

- AM #148 sweep shipped the revenue alerts that these annotations belong to.
- Future: I2 revenue-alerts synthetic-fire DoD (still pending user go-ahead, blocked on prod DB UPDATE window) — that exercise would exercise these exact paths end-to-end through Telegram.