### PR TITLE
Q3: SSO E2E specs + Authentik container setup

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -4,3 +4,4 @@ test-results/
 .pw-cache/
 .walkthrough-out/
 .e2e-fixture.json
+.sso-fixture.json

--- a/e2e/docker-compose.test.yml
+++ b/e2e/docker-compose.test.yml
@@ -1,0 +1,85 @@
+# Authentik IdP for SSO E2E tests (QA Q3).
+#
+# Spins up a disposable Authentik instance on localhost:9000 with a
+# pre-configured admin user. The bootstrap script (scripts/bootstrap-authentik.sh)
+# creates OIDC + SAML applications via the Authentik API after first boot.
+#
+# Usage:
+#   docker compose -f e2e/docker-compose.test.yml up -d
+#   bash e2e/scripts/bootstrap-authentik.sh   # creates IdP apps
+#   DATANIKA_E2E_SSO_AUTHENTIK=1 npx playwright test sso-
+#   docker compose -f e2e/docker-compose.test.yml down -v
+#
+# The compose file is self-contained — no dependency on the main
+# docker-compose.yml. Ports deliberately avoid conflict with the main
+# stack (9000 vs 3000/8000).
+
+services:
+  authentik-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: authentik
+      POSTGRES_USER: authentik
+      POSTGRES_PASSWORD: authentik-test-pw
+    volumes:
+      - authentik-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U authentik"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  authentik-redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  authentik-server:
+    image: ghcr.io/goauthentik/server:2024.12
+    command: server
+    environment:
+      AUTHENTIK_SECRET_KEY: e2e-test-secret-key-not-for-production
+      AUTHENTIK_REDIS__HOST: authentik-redis
+      AUTHENTIK_POSTGRESQL__HOST: authentik-db
+      AUTHENTIK_POSTGRESQL__USER: authentik
+      AUTHENTIK_POSTGRESQL__NAME: authentik
+      AUTHENTIK_POSTGRESQL__PASSWORD: authentik-test-pw
+      # Bootstrap admin credentials — used by bootstrap-authentik.sh
+      AUTHENTIK_BOOTSTRAP_EMAIL: admin@datanika.test
+      AUTHENTIK_BOOTSTRAP_PASSWORD: e2e-admin-password
+      AUTHENTIK_BOOTSTRAP_TOKEN: e2e-bootstrap-token
+    ports:
+      - "9000:9000"
+    depends_on:
+      authentik-db:
+        condition: service_healthy
+      authentik-redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "ak", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  authentik-worker:
+    image: ghcr.io/goauthentik/server:2024.12
+    command: worker
+    environment:
+      AUTHENTIK_SECRET_KEY: e2e-test-secret-key-not-for-production
+      AUTHENTIK_REDIS__HOST: authentik-redis
+      AUTHENTIK_POSTGRESQL__HOST: authentik-db
+      AUTHENTIK_POSTGRESQL__USER: authentik
+      AUTHENTIK_POSTGRESQL__NAME: authentik
+      AUTHENTIK_POSTGRESQL__PASSWORD: authentik-test-pw
+    depends_on:
+      authentik-db:
+        condition: service_healthy
+      authentik-redis:
+        condition: service_healthy
+
+volumes:
+  authentik-pg:

