### PR TITLE
[Engineering] core#113: extend E2E seed with org B + viewer + optional api keys

### DIFF
--- a/datanika/scripts/e2e_seed.py
+++ b/datanika/scripts/e2e_seed.py
@@ -2,11 +2,13 @@
 
 Creates a clean org + owner user + DuckDB connection that the Playwright
 harness can log into without knowing anything about the runtime state.
+Also seeds a second tenant (org B) with one-of-every-resource-type and a
+viewer-role membership in org A for RBAC + tenant-isolation tests.
 
 Re-running is idempotent: if the fixture already exists in the configured
 state, the script exits 0 without raising. If data has drifted (different
-email, different slug, leftover extra rows in the fixture org), the script
-tears the fixture org down and recreates it.
+email, different slug, leftover extra rows in either fixture org), the
+script tears both fixture orgs down and recreates them.
 
 Emits the fixture as a JSON payload on stdout so Playwright / CI can
 capture it with:
@@ -14,12 +16,16 @@ capture it with:
     uv run python -m datanika.scripts.e2e_seed > .e2e-fixture.json
 
 Safety:
-- Targets ONLY the fixture org (slug `e2e-fixture`) and the fixture user
-  (email `e2e@datanika.test`). Never touches anything else.
+- Targets ONLY the fixture orgs (slugs ``e2e-fixture`` / ``e2e-fixture-b``)
+  and the three fixture users. Never touches anything else.
 - Refuses to run if DATABASE_URL looks like a production host. Override
-  with `E2E_SEED_ALLOW_ANY_HOST=1` for CI runs against ephemeral stacks.
+  with ``E2E_SEED_ALLOW_ANY_HOST=1`` for CI runs against ephemeral stacks.
+- API key creation is opt-in via ``E2E_SEED_INCLUDE_API_KEYS=1`` — off by
+  default so most test runs don't touch the api_keys table at all. When
+  on, mints two keys (one per org) and returns the plaintext in the JSON
+  payload; the raw key is never recoverable after this.
 - Uses the existing sync engine. No schema migrations — assumes
