### PR TITLE
[Infra] Bump azure/setup-helm to v5 + helm lint in pre-push hook (closes #210)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.17.3
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -23,4 +23,17 @@ echo "pre-push: ruff format --check"
 "$PY" -m ruff format --check datanika tests
 echo "pre-push: pytest"
 "$PY" -m pytest tests/ -x -q --tb=short
+
+# Helm lint — only if chart files were modified in the push range
+if command -v helm >/dev/null 2>&1 && [ -d "$REPO_ROOT/deploy/helm" ]; then
+  CHANGED=$(git diff --name-only @{upstream}..HEAD -- deploy/helm/ 2>/dev/null || true)
+  if [ -n "$CHANGED" ]; then
+    echo "pre-push: helm lint (chart files changed)"
+    helm lint deploy/helm/datanika
+    helm template test-release deploy/helm/datanika > /dev/null
+  else
+    echo "pre-push: helm lint skipped (no chart changes)"
+  fi
+fi
+
 echo "pre-push: all checks passed"


### PR DESCRIPTION
## Summary

- **CI**: `azure/setup-helm@v4` → `@v5` — Node.js 24 compatible, fixes the deprecation warning before the 2026-06-02 forced migration deadline.
- **Pre-push hook**: adds conditional `helm lint` + `helm template` that only runs when files under `deploy/helm/` changed in the push range. Skips if helm is not installed or chart dir doesn't exist.

Closes #210

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [ ] CI helm-lint job passes with `@v5` (no more Node.js 20 deprecation warning)
- [x] Pre-push hook: verified `helm lint` + `helm template` run clean locally