### PR TITLE
[Engineering] V2 P1 core IR scaffolding (Source -> IR -> {ETL,ELT})

### DIFF
--- a/datanika/migrations/versions/z6a1b2c3d4e5_add_mode_to_uploads_and_pipelines.py
+++ b/datanika/migrations/versions/z6a1b2c3d4e5_add_mode_to_uploads_and_pipelines.py
@@ -1,0 +1,51 @@
+"""Add mode column to uploads and pipelines.
+
+V2 P1 IR scaffolding (SPEC_ELT_IR_ARCHITECTURE.md §5.6 / §11).
+Source → IR → {dlt ETL, dbt ELT} dispatch flag. Defaults to 'etl' for
+existing rows so nothing changes at runtime until the ELT builders land
+in P3.
+
+Revision ID: z6a1b2c3d4e5
+Revises: z5v2w3x4y6a7
+Create Date: 2026-04-16 00:05:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "z6a1b2c3d4e5"
+down_revision: str | None = "z5v2w3x4y6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "uploads",
+        sa.Column(
+            "mode",
+            sa.String(length=20),
+            nullable=False,
+            server_default="etl",
+        ),
+    )
+    op.add_column(
+        "pipelines",
+        sa.Column(
+            "mode",
+            sa.String(length=20),
+            nullable=False,
+            server_default="etl",
+        ),
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    op.drop_column("pipelines", "mode")
+    op.drop_column("uploads", "mode")
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/pipeline.py
+++ b/datanika/models/pipeline.py
@@ -23,6 +23,17 @@ class PipelineStatus(enum.StrEnum):
     ERROR = "error"
 
 
+class PipelineMode(enum.StrEnum):
+    """V2 P1 scaffolding — Source → IR → {dlt ETL, dbt ELT} dispatch.
+
+    ETL: existing dbt-over-dlt-raw path (default, back-compat).
+    ELT: dbt-over-parquet-raw path, lands in P3 (SPEC_ELT_IR_ARCHITECTURE.md §9).
+    """
+
+    ETL = "etl"
+    ELT = "elt"
+
+
 class Pipeline(Base, TenantMixin, TimestampMixin):
     __tablename__ = "pipelines"
 
@@ -44,6 +55,12 @@ class Pipeline(Base, TenantMixin, TimestampMixin):
         Enum(PipelineStatus, native_enum=False, length=20),
         nullable=False,
         default=PipelineStatus.DRAFT,
+    )
+    mode: Mapped[PipelineMode] = mapped_column(
+        Enum(PipelineMode, native_enum=False, length=20),
+        nullable=False,
+        default=PipelineMode.ETL,
+        server_default=PipelineMode.ETL.value,
     )
 
     destination_connection = relationship(

--- a/datanika/models/upload.py
+++ b/datanika/models/upload.py
@@ -14,6 +14,17 @@ class UploadStatus(enum.StrEnum):
     ERROR = "error"
 
 
+class UploadMode(enum.StrEnum):
+    """V2 P1 scaffolding — Source → IR → {dlt ETL, dbt ELT} dispatch.
+
+    ETL: existing dlt path (default, back-compat).
+    ELT: stream source → parquet → raw, lands in P3 (SPEC_ELT_IR_ARCHITECTURE.md §9).
+    """
+
+    ETL = "etl"
+    ELT = "elt"
+
+
 class Upload(Base, TenantMixin, TimestampMixin):
     __tablename__ = "uploads"
 
@@ -31,6 +42,12 @@ class Upload(Base, TenantMixin, TimestampMixin):
         Enum(UploadStatus, native_enum=False, length=20),
         nullable=False,
         default=UploadStatus.DRAFT,
+    )
+    mode: Mapped[UploadMode] = mapped_column(
+        Enum(UploadMode, native_enum=False, length=20),
+        nullable=False,
+        default=UploadMode.ETL,
+        server_default=UploadMode.ETL.value,
     )
 
     source_connection = relationship(

--- a/datanika/services/elt_runner.py
+++ b/datanika/services/elt_runner.py
@@ -1,0 +1,14 @@
+"""ELT runner — P1 stub. Lands in P3.
+
+Per SPEC_ELT_IR_ARCHITECTURE.md §5.3: streams Source → Arrow RecordBatches →
+parquet files landed into the destination's raw schema. Destination adapters
+decide whether parquet lands via COPY, EXTERNAL TABLE, or native Arrow ingest.
+"""
+
+from typing import Any
+
+
+def stream_to_raw(ir: Any, run_id: int) -> Any:
+    raise NotImplementedError(
+        "ELT streaming runner lands in V2 P3 — SPEC_ELT_IR_ARCHITECTURE.md §5.3"
+    )

--- a/datanika/services/ir/__init__.py
+++ b/datanika/services/ir/__init__.py
@@ -1,0 +1,10 @@
+"""V2 P1 IR scaffolding — Source → IR → {dlt ETL, dbt ELT}.
+
+Stub package. `build_ir`, `validate_ir`, and `introspect_columns` raise
+`NotImplementedError` until the ELT builders land in P3 per
+SPEC_ELT_IR_ARCHITECTURE.md §9.
+"""
+
+IR_VERSION: int = 1
+
+__all__ = ["IR_VERSION"]

--- a/datanika/services/ir/builder.py
+++ b/datanika/services/ir/builder.py
@@ -1,0 +1,7 @@
+"""IR builder — P1 stub. Lands in P3."""
+
+from typing import Any
+
+
+def build_ir(source: Any) -> Any:
+    raise NotImplementedError("IR builder lands in V2 P3 — SPEC_ELT_IR_ARCHITECTURE.md §5.6")

--- a/datanika/services/ir/introspect.py
+++ b/datanika/services/ir/introspect.py
@@ -1,0 +1,9 @@
+"""IR column introspection — P1 stub. Lands in P3."""
+
+from typing import Any
+
+
+def introspect_columns(source: Any) -> Any:
+    raise NotImplementedError(
+        "Column introspection lands in V2 P3 — SPEC_ELT_IR_ARCHITECTURE.md §5.6"
+    )

--- a/datanika/services/ir/validator.py
+++ b/datanika/services/ir/validator.py
@@ -1,0 +1,7 @@
+"""IR validator — P1 stub. Lands in P3."""
+
+from typing import Any
+
+
+def validate_ir(ir: Any) -> Any:
+    raise NotImplementedError("IR validator lands in V2 P3 — SPEC_ELT_IR_ARCHITECTURE.md §5.6")

--- a/datanika/tasks/pipeline_tasks.py
+++ b/datanika/tasks/pipeline_tasks.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from datanika.models.catalog_entry import CatalogEntryType
 from datanika.models.connection import Connection
 from datanika.models.dependency import NodeType
-from datanika.models.pipeline import Pipeline, PipelineStatus
+from datanika.models.pipeline import Pipeline, PipelineMode, PipelineStatus
 from datanika.models.run import Run
 from datanika.models.transformation import Transformation
 from datanika.models.user import Organization
@@ -177,6 +177,11 @@ def run_pipeline(
         pipeline = session.execute(
             select(Pipeline).where(Pipeline.id == run.target_id, Pipeline.org_id == org_id)
         ).scalar_one()
+
+        if pipeline.mode == PipelineMode.ELT:
+            raise NotImplementedError(
+                "ELT pipeline path lands in V2 P3 — SPEC_ELT_IR_ARCHITECTURE.md §5.3"
+            )
 
         predicted = PipelineService.predict_run_count(pipeline)
         _emit_hook(

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -11,7 +11,7 @@ from datanika.models.catalog_entry import CatalogEntryType
 from datanika.models.connection import Connection
 from datanika.models.dependency import NodeType
 from datanika.models.run import Run
-from datanika.models.upload import Upload, UploadStatus
+from datanika.models.upload import Upload, UploadMode, UploadStatus
 from datanika.services.catalog_service import CatalogService
 from datanika.services.connection_service import _build_sa_url
 from datanika.services.dbt_project import DbtProjectService
@@ -125,6 +125,11 @@ def run_upload(
         upload = session.execute(
             select(Upload).where(Upload.id == run.target_id, Upload.org_id == org_id)
         ).scalar_one()
+
+        if upload.mode == UploadMode.ELT:
+            raise NotImplementedError(
+                "ELT upload path lands in V2 P3 — SPEC_ELT_IR_ARCHITECTURE.md §5.3"
+            )
 
         src_conn = session.get(Connection, upload.source_connection_id)
         dst_conn = session.get(Connection, upload.destination_connection_id)

--- a/tests/test_migrations/test_migration_coverage.py
+++ b/tests/test_migrations/test_migration_coverage.py
@@ -39,15 +39,19 @@ def _scan_migration_files() -> tuple[set[str], dict[str, set[str]]]:
 
     Detects:
     - op.create_table("name", ...) — extracts table name and sa.Column names
-    - op.rename_table("old", "new") — registers the new name
+    - op.rename_table("old", "new") — transfers columns from old → new name
     - op.add_column("table", sa.Column("col", ...)) — registers column addition
+
+    Operations are processed in source order within each file so that a
+    rename_table correctly captures the columns of the table at that point
+    in time (any later create_table reusing the old name gets fresh columns).
     """
     versions_dir = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
     tables: set[str] = set()
     columns: dict[str, set[str]] = {}
 
     create_table_re = re.compile(r'op\.create_table\(\s*"(\w+)"')
