### PR TITLE
Wrap auth form inputs in <label> for a11y + e2e selector parity

### DIFF
--- a/datanika/ui/pages/login.py
+++ b/datanika/ui/pages/login.py
@@ -32,14 +32,22 @@ def login_page() -> rx.Component:
             ),
             rx.form(
                 rx.vstack(
-                    rx.text(_t["auth.email"], size="2", weight="medium"),
+                    rx.el.label(
+                        rx.text(_t["auth.email"], size="2", weight="medium"),
+                        html_for="login-email",
+                    ),
                     rx.input(
+                        id="login-email",
                         placeholder=_t["auth.ph_email"],
                         name="email",
                         width="100%",
                     ),
-                    rx.text(_t["auth.password"], size="2", weight="medium"),
+                    rx.el.label(
+                        rx.text(_t["auth.password"], size="2", weight="medium"),
+                        html_for="login-password",
+                    ),
                     rx.input(
+                        id="login-password",
                         placeholder=_t["auth.ph_password"],
                         name="password",
                         type="password",

--- a/datanika/ui/pages/signup.py
+++ b/datanika/ui/pages/signup.py
@@ -30,21 +30,33 @@ def signup_page() -> rx.Component:
             ),
             rx.form(
                 rx.vstack(
-                    rx.text(_t["auth.full_name"], size="2", weight="medium"),
+                    rx.el.label(
+                        rx.text(_t["auth.full_name"], size="2", weight="medium"),
+                        html_for="signup-full-name",
+                    ),
                     rx.input(
+                        id="signup-full-name",
                         placeholder=_t["auth.ph_full_name"],
                         name="full_name",
                         width="100%",
                     ),
-                    rx.text(_t["auth.email"], size="2", weight="medium"),
+                    rx.el.label(
+                        rx.text(_t["auth.email"], size="2", weight="medium"),
+                        html_for="signup-email",
+                    ),
                     rx.input(
+                        id="signup-email",
                         placeholder=_t["auth.ph_email"],
                         name="email",
                         default_value=AuthState.invite_email,
                         width="100%",
                     ),
-                    rx.text(_t["auth.password"], size="2", weight="medium"),
+                    rx.el.label(
+                        rx.text(_t["auth.password"], size="2", weight="medium"),
+                        html_for="signup-password",
+                    ),
                     rx.input(
+                        id="signup-password",
                         placeholder=_t["auth.ph_password"],
                         name="password",
                         type="password",


### PR DESCRIPTION
## Summary

- `ui/pages/login.py` and `ui/pages/signup.py` rendered field captions as sibling `rx.text` + `rx.input` pairs with no label/input association. That broke screen-reader field pairing (WCAG 1.3.1 / 4.1.2) and Playwright's `getByLabel()` — which walks `<label>` / `aria-label` / `aria-labelledby`, **not** placeholders or adjacent text siblings.
- Wrap each caption in `rx.el.label(html_for=...)` and add a matching `id=` on the paired `rx.input`. Inner `rx.text(size="2", weight="medium")` kept verbatim so Radix visual styling is preserved.
- IDs: `login-email`, `login-password`, `signup-full-name`, `signup-email`, `signup-password`.

## Scope

- 2 files only: `datanika/ui/pages/login.py` (email + password = 2 inputs), `datanika/ui/pages/signup.py` (full_name + email + password = 3 inputs).
- No i18n key changes — `auth.email`, `auth.password`, `auth.full_name`, `auth.ph_*` all unchanged.
- `rx.el.label` wraps the existing `rx.text` rather than replacing it, so Radix `size="2" weight="medium"` still drives the visual. `<label>` becomes a flex item in the surrounding `rx.vstack`, which blockifies it — same vertical flow as before.

## Why this unblocks QA Q4b

QA's Playwright specs currently fail on the 3 tests below because `page.getByLabel(/email/i)` finds no match:

- `oauth-template-param--email-signup`
- `template-prefill-Pipeline--*` (×2)

Once this lands on dev, a re-run should flip all three green.

## Test plan

- [x] `bash plans/precheck.sh worktrees/datanika-core-engineering` → 1864 passed
- [ ] QA re-runs the 3 listed Playwright specs against dev → expect green
- [ ] Visual parity on `/login` and `/signup` via `uv run reflex run` (human spot-check — mechanical edit + precheck passes, but browser-level confirmation is QA's to do before promotion)

Closes #167 on merge-to-dev.