--- a/e2e/scripts/bootstrap-authentik.sh
+++ b/e2e/scripts/bootstrap-authentik.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# bootstrap-authentik.sh — configure Authentik with OIDC + SAML apps for E2E SSO tests.
+#
+# Prerequisites:
+#   docker compose -f e2e/docker-compose.test.yml up -d
+#   Wait for healthcheck: docker compose -f e2e/docker-compose.test.yml ps
+#
+# This script:
+#   1. Waits for Authentik API to be ready
+#   2. Creates a test user (sso-user@datanika.test)
+#   3. Creates an OIDC provider + application
+#   4. Creates a SAML provider + application
+#   5. Writes connection details to e2e/.sso-fixture.json (gitignored)
+#
+# All values are deterministic so the script is idempotent on a fresh container.
+
+set -euo pipefail
+
+AUTHENTIK_URL="${AUTHENTIK_URL:-http://localhost:9000}"
+AUTHENTIK_TOKEN="${AUTHENTIK_TOKEN:-e2e-bootstrap-token}"
+API="${AUTHENTIK_URL}/api/v3"
+AUTH_HEADER="Authorization: Bearer ${AUTHENTIK_TOKEN}"
+
+# Datanika app callback URLs — adjust if your local dev uses different ports.
+DATANIKA_BASE="${DATANIKA_E2E_BASE_URL:-http://localhost:8000}"
+OIDC_REDIRECT_URI="${DATANIKA_BASE}/api/auth/sso/callback"
+SAML_ACS_URL="${DATANIKA_BASE}/api/auth/sso/callback"
+SAML_SP_ENTITY_ID="datanika"
+
+FIXTURE_FILE="$(dirname "$0")/../.sso-fixture.json"
+
+log() { echo "[bootstrap-authentik] $*"; }
+
+# --- 1. Wait for API ---
+log "Waiting for Authentik API at ${AUTHENTIK_URL}..."
+for i in $(seq 1 30); do
+  if curl -sf "${AUTHENTIK_URL}/-/health/ready/" > /dev/null 2>&1; then
+    log "Authentik ready (attempt ${i})."
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    log "ERROR: Authentik not ready after 30 attempts."
+    exit 1
+  fi
+  sleep 2
+done
+
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sf -X "${method}" "${API}${path}" \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+# --- 2. Create test user ---
+log "Creating test user sso-user@datanika.test..."
+SSO_USER=$(api POST /core/users/ -d '{
+  "username": "sso-user",
+  "name": "SSO Test User",
+  "email": "sso-user@datanika.test",
+  "is_active": true
+}' 2>/dev/null || true)
+
+if [ -z "$SSO_USER" ]; then
+  log "User may already exist, fetching..."
+  SSO_USER=$(api GET "/core/users/?search=sso-user@datanika.test" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(json.dumps(data['results'][0]) if data['results'] else '')
+")
+fi
+SSO_USER_ID=$(echo "$SSO_USER" | python3 -c "import json,sys; print(json.load(sys.stdin)['pk'])")
+log "Test user ID: ${SSO_USER_ID}"
+
+# Set password for the test user
+api POST "/core/users/${SSO_USER_ID}/set_password/" \
+  -d '{"password": "SsoTestPassword-2026"}' > /dev/null
+
+# --- 3. Create OIDC provider + application ---
+log "Creating OIDC provider..."
+OIDC_PROVIDER=$(api POST /providers/oauth2/ -d "{
+  \"name\": \"datanika-oidc-e2e\",
+  \"authorization_flow\": \"$(api GET '/flows/instances/?slug=default-provider-authorization-implicit-consent' | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")\",
+  \"client_type\": \"confidential\",
+  \"client_id\": \"datanika-oidc-e2e\",
+  \"client_secret\": \"oidc-e2e-secret-not-for-production\",
+  \"redirect_uris\": \"${OIDC_REDIRECT_URI}\",
+  \"signing_key\": \"$(api GET '/crypto/certificatekeypairs/?name=authentik+Self-signed+Certificate' | python3 -c "import json,sys; r=json.load(sys.stdin)['results']; print(r[0]['pk'] if r else '')")\",
+  \"sub_mode\": \"user_email\"
+}" 2>/dev/null || true)
+
+if [ -z "$OIDC_PROVIDER" ]; then
+  log "OIDC provider may already exist, fetching..."
+  OIDC_PROVIDER=$(api GET "/providers/oauth2/?name=datanika-oidc-e2e" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(json.dumps(data['results'][0]) if data['results'] else '')
+")
+fi
+OIDC_PROVIDER_ID=$(echo "$OIDC_PROVIDER" | python3 -c "import json,sys; print(json.load(sys.stdin)['pk'])")
+log "OIDC provider ID: ${OIDC_PROVIDER_ID}"
+
+log "Creating OIDC application..."
+api POST /core/applications/ -d "{
+  \"name\": \"Datanika OIDC E2E\",
+  \"slug\": \"datanika-oidc-e2e\",
+  \"provider\": ${OIDC_PROVIDER_ID}
+}" > /dev/null 2>&1 || log "OIDC application may already exist."
+
+# --- 4. Create SAML provider + application ---
+log "Creating SAML provider..."
+SAML_PROVIDER=$(api POST /providers/saml/ -d "{
+  \"name\": \"datanika-saml-e2e\",
+  \"authorization_flow\": \"$(api GET '/flows/instances/?slug=default-provider-authorization-implicit-consent' | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")\",
+  \"acs_url\": \"${SAML_ACS_URL}\",
+  \"audience\": \"${SAML_SP_ENTITY_ID}\",
+  \"issuer\": \"${AUTHENTIK_URL}/application/saml/datanika-saml-e2e/sso/binding/redirect/\",
+  \"sp_binding\": \"redirect\",
+  \"name_id_mapping\": \"$(api GET '/propertymappings/saml/?managed=goauthentik.io%2Fmanaged%2Fmappings%2Fsaml%2Fupn' | python3 -c "import json,sys; r=json.load(sys.stdin)['results']; print(r[0]['pk'] if r else '')")\",
+  \"signing_kp\": \"$(api GET '/crypto/certificatekeypairs/?name=authentik+Self-signed+Certificate' | python3 -c "import json,sys; r=json.load(sys.stdin)['results']; print(r[0]['pk'] if r else '')")\"
+}" 2>/dev/null || true)
+
+if [ -z "$SAML_PROVIDER" ]; then
+  log "SAML provider may already exist, fetching..."
+  SAML_PROVIDER=$(api GET "/providers/saml/?name=datanika-saml-e2e" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(json.dumps(data['results'][0]) if data['results'] else '')
+")
+fi
+SAML_PROVIDER_ID=$(echo "$SAML_PROVIDER" | python3 -c "import json,sys; print(json.load(sys.stdin)['pk'])")
+log "SAML provider ID: ${SAML_PROVIDER_ID}"
+
+log "Creating SAML application..."
+api POST /core/applications/ -d "{
+  \"name\": \"Datanika SAML E2E\",
+  \"slug\": \"datanika-saml-e2e\",
+  \"provider\": ${SAML_PROVIDER_ID}
+}" > /dev/null 2>&1 || log "SAML application may already exist."
+
+# --- 5. Write fixture file ---
+OIDC_ISSUER="${AUTHENTIK_URL}/application/o/datanika-oidc-e2e/"
+
+# Fetch SAML metadata URL and IdP cert
+SAML_METADATA_URL="${AUTHENTIK_URL}/application/saml/datanika-saml-e2e/metadata/"
+SAML_SSO_URL="${AUTHENTIK_URL}/application/saml/datanika-saml-e2e/sso/binding/redirect/"
+
+cat > "$FIXTURE_FILE" << FIXTURE_EOF
+{
+  "authentik_url": "${AUTHENTIK_URL}",
+  "sso_user_email": "sso-user@datanika.test",
+  "sso_user_password": "SsoTestPassword-2026",
+  "oidc": {
+    "issuer_url": "${OIDC_ISSUER}",
+    "client_id": "datanika-oidc-e2e",
+    "client_secret": "oidc-e2e-secret-not-for-production"
+  },
+  "saml": {
+    "idp_metadata_url": "${SAML_METADATA_URL}",
+    "idp_entity_id": "${AUTHENTIK_URL}/application/saml/datanika-saml-e2e/sso/binding/redirect/",
+    "idp_sso_url": "${SAML_SSO_URL}",
+    "sp_entity_id": "${SAML_SP_ENTITY_ID}"
+  }
+}
+FIXTURE_EOF
+
+log "Fixture written to ${FIXTURE_FILE}"
+log "Done. Authentik is ready for SSO E2E tests."

