### PR TITLE
fix(e2e): template-prefill selector — button role, not <select>

### DIFF
--- a/e2e/tests/template-prefill.spec.ts
+++ b/e2e/tests/template-prefill.spec.ts
@@ -13,9 +13,9 @@ test.describe("Pipeline template prefill via ?template=", () => {
   test("stripe-to-postgres template prefills connection form", async ({ loggedInPage: page }) => {
     await page.goto("/connections?template=stripe-to-postgres");
 
-    // The connection type select should be prefilled to "stripe"
-    // ConnectionState.form_type is bound to the select element
-    await expect(page.locator("select")).toHaveValue(/stripe/i);
+    // The connection type picker is a custom searchable_select (popover trigger button),
+    // not a native <select>. When form_type is prefilled, the button shows the value.
+    await expect(page.getByRole("button", { name: /stripe/i })).toBeVisible();
   });
 
   test("template_selected Plausible event fires on templates page", async ({


### PR DESCRIPTION
## Summary

Follow-up to #216. The first spec still failed because `page.locator("select")` finds nothing — the connection type picker is a `searchable_select` (custom popover trigger button), not a native `<select>`.

### Fix
```diff
- await expect(page.locator("select")).toHaveValue(/stripe/i);
+ await expect(page.getByRole("button", { name: /stripe/i })).toBeVisible();
```

The `searchable_select` renders as `rx.popover.trigger(rx.button(value, ...))`. When `ConnectionState.form_type = "stripe"`, the button text is "stripe".

## Evidence from CI
- Spec 2 (Plausible event) **already passes** after #216 (✓ in run 24538825803)
- Spec 1 fails at `locator("select")` — element not found (no native select on page)

Closes #215