-  `alembic upgrade head` already ran.
+  ``alembic upgrade head`` already ran.
 """
 
 from __future__ import annotations
@@ -37,8 +43,15 @@ from sqlalchemy.orm import Session
 
 from datanika.config import settings
 from datanika.db import get_sync_session
+from datanika.models.api_key import ApiKey
 from datanika.models.connection import Connection, ConnectionType
+from datanika.models.dependency import NodeType
+from datanika.models.pipeline import DbtCommand, Pipeline
+from datanika.models.schedule import Schedule
+from datanika.models.transformation import Materialization, Transformation
+from datanika.models.upload import Upload
 from datanika.models.user import MemberRole, Membership, Organization, User
+from datanika.services.api_key_service import ApiKeyService
 from datanika.services.auth import AuthService
 from datanika.services.connection_service import ConnectionService, infer_direction
 from datanika.services.encryption import EncryptionService
@@ -54,11 +67,35 @@ FIXTURE_CONNECTION_NAME = "e2e_duckdb_fixture"
 # don't trip over a hardcoded /tmp/ that doesn't exist.
 FIXTURE_DUCKDB_PATH = str(Path(tempfile.gettempdir()) / "e2e_fixture.duckdb")
 
+# Second user in org A with VIEWER role — for RBAC tests (viewer can read
+# but not mutate). Same password as the primary user for harness simplicity.
+FIXTURE_VIEWER_USER_EMAIL = "e2e-viewer@datanika.test"
+FIXTURE_VIEWER_USER_NAME = "E2E Fixture Viewer"
+FIXTURE_VIEWER_USER_PASSWORD = "e2e-fixture-password-not-a-secret"  # noqa: S105
+
+# Org B — second tenant with one of every resource type, and a dedicated
+# owner user so tenant-isolation tests have a clean "user in A only" vs
+# "user in B only" boundary (no shared user across tenants).
+FIXTURE_ORG_B_SLUG = "e2e-fixture-b"
+FIXTURE_ORG_B_NAME = "E2E Fixture Org B"
+FIXTURE_ORG_B_USER_EMAIL = "e2e-org-b@datanika.test"
+FIXTURE_ORG_B_USER_NAME = "E2E Fixture Org B Owner"
+FIXTURE_ORG_B_USER_PASSWORD = "e2e-fixture-password-not-a-secret"  # noqa: S105
+FIXTURE_ORG_B_CONNECTION_NAME = "e2e_duckdb_fixture_b"
+FIXTURE_ORG_B_UPLOAD_NAME = "e2e_upload_b"
+FIXTURE_ORG_B_PIPELINE_NAME = "e2e_pipeline_b"
+FIXTURE_ORG_B_TRANSFORMATION_NAME = "e2e_transformation_b"
+FIXTURE_ORG_B_DUCKDB_PATH = str(Path(tempfile.gettempdir()) / "e2e_fixture_b.duckdb")
+
+FIXTURE_API_KEY_NAME_A = "e2e-fixture-api-key-a"
+FIXTURE_API_KEY_NAME_B = "e2e-fixture-api-key-b"
+
 PROD_HOST_MARKERS = ("datanika.io", "app.datanika.io", "prod", "production")
 
 
 @dataclass
 class SeedResult:
+    # Primary org A fixture (back-compat — Playwright has hardcoded these).
     org_id: int
     org_slug: str
     user_id: int
@@ -71,6 +108,31 @@ class SeedResult:
     # JSON contract with Playwright: the harness uses this to detect
     # stale `.e2e-fixture.json` artifacts across CI runs.
     seeded_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    # Viewer-role membership in org A (RBAC tests).
+    viewer_user_id: int = 0
+    viewer_user_email: str = ""
+    viewer_user_password: str = ""
+
+    # Org B — one of every resource type for tenant-isolation tests
+    # (core#168 tenant-jwt-boundary spec + Q1a). Dedicated owner user.
+    org_b_id: int = 0
+    org_b_slug: str = ""
+    org_b_user_id: int = 0
+    org_b_user_email: str = ""
+    org_b_user_password: str = ""
+    org_b_connection_id: int = 0
+    org_b_upload_id: int = 0
+    org_b_pipeline_id: int = 0
+    org_b_transformation_id: int = 0
+    org_b_schedule_id: int = 0
+
+    # API keys — gated by ``E2E_SEED_INCLUDE_API_KEYS=1``. Sentinel values
+    # (0 / "") when the flag is off so the JSON shape stays stable.
+    org_a_api_key_id: int = 0
+    org_a_api_key_plaintext: str = ""
+    org_b_api_key_id: int = 0
+    org_b_api_key_plaintext: str = ""
 
 
 class UnsafeTargetError(RuntimeError):
@@ -90,24 +152,47 @@ def _assert_safe_target() -> None:
 
 
 def _tear_down_fixture(session: Session) -> None:
-    """Hard-delete the fixture org and everything scoped to it.
+    """Hard-delete both fixture orgs and everything scoped to them.
 
-    Only touches rows that belong to the fixture org or user by the
-    deterministic markers above. Never uses raw DELETE across tables.
+    Only touches rows that belong to a fixture org or fixture user by the
+    deterministic markers at the top of this module. Never uses raw DELETE
+    across tables.
+
+    FK-safe ordering: children before parents, with api_keys cleared before
+    the users they reference.
     """