-    rename_table_re = re.compile(r'op\.rename_table\(\s*"\w+"\s*,\s*"(\w+)"')
+    rename_table_re = re.compile(r'op\.rename_table\(\s*"(\w+)"\s*,\s*"(\w+)"')
     column_in_create_re = re.compile(r'sa\.Column\(\s*"(\w+)"')
     add_column_re = re.compile(r'op\.add_column\(\s*"(\w+)"\s*,\s*sa\.Column\(\s*"(\w+)"')
 
@@ -60,29 +64,38 @@ def _scan_migration_files() -> tuple[set[str], dict[str, set[str]]]:
             continue
         upgrade_body = upgrade_match.group(0)
 
-        # Find create_table blocks and their columns
-        for ct_match in create_table_re.finditer(upgrade_body):
-            table_name = ct_match.group(1)
-            tables.add(table_name)
-            start = ct_match.start()
-            rest = upgrade_body[start:]
-            block_end = len(rest)
-            next_op = re.search(r"\n    op\.", rest[10:])
-            if next_op:
-                block_end = next_op.start() + 10
-            block = rest[:block_end]
-            cols = column_in_create_re.findall(block)
-            columns.setdefault(table_name, set()).update(cols)
+        # Collect all op calls with their source positions so we can
+        # process them in order (rename_table must see the table's columns
+        # as they exist at that exact point in the file).
+        events: list[tuple[int, str, tuple]] = []
+        for m in create_table_re.finditer(upgrade_body):
+            events.append((m.start(), "create", (m.group(1), m.start())))
+        for m in rename_table_re.finditer(upgrade_body):
+            events.append((m.start(), "rename", (m.group(1), m.group(2))))
+        for m in add_column_re.finditer(upgrade_body):
+            events.append((m.start(), "add_col", (m.group(1), m.group(2))))
+        events.sort(key=lambda e: e[0])
 
