### PR TITLE
QU3: fix signup button selector in e2e spec

### DIFF
--- a/e2e/tests/oauth-template-param.spec.ts
+++ b/e2e/tests/oauth-template-param.spec.ts
@@ -20,7 +20,7 @@ test.describe("?template= preservation through OAuth signup", () => {
     await page.goto("/signup?template=stripe-to-postgres");
     await page.getByLabel(/email/i).fill(`qa-${Date.now()}@datanika.test`);
     await page.getByLabel(/password/i).fill("QaTemplateOauth-2026");
-    await page.getByRole("button", { name: /sign up/i }).click();
+    await page.getByRole("button", { name: /create account/i }).click();
     await expect(page).toHaveURL(/template=stripe-to-postgres/);
   });
 


### PR DESCRIPTION
## Summary

Fix `getByRole("button", { name: /sign up/i })` → `getByRole("button", { name: /create account/i })` in `oauth-template-param.spec.ts:23`.

The button text is `_t["auth.create_account"]` = "Create Account" (en.json:20), not "Sign Up". This was the last Q4b failure after core#169 fixed the `getByLabel` selectors.

## Impact

Unblocks 1 of 3 e2e-staging failures. The other 2 (`template-prefill` — stripe text not visible, Plausible event not captured) are separate issues, not selector mismatches.

## Test plan

- [x] Spec parses and lists correctly
- [ ] e2e-staging run: `oauth-template-param` email-signup test turns green

Closes #194