### PR TITLE
fix: proxy /api/* from Vite frontend to backend (SSO 200-SPA bug)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ COPY datanika-cloud/ /cloud/
 # Reflex needs to initialize on first run (recreates .venv)
 RUN uv run reflex init
 
+# Patch Vite config to proxy /api/* to backend (fixes #200 — SSO/OAuth
+# routes return SPA shell instead of proper HTTP status on :3000)
+RUN uv run python scripts/patch-vite-proxy.py
+
 # Install cloud plugin AFTER reflex init (which recreates the venv)
 RUN uv pip install /cloud
 

--- a/scripts/patch-vite-proxy.py
+++ b/scripts/patch-vite-proxy.py
@@ -1,0 +1,62 @@
+"""Patch the Reflex-generated vite.config.ts to add an API proxy.
+
+Reflex's frontend (Vite SSR at :3000) has no proxy for /api/* paths,
+so requests to SSO/OAuth/API endpoints return the SPA shell instead of
+proxying to the backend (:8000). This script injects a Vite server.proxy
+rule into the generated config.
+
+Run after `reflex init` and before `reflex run`:
+    python scripts/patch-vite-proxy.py
+
+See: https://github.com/datanika-io/datanika-core/issues/200
+"""
+
+import re
+import sys
+from pathlib import Path
+
+VITE_CONFIG = Path(".web/vite.config.ts")
+
+PROXY_BLOCK = """\
+    proxy: {
+      "/api/": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+      },
+    },"""
+
+
+def patch():
+    if not VITE_CONFIG.exists():
+        print(f"SKIP: {VITE_CONFIG} not found (run 'reflex init' first)", file=sys.stderr)
+        return
+
+    content = VITE_CONFIG.read_text(encoding="utf-8")
+
+    if '"/api/"' in content:
+        print(f"SKIP: {VITE_CONFIG} already has /api/ proxy")
+        return
+
+    # Insert proxy block inside the server: { ... } section, after the port line
+    patched = re.sub(
+        r"(server:\s*\{[^}]*?port:\s*process\.env\.PORT,?)",
+        r"\1\n" + PROXY_BLOCK,
+        content,
+        count=1,
+    )
+
+    if patched == content:
+        print(f"WARN: could not find injection point in {VITE_CONFIG}", file=sys.stderr)
+        # Fallback: insert before the closing of defineConfig
+        patched = content.replace(
+            "server: {",
+            "server: {\n" + PROXY_BLOCK,
+            1,
+        )
+
+    VITE_CONFIG.write_text(patched, encoding="utf-8")
+    print(f"PATCHED: {VITE_CONFIG} — /api/ proxy → http://127.0.0.1:8000")
+
+
+if __name__ == "__main__":
+    patch()


### PR DESCRIPTION
## Summary

Fixes SSO/OAuth/API routes returning 200 (SPA shell) instead of proper HTTP status codes when accessed through the Vite frontend at :3000.

### Root cause
Reflex's Vite SSR frontend has no proxy config — it returns `index.html` for any unmatched path. SSO routes registered via `app._api.routes.append()` only exist on the backend at :8000. Production was unaffected (nginx proxies `/api/` → :8000), but Docker prod mode (:3000 direct) and dev mode were broken.

### Fix
- New `scripts/patch-vite-proxy.py` injects a Vite `server.proxy` rule for `/api/` → `http://127.0.0.1:8000` into the Reflex-generated `vite.config.ts`
- Dockerfile calls the script after `reflex init` (build-time patching)
- Idempotent — skips if already patched or if vite config doesn't exist

### Before / After

| Route | :3000 before | :3000 after |
|---|---|---|
| `/api/auth/sso/login/nonexistent` | 200 (SPA) | 302 (redirect) |
| `/api/auth/sso/callback?code=&state=fake` | 200 (SPA) | 302 (redirect) |
| `/api/v1/notifications` (no auth) | 200 (SPA) | 401 (JSON) |

## Test plan

- [x] 1932 tests passing, ruff clean
- [ ] CI green
- [ ] Docker build: verify `RUN uv run python scripts/patch-vite-proxy.py` succeeds
- [ ] After deploy: `curl -sI http://localhost:3000/api/auth/sso/login/test` returns 302, not 200

Closes #200