-        # Find rename_table
-        for rt_match in rename_table_re.finditer(upgrade_body):
-            tables.add(rt_match.group(1))
-
-        # Find add_column
-        for ac_match in add_column_re.finditer(upgrade_body):
-            table_name = ac_match.group(1)
-            col_name = ac_match.group(2)
-            columns.setdefault(table_name, set()).add(col_name)
+        for _pos, kind, args in events:
+            if kind == "create":
+                table_name, start = args
+                tables.add(table_name)
+                rest = upgrade_body[start:]
+                block_end = len(rest)
+                next_op = re.search(r"\n    op\.", rest[10:])
+                if next_op:
+                    block_end = next_op.start() + 10
+                block = rest[:block_end]
+                cols = column_in_create_re.findall(block)
+                columns.setdefault(table_name, set()).update(cols)
+            elif kind == "rename":
+                old_name, new_name = args
+                tables.add(new_name)
+                if old_name in columns:
+                    columns.setdefault(new_name, set()).update(columns.pop(old_name))
+            elif kind == "add_col":
+                table_name, col_name = args
+                columns.setdefault(table_name, set()).add(col_name)
 
     return tables, columns
 

--- a/tests/test_models/test_all_models.py
+++ b/tests/test_models/test_all_models.py
@@ -226,6 +226,7 @@ class TestUpload:
         assert "destination_connection_id" in cols
         assert "dlt_config" in cols
         assert "status" in cols
