### PR TITLE
[Infra] Add e2e-sso CI job — Authentik on Hetzner + 16 SSO specs (closes #212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,142 @@ jobs:
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
 
+  # SSO E2E tests — runs 16 Playwright specs (OIDC + SAML + edge cases)
+  # against the staging app with a disposable Authentik IdP on Hetzner.
+  #
+  # Topology: Authentik on Hetzner :9000 (same host as staging), SSH tunnel
+  # to the CI runner so the Playwright browser can reach the IdP login form.
+  # Bootstrap + seed run on Hetzner via SSH (they need docker exec).
+  e2e-sso:
+    needs: [deploy-staging]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install chromium --with-deps
+
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+      - name: Start Authentik on staging server
+        env:
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          ssh root@$SSH_HOST "mkdir -p /opt/datanika/e2e-sso/scripts"
+          scp e2e/docker-compose.test.yml root@$SSH_HOST:/opt/datanika/e2e-sso/
+          scp e2e/scripts/bootstrap-authentik.sh root@$SSH_HOST:/opt/datanika/e2e-sso/scripts/
+          scp e2e/scripts/seed-sso-configs.py root@$SSH_HOST:/opt/datanika/e2e-sso/scripts/
+
+          # Start with project name 'e2e' so containers are e2e-authentik-{db,server}-1
+          # (matches the docker exec names in bootstrap-authentik.sh)
+          ssh root@$SSH_HOST "cd /opt/datanika/e2e-sso && docker compose -p e2e -f docker-compose.test.yml up -d"
+
+          # Wait for Authentik to be healthy (~90s first boot with migrations)
+          ssh root@$SSH_HOST 'for i in $(seq 1 30); do
+            status=$(docker inspect --format="{{.State.Health.Status}}" e2e-authentik-server-1 2>/dev/null)
+            echo "attempt $i: $status"
+            if [ "$status" = "healthy" ]; then exit 0; fi
+            sleep 10
+          done
+          echo "Authentik failed to become healthy"
+          docker logs e2e-authentik-server-1 --tail 50
+          exit 1'
+
+      - name: Bootstrap Authentik (OIDC + SAML providers)
+        env:
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          ssh root@$SSH_HOST "cd /opt/datanika/e2e-sso && DATANIKA_E2E_BASE_URL=https://staging-app.datanika.io bash scripts/bootstrap-authentik.sh"
+
+      - name: Seed SSO configs in staging DB
+        env:
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          # Copy fixture JSON (written by bootstrap) into staging container
+          ssh root@$SSH_HOST "docker cp /opt/datanika/e2e-sso/.sso-fixture.json datanika-staging-app:/app/e2e/.sso-fixture.json"
+          # Run seed inside staging container (needs Datanika imports + DB)
+          ssh root@$SSH_HOST "docker exec datanika-staging-app uv run python e2e/scripts/seed-sso-configs.py"
+
+      - name: Open SSH tunnel to Authentik
+        env:
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          ssh -f -N -L 9000:localhost:9000 root@$SSH_HOST
+          # Verify tunnel
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:9000/-/health/ready/ > /dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "SSH tunnel to Authentik failed"
+          exit 1
+
+      - name: Run SSO specs
+        working-directory: e2e
+        env:
+          CI: "true"
+          DATANIKA_E2E_SSO_AUTHENTIK: "1"
+          DATANIKA_E2E_SLOW: "1"
+          DATANIKA_E2E_SKIP_SEED: "1"
+          DATANIKA_E2E_USER_EMAIL: "sso-user@datanika.test"
+          DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
+          DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
+          DATANIKA_E2E_ORG_SLUG: e2e-fixture
+          DATANIKA_E2E_SAML_ORG_SLUG: e2e-fixture-saml
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
+        run: npx playwright test sso-
+
+      - name: Upload SSO Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sso-playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      - name: Cleanup Authentik
+        if: always()
+        env:
+          SSH_HOST: ${{ secrets.HETZNER_HOST }}
+        run: |
+          ssh root@$SSH_HOST "cd /opt/datanika/e2e-sso && docker compose -p e2e -f docker-compose.test.yml down -v 2>/dev/null; rm -rf /opt/datanika/e2e-sso" || true
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          SHORT_SHA=${COMMIT_SHA:0:7}
+          FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+          TEXT=$(printf '\xf0\x9f\x9a\xa8 *SSO E2E failed*\n\n*Commit:* `%s`\n*Message:* %s\n*Run:* %s' \
+            "$SHORT_SHA" "$FIRST_LINE" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=1201995" \
+            --data-urlencode "text=${TEXT}" \
+            --data-urlencode "parse_mode=Markdown"
+
   # Post-deploy smoke gate. Fails loud if any curated URL 404s, returns an
   # empty body, or serves the wrong content-type/body substring. See
   # plans/growth/SMOKE_URLS.md (Growth-owned SoT) for the curation rationale.


### PR DESCRIPTION
## Summary

New `e2e-sso` job in ci.yml, triggered on push to `dev` after `deploy-staging`:

1. **SCPs** `docker-compose.test.yml` + bootstrap + seed scripts to `/opt/datanika/e2e-sso/` on Hetzner
2. **Starts Authentik** (4 containers: server, worker, postgres, redis) with compose project `e2e` so container names match the bootstrap script (`e2e-authentik-{db,server}-1`)
3. **Bootstraps** OIDC + SAML providers + test user via Authentik API (runs on Hetzner via SSH — needs `docker exec`)
4. **Seeds** 2 Datanika orgs with SSO configs pointing to Authentik (copies `.sso-fixture.json` into staging container, runs seed inside container)
5. **Opens SSH tunnel** (localhost:9000) so the Playwright browser on the CI runner can reach the Authentik login form
6. **Runs 16 SSO specs** with `DATANIKA_E2E_SSO_AUTHENTIK=1`, CF Access headers, `SKIP_SEED=1`
7. **Uploads** Playwright report artifact (7 days)
8. **Cleanup** (always): `docker compose down -v` + `rm -rf /opt/datanika/e2e-sso/`
9. **Telegram alert** on failure

### Network topology

```
CI runner (GitHub)              Hetzner (46.225.214.120)
├─ Playwright browser ─────────── SSH tunnel :9000 ──── Authentik :9000
│  (hits IdP login form)                                 ├─ authentik-server
│                                                        ├─ authentik-worker
├─ CF Access headers ──────────── staging-app :3100 ──── ├─ authentik-db
   (hits staging SSO routes)       └─ backend :8000 ────── └─ authentik-redis
                                     (OIDC discovery +
                                      code exchange at
                                      localhost:9000)
```

### Resource impact on Hetzner

~1.5 GB RAM for Authentik stack, ephemeral (cleaned up in `if: always()` step). Staging server has 8 GB.

Closes #212

## Test plan

- [ ] CI lint + test + helm-lint pass (no Python changes)
- [ ] First real run after merge to dev: Authentik boots, bootstrap succeeds, specs execute
- [ ] Cleanup step removes containers + directory
- [ ] Telegram fires on failure