-    org = session.execute(
-        select(Organization).where(Organization.slug == FIXTURE_ORG_SLUG)
-    ).scalar_one_or_none()
-    if org is not None:
-        session.execute(Connection.__table__.delete().where(Connection.org_id == org.id))
-        session.execute(Membership.__table__.delete().where(Membership.org_id == org.id))
-        session.execute(Organization.__table__.delete().where(Organization.id == org.id))
-    user = session.execute(
-        select(User).where(User.email == FIXTURE_USER_EMAIL)
-    ).scalar_one_or_none()
-    if user is not None:
-        session.execute(Membership.__table__.delete().where(Membership.user_id == user.id))
-        session.execute(User.__table__.delete().where(User.id == user.id))
+    fixture_org_slugs = (FIXTURE_ORG_SLUG, FIXTURE_ORG_B_SLUG)
+    fixture_user_emails = (
+        FIXTURE_USER_EMAIL,
+        FIXTURE_VIEWER_USER_EMAIL,
+        FIXTURE_ORG_B_USER_EMAIL,
+    )
+
+    orgs = list(
+        session.execute(
+            select(Organization).where(Organization.slug.in_(fixture_org_slugs))
+        ).scalars()
+    )
+    org_ids = [o.id for o in orgs]
+
+    if org_ids:
+        # Resources with no FK dependents — delete first so nothing else
+        # references their rows.
+        session.execute(Schedule.__table__.delete().where(Schedule.org_id.in_(org_ids)))
+        session.execute(Upload.__table__.delete().where(Upload.org_id.in_(org_ids)))
+        session.execute(Pipeline.__table__.delete().where(Pipeline.org_id.in_(org_ids)))
+        session.execute(Transformation.__table__.delete().where(Transformation.org_id.in_(org_ids)))
+        session.execute(ApiKey.__table__.delete().where(ApiKey.org_id.in_(org_ids)))
+        session.execute(Connection.__table__.delete().where(Connection.org_id.in_(org_ids)))
+        session.execute(Membership.__table__.delete().where(Membership.org_id.in_(org_ids)))
+        session.execute(Organization.__table__.delete().where(Organization.id.in_(org_ids)))
+
+    users = list(session.execute(select(User).where(User.email.in_(fixture_user_emails))).scalars())
+    user_ids = [u.id for u in users]
+    if user_ids:
+        session.execute(ApiKey.__table__.delete().where(ApiKey.user_id.in_(user_ids)))
+        session.execute(Membership.__table__.delete().where(Membership.user_id.in_(user_ids)))
+        session.execute(User.__table__.delete().where(User.id.in_(user_ids)))
     session.flush()
 
 
@@ -116,6 +201,7 @@ def _build_fixture(session: Session) -> SeedResult:
     encryption = EncryptionService(settings.credential_encryption_key)
     connection_service = ConnectionService(encryption)
 