--- a/e2e/tests/sso-edge-cases.spec.ts
+++ b/e2e/tests/sso-edge-cases.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * SSO edge-case and misconfiguration tests.
+ *
+ * Reference: PLAN_QA.md Q3.
+ *
+ * These tests exercise error paths and boundary conditions in the SSO
+ * flow. Some require the Authentik container; others test purely against
+ * Datanika's SSO endpoints with invalid inputs.
+ *
+ * Split from sso-oidc/sso-saml to keep the happy-path specs clean.
+ */
+
+const SSO_GATE = process.env.DATANIKA_E2E_SSO_AUTHENTIK !== "1";
+const ORG_SLUG = process.env.DATANIKA_E2E_ORG_SLUG ?? "e2e-fixture";
+
+test.describe("SSO edge cases @slow", () => {
+  test("login with nonexistent org slug returns 404", async ({ request }) => {
+    const response = await request.get("/api/auth/sso/login/org-that-does-not-exist");
+    expect(response.status()).toBe(404);
+  });
+
+  test("login with org that has no SSO config returns error", async ({ request }) => {
+    // The seed org (e2e-fixture) may or may not have SSO configured.
+    // If it doesn't, this should return 404 or a descriptive error, not 5xx.
+    const response = await request.get(`/api/auth/sso/login/${ORG_SLUG}`);
+    // Accept 302 (has config) or 404 (no config) — reject 5xx
+    expect(response.status()).toBeLessThan(500);
+  });
+
+  test("callback with missing state cookie returns 400", async ({ request }) => {
+    // No sso_state cookie → the callback should reject
+    const response = await request.get("/api/auth/sso/callback?code=fakecode&state=fakestate");
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+    expect(response.status()).toBeLessThan(500);
+  });
+
+  test("callback with empty code returns 400", async ({ request }) => {
+    const response = await request.get("/api/auth/sso/callback?code=&state=fakestate");
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+    expect(response.status()).toBeLessThan(500);
+  });
+
+  test("metadata for nonexistent org returns 404", async ({ request }) => {
+    const response = await request.get("/api/auth/sso/metadata/org-that-does-not-exist");
+    expect(response.status()).toBe(404);
+  });
+
+  test.describe("OIDC misconfiguration", () => {
+    test.skip(() => SSO_GATE, "Requires Authentik container");
+
+    test("OIDC with unreachable issuer_url fails gracefully", async ({ request }) => {
+      // This would require setting up an SSO config pointing to a dead URL.
+      // The test verifies that the login endpoint returns a user-facing error,
+      // not a 500 with a stack trace.
+      // Placeholder — requires API or direct DB access to create a misconfigured SSO entry.
+      test.skip(true, "Requires SSO config API or direct DB seeding of a bad OIDC config");
+    });
+  });
+
+  test.describe("Quota gating (Enterprise only)", () => {
+    test("creating SSO config on Free plan is rejected by cloud hook", async ({ request }) => {
+      // This tests the cloud plugin's sso_config.before_create hook.
+      // Requires DATANIKA_EDITION=cloud and a Free-plan org.
+      // The hook raises QuotaExceededError("SSO requires an Enterprise plan").
+      test.skip(
+        true,
+        "Requires cloud edition + Free-plan org. Covered by cloud unit tests " +
+          "(test_plan_restrictions.py:507-524). E2E coverage deferred until " +
+          "SSO admin UI ships.",
+      );
+    });
+  });
+});

