### PR TITLE
[Infra] P1 staging auth wall \u2014 CF Access headers for smoke + e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
     needs: [deploy-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v6
 
@@ -168,6 +169,9 @@ jobs:
 
       - name: Run smoke probes
         id: smoke
+        env:
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
         run: pytest scripts/smoke/ -v --tb=short
 
       - name: Telegram alert on failure
@@ -222,6 +226,8 @@ jobs:
         env:
           CI: "true"
           DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
           DATANIKA_E2E_SEED_CMD: >-
             ssh root@${{ secrets.HETZNER_HOST }}
             'E2E_SEED_ALLOW_ANY_HOST=1 docker exec datanika-staging-app uv run python -m datanika.scripts.e2e_seed'

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,6 +2,18 @@ import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = process.env.DATANIKA_E2E_BASE_URL ?? "http://localhost:3000";
 
+// staging-app.datanika.io is fronted by Cloudflare Access (see
+// plans/infra/PLAN_INFRASTRUCTURE.md §P1). When both env vars are set,
+// every browser request is authenticated via CF Access service token;
+// unset (local dev against localhost:3000) they're harmlessly absent.
+const extraHTTPHeaders: Record<string, string> = {};
+const cfAccessClientId = process.env.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID;
+const cfAccessClientSecret = process.env.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET;
+if (cfAccessClientId && cfAccessClientSecret) {
+  extraHTTPHeaders["CF-Access-Client-Id"] = cfAccessClientId;
+  extraHTTPHeaders["CF-Access-Client-Secret"] = cfAccessClientSecret;
+}
+
 export default defineConfig({
   testDir: "./tests",
   timeout: 60_000,
@@ -24,6 +36,7 @@ export default defineConfig({
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
+    extraHTTPHeaders,
   },
   projects: [
     {

--- a/scripts/smoke/conftest.py
+++ b/scripts/smoke/conftest.py
@@ -21,6 +21,24 @@ def _normalize(url: str) -> str:
     return url.rstrip("/")
 
 
+def _core_headers() -> dict[str, str]:
+    """Headers for the core smoke client.
+
+    staging-app.datanika.io is fronted by Cloudflare Access (see
+    plans/infra/PLAN_INFRASTRUCTURE.md §P1). Public requests return the
+    CF challenge page, not the app. When CI sets both env vars from GH
+    secrets, the service token bypasses the challenge; unset (e.g. local
+    runs against https://app.datanika.io) they're harmlessly absent.
+    """
+    headers = {"User-Agent": "datanika-qa-smoke/1"}
+    cf_id = os.environ.get("DATANIKA_STAGING_CF_ACCESS_CLIENT_ID")
+    cf_secret = os.environ.get("DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET")
+    if cf_id and cf_secret:
+        headers["CF-Access-Client-Id"] = cf_id
+        headers["CF-Access-Client-Secret"] = cf_secret
+    return headers
+
+
 @pytest.fixture(scope="session")
 def core_base_url() -> str:
     return _normalize(os.environ.get("DATANIKA_SMOKE_CORE_URL", CORE_DEFAULT))
@@ -37,7 +55,7 @@ def core_client(core_base_url: str):
         base_url=core_base_url,
         timeout=TIMEOUT_SECONDS,
         follow_redirects=True,
-        headers={"User-Agent": "datanika-qa-smoke/1"},
+        headers=_core_headers(),
     ) as client:
         yield client
 


### PR DESCRIPTION
## Summary

- **Code side of the Staging Auth Wall P1** from `plans/infra/PLAN_INFRASTRUCTURE.md` §P1. `staging-app.datanika.io` is being fronted by Cloudflare Access (zero-trust gate, free tier) to stop public discovery of the shared Paddle sandbox credentials. This PR wires CI to keep reaching staging after the wall goes live, but ships silent until the CF Access application is created and the GH secrets are populated — it's `if env is set` all the way down.
- Ships subtasks **3** and **4** (code). Subtasks **1**, **2**, **5** need CF API credentials and are filed at [`plans/PLAN_HUMAN_LOCKERS.md#staging-cf-access-setup`](../plans/PLAN_HUMAN_LOCKERS.md) with exact commands.

## Changes

1. **`e2e/playwright.config.ts`** — new `extraHTTPHeaders` block. When both `DATANIKA_STAGING_CF_ACCESS_CLIENT_ID` and `DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET` are set, every Playwright browser request carries `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers. Unset (local dev against `localhost:3000`), they're harmlessly absent and nothing changes.
2. **`scripts/smoke/conftest.py`** — new `_core_headers()` helper injecting the same CF Access headers into `core_client`'s httpx session. Landing client left alone (`datanika.io` is not behind CF Access). Verified both branches of the helper return correctly via smoke import test.
3. **`.github/workflows/ci.yml`** — smoke-staging pytest step and e2e-staging Playwright step both gain `env:` blocks reading the secrets from GH. `smoke-staging` additionally gets `environment: production` so it can access the environment-scoped secrets (`e2e-staging` already had it).

## What's NOT touched

- **`deploy-staging`** — SSH-based, bypasses the CF edge entirely. The 180s health wait is a `docker inspect` call (not a curl), so CF Access doesn't affect it. The PLAN_INFRASTRUCTURE.md §P1 mention of "180s health wait curl" is slightly out-of-date but benign — nothing to do here.
- **`global-setup.ts`** — the PLAN suggested injecting via `global-setup.ts` but `playwright.config.ts`'s `extraHTTPHeaders` is the correct place for auth headers; `global-setup.ts` is for seed-time work only (runs once per test session, not per request).
- **Landing repo** — `datanika.io` is not behind CF Access, no headers needed on that side.

## Behavior when secrets are absent

Until the user runs the `staging-cf-access-setup` locker, both secrets resolve to empty string in CI. The helpers skip the header injection and the requests hit staging unauthenticated — which matches the current behavior. The moment the user creates the CF Access app, generates the service token, and uploads the two secrets to the core repo's `production` environment, this PR lights up.

## Test plan

- [x] `ruff check` + `ruff format --check` on `scripts/smoke/conftest.py`
- [x] Python smoke test of `_core_headers()` verifying both the empty and populated branches
- [x] `pytest scripts/smoke/ --collect-only` — all 10 tests collect cleanly
- [x] `yaml.safe_load()` on `ci.yml`, both `smoke-staging` and `e2e-staging` read `environment: production`
- [ ] Post-merge verification requires the CF Access app to exist — once `staging-cf-access-setup` locker lands, a push to `dev` will exercise the full header path end-to-end