+    # --- Org A: primary tenant (owner + viewer + one connection) ---
     user = User(
         email=FIXTURE_USER_EMAIL,
         password_hash=auth.hash_password(FIXTURE_USER_PASSWORD),
@@ -126,11 +212,22 @@ def _build_fixture(session: Session) -> SeedResult:
     session.add(user)
     session.flush()
 
+    viewer_user = User(
+        email=FIXTURE_VIEWER_USER_EMAIL,
+        password_hash=auth.hash_password(FIXTURE_VIEWER_USER_PASSWORD),
+        full_name=FIXTURE_VIEWER_USER_NAME,
+        is_active=True,
+        email_verified=True,
+    )
+    session.add(viewer_user)
+    session.flush()
+
     org = Organization(name=FIXTURE_ORG_NAME, slug=FIXTURE_ORG_SLUG)
     session.add(org)
     session.flush()
 
     session.add(Membership(user_id=user.id, org_id=org.id, role=MemberRole.OWNER))
+    session.add(Membership(user_id=viewer_user.id, org_id=org.id, role=MemberRole.VIEWER))
     session.flush()
 
     connection = Connection(
@@ -143,6 +240,102 @@ def _build_fixture(session: Session) -> SeedResult:
     session.add(connection)
     session.flush()
 
+    # --- Org B: second tenant with one of every resource type ---
+    org_b_user = User(
+        email=FIXTURE_ORG_B_USER_EMAIL,
+        password_hash=auth.hash_password(FIXTURE_ORG_B_USER_PASSWORD),
+        full_name=FIXTURE_ORG_B_USER_NAME,
+        is_active=True,
+        email_verified=True,
+    )
+    session.add(org_b_user)
+    session.flush()
+
+    org_b = Organization(name=FIXTURE_ORG_B_NAME, slug=FIXTURE_ORG_B_SLUG)
+    session.add(org_b)
+    session.flush()
+
+    session.add(Membership(user_id=org_b_user.id, org_id=org_b.id, role=MemberRole.OWNER))
+    session.flush()
+
+    org_b_connection = Connection(
+        org_id=org_b.id,
+        name=FIXTURE_ORG_B_CONNECTION_NAME,
+        connection_type=ConnectionType.DUCKDB,
+        direction=infer_direction(ConnectionType.DUCKDB),
+        config_encrypted=connection_service._encryption.encrypt(
+            {"path": FIXTURE_ORG_B_DUCKDB_PATH}
+        ),
+    )
+    session.add(org_b_connection)
+    session.flush()
+
+    org_b_upload = Upload(
+        org_id=org_b.id,
+        name=FIXTURE_ORG_B_UPLOAD_NAME,
+        source_connection_id=org_b_connection.id,
+        destination_connection_id=org_b_connection.id,
+        dlt_config={},
+    )
+    session.add(org_b_upload)
+    session.flush()
+
+    org_b_pipeline = Pipeline(
+        org_id=org_b.id,
+        name=FIXTURE_ORG_B_PIPELINE_NAME,
+        destination_connection_id=org_b_connection.id,
+        command=DbtCommand.RUN,
+        models=[],
+    )
+    session.add(org_b_pipeline)
+    session.flush()
+
+    org_b_transformation = Transformation(
+        org_id=org_b.id,
+        name=FIXTURE_ORG_B_TRANSFORMATION_NAME,
+        sql_body="SELECT 1 AS value",
+        materialization=Materialization.VIEW,
+        schema_name="staging",
+        destination_connection_id=org_b_connection.id,
+    )
+    session.add(org_b_transformation)
+    session.flush()
+
+    org_b_schedule = Schedule(
+        org_id=org_b.id,
+        target_type=NodeType.PIPELINE,
+        target_id=org_b_pipeline.id,
+        cron_expression="0 6 * * *",
+        timezone="UTC",
+        is_active=False,
+    )
+    session.add(org_b_schedule)
+    session.flush()
+
+    # --- Optional API keys (E2E_SEED_INCLUDE_API_KEYS=1) ---
+    api_key_a_id = 0
+    api_key_a_raw = ""
+    api_key_b_id = 0
+    api_key_b_raw = ""
+    if os.environ.get("E2E_SEED_INCLUDE_API_KEYS") == "1":
+        api_key_svc = ApiKeyService()
+        key_a, raw_a = api_key_svc.create_api_key(
+            session,
+            org_id=org.id,
+            user_id=user.id,
+            name=FIXTURE_API_KEY_NAME_A,
+        )
+        key_b, raw_b = api_key_svc.create_api_key(
+            session,
+            org_id=org_b.id,
+            user_id=org_b_user.id,
+            name=FIXTURE_API_KEY_NAME_B,
+        )
+        api_key_a_id = key_a.id
+        api_key_a_raw = raw_a
+        api_key_b_id = key_b.id
+        api_key_b_raw = raw_b
+
     return SeedResult(
         org_id=org.id,
         org_slug=org.slug,
@@ -152,6 +345,23 @@ def _build_fixture(session: Session) -> SeedResult:
         connection_id=connection.id,
         connection_name=connection.name,
         connection_type=ConnectionType.DUCKDB.value,
+        viewer_user_id=viewer_user.id,
+        viewer_user_email=viewer_user.email,
+        viewer_user_password=FIXTURE_VIEWER_USER_PASSWORD,
+        org_b_id=org_b.id,
+        org_b_slug=org_b.slug,
+        org_b_user_id=org_b_user.id,
+        org_b_user_email=org_b_user.email,
+        org_b_user_password=FIXTURE_ORG_B_USER_PASSWORD,
+        org_b_connection_id=org_b_connection.id,
+        org_b_upload_id=org_b_upload.id,
+        org_b_pipeline_id=org_b_pipeline.id,
+        org_b_transformation_id=org_b_transformation.id,
+        org_b_schedule_id=org_b_schedule.id,
+        org_a_api_key_id=api_key_a_id,
+        org_a_api_key_plaintext=api_key_a_raw,
+        org_b_api_key_id=api_key_b_id,
+        org_b_api_key_plaintext=api_key_b_raw,
     )
 
 

--- a/tests/test_scripts/test_e2e_seed.py
+++ b/tests/test_scripts/test_e2e_seed.py
@@ -7,14 +7,22 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import select
 
+from datanika.models.api_key import ApiKey
 from datanika.models.connection import Connection, ConnectionType
-from datanika.models.user import Membership, Organization, User
+from datanika.models.pipeline import Pipeline
+from datanika.models.schedule import Schedule
+from datanika.models.transformation import Transformation
+from datanika.models.upload import Upload
+from datanika.models.user import MemberRole, Membership, Organization, User
 from datanika.scripts import e2e_seed
 from datanika.scripts.e2e_seed import (
     FIXTURE_CONNECTION_NAME,
+    FIXTURE_ORG_B_SLUG,
+    FIXTURE_ORG_B_USER_EMAIL,
     FIXTURE_ORG_SLUG,
     FIXTURE_USER_EMAIL,
     FIXTURE_USER_PASSWORD,
+    FIXTURE_VIEWER_USER_EMAIL,
     SeedResult,
     UnsafeTargetError,
     _assert_safe_target,
@@ -53,8 +61,11 @@ def test_seed_creates_fixture_on_empty_db(db_session):
     memberships = list(
         db_session.execute(select(Membership).where(Membership.org_id == org.id)).scalars()
     )
-    assert len(memberships) == 1
-    assert memberships[0].user_id == user.id
+    # Org A has the primary owner + the viewer-role user.
+    assert len(memberships) == 2
+    owner_memberships = [m for m in memberships if m.user_id == user.id]
+    assert len(owner_memberships) == 1
+    assert owner_memberships[0].role == MemberRole.OWNER
 
     connections = list(
         db_session.execute(select(Connection).where(Connection.org_id == org.id)).scalars()
@@ -193,6 +204,7 @@ def test_seed_result_shape():
 
     names = {f.name for f in fields(SeedResult)}
     assert names == {
+        # Primary org A fixture (back-compat — Playwright has hardcoded these)
         "org_id",
         "org_slug",
         "user_id",
@@ -202,7 +214,214 @@ def test_seed_result_shape():
         "connection_name",
         "connection_type",
         "seeded_at",
+        # Org A viewer-role membership (for RBAC/permission tests)
+        "viewer_user_id",
+        "viewer_user_email",
+        "viewer_user_password",
+        # Org B — one-of-every-resource-type (for tenant-isolation tests,
+        # core#168 tenant-jwt-boundary spec + Q1a)
+        "org_b_id",
+        "org_b_slug",
+        "org_b_user_id",
+        "org_b_user_email",
+        "org_b_user_password",
+        "org_b_connection_id",
+        "org_b_upload_id",
+        "org_b_pipeline_id",
+        "org_b_transformation_id",
+        "org_b_schedule_id",
+        # API keys — only populated when E2E_SEED_INCLUDE_API_KEYS=1
+        "org_a_api_key_id",
+        "org_a_api_key_plaintext",
+        "org_b_api_key_id",
+        "org_b_api_key_plaintext",
     }
+
+
+def test_seed_creates_viewer_user_in_org_a(db_session):
+    """A second user with VIEWER role exists in org A for RBAC tests."""
+    result = seed(session=db_session)
+
+    viewer = db_session.execute(
+        select(User).where(User.email == FIXTURE_VIEWER_USER_EMAIL)
+    ).scalar_one()
+    assert viewer.is_active is True
+    assert viewer.email_verified is True
+    assert result.viewer_user_id == viewer.id
+    assert result.viewer_user_email == FIXTURE_VIEWER_USER_EMAIL
+    assert result.viewer_user_password  # non-empty
+    # Password is verifiable via the contract.
+    assert AuthService("test-secret").verify_password(
+        result.viewer_user_password, viewer.password_hash
+    )
+
+    # The viewer is in org A with VIEWER role, not the primary org A owner.
+    org_a = db_session.execute(
+        select(Organization).where(Organization.slug == FIXTURE_ORG_SLUG)
+    ).scalar_one()
+    viewer_membership = db_session.execute(
+        select(Membership).where(
+            Membership.user_id == viewer.id,
+            Membership.org_id == org_a.id,
+        )
+    ).scalar_one()
+    assert viewer_membership.role == MemberRole.VIEWER
+
+
+def test_seed_creates_org_b_with_full_resource_set(db_session):
+    """Org B exists with one Connection, Upload, Pipeline, Transformation, Schedule.
+
+    Covers tenant-isolation tests that need a second tenant with real resources
+    (QA core#168 + Q1a — tenant-jwt-boundary spec).
+    """
+    result = seed(session=db_session)
+
+    org_b = db_session.execute(
+        select(Organization).where(Organization.slug == FIXTURE_ORG_B_SLUG)
+    ).scalar_one()
+    assert result.org_b_id == org_b.id
+    assert result.org_b_slug == FIXTURE_ORG_B_SLUG
+
+    # Org B owner is a DIFFERENT user from the primary fixture user, so
+    # tenant-isolation tests have a clean "user in A only" vs "user in B only"
+    # distinction.
+    org_b_owner = db_session.execute(
+        select(User).where(User.email == FIXTURE_ORG_B_USER_EMAIL)
+    ).scalar_one()
+    assert result.org_b_user_id == org_b_owner.id
+    assert result.org_b_user_email == FIXTURE_ORG_B_USER_EMAIL
+    owner_membership = db_session.execute(
+        select(Membership).where(
+            Membership.user_id == org_b_owner.id,
+            Membership.org_id == org_b.id,
+        )
+    ).scalar_one()
+    assert owner_membership.role == MemberRole.OWNER
+
+    # One of every resource type in org B.
+    conn = db_session.execute(select(Connection).where(Connection.org_id == org_b.id)).scalar_one()
+    assert result.org_b_connection_id == conn.id
+
+    upload = db_session.execute(select(Upload).where(Upload.org_id == org_b.id)).scalar_one()
+    assert result.org_b_upload_id == upload.id
+
+    pipeline = db_session.execute(select(Pipeline).where(Pipeline.org_id == org_b.id)).scalar_one()
+    assert result.org_b_pipeline_id == pipeline.id
+
+    transformation = db_session.execute(
+        select(Transformation).where(Transformation.org_id == org_b.id)
+    ).scalar_one()
+    assert result.org_b_transformation_id == transformation.id
+
+    schedule = db_session.execute(select(Schedule).where(Schedule.org_id == org_b.id)).scalar_one()
+    assert result.org_b_schedule_id == schedule.id
+
+
+def test_seed_does_not_create_api_keys_by_default(db_session):
+    """Without E2E_SEED_INCLUDE_API_KEYS=1, no ApiKey rows are created."""
+    result = seed(session=db_session)
+
+    api_keys = list(db_session.execute(select(ApiKey)).scalars())
+    assert api_keys == []
+
+    # Sentinel values in the result — these keep the JSON contract shape
+    # stable whether the flag is on or off.
+    assert result.org_a_api_key_id == 0
+    assert result.org_a_api_key_plaintext == ""
+    assert result.org_b_api_key_id == 0
+    assert result.org_b_api_key_plaintext == ""
+
+
+def test_seed_creates_api_keys_when_flag_set(db_session, monkeypatch):
+    """With E2E_SEED_INCLUDE_API_KEYS=1, 2 ApiKey rows are created — one per org."""
+    monkeypatch.setenv("E2E_SEED_INCLUDE_API_KEYS", "1")
+
+    result = seed(session=db_session)
+
+    api_keys = list(db_session.execute(select(ApiKey)).scalars())
+    assert len(api_keys) == 2
+
+    # Plaintext keys are returned in the result — they're hashed in the DB,
+    # so Playwright must capture them here or they're lost forever.
+    assert result.org_a_api_key_id > 0
+    assert result.org_a_api_key_plaintext.startswith("etf_")
+    assert result.org_b_api_key_id > 0
+    assert result.org_b_api_key_plaintext.startswith("etf_")
+
+    # Each key is scoped to its respective org (tenant-isolation critical).
+    org_a = db_session.execute(
+        select(Organization).where(Organization.slug == FIXTURE_ORG_SLUG)
+    ).scalar_one()
+    org_b = db_session.execute(
+        select(Organization).where(Organization.slug == FIXTURE_ORG_B_SLUG)
+    ).scalar_one()
+
+    key_a = db_session.execute(
+        select(ApiKey).where(ApiKey.id == result.org_a_api_key_id)
+    ).scalar_one()
+    assert key_a.org_id == org_a.id
+
+    key_b = db_session.execute(
+        select(ApiKey).where(ApiKey.id == result.org_b_api_key_id)
+    ).scalar_one()
+    assert key_b.org_id == org_b.id
+
+
+def test_seed_is_idempotent_with_extended_fixture(db_session, monkeypatch):
+    """Re-running with api keys on doesn't duplicate org B resources or keys."""
+    monkeypatch.setenv("E2E_SEED_INCLUDE_API_KEYS", "1")
+
+    seed(session=db_session)
+    seed(session=db_session)
+
+    # Exactly one of each resource per org after the second call.
+    org_b = db_session.execute(
+        select(Organization).where(Organization.slug == FIXTURE_ORG_B_SLUG)
+    ).scalar_one()
+    for model in (Connection, Upload, Pipeline, Transformation, Schedule):
+        rows = list(db_session.execute(select(model).where(model.org_id == org_b.id)).scalars())
+        assert len(rows) == 1, f"{model.__name__} duplicated in org B after re-seed"
+
+    # Viewer user and org B owner each exist exactly once.
+    viewers = list(
+        db_session.execute(select(User).where(User.email == FIXTURE_VIEWER_USER_EMAIL)).scalars()
+    )
+    assert len(viewers) == 1
+    org_b_owners = list(
+        db_session.execute(select(User).where(User.email == FIXTURE_ORG_B_USER_EMAIL)).scalars()
+    )
+    assert len(org_b_owners) == 1
+
+    # Exactly 2 api keys (one per org).
+    api_keys = list(db_session.execute(select(ApiKey)).scalars())
+    assert len(api_keys) == 2
+
+
+def test_seed_tears_down_drifted_org_b(db_session):
+    """Drift in org B (extra rows) gets rebuilt clean on re-seed."""
+    seed(session=db_session)
+
+    org_b = db_session.execute(
+        select(Organization).where(Organization.slug == FIXTURE_ORG_B_SLUG)
+    ).scalar_one()
+
+    drift = Connection(
+        org_id=org_b.id,
+        name="drift_org_b_connection",
+        connection_type=ConnectionType.DUCKDB,
+        direction="both",
+        config_encrypted="{}",
+    )
+    db_session.add(drift)
+    db_session.flush()
+
+    seed(session=db_session)
+
+    connections = list(
+        db_session.execute(select(Connection).where(Connection.org_id == org_b.id)).scalars()
+    )
+    assert len(connections) == 1
+    assert connections[0].name != "drift_org_b_connection"
 
 
 def test_seeded_at_is_iso_utc(db_session):


### PR DESCRIPTION
## Summary

Unblocks QA's **tenant-jwt-boundary spec** (core#168) and **Q1a** in one shot. Extends the deterministic E2E seed fixture with a second tenant (org B) containing one-of-every-resource-type, a viewer-role membership in org A for RBAC tests, and an opt-in flag for minting API keys scoped to each org.

## What the seed now creates

### Primary (back-compat — existing Playwright specs unchanged)
- Org A (slug `e2e-fixture`) + owner `e2e@datanika.test` + 1 DuckDB connection.

### New — viewer RBAC
- `e2e-viewer@datanika.test` with role=VIEWER in org A. Same password as the primary user for harness simplicity.

### New — org B tenant-isolation fixture
- Org B (slug `e2e-fixture-b`) with a **dedicated** owner user `e2e-org-b@datanika.test`. Not the primary user — clean "user in A only" vs "user in B only" boundary so tenant-jwt-boundary tests don't have to reason about shared identities.
- One of every resource type in org B:
  - `Connection` (DuckDB, staging)
  - `Upload` (source = destination = the org B connection)
  - `Pipeline` (dbt run, no models selector)
  - `Transformation` (`SELECT 1 AS value`, view materialization)
  - `Schedule` (cron `0 6 * * *`, targeting the org B pipeline, `is_active=False` so nothing fires in test envs)

### New — opt-in API key minting

`E2E_SEED_INCLUDE_API_KEYS=1` (off by default) mints two `ApiKey` rows — one scoped to org A (owned by primary user), one to org B (owned by the org B owner). Plaintext keys are returned in the `SeedResult` payload because `ApiKeyService.create_api_key` returns the raw key only at creation time; Playwright must capture them from `.e2e-fixture.json` on the same run.

When the flag is off, the four api-key fields are sentinel values (`0` / `""`) so the JSON contract shape stays stable regardless of env vars. No `api_keys` table writes happen when the flag is off.

## Teardown safety

`_tear_down_fixture` now cleans both orgs and all three fixture users in FK-safe order:

1. Per-org resources: `Schedule` → `Upload` → `Pipeline` → `Transformation` → `ApiKey` → `Connection` → `Membership` → `Organization`
2. Per-user cleanup: `ApiKey` (by user_id) → `Membership` (by user_id) → `User`

Safety markers unchanged — still only touches rows matching the fixture slugs (`e2e-fixture` / `e2e-fixture-b`) or fixture emails. `test_seed_does_not_touch_non_fixture_data` is unmodified and still green.

## SeedResult contract

The dataclass grows from 9 to 25 fields, all additive. Existing Playwright code that reads the 9 back-compat fields keeps working; new tests opt into the extended fields.

```python
@dataclass
class SeedResult:
    # Back-compat (org A primary fixture)
    org_id, org_slug, user_id, user_email, user_password,
    connection_id, connection_name, connection_type, seeded_at

    # Viewer role in org A
    viewer_user_id, viewer_user_email, viewer_user_password

    # Org B + its resources
    org_b_id, org_b_slug,
    org_b_user_id, org_b_user_email, org_b_user_password,
    org_b_connection_id, org_b_upload_id, org_b_pipeline_id,
    org_b_transformation_id, org_b_schedule_id

    # API keys (sentinel 0/"" when E2E_SEED_INCLUDE_API_KEYS unset)
    org_a_api_key_id, org_a_api_key_plaintext,
    org_b_api_key_id, org_b_api_key_plaintext
```

`test_seed_result_shape` pins the full set — catches any future drift.

## Tests

6 new tests, 1 updated existing, **1870 total passing** (was 1864):

- `test_seed_creates_viewer_user_in_org_a` — VIEWER role membership present
- `test_seed_creates_org_b_with_full_resource_set` — all 5 resource types land in org B with matching IDs in SeedResult
- `test_seed_does_not_create_api_keys_by_default` — sentinel values, zero api_key rows
- `test_seed_creates_api_keys_when_flag_set` — 2 keys, each scoped to its org, `etf_` prefix verified
- `test_seed_is_idempotent_with_extended_fixture` — re-run with flag on doesn't duplicate org B resources or api keys
- `test_seed_tears_down_drifted_org_b` — drift injection in org B gets cleaned up
- `test_seed_creates_fixture_on_empty_db` (updated) — org A now has 2 memberships (owner + viewer)

Precheck: ruff check + format clean, 1870 passed in 98s.

## Test plan

- [x] Precheck green locally (1870 passed)
- [x] JSON shape contract pinned in `test_seed_result_shape`
- [ ] CI green
- [ ] After merge to dev, QA pulls `.e2e-fixture.json` and wires tenant-jwt-boundary.spec.ts (core#168) + Q1a against the new `org_b_*` + `org_a_api_key_plaintext` / `org_b_api_key_plaintext` fields
- [ ] QA confirms `E2E_SEED_INCLUDE_API_KEYS=1` behaves as expected in the CI seed step

Closes #113.