+        assert "mode" in cols
         assert "created_at" in cols
         assert "updated_at" in cols
 
@@ -246,6 +247,90 @@ class TestUpload:
             UploadStatus.PAUSED,
             UploadStatus.ERROR,
         }
+
+    def test_mode_enum(self):
+        from datanika.models.upload import UploadMode
+
+        assert set(UploadMode) == {UploadMode.ETL, UploadMode.ELT}
+        assert UploadMode.ETL.value == "etl"
+        assert UploadMode.ELT.value == "elt"
+
+    def test_mode_defaults_to_etl(self, db_session):
+        from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
+        from datanika.models.upload import Upload, UploadMode
+        from datanika.models.user import Organization
+
+        org = Organization(name="Acme", slug="acme-mode-default")
+        db_session.add(org)
+        db_session.flush()
+
+        src = Connection(
+            org_id=org.id,
+            name="src",
+            connection_type=ConnectionType.POSTGRES,
+            direction=ConnectionDirection.SOURCE,
+            config_encrypted="x",
+        )
+        dst = Connection(
+            org_id=org.id,
+            name="dst",
+            connection_type=ConnectionType.POSTGRES,
+            direction=ConnectionDirection.DESTINATION,
+            config_encrypted="y",
+        )
+        db_session.add_all([src, dst])
+        db_session.flush()
+
+        upload = Upload(
+            org_id=org.id,
+            name="default_mode",
+            source_connection_id=src.id,
+            destination_connection_id=dst.id,
+        )
+        db_session.add(upload)
+        db_session.flush()
+        db_session.refresh(upload)
+
+        assert upload.mode == UploadMode.ETL
+
+    def test_mode_elt_roundtrips(self, db_session):
+        from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
+        from datanika.models.upload import Upload, UploadMode
+        from datanika.models.user import Organization
+
+        org = Organization(name="Acme", slug="acme-mode-elt")
+        db_session.add(org)
+        db_session.flush()
+
+        src = Connection(
+            org_id=org.id,
+            name="src",
+            connection_type=ConnectionType.POSTGRES,
+            direction=ConnectionDirection.SOURCE,
+            config_encrypted="x",
+        )
+        dst = Connection(
+            org_id=org.id,
+            name="dst",
+            connection_type=ConnectionType.POSTGRES,
+            direction=ConnectionDirection.DESTINATION,
+            config_encrypted="y",
+        )
+        db_session.add_all([src, dst])
+        db_session.flush()
+
+        upload = Upload(
+            org_id=org.id,
+            name="elt_upload",
+            source_connection_id=src.id,
+            destination_connection_id=dst.id,
+            mode=UploadMode.ELT,
+        )
+        db_session.add(upload)
+        db_session.flush()
+
+        fetched = db_session.get(Upload, upload.id)
+        assert fetched.mode == UploadMode.ELT
 
     def test_create_upload(self, db_session):
         from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
@@ -848,6 +933,7 @@ class TestPipeline:
         assert "models" in cols
         assert "custom_selector" in cols
         assert "status" in cols
+        assert "mode" in cols
         assert "created_at" in cols
         assert "updated_at" in cols
 
