### PR TITLE
[Infra] Pre-push hook: auto-rebase onto origin/dev

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -7,6 +7,24 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# Auto-rebase onto origin/dev (feature branches only)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "dev" && "$BRANCH" != "master" && "$BRANCH" != "main" ]]; then
+  git fetch origin dev --quiet 2>/dev/null || true
+  if ! git merge-base --is-ancestor origin/dev HEAD 2>/dev/null; then
+    echo "pre-push: branch is behind origin/dev — rebasing..."
+    if git rebase origin/dev --quiet; then
+      echo "pre-push: rebased onto origin/dev. Push again (--force-with-lease if already pushed)."
+      exit 1
+    else
+      git rebase --abort
+      echo "pre-push: rebase has conflicts — resolve manually:"
+      echo "  git fetch origin dev && git rebase origin/dev"
+      exit 1
+    fi
+  fi
+fi
+
 # Find venv
 if [ -x ".venv/Scripts/python.exe" ]; then
   PY=".venv/Scripts/python.exe"


### PR DESCRIPTION
## Summary

Adds auto-rebase to the pre-push hook. On `git push`, feature branches are automatically rebased onto `origin/dev` before lint/test checks run.

**Flow:**
1. `git push` → hook fetches `origin/dev`
2. If branch is already up-to-date → proceeds to lint/test
3. If behind → rebases onto `origin/dev`
   - Clean rebase → fails push with: *"Rebased onto origin/dev. Push again (--force-with-lease if already pushed)."*
   - Conflicts → aborts rebase, fails with manual instructions
4. Second `git push --force-with-lease` → branch is rebased, passes check, push succeeds

Skips `dev`/`master`/`main`. Prevents the merge-conflict-on-PR issue (e.g., #219 needed a manual rebase request).

## Test plan
- [x] Hook syntax valid (bash -n)
- [ ] CI green