### PR TITLE
ci: auto-file GitHub issue on e2e failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,20 @@ jobs:
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
 
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "[QA] e2e-staging failure on ${GITHUB_SHA:0:7}" \
+            --body "$(printf '**Run:** %s\n**Commit:** \`%s\`\n**Message:** %s\n**Report:** playwright-report artifact on the run page' \
+              '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              '${GITHUB_SHA:0:7}' \
+              '$(echo "${{ github.event.head_commit.message }}" | head -1)')" \
+            --label "e2e-failure"
+
   # SSO E2E tests — runs 16 Playwright specs (OIDC + SAML + edge cases)
   # against the staging app with a disposable Authentik IdP on Hetzner.
   #
@@ -393,6 +407,20 @@ jobs:
             --data-urlencode "chat_id=1201995" \
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
+
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "[QA] e2e-sso failure on ${GITHUB_SHA:0:7}" \
+            --body "$(printf '**Run:** %s\n**Commit:** \`%s\`\n**Message:** %s\n**Report:** playwright-report-sso artifact on the run page' \
+              '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              '${GITHUB_SHA:0:7}' \
+              '$(echo "${{ github.event.head_commit.message }}" | head -1)')" \
+            --label "e2e-failure"
 
   # Post-deploy smoke gate. Fails loud if any curated URL 404s, returns an
   # empty body, or serves the wrong content-type/body substring. See


### PR DESCRIPTION
## Summary

When `e2e-staging` or `e2e-sso` CI jobs fail, automatically create a GitHub issue with the `e2e-failure` label. Runs after the existing Telegram alert step.

### Issue content
- Run URL (clickable link to GHA)
- Commit SHA + first line of commit message
- Pointer to Playwright report artifact

### Why
Telegram alerts are ephemeral — they scroll off. Issues persist, show up in `gh issue list --label e2e-failure`, and can be assigned/closed as part of the normal workflow.

### Label
`e2e-failure` (red, created on the repo) — filter with `gh issue list --label e2e-failure` or the GitHub UI.

## Test plan
- [x] YAML syntax valid
- [ ] CI green
- [ ] Next e2e failure auto-creates an issue with the label