@@ -916,3 +1002,73 @@ class TestPipeline:
         assert pipeline.command == DbtCommand.BUILD
         assert pipeline.status == PipelineStatus.DRAFT
         assert pipeline.models == [{"name": "orders", "upstream": True, "downstream": False}]
+
+    def test_pipeline_mode_enum(self):
+        from datanika.models.pipeline import PipelineMode
+
+        assert set(PipelineMode) == {PipelineMode.ETL, PipelineMode.ELT}
+        assert PipelineMode.ETL.value == "etl"
+        assert PipelineMode.ELT.value == "elt"
+
+    def test_pipeline_mode_defaults_to_etl(self, db_session):
+        from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
+        from datanika.models.pipeline import DbtCommand, Pipeline, PipelineMode
+        from datanika.models.user import Organization
+
+        org = Organization(name="Acme", slug="acme-pipe-mode-default")
+        db_session.add(org)
+        db_session.flush()
+
+        dst = Connection(
+            org_id=org.id,
+            name="dst",
+            connection_type=ConnectionType.POSTGRES,
+            direction=ConnectionDirection.DESTINATION,
+            config_encrypted="y",
+        )
+        db_session.add(dst)
+        db_session.flush()
+
+        pipeline = Pipeline(
+            org_id=org.id,
+            name="default_mode_pipe",
+            destination_connection_id=dst.id,
+            command=DbtCommand.RUN,
+        )
+        db_session.add(pipeline)
+        db_session.flush()
+        db_session.refresh(pipeline)
+
+        assert pipeline.mode == PipelineMode.ETL
+
+    def test_pipeline_mode_elt_roundtrips(self, db_session):
+        from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
+        from datanika.models.pipeline import DbtCommand, Pipeline, PipelineMode
+        from datanika.models.user import Organization
+
+        org = Organization(name="Acme", slug="acme-pipe-mode-elt")
+        db_session.add(org)
+        db_session.flush()
+
+        dst = Connection(
+            org_id=org.id,
+            name="dst",
+            connection_type=ConnectionType.POSTGRES,
+            direction=ConnectionDirection.DESTINATION,
+            config_encrypted="y",
+        )
+        db_session.add(dst)
+        db_session.flush()
+
+        pipeline = Pipeline(
+            org_id=org.id,
+            name="elt_pipe",
+            destination_connection_id=dst.id,
+            command=DbtCommand.RUN,
+            mode=PipelineMode.ELT,
+        )
+        db_session.add(pipeline)
+        db_session.flush()
+
+        fetched = db_session.get(Pipeline, pipeline.id)
+        assert fetched.mode == PipelineMode.ELT

--- a/tests/test_services/test_ir_scaffolding.py
+++ b/tests/test_services/test_ir_scaffolding.py
@@ -1,0 +1,71 @@
+"""V2 P1 scaffolding — IR package + elt_runner stub.
+
+Per SPEC_ELT_IR_ARCHITECTURE.md §5.6, the Source → IR → {dlt ETL, dbt ELT}
+module layout lands in P1 as empty stubs; builders/validators/runners
+ship in P3. These tests pin the public interface so P3 doesn't drift
+from the spec.
+"""
+
+import pytest
+
+
+class TestIRPackageLayout:
+    def test_ir_package_importable(self):
+        import datanika.services.ir as ir
+
+        assert ir is not None
+
+    def test_ir_builder_module_exists(self):
+        from datanika.services.ir import builder
+
+        assert hasattr(builder, "build_ir")
+
+    def test_ir_validator_module_exists(self):
+        from datanika.services.ir import validator
+
+        assert hasattr(validator, "validate_ir")
+
+    def test_ir_introspect_module_exists(self):
+        from datanika.services.ir import introspect
+
+        assert hasattr(introspect, "introspect_columns")
+
+    def test_ir_version_constant_exported(self):
+        from datanika.services.ir import IR_VERSION
+
+        assert IR_VERSION == 1
+
+
+class TestIRStubsRaiseNotImplemented:
+    """P1 stubs must raise so a mis-wired ELT path fails loudly, not silently."""
+
+    def test_build_ir_raises(self):
+        from datanika.services.ir.builder import build_ir
+
+        with pytest.raises(NotImplementedError, match="P3"):
+            build_ir(source=None)
+
+    def test_validate_ir_raises(self):
+        from datanika.services.ir.validator import validate_ir
+
+        with pytest.raises(NotImplementedError, match="P3"):
+            validate_ir(ir=None)
+
+    def test_introspect_columns_raises(self):
+        from datanika.services.ir.introspect import introspect_columns
+
+        with pytest.raises(NotImplementedError, match="P3"):
+            introspect_columns(source=None)
+
+
+class TestEltRunnerStub:
+    def test_elt_runner_importable(self):
+        from datanika.services import elt_runner
+
+        assert hasattr(elt_runner, "stream_to_raw")
+
+    def test_stream_to_raw_raises(self):
+        from datanika.services.elt_runner import stream_to_raw
+
+        with pytest.raises(NotImplementedError, match="P3"):
+            stream_to_raw(ir=None, run_id=1)

