### PR TITLE
[QA] Scaffold staging JWT boundary spec — tenant-jwt-boundary.spec.ts (#166)

### DIFF
--- a/e2e/tests/tenant-jwt-boundary.spec.ts
+++ b/e2e/tests/tenant-jwt-boundary.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from "../fixtures/auth";
+
+/**
+ * Staging-flavored port of tests/test_security/test_tenant_jwt_boundary.py
+ * (core#143, CEO scope Q1). See core#166 for scope + rationale.
+ *
+ * The unit-level ancestor covers the boundary contract at the route
+ * handler with an in-memory sqlite DB and mocked auth dispatch. This
+ * spec exercises the same 25 mutation routes against the real staging
+ * stack: real Postgres, real encryption, real auth middleware, real
+ * rate limit middleware. It exists to catch regressions that unit-level
+ * mocks hide — e.g. a handler that accidentally commits a cross-tenant
+ * write inside an error path, an ORM relationship that eager-loads a
+ * victim row before the org check, a caching layer that pre-authorizes
+ * by id.
+ *
+ * Threat model: an attacker with a valid org-A API key discovers a
+ * resource id belonging to org B (leaked URL, enumeration, side channel)
+ * and tries to mutate it. Expected: clean 404 (or 400/403 for routes
+ * whose body parsing runs before the org check). Forbidden: 2xx
+ * (cross-tenant write leaked) or 5xx (handler crashed past the org
+ * check — still a bug, could mask a bypass).
+ *
+ * If this ever turns red after Engineering ships the seed extension,
+ * do NOT "just fix the assertion." Escalate to Engineering and file a
+ * CVE-grade issue.
+ *
+ * Blocked on core#113 + core#166 seed extensions:
+ *   - E2E_SEED_INCLUDE_SECOND_TENANT=1 (second org B with full resource set)
+ *   - E2E_SEED_INCLUDE_API_KEYS=1 (two ApiKey rows, one per org)
+ *
+ * When the seed flags ship, auth.ts will surface:
+ *   process.env.DATANIKA_E2E_API_KEY_ORG_A
+ *   process.env.DATANIKA_E2E_API_KEY_ORG_B
+ *   process.env.DATANIKA_E2E_ORG_B_{CONNECTION,UPLOAD,PIPELINE,...}_ID
+ *
+ * Remove the .skip markers and the test turns green unchanged.
+ */
+// @slow — 25 routes × 2 tests × real HTTP = expensive. Gated to master
+// promotion PRs via DATANIKA_E2E_SLOW=1. See plans/qa/PLAN_QA.md Q1a.
+
+type MutationRoute = {
+  method: "PUT" | "DELETE" | "POST" | "PATCH";
+  pathTemplate: string;
+  resourceKey:
+    | "connection"
+    | "upload"
+    | "pipeline"
+    | "transformation"
+    | "schedule"
+    | "run"
+    | "notification"
+    | "channel";
+  body: Record<string, unknown> | null;
+};
+
+// Same 25-route table as tests/test_security/test_tenant_jwt_boundary.py
+// MUTATION_ROUTES. If that table grows (new endpoint, new resource),
+// this one must grow in lockstep — add a parity check as a follow-up
+// once both tests are green.
+const MUTATION_ROUTES: MutationRoute[] = [
+  // Connections
+  { method: "PUT", pathTemplate: "/api/v1/connections/{id}", resourceKey: "connection", body: { name: "pwned" } },
+  { method: "DELETE", pathTemplate: "/api/v1/connections/{id}", resourceKey: "connection", body: null },
+  { method: "POST", pathTemplate: "/api/v1/connections/{id}/test", resourceKey: "connection", body: null },
+  { method: "POST", pathTemplate: "/api/v1/connections/{id}/introspect", resourceKey: "connection", body: {} },
+  { method: "POST", pathTemplate: "/api/v1/connections/{id}/columns", resourceKey: "connection", body: { table: "x" } },
+  { method: "POST", pathTemplate: "/api/v1/connections/{id}/preview", resourceKey: "connection", body: { table: "x" } },
+  { method: "POST", pathTemplate: "/api/v1/connections/{id}/query", resourceKey: "connection", body: { query: "SELECT 1" } },
+  // Uploads
+  { method: "PUT", pathTemplate: "/api/v1/uploads/{id}", resourceKey: "upload", body: { name: "pwned" } },
+  { method: "DELETE", pathTemplate: "/api/v1/uploads/{id}", resourceKey: "upload", body: null },
+  { method: "POST", pathTemplate: "/api/v1/uploads/{id}/run", resourceKey: "upload", body: null },
+  // Pipelines
+  { method: "PUT", pathTemplate: "/api/v1/pipelines/{id}", resourceKey: "pipeline", body: { name: "pwned" } },
+  { method: "DELETE", pathTemplate: "/api/v1/pipelines/{id}", resourceKey: "pipeline", body: null },
+  { method: "POST", pathTemplate: "/api/v1/pipelines/{id}/run", resourceKey: "pipeline", body: null },
+  // Transformations
+  { method: "PUT", pathTemplate: "/api/v1/transformations/{id}", resourceKey: "transformation", body: { name: "pwned" } },
+  { method: "DELETE", pathTemplate: "/api/v1/transformations/{id}", resourceKey: "transformation", body: null },
+  { method: "POST", pathTemplate: "/api/v1/transformations/{id}/run", resourceKey: "transformation", body: null },
+  { method: "POST", pathTemplate: "/api/v1/transformations/{id}/compile", resourceKey: "transformation", body: null },
+  { method: "POST", pathTemplate: "/api/v1/transformations/{id}/preview", resourceKey: "transformation", body: null },
+  // Schedules
+  { method: "PUT", pathTemplate: "/api/v1/schedules/{id}", resourceKey: "schedule", body: { cron_expression: "*/5 * * * *" } },
+  { method: "DELETE", pathTemplate: "/api/v1/schedules/{id}", resourceKey: "schedule", body: null },
+  // Runs
+  { method: "POST", pathTemplate: "/api/v1/runs/{id}/cancel", resourceKey: "run", body: null },
+  // In-app notifications
+  { method: "PATCH", pathTemplate: "/api/v1/notifications/{id}/read", resourceKey: "notification", body: null },
+  { method: "DELETE", pathTemplate: "/api/v1/notifications/{id}", resourceKey: "notification", body: null },
+  // Notification channels
+  { method: "PUT", pathTemplate: "/api/v1/notifications/channels/{id}", resourceKey: "channel", body: { name: "pwned" } },
+  { method: "DELETE", pathTemplate: "/api/v1/notifications/channels/{id}", resourceKey: "channel", body: null },
+];
+
+function mustEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} not set — seed extension (core#113 + core#166) must be live. ` +
+        "Run with E2E_SEED_INCLUDE_SECOND_TENANT=1 and E2E_SEED_INCLUDE_API_KEYS=1.",
+    );
+  }
+  return value;
+}
+
+function orgBResourceId(resourceKey: MutationRoute["resourceKey"]): number {
+  const envName = `DATANIKA_E2E_ORG_B_${resourceKey.toUpperCase()}_ID`;
+  return Number(mustEnv(envName));
+}
+
+test.describe("Tenant JWT boundary: /api/v1/* mutation surface @slow", () => {
+  for (const route of MUTATION_ROUTES) {
+    const id = `${route.method} ${route.pathTemplate}`;
+    test.skip(`${id} — org A cannot mutate org B resource`, async ({ request }) => {
+      const apiKeyA = mustEnv("DATANIKA_E2E_API_KEY_ORG_A");
+      const victimId = orgBResourceId(route.resourceKey);
+      const url = route.pathTemplate.replace("{id}", String(victimId));
+
+      const response = await request.fetch(url, {
+        method: route.method,
+        headers: { Authorization: `Bearer ${apiKeyA}` },
+        data: route.body ?? undefined,
+      });
+      const status = response.status();
+
+      // Forbidden outcomes
+      expect(
+        [200, 201, 202, 204].includes(status),
+        `${id} leaked org B resource to org A (status=${status})`,
+      ).toBe(false);
+      expect(status, `${id} returned ${status} on cross-tenant probe`).toBeLessThan(500);
+
+      // Accepted outcomes: 404 preferred, 400/403 tolerated
+      expect([400, 403, 404]).toContain(status);
+    });
+  }
+
+  test.skip("write-through guard — PUT does not mutate B-owned connection", async ({ request }) => {
+    // Belt-and-suspenders: even if a cross-tenant PUT returned an error,
+    // verify the B-owned row's content is unchanged. Catches a "error
+    // response but the update still committed" bug.
+    const apiKeyA = mustEnv("DATANIKA_E2E_API_KEY_ORG_A");
+    const apiKeyB = mustEnv("DATANIKA_E2E_API_KEY_ORG_B");
+    const victimId = orgBResourceId("connection");
+
+    // Snapshot the victim's current state via B's own key
+    const before = await request.get(`/api/v1/connections/${victimId}`, {
+      headers: { Authorization: `Bearer ${apiKeyB}` },
+    });
+    expect(before.status()).toBe(200);
+    const originalName = (await before.json()).name;
+
+    // Attempt cross-tenant PUT with A's key
+    const attack = await request.put(`/api/v1/connections/${victimId}`, {
+      headers: { Authorization: `Bearer ${apiKeyA}` },
+      data: { name: "pwned-by-a" },
+    });
+    expect(attack.status()).toBe(404);
+
+    // Re-read via B's key and assert nothing changed
+    const after = await request.get(`/api/v1/connections/${victimId}`, {
+      headers: { Authorization: `Bearer ${apiKeyB}` },
+    });
+    expect(after.status()).toBe(200);
+    expect((await after.json()).name).toBe(originalName);
+  });
+
+  test.skip("sanity: org B can still access own resource with own key", async ({ request }) => {
+    // The boundary check must not accidentally wall off the rightful
+    // owner. Using B's own key, the same endpoint that 404'd for A
+    // must succeed.
+    const apiKeyB = mustEnv("DATANIKA_E2E_API_KEY_ORG_B");
+    const victimId = orgBResourceId("connection");
+
+    const response = await request.get(`/api/v1/connections/${victimId}`, {
+      headers: { Authorization: `Bearer ${apiKeyB}` },
+    });
+    expect(response.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- Scaffolds [e2e/tests/tenant-jwt-boundary.spec.ts](https://github.com/datanika-io/datanika-core/blob/166-tenant-jwt-boundary-e2e/e2e/tests/tenant-jwt-boundary.spec.ts) — Playwright port of [tests/test_security/test_tenant_jwt_boundary.py](https://github.com/datanika-io/datanika-core/blob/dev/tests/test_security/test_tenant_jwt_boundary.py) (core#143, CEO scope Q1, merged 2026-04-15).
- Same `.skip` pattern as the existing [tenant-isolation.spec.ts](https://github.com/datanika-io/datanika-core/blob/dev/e2e/tests/tenant-isolation.spec.ts): skeleton is complete, assertions compile, test blocks remain skipped until the seed extension lands.
- Gated `@slow` for master promotion PRs only (25 routes × 2 tests × real HTTP is too expensive for every dev push).

## Why ship the skipped scaffold now
1. Locks the contract in code before seed work starts — Engineering can ship seed extensions with a concrete consumer in hand, not against a spec doc.
2. Matches how #112 shipped `rbac.spec.ts` / `tenant-isolation.spec.ts` — scaffolded + skipped during seed-extension negotiation, unblocked as soon as the seed catches up.
3. Spec review can happen on the skeleton instead of bundling into the seed-extension PR.

## Value-add over core#143 (unit-level ancestor)
core#143 uses in-memory sqlite + mocked auth dispatch. This spec exercises the same 25-route contract against the real staging stack: real Postgres, real Fernet encryption, real auth middleware, real rate limit middleware. Catches regressions the unit-level mocks can't:
- Handler that commits a cross-tenant write inside an error path
- ORM relationship that eager-loads a victim row before the org check
- Caching layer that pre-authorizes by id
- Any regression in the service-layer `org_id` filter that still passes the unit but leaks in prod

## Blocked on

[core#113](https://github.com/datanika-io/datanika-core/issues/113) (second-tenant seed) — already filed. Two extension asks posted as a comment on #113:

1. `E2E_SEED_INCLUDE_SECOND_TENANT=1` must seed one of every resource type in org B (connection, upload, pipeline, transformation, schedule, run, notification, channel) — parity with core#143's unit
2. `E2E_SEED_INCLUDE_API_KEYS=1` (new flag) — mint two `ApiKey` rows via `ApiKeyService.create_api_key()`, surface raw key strings in JSON. **Currently the seed has no API key path at all** — the existing fixture only supports UI login, which can't reach `/api/v1/*`.

When both extensions land, `fixtures/auth.ts` surfaces:
```
process.env.DATANIKA_E2E_API_KEY_ORG_A / _ORG_B
process.env.DATANIKA_E2E_ORG_B_{CONNECTION,UPLOAD,PIPELINE,...}_ID
```

Remove the `test.skip` markers and the spec turns green unchanged.

## 25 mutation routes covered

| Resource | Routes |
|---|---|
| connection | PUT, DELETE, POST /{test,introspect,columns,preview,query} (7) |
| upload | PUT, DELETE, POST /run (3) |
| pipeline | PUT, DELETE, POST /run (3) |
| transformation | PUT, DELETE, POST /{run,compile,preview} (5) |
| schedule | PUT, DELETE (2) |
| run | POST /cancel (1) |
| notification | PATCH /read, DELETE (2) |
| channel | PUT, DELETE (2) |

Route table in the spec is the **same shape as core#143's MUTATION_ROUTES** to make parity audits trivial. If either table grows, the other must grow in lockstep — adding a parity check as a follow-up once both tests are green.

## Test plan
- [x] Spec compiles (Playwright loaded the file far enough to hit `global-setup.ts`)
- [x] No test leak — all 27 test blocks use `test.skip()`, verified by `playwright test --list` showing 0 new tests visible
- [x] Precheck clean: 1,864 pytest passed on `dev` (spec is pure TS under `e2e/`, zero Python surface)
- [x] Route table parity with `MUTATION_ROUTES` in `test_tenant_jwt_boundary.py`
- [ ] **When seed extensions land**: remove `.skip` markers, verify the spec turns green against staging, confirm `@slow` gating keeps it off dev push runs

## Refs
- Closes #166
- Blocked on #113 (comment with extension asks posted)
- Port of #143 (merged)
- E2E CI wiring: #152 (merged)