### PR TITLE
[Infra] Fix bootstrap api(): allow 204 No Content

### DIFF
--- a/e2e/scripts/bootstrap-authentik.sh
+++ b/e2e/scripts/bootstrap-authentik.sh
@@ -66,12 +66,14 @@ api() {
   http_code=$(echo "$response" | tail -1)
   local body
   body=$(echo "$response" | sed '$d')
-  if [ "$http_code" -ge 400 ] 2>/dev/null || [ -z "$body" ]; then
+  if [ "$http_code" -ge 400 ] 2>/dev/null; then
     log "ERROR: API ${method} ${path} → HTTP ${http_code}"
     log "Response: ${body:-<empty>}"
     return 1
   fi
-  echo "$body"
+  # 2xx with empty body (e.g. 204 No Content) is valid — just print nothing
+  [ -n "$body" ] && echo "$body"
+  return 0
 }
 
 # --- Verify token works ---


### PR DESCRIPTION
e2e-sso run #3: bootstrap passed token verify + flows + user creation, then died at `set_password` — the endpoint returns 204 No Content, which the fail-loud `api()` from core#217 treated as error (empty body).

Fix: `api()` now only fails on HTTP >= 400. Empty body with 2xx is valid (returns 0).

## Test plan
- [ ] CI green
- [ ] Next e2e-sso run: bootstrap passes set_password and proceeds to OIDC/SAML provider creation