### PR TITLE
[Infra] Add Grafana bind mount for volume-dashboard.json (closes #176)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,7 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ../datanika-cloud/monitoring/revenue-dashboard.json:/var/lib/grafana/dashboards/cloud/revenue.json:ro
+      - ../datanika-cloud/monitoring/volume-dashboard.json:/var/lib/grafana/dashboards/cloud/volume.json:ro
       - ./monitoring/db-performance-dashboard.json:/var/lib/grafana/dashboards/infra/db-performance.json:ro
       - ./monitoring/grafana-dashboard.json:/var/lib/grafana/dashboards/infra/server-overview.json:ro
     depends_on:


### PR DESCRIPTION
## Summary
- Adds `volume-dashboard.json` bind mount to the Grafana container in `docker-compose.yml`
- Mounts `../datanika-cloud/monitoring/volume-dashboard.json` → `/var/lib/grafana/dashboards/cloud/volume.json:ro`
- Placed right after the existing revenue-dashboard mount, auto-loaded by the `datanika-cloud` dashboard provider into the "Datanika Cloud" Grafana folder

## Context
Unblocked by cloud#35 → cloud dev→master promotion during the 2026-04-16 atomic sweep (Phase F). The file now exists on Hetzner at `/opt/datanika/datanika-cloud/monitoring/volume-dashboard.json`.

## Test plan
- [ ] Verify `docker compose config` parses without errors
- [ ] Post-promotion on Hetzner: `docker logs datanika-grafana 2>&1 | grep -i "volume\|provision" | tail -20` — should show the dashboard loaded with no parse errors
- [ ] Grafana UI: "Datanika Cloud" folder shows both "Revenue Metrics" and "Volume Metrics" dashboards