### PR TITLE
[Infra] Add pre-push git hook — lint + test gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+scripts/hooks/* text eol=lf

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# pre-push hook — runs lint + tests before every push.
+# Mirrors the CI gate (ruff check, ruff format --check, pytest).
+# Install: git config core.hooksPath scripts/hooks
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# Find venv
+if [ -x ".venv/Scripts/python.exe" ]; then
+  PY=".venv/Scripts/python.exe"
+elif [ -x ".venv/bin/python" ]; then
+  PY=".venv/bin/python"
+else
+  echo "pre-push: no .venv found at $REPO_ROOT — run 'uv venv && uv pip install -e .[dev]'"
+  exit 1
+fi
+
+echo "pre-push: ruff check"
+"$PY" -m ruff check datanika tests
+echo "pre-push: ruff format --check"
+"$PY" -m ruff format --check datanika tests
+echo "pre-push: pytest"
+"$PY" -m pytest tests/ -x -q --tb=short
+echo "pre-push: all checks passed"


### PR DESCRIPTION
## Summary
- Add `scripts/hooks/pre-push` that mirrors CI: ruff check, ruff format --check, pytest
- Blocks pushes that would fail CI, catching errors locally (~2 min) instead of the remote round-trip
- Activate: `git config core.hooksPath scripts/hooks` (one-time per checkout, inherited by all worktrees)
- `.gitattributes` updated to force LF on hook files (Windows safety)

## Test plan
- [ ] `git config core.hooksPath scripts/hooks` on a worktree
- [ ] Push with a lint error — hook blocks the push
- [ ] Push clean code — hook passes, push succeeds