--- a/tests/test_tasks/test_pipeline_tasks.py
+++ b/tests/test_tasks/test_pipeline_tasks.py
@@ -617,3 +617,24 @@ class TestRunPipelinePredictedRuns:
             )
 
         assert captured["predicted_runs"] is None
+
+    def test_elt_mode_raises_before_dbt_called(self, db_session, encryption, setup_pipeline):
+        """V2 P1 scaffolding — mode=elt fails fast with NotImplementedError."""
+        from datanika.models.pipeline import PipelineMode
+
+        org, conn, pipeline, transformations, run = setup_pipeline
+        pipeline.mode = PipelineMode.ELT
+        db_session.flush()
+
+        with _mock_dbt_project() as mock_dbt_cls:
+            run_pipeline(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+                encryption=encryption,
+            )
+            mock_dbt_cls.return_value.run_command.assert_not_called()
+
+        db_session.refresh(run)
+        assert run.status == RunStatus.FAILED
+        assert "P3" in (run.error_message or "")

--- a/tests/test_tasks/test_upload_tasks.py
+++ b/tests/test_tasks/test_upload_tasks.py
@@ -162,6 +162,27 @@ class TestRunUploadTask:
         db_session.refresh(upload)
         assert upload.status == UploadStatus.ACTIVE
 
+    def test_elt_mode_raises_before_dlt_called(self, db_session, setup_upload):
+        """V2 P1 scaffolding — mode=elt fails fast with NotImplementedError."""
+        from datanika.models.upload import UploadMode
+
+        org, upload, run, encryption = setup_upload
+        upload.mode = UploadMode.ELT
+        db_session.flush()
+
+        with _mock_dlt_runner() as mock_runner_cls:
+            run_upload(
+                run_id=run.id,
+                org_id=org.id,
+                session=db_session,
+                encryption=encryption,
+            )
+            mock_runner_cls.return_value.execute.assert_not_called()
+
+        db_session.refresh(run)
+        assert run.status == RunStatus.FAILED
+        assert "P3" in (run.error_message or "")
+
     def test_upload_status_error_on_failure(self, db_session, setup_upload):
         org, upload, run, encryption = setup_upload
         assert upload.status == UploadStatus.DRAFT


### PR DESCRIPTION
## Summary
V2 P1 IR scaffolding: `Source -> IR -> {ETL, ELT}` dispatch layer.

Rebased onto `dev` after #164 merged — the old #164 commit (bytes metering columns) dropped as a content-duplicate on rebase, leaving only the IR scaffolding commit on top.

## Context
- Originally opened as [#171](https://github.com/datanika-io/datanika-core/pull/171) stacked on `162-bytes-metering-migration`. GitHub auto-closed #171 when that base branch was deleted on #164's merge. This PR replaces it.
- New SHA: `7caf310`.
- 1882 tests passing at original merge time (per Engineering's pre-merge validation).

## Test plan
- [ ] lint + test + helm-lint CI green
- [ ] Part of atomic sweep Phase A (core dev merges)