--- a/e2e/tests/sso-oidc.spec.ts
+++ b/e2e/tests/sso-oidc.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * SSO OIDC flow tests against a live Authentik container.
+ *
+ * Reference: PLAN_QA.md Q3, SPEC_SOC2_ROADMAP.md §SSO.
+ *
+ * Prerequisites:
+ *   docker compose -f e2e/docker-compose.test.yml up -d
+ *   bash e2e/scripts/bootstrap-authentik.sh
+ *   DATANIKA_E2E_SSO_AUTHENTIK=1 npx playwright test sso-oidc
+ *
+ * These tests exercise the real Authentik↔Datanika OIDC flow end-to-end:
+ * discovery, authorization redirect, Authentik login, code exchange,
+ * userinfo fetch, JIT provisioning, session creation.
+ *
+ * Gated behind DATANIKA_E2E_SSO_AUTHENTIK=1 since they require the
+ * Authentik container running. Skipped in regular CI.
+ */
+
+const SSO_GATE = process.env.DATANIKA_E2E_SSO_AUTHENTIK !== "1";
+
+// Fixture values from bootstrap-authentik.sh → .sso-fixture.json
+const SSO_USER_EMAIL = "sso-user@datanika.test";
+const SSO_USER_PASSWORD = "SsoTestPassword-2026";
+const ORG_SLUG = process.env.DATANIKA_E2E_ORG_SLUG ?? "e2e-fixture";
+
+test.describe("SSO OIDC: Authentik @slow", () => {
+  test.skip(() => SSO_GATE, "Requires DATANIKA_E2E_SSO_AUTHENTIK=1 + Authentik container");
+
+  test("OIDC login redirects to Authentik authorization endpoint", async ({ page }) => {
+    const ssoLoginUrl = `/api/auth/sso/login/${ORG_SLUG}`;
+    const response = await page.goto(ssoLoginUrl);
+
+    // The SSO login endpoint should redirect (302) to Authentik's authorize URL
+    const finalUrl = page.url();
+    expect(finalUrl).toContain("/application/o/authorize/");
+    expect(finalUrl).toContain("client_id=datanika-oidc-e2e");
+    expect(finalUrl).toContain("response_type=code");
+    expect(finalUrl).toContain("redirect_uri=");
+  });
+
+  test("OIDC full flow: login via Authentik → session created", async ({ page }) => {
+    // 1. Navigate to SSO login — redirects to Authentik
+    await page.goto(`/api/auth/sso/login/${ORG_SLUG}`);
+
+    // 2. Authentik login form
+    await page.waitForURL(/.*\/application\/o\/authorize\/.*/);
+    await page.getByLabel(/username|email/i).fill(SSO_USER_EMAIL);
+    await page.getByLabel(/password/i).fill(SSO_USER_PASSWORD);
+    await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
+
+    // 3. Authentik may show a consent screen — auto-approve if present
+    const consentButton = page.getByRole("button", { name: /continue|allow|approve/i });
+    if (await consentButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await consentButton.click();
+    }
+
+    // 4. Callback redirects back to Datanika with tokens
+    await page.waitForURL(/.*\/(connections|dashboard|pipelines).*/i, { timeout: 15000 });
+
+    // 5. Verify session — user should be logged in
+    const url = page.url();
+    expect(url).not.toContain("/login");
+    expect(url).not.toContain("/signup");
+  });
+
+  test("OIDC JIT provisioning: new SSO user gets Membership with VIEWER role", async ({
+    request,
+  }) => {
+    // After the OIDC flow, the user should exist in the org with VIEWER role.
+    // This test uses the API to verify the provisioning side-effect.
+    const apiKey = process.env.DATANIKA_E2E_API_KEY_ORG_A;
+    test.skip(!apiKey, "Requires API key from seed — run with extended seed");
+
+    const membersResp = await request.get("/api/v1/members", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(membersResp.status()).toBe(200);
+    const members = await membersResp.json();
+
+    const ssoMember = members.find(
+      (m: { email: string }) => m.email === SSO_USER_EMAIL,
+    );
+    expect(ssoMember, `SSO user ${SSO_USER_EMAIL} not provisioned in org`).toBeDefined();
+    expect(ssoMember.role).toBe("viewer");
+  });
+
+  test("OIDC with invalid org slug returns error", async ({ page }) => {
+    const response = await page.goto("/api/auth/sso/login/nonexistent-org-slug");
+    // Should get a 404 or error page, not a crash
+    expect(response?.status()).toBeGreaterThanOrEqual(400);
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test("OIDC state tampering is rejected", async ({ page, context }) => {
+    // Start a legitimate OIDC flow to get a state cookie
+    await page.goto(`/api/auth/sso/login/${ORG_SLUG}`);
+    await page.waitForURL(/.*\/application\/o\/authorize\/.*/);
+
+    // Tamper with the sso_state cookie
+    const cookies = await context.cookies();
+    const ssoCookie = cookies.find((c) => c.name === "sso_state");
+    if (ssoCookie) {
+      await context.addCookies([
+        { ...ssoCookie, value: "tampered:state:invalidsig" },
+      ]);
+    }
+
+    // Simulate callback with tampered state
+    const callbackResp = await page.goto(
+      "/api/auth/sso/callback?code=fake&state=tampered",
+    );
+    // Should reject with 400/403, never 200
+    expect(callbackResp?.status()).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/e2e/tests/sso-saml.spec.ts
+++ b/e2e/tests/sso-saml.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * SSO SAML flow tests against a live Authentik container.
+ *
+ * Reference: PLAN_QA.md Q3, SPEC_SOC2_ROADMAP.md §SSO.
+ *
+ * Tests the SP-initiated SAML flow: AuthnRequest → Authentik login →
+ * SAMLResponse → callback → JIT provisioning → session.
+ *
+ * Gated behind DATANIKA_E2E_SSO_AUTHENTIK=1.
+ */
+
+const SSO_GATE = process.env.DATANIKA_E2E_SSO_AUTHENTIK !== "1";
+
+const SSO_USER_EMAIL = "sso-user@datanika.test";
+const SSO_USER_PASSWORD = "SsoTestPassword-2026";
+const ORG_SLUG = process.env.DATANIKA_E2E_ORG_SLUG ?? "e2e-fixture";
+
+test.describe("SSO SAML: Authentik @slow", () => {
+  test.skip(() => SSO_GATE, "Requires DATANIKA_E2E_SSO_AUTHENTIK=1 + Authentik container");
+
+  test("SAML login redirects to Authentik SSO endpoint with AuthnRequest", async ({ page }) => {
+    const response = await page.goto(`/api/auth/sso/login/${ORG_SLUG}`);
+
+    // SP-initiated SAML: should redirect to Authentik with SAMLRequest param
+    const finalUrl = page.url();
+    expect(finalUrl).toContain("SAMLRequest=");
+    expect(finalUrl).toContain("RelayState=");
+  });
+
+  test("SAML full flow: login via Authentik → session created", async ({ page }) => {
+    // 1. Navigate to SSO login — redirects to Authentik SAML endpoint
+    await page.goto(`/api/auth/sso/login/${ORG_SLUG}`);
+
+    // 2. Authentik login form (same UI for OIDC and SAML)
+    await page.getByLabel(/username|email/i).fill(SSO_USER_EMAIL);
+    await page.getByLabel(/password/i).fill(SSO_USER_PASSWORD);
+    await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
+
+    // 3. Authentik may show consent — auto-approve
+    const consentButton = page.getByRole("button", { name: /continue|allow|approve/i });
+    if (await consentButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await consentButton.click();
+    }
+
+    // 4. SAMLResponse POST to callback → redirect to app
+    await page.waitForURL(/.*\/(connections|dashboard|pipelines).*/i, { timeout: 15000 });
+
+    // 5. Verify logged in
+    const url = page.url();
+    expect(url).not.toContain("/login");
+  });
+
+  test("SAML SP metadata endpoint returns valid XML", async ({ request }) => {
+    const response = await request.get(`/api/auth/sso/metadata/${ORG_SLUG}`);
+    expect(response.status()).toBe(200);
+
+    const contentType = response.headers()["content-type"];
+    expect(contentType).toContain("xml");
+
+    const body = await response.text();
+    expect(body).toContain("EntityDescriptor");
+    expect(body).toContain("AssertionConsumerService");
+    expect(body).toContain("NameIDFormat");
+  });
+
+  test("SAML assertion with wrong audience is rejected", async ({ request }) => {
+    // Craft a callback with an invalid SAMLResponse — should be rejected
+    const response = await request.post("/api/auth/sso/callback", {
+      form: {
+        SAMLResponse: Buffer.from("<invalid-xml>").toString("base64"),
+        RelayState: `${ORG_SLUG}:fakestate:invalidsig`,
+      },
+    });
+    // Should reject, not crash
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+    expect(response.status()).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Authentik IdP container (`docker-compose.test.yml`) — disposable, no paid signup
- Bootstrap script creates OIDC + SAML applications via Authentik API
- 16 Playwright specs: 5 OIDC, 4 SAML, 7 edge-case (red-first TDD)
- Gated behind `DATANIKA_E2E_SSO_AUTHENTIK=1` + `@slow`

## Test coverage

| Spec | Tests | What it exercises |
|------|-------|-------------------|
| `sso-oidc.spec.ts` | 5 | OIDC discovery redirect, full login flow, JIT provisioning (VIEWER role), invalid org, state tampering |
| `sso-saml.spec.ts` | 4 | SAML AuthnRequest redirect, full login flow, SP metadata XML, invalid SAMLResponse |
| `sso-edge-cases.spec.ts` | 7 | Nonexistent org, no SSO config, missing state cookie, empty code, metadata 404, misconfigured issuer (placeholder), quota gating (placeholder) |

## How to run

```bash
docker compose -f e2e/docker-compose.test.yml up -d
bash e2e/scripts/bootstrap-authentik.sh
DATANIKA_E2E_SSO_AUTHENTIK=1 DATANIKA_E2E_SLOW=1 npx playwright test sso-
docker compose -f e2e/docker-compose.test.yml down -v
```

## Test plan

- [x] All 16 specs parse and list under `@slow` gate
- [x] Specs correctly skip when `DATANIKA_E2E_SSO_AUTHENTIK` is unset
- [ ] Full run against Authentik + local Datanika stack (requires both containers)

Closes #192