### PR TITLE
perf: debounce api_keys.last_used_at — skip UPDATE within 60s

### DIFF
--- a/datanika/services/api_key_service.py
+++ b/datanika/services/api_key_service.py
@@ -83,8 +83,16 @@ class ApiKeyService:
         ):
             return None
 
-        # Update last_used_at
-        api_key.last_used_at = datetime.now(UTC)
+        # Debounce last_used_at: skip the UPDATE if written within the last 60s.
+        # Under load (100 concurrent VUs on one key), the synchronous UPDATE
+        # serializes behind a row lock → p95 8s. Debouncing reduces writes
+        # from every request to at most once per key per 60s.
+        now = datetime.now(UTC)
+        if api_key.last_used_at is not None:
+            elapsed = (now - api_key.last_used_at.replace(tzinfo=UTC)).total_seconds()
+            if elapsed < 60:
+                return api_key
+        api_key.last_used_at = now
         session.flush()
         return api_key
 

--- a/tests/test_services/test_api_key_service.py
+++ b/tests/test_services/test_api_key_service.py
@@ -111,6 +111,46 @@ class TestAuthenticateApiKey:
         assert result is not None
 
 
+class TestLastUsedAtDebounce:
+    """Debounce: skip the UPDATE if last_used_at was written within 60s."""
+
+    def test_first_auth_writes_last_used_at(self, svc, db_session, org, user):
+        key, raw_key = svc.create_api_key(db_session, org.id, user.id, "K")
+        assert key.last_used_at is None
+        svc.authenticate_api_key(db_session, raw_key)
+        db_session.refresh(key)
+        assert key.last_used_at is not None
+
+    def test_second_auth_within_60s_skips_write(self, svc, db_session, org, user):
+        key, raw_key = svc.create_api_key(db_session, org.id, user.id, "K")
+        svc.authenticate_api_key(db_session, raw_key)
+        db_session.refresh(key)
+        first_ts = key.last_used_at
+
+        # Second call within 60s — should NOT update last_used_at
+        svc.authenticate_api_key(db_session, raw_key)
+        db_session.refresh(key)
+        assert key.last_used_at == first_ts
+
+    def test_auth_after_debounce_window_writes(self, svc, db_session, org, user):
+        key, raw_key = svc.create_api_key(db_session, org.id, user.id, "K")
+        svc.authenticate_api_key(db_session, raw_key)
+        db_session.refresh(key)
+
+        # Simulate time passing: set last_used_at to 61s ago (naive for SQLite compat)
+        old_ts = datetime.now(UTC) - timedelta(seconds=61)
+        key.last_used_at = old_ts.replace(tzinfo=None)
+        db_session.flush()
+
+        svc.authenticate_api_key(db_session, raw_key)
+        db_session.refresh(key)
+        # last_used_at should have been refreshed (newer than old_ts)
+        refreshed = key.last_used_at
+        if refreshed.tzinfo is None:
+            refreshed = refreshed.replace(tzinfo=UTC)
+        assert refreshed > old_ts
+
+
 class TestListApiKeys:
     def test_empty(self, svc, db_session, org):
         assert svc.list_api_keys(db_session, org.id) == []


### PR DESCRIPTION
## Summary

- Skips the `UPDATE api_keys SET last_used_at` if the ORM-loaded `last_used_at` was written within 60 seconds
- No Redis dependency — the timestamp is already loaded by the authentication SELECT
- Reduces per-request DB writes from every authenticated call to at most once per key per minute

## Root cause (LOAD_TEST_BASELINE_2026-04-16.md Run 3)

| Metric | Before | After (expected) |
|---|---|---|
| UPDATE calls at 100 VUs / 19 min | 186,537 | ~19 (one per 60s) |
| UPDATE avg latency | 16ms | n/a (skipped) |
| UPDATE max latency (row lock) | 1,515ms | n/a |
| p95 at 100 VUs | 8s | <500ms (pending re-baseline) |

The fix is 6 lines in `authenticate_api_key()`. The synchronous `session.flush()` was serializing 100 concurrent connections behind a single row lock — this is what actually caused the 8s p95, not Granian worker count.

## Test plan

- [x] 1913 tests passing, 0 failures
- [x] 3 new debounce tests: first-auth writes, second-within-60s skips, after-window writes
- [x] Ruff clean
- [ ] CI green
- [ ] Re-run k6 after merge to verify p95 drop

Closes #197