### PR TITLE
perf: bump Granian workers from 1 to 4 on CPX31

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       - "127.0.0.1:8000:8000"
     env_file:
       - .env.docker
+    environment:
+      GRANIAN_WORKERS: "4"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Sets `GRANIAN_WORKERS=4` in docker-compose app service environment
- k6 baseline (LOAD_TEST_BASELINE_2026-04-16.md) showed p95 7-8s at 100 VUs with server CPU at 32% — single Granian worker saturating on the 4-vCPU CPX31
- Reflex reads `GRANIAN_WORKERS` env var and passes it to Granian at startup (reflex/utils/exec.py:678)
- Expected: p95 drops to <500ms, supports 150-200 concurrent users
- Memory: 4 workers ≈ 1.8 GB (vs 470 MB single), total system ~3 GB / 8 GB

## Deploy

After merge to dev → master promotion:
```bash
ssh root@46.225.214.120
cd /opt/datanika/datanika && git pull origin master
set -a && source .env.docker && set +a
docker compose up -d --build app
docker exec datanika-app printenv GRANIAN_WORKERS  # should print 4
```

## Test plan

- [ ] Merge to dev, CI green
- [ ] Promote dev → master, deploy to Hetzner
- [ ] Verify `GRANIAN_WORKERS=4` inside container
- [ ] Re-run k6 baseline — p95 for authed endpoints should drop from 7-8s to <500ms at 100 VUs
- [ ] Monitor `docker stats` — CPU should scale to ~4× single-worker under load, memory <3 GB

Closes #178