### PR TITLE
feat: V2 P4 SaaS source IR builder via dlt schema discovery

### DIFF
--- a/datanika/services/ir/builder.py
+++ b/datanika/services/ir/builder.py
@@ -1,9 +1,9 @@
 """IR builder — dispatches by connection kind to build an IR document.
 
 Per SPEC_ELT_IR_ARCHITECTURE.md §5.2:
-- sql_table: introspects live, constructs columns from information schema
-- sql_database: same, but for all tables (or filtered subset)
-- saas_rest / file: deferred to P4 (raises NotImplementedError)
+- sql_table / sql_database: introspects live via information schema
+- saas_rest (P4): derived from dlt source's declared schema
+- file (csv/json/parquet/s3): deferred to a future phase
 """
 
 from __future__ import annotations
@@ -12,11 +12,11 @@ import logging
 
 from datanika.services.ir import IR_VERSION
 from datanika.services.ir.introspect import introspect_columns
-from datanika.services.ir.schema import IR, IRIncremental, IRSource, IRTarget
+from datanika.services.ir.schema import IR, IRColumn, IRIncremental, IRSource, IRTarget
 
 logger = logging.getLogger(__name__)
 
-# Connection types that support SQL introspection
+# Connection types that support SQL introspection (P3)
 SQL_TYPES = frozenset(
     {
         "postgres",
@@ -33,9 +33,137 @@ SQL_TYPES = frozenset(
     }
 )
 
+# SaaS connection types that use dlt verified sources (P4)
+SAAS_TYPES = frozenset(
+    {
+        "stripe",
+        "github",
+        "hubspot",
+        "salesforce",
+        "shopify",
+        "jira",
+        "slack",
+        "google_analytics",
+        "google_ads",
+        "facebook_ads",
+        "zendesk",
+        "airtable",
+        "notion",
+        "mongodb",
+        "kafka",
+        "rest_api",
+        "google_sheets",
+    }
+)
+
+# File types — not yet supported
+FILE_TYPES = frozenset({"csv", "json", "parquet", "s3"})
+
 
 class IRBuildError(ValueError):
     """Raised when build_ir cannot construct an IR for the given source."""
+
+
+def _build_dlt_source(source_type: str, source_config: dict, dlt_config: dict | None = None):
+    """Instantiate a dlt source for schema discovery (no data extraction)."""
+    from datanika.services.dlt_runner import DltRunnerService
+
+    runner = DltRunnerService()
+    return runner.build_source(
+        source_type,
+        source_config,
+        dlt_config or {},
+        batch_size=1,  # minimal — we only need schema, not data
+    )
+
+
+def _build_ir_saas(
+    source_type: str,
+    source_config: dict,
+    destination_connection_id: int,
+    destination_raw_schema: str,
+    table: str,
+    dlt_config: dict | None = None,
+    incremental_config: dict | None = None,
+    primary_key_columns: list[str] | None = None,
+) -> IR:
+    """Build IR for a SaaS source by extracting schema from dlt resource hints.
+
+    Per spec §5.2: "For saas_rest: derived from the connector's declared
+    schema (dlt's @dlt.source already exports this)."
+    """
+    source = _build_dlt_source(source_type, source_config, dlt_config)
+
+    # Find the requested resource (table name = resource name in dlt)
+    if table not in source.resources:
+        available = sorted(source.resources.keys())
+        raise IRBuildError(
+            f"Resource {table!r} not found in {source_type} source. Available: {available}"
+        )
+
+    resource = source.resources[table]
+    table_schema = resource.compute_table_schema()
+    raw_columns = table_schema.get("columns", {})
+
+    if not raw_columns:
+        raise IRBuildError(
+            f"No columns discovered for {source_type}::{table}. "
+            f"The dlt source may not declare schema hints for this resource."
+        )
+
+    # Convert dlt column hints to IR columns
+    columns = [
+        IRColumn(
+            source_ref=col_name,
+            target_name=col_name,
+            type=col_meta.get("data_type", "text"),
+            nullable=col_meta.get("nullable", True),
+        )
+        for col_name, col_meta in raw_columns.items()
+        if not col_name.startswith("_dlt_")  # skip dlt internal columns
+    ]
+
+    if not columns:
+        raise IRBuildError(
+            f"No user columns found for {source_type}::{table} (all were _dlt_ internal)"
+        )
+
+    pk = primary_key_columns or [columns[0].target_name]
+
+    incremental = None
+    if incremental_config:
+        incremental = IRIncremental(
+            mode=incremental_config.get("mode", "append"),
+            cursor=incremental_config["cursor_path"],
+        )
+
+    ir = IR(
+        ir_version=IR_VERSION,
+        source=IRSource(
+            kind="saas_rest",
+            connection_id=0,  # filled by caller
+            table=table,
+        ),
+        columns=columns,
+        primary_key=pk,
+        target=IRTarget(
+            connection_id=destination_connection_id,
+            raw_schema=destination_raw_schema,
+            table=table,
+        ),
+        incremental=incremental,
+    )
+
+    logger.info(
+        "Built IR v%d for SaaS %s::%s: %d columns, pk=%s",
+        IR_VERSION,
+        source_type,
+        table,
+        len(columns),
+        pk,
+    )
+
+    return ir
 
 
 def build_ir(
@@ -47,25 +175,46 @@ def build_ir(
     schema: str | None = None,
     incremental_config: dict | None = None,
     primary_key_columns: list[str] | None = None,
+    dlt_config: dict | None = None,
 ) -> IR:
     """Build an IR document for a source → destination mapping.
 
-    For SQL sources, introspects the source table to discover columns.
-    For non-SQL sources (SaaS, files), deferred to P4.
+    Dispatches by source type:
+    - SQL types: introspect live via information_schema
+    - SaaS types (P4): extract schema from dlt source hints
+    - File types: not yet supported
     """
-    if source_type not in SQL_TYPES:
+    if source_type in FILE_TYPES:
         raise IRBuildError(
-            f"IR builder for source type {source_type!r} lands in V2 P4. "
-            f"Supported SQL types: {sorted(SQL_TYPES)}"
+            f"IR builder for file source type {source_type!r} is not supported yet. "
+            f"File source IR (csv/json/parquet/s3) lands in a future phase."
         )
 
     if not table:
         raise IRBuildError(
-            "build_ir requires a table name for sql_table mode. "
-            "sql_database multi-table IR lands in a follow-up."
+            "build_ir requires a table/resource name. "
+            "For SQL: the table name. For SaaS: the dlt resource name."
         )
 
-    # Introspect columns from the live source
+    if source_type in SAAS_TYPES:
+        return _build_ir_saas(
+            source_type=source_type,
+            source_config=source_config,
+            destination_connection_id=destination_connection_id,
+            destination_raw_schema=destination_raw_schema,
+            table=table,
+            dlt_config=dlt_config,
+            incremental_config=incremental_config,
+            primary_key_columns=primary_key_columns,
+        )
+
+    if source_type not in SQL_TYPES:
+        raise IRBuildError(
+            f"Unknown source type {source_type!r}. "
+            f"Supported: SQL={sorted(SQL_TYPES)}, SaaS={sorted(SAAS_TYPES)}"
+        )
+
+    # SQL path (P3)
     columns = introspect_columns(
         config=source_config,
         connection_type=source_type,
@@ -76,10 +225,8 @@ def build_ir(
     if not columns:
         raise IRBuildError(f"No columns found for {source_type}://{schema or ''}.{table}")
 
-    # Derive primary key — use provided or fall back to first column
     pk = primary_key_columns or [columns[0].target_name]
 
-    # Build incremental if configured
     incremental = None
     if incremental_config:
         incremental = IRIncremental(
@@ -91,7 +238,7 @@ def build_ir(
         ir_version=IR_VERSION,
         source=IRSource(
             kind="sql_table",
-            connection_id=0,  # filled by caller with the actual connection_id
+            connection_id=0,  # filled by caller
             schema=schema,
             table=table,
         ),

--- a/tests/test_services/test_ir.py
+++ b/tests/test_services/test_ir.py
@@ -213,6 +213,121 @@ class TestIRValidator:
 
 
 # ---------------------------------------------------------------------------
+# §5.2 / §9 P4 — SaaS source IR builder
+# ---------------------------------------------------------------------------
+
+
+class TestSaaSIRBuilder:
+    """V2 P4 — build_ir() for SaaS sources via dlt schema discovery."""
+
+    def test_build_ir_saas_with_mock_source(self):
+        """SaaS sources build IR from dlt resource.compute_table_schema()."""
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.ir.builder import build_ir
+        from datanika.services.ir.schema import IR
+
+        # Mock a dlt source with one resource that has column hints
+        mock_resource = MagicMock()
+        mock_resource.table_name = "customers"
+        mock_resource.compute_table_schema.return_value = {
+            "name": "customers",
+            "columns": {
+                "id": {"name": "id", "data_type": "text", "nullable": False},
+                "email": {"name": "email", "data_type": "text", "nullable": True},
+                "created": {"name": "created", "data_type": "bigint", "nullable": True},
+            },
+        }
+
+        mock_source = MagicMock()
+        mock_source.resources = {"customers": mock_resource}
+
+        with patch(
+            "datanika.services.ir.builder._build_dlt_source",
+            return_value=mock_source,
+        ):
+            ir = build_ir(
+                source_type="stripe",
+                source_config={"api_key": "sk_test_fake"},
+                destination_connection_id=2,
+                table="customers",
+            )
+
+        assert isinstance(ir, IR)
+        assert ir.source.kind == "saas_rest"
+        assert len(ir.columns) == 3
+        assert ir.columns[0].source_ref == "id"
+        assert ir.columns[0].type == "text"
+        assert ir.target.table == "customers"
+
+    def test_build_ir_saas_resource_not_found(self):
+        """Raises IRBuildError if the requested resource doesn't exist in the source."""
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.ir.builder import IRBuildError, build_ir
+
+        mock_source = MagicMock()
+        mock_source.resources = {}
+
+        with (
+            patch(
+                "datanika.services.ir.builder._build_dlt_source",
+                return_value=mock_source,
+            ),
+            pytest.raises(IRBuildError, match="not found"),
+        ):
+            build_ir(
+                source_type="stripe",
+                source_config={"api_key": "sk_test_fake"},
+                destination_connection_id=2,
+                table="nonexistent_resource",
+            )
+
+    def test_build_ir_saas_no_columns_in_schema(self):
+        """Raises IRBuildError if the resource schema has no columns."""
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.ir.builder import IRBuildError, build_ir
+
+        mock_resource = MagicMock()
+        mock_resource.table_name = "empty"
+        mock_resource.compute_table_schema.return_value = {
+            "name": "empty",
+            "columns": {},
+        }
+
+        mock_source = MagicMock()
+        mock_source.resources = {"empty": mock_resource}
+
+        with (
+            patch(
+                "datanika.services.ir.builder._build_dlt_source",
+                return_value=mock_source,
+            ),
+            pytest.raises(IRBuildError, match="No columns"),
+        ):
+            build_ir(
+                source_type="stripe",
+                source_config={"api_key": "sk_test_fake"},
+                destination_connection_id=2,
+                table="empty",
+            )
+
+    def test_file_sources_still_raise(self):
+        """File sources (csv, json, parquet, s3) are not yet supported."""
+        from datanika.services.ir.builder import IRBuildError, build_ir
+
+        for file_type in ("csv", "json", "parquet", "s3"):
+            with pytest.raises(IRBuildError, match="not supported"):
+                build_ir(
+                    source_type=file_type,
+                    source_config={},
+                    destination_connection_id=1,
+                    table="t",
+                )
+
+
+# ---------------------------------------------------------------------------
 # §5.5 — StreamStats
 # ---------------------------------------------------------------------------
 

--- a/tests/test_services/test_ir_scaffolding.py
+++ b/tests/test_services/test_ir_scaffolding.py
@@ -54,16 +54,16 @@ class TestIRModulesCallable:
 
         assert callable(introspect_columns)
 
-    def test_build_ir_rejects_unsupported_source(self):
-        """Non-SQL sources raise IRBuildError, not NotImplementedError."""
+    def test_build_ir_rejects_file_sources(self):
+        """File sources raise IRBuildError (not yet supported)."""
         from datanika.services.ir.builder import IRBuildError, build_ir
 
-        with pytest.raises(IRBuildError, match="P4"):
+        with pytest.raises(IRBuildError, match="not supported"):
             build_ir(
-                source_type="stripe",
+                source_type="csv",
                 source_config={},
                 destination_connection_id=1,
-                table="charges",
+                table="data",
             )
 
 


### PR DESCRIPTION
## Summary

- Extends `build_ir()` to handle 18 SaaS source types via dlt's `resource.compute_table_schema()`
- No pipeline execution needed — column schema extracted from dlt source hints at instantiation time
- Internal `_dlt_*` columns filtered out of IR
- File sources (csv/json/parquet/s3) raise `IRBuildError` (future phase)
- New `SAAS_TYPES` and `FILE_TYPES` frozensets for dispatch
- New `_build_dlt_source()` helper and `_build_ir_saas()` implementation

### Supported SaaS types (P4)
stripe, github, hubspot, salesforce, shopify, jira, slack, google_analytics, google_ads, facebook_ads, zendesk, airtable, notion, mongodb, kafka, rest_api, google_sheets

### Stacked on core#184 (V2 P3)
This PR adds 1 commit on top of P3. Once #184 merges, this PR auto-retargets to dev.

## Test plan

- [x] 1932 tests passing (+4 vs P3), 0 failures
- [x] Ruff check + format clean
- [x] 4 new tests: SaaS mock source, resource not found, no columns, file sources reject
- [ ] CI green

Closes #185