### PR TITLE
[Infra] Fix bootstrap-authentik.sh: python → python3

### DIFF
--- a/e2e/scripts/bootstrap-authentik.sh
+++ b/e2e/scripts/bootstrap-authentik.sh
@@ -30,7 +30,7 @@ SAML_SP_ENTITY_ID="datanika"
 FIXTURE_FILE="$(dirname "$0")/../.sso-fixture.json"
 
 log() { echo "[bootstrap-authentik] $*"; }
-py() { python -c "$1"; }
+py() { python3 -c "$1"; }
 
 # --- 1. Wait for API ---
 log "Waiting for Authentik API at ${AUTHENTIK_URL}..."


### PR DESCRIPTION
First e2e-sso run failed at bootstrap step: `python: command not found` (exit 127). Hetzner Ubuntu 24.04 has `python3`, not bare `python`.

One-char fix: `py()` helper now calls `python3 -c`.

## Test plan
- [ ] CI green
- [ ] Re-run e2e-sso after merge — bootstrap should pass the `py()` calls