### PR TITLE
fix(ci): grant issues:write to e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -287,6 +290,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

The issue-creation step added in #221/#224 failed with:
```
GraphQL: Resource not accessible by integration (createIssue)
```

### Root cause
The default `GITHUB_TOKEN` is read-only. `gh issue create` needs `issues: write`.

### Fix
Add per-job `permissions` block to `e2e-staging` and `e2e-sso`:
```yaml
permissions:
  contents: read
  issues: write
```

Minimal scope — other jobs keep the read-only default.

## Test plan
- [x] YAML valid
- [ ] Next e2e failure successfully auto-files an issue with `e2e-failure` label