### PR TITLE
perf: E6 Arrow mode + E7 file-size guard for ELT streaming

### DIFF
--- a/datanika/services/destinations/postgres.py
+++ b/datanika/services/destinations/postgres.py
@@ -1,7 +1,13 @@
-"""Postgres raw lander — COPY FROM STDIN with Arrow/parquet batches.
+"""Postgres raw lander — COPY FROM STDIN with Arrow batches.
 
 Per SPEC_ELT_IR_ARCHITECTURE.md §5.3: Postgres landing uses COPY FROM STDIN
-BINARY with parquet→arrow→COPY chunks.
+with CSV format (psycopg copy_expert). Each Arrow batch is converted to
+CSV and streamed to COPY.
+
+E7 file-size guard: batches larger than FILE_MAX_BYTES (100 MB) are split
+by slicing the Arrow table into sub-tables before conversion, preventing
+OOM on large extracts. See Whisk doc §"Critical fix" — single multi-GB
+uploads time out.
 """
 
 from __future__ import annotations
@@ -15,6 +21,7 @@ import pyarrow.csv as pcsv
 from sqlalchemy import create_engine, text
 
 from datanika.services.connection_service import _build_sa_url
+from datanika.services.elt_runner import FILE_MAX_BYTES
 
 if TYPE_CHECKING:
     from datanika.services.ir.schema import IR
@@ -23,7 +30,11 @@ logger = logging.getLogger(__name__)
 
 
 class PostgresLander:
-    """Lands Arrow data into Postgres via COPY FROM STDIN (CSV format)."""
+    """Lands Arrow data into Postgres via COPY FROM STDIN (CSV format).
+
+    Large Arrow tables are sliced to keep each COPY payload under
+    FILE_MAX_BYTES (100 MB) per E7.
+    """
 
     def land(
         self,
@@ -42,12 +53,16 @@ class PostgresLander:
         batches = 0
 
         try:
-            # Ensure raw schema + table exist
+            # Ensure raw schema + table exist.
             with engine.connect() as conn:
                 conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {ir.target.raw_schema}"))
                 conn.commit()
 
-            # Extract from source — dlt sources yield dicts or Arrow batches
+            qualified = f"{ir.target.raw_schema}.{ir.target.table}"
+            schema_ensured = False
+
+            # Extract from source — dlt sources yield dicts or Arrow batches.
+            # In Arrow mode (E6), SQL sources yield pa.Table per chunk.
             for item in source:
                 if isinstance(item, (pa.Table, pa.RecordBatch)):
                     table = item if isinstance(item, pa.Table) else pa.Table.from_batches([item])
@@ -61,37 +76,34 @@ class PostgresLander:
                 if table.num_rows == 0:
                     continue
 
-                # Track input bytes
                 total_bytes_in += table.nbytes
 
-                # Write to CSV buffer for COPY
-                buf = io.BytesIO()
-                pcsv.write_csv(table, buf)
-                csv_bytes = buf.getvalue()
-                total_bytes_out += len(csv_bytes)
+                # Ensure destination table exists (once, on first non-empty batch).
+                if not schema_ensured:
+                    with engine.connect() as conn:
+                        _ensure_table(conn, qualified, table.schema)
+                    schema_ensured = True
 
-                # Create table if needed and COPY
-                qualified = f"{ir.target.raw_schema}.{ir.target.table}"
-                with engine.connect() as conn:
-                    _ensure_table(conn, qualified, table.schema)
-                    conn.execute(
-                        text(f"COPY {qualified} FROM STDIN WITH (FORMAT csv, HEADER true)"),
-                    )
-                    # Use raw_connection for COPY
+                # E7: split large tables into chunks <= FILE_MAX_BYTES.
+                # Estimate target rows per chunk from nbytes ratio. If the
+                # full table is already under the guard, this yields one chunk.
+                for chunk in _split_by_bytes(table, FILE_MAX_BYTES):
+                    csv_bytes = _table_to_csv_bytes(chunk)
+                    total_bytes_out += len(csv_bytes)
+
                     raw_conn = engine.raw_connection()
                     try:
                         cursor = raw_conn.cursor()
-                        buf.seek(0)
                         cursor.copy_expert(
                             f"COPY {qualified} FROM STDIN WITH (FORMAT csv, HEADER true)",
-                            buf,
+                            io.BytesIO(csv_bytes),
                         )
                         raw_conn.commit()
                     finally:
                         raw_conn.close()
 
-                total_rows += table.num_rows
-                batches += 1
+                    total_rows += chunk.num_rows
+                    batches += 1
 
         finally:
             engine.dispose()
@@ -102,6 +114,34 @@ class PostgresLander:
             "bytes_out": total_bytes_out,
             "batches": batches,
         }
+
+
+def _split_by_bytes(table: pa.Table, max_bytes: int) -> list[pa.Table]:
+    """Slice an Arrow table so each piece's nbytes <= max_bytes.
+
+    nbytes is the in-memory Arrow footprint, a conservative upper bound
+    for the resulting CSV size after serialization (CSV can be larger for
+    strings with escapes, but also smaller for nullable integer columns).
+    """
+    if table.num_rows == 0 or table.nbytes <= max_bytes:
+        return [table]
+
+    # Derive rows-per-chunk from the byte ratio.
+    rows_per_chunk = max(1, (table.num_rows * max_bytes) // table.nbytes)
+    chunks: list[pa.Table] = []
+    offset = 0
+    while offset < table.num_rows:
+        length = min(rows_per_chunk, table.num_rows - offset)
+        chunks.append(table.slice(offset, length))
+        offset += length
+    return chunks
+
+
+def _table_to_csv_bytes(table: pa.Table) -> bytes:
+    """Serialize an Arrow table to CSV bytes for COPY FROM STDIN."""
+    buf = io.BytesIO()
+    pcsv.write_csv(table, buf)
+    return buf.getvalue()
 
 
 def _ensure_table(conn, qualified_name: str, arrow_schema: pa.Schema) -> None:

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -51,6 +51,7 @@ INTERNAL_CONFIG_KEYS = {
     "table_names",
     "incremental",
     "batch_size",
+    "backend",
     "filters",
     "bucket_url",
     "file_glob",
@@ -240,10 +241,17 @@ class DltRunnerService:
 
         creds = self._to_dlt_credentials(connection_type, config)
 
+        # Arrow backend (E6) — when callers set backend="pyarrow", dlt's
+        # sql_database/sql_table yields pa.Table per chunk instead of dicts.
+        # Bypasses JSON normalization — 5.8x speedup on large MySQL loads.
+        backend = dlt_config.get("backend")
+
         if mode == "single_table":
             kwargs = {"credentials": creds, "table": dlt_config["table"], "chunk_size": batch_size}
             if schema is not None:
                 kwargs["schema"] = schema
+            if backend is not None:
+                kwargs["backend"] = backend
             incremental_cfg = dlt_config.get("incremental")
             if incremental_cfg is not None:
                 inc_kwargs = {"cursor_path": incremental_cfg["cursor_path"]}
@@ -257,6 +265,8 @@ class DltRunnerService:
             kwargs = {"credentials": creds, "chunk_size": batch_size}
             if schema is not None:
                 kwargs["schema"] = schema
+            if backend is not None:
+                kwargs["backend"] = backend
             table_names = dlt_config.get("table_names")
             if table_names is not None:
                 kwargs["table_names"] = table_names

--- a/datanika/services/elt_runner.py
+++ b/datanika/services/elt_runner.py
@@ -2,6 +2,16 @@
 
 Per SPEC_ELT_IR_ARCHITECTURE.md §5.3: destination adapters decide whether
 parquet lands via COPY, EXTERNAL TABLE, or native Arrow ingest.
+
+Arrow mode (E6, from Whisk architecture): SQL sources yield pa.Table per
+chunk instead of dict rows. This bypasses dlt's JSON normalization entirely
+— proven 5.8x speedup on 54M-row MySQL loads. See
+D:/Projects/whisk/data_repos/DB data transfer architecture.md §"MySQL
+Source: Arrow Mode".
+
+File size guard (E7): DATA_WRITER__FILE_MAX_BYTES splits multi-GB Arrow
+extracts into uploadable chunks. Without it, single files time out on
+HTTP upload. See Whisk doc §"Critical fix".
 """
 
 from __future__ import annotations
@@ -15,12 +25,26 @@ from datanika.services.ir.schema import IR
 
 logger = logging.getLogger(__name__)
 
-# Arrow-mode env vars per spec §5.3 / §16.1 — must be set before dlt import
+# Arrow-mode env vars per SPEC §5.3 / §16.1 + Whisk architecture.
+# MUST be set BEFORE any dlt module is imported — dlt reads these at
+# import time into its global config. Setting them inside stream_to_raw()
+# is too late if dlt has already been imported elsewhere in the process.
+#
+# Prefix MUST be DATA_WRITER__ (global), NOT NORMALIZE__ — Arrow direct-
+# import skips the normalize step, so NORMALIZE__ settings are ignored.
 _ARROW_ENV = {
     "DATA_WRITER__FILE_MAX_ITEMS": "10000",
     "DATA_WRITER__FILE_MAX_BYTES": "100000000",  # 100 MB
     "LOAD__DELETE_COMPLETED_JOBS": "true",
 }
+
+# Apply at module import time so dlt sees them first.
+for _k, _v in _ARROW_ENV.items():
+    os.environ.setdefault(_k, _v)
+
+# Exported for adapters that need the same threshold for their own
+# in-memory buffers (e.g., PostgresLander CSV COPY batching).
+FILE_MAX_BYTES = int(os.environ["DATA_WRITER__FILE_MAX_BYTES"])
 
 
 @dataclass(frozen=True)
@@ -32,13 +56,6 @@ class StreamStats:
     bytes_out: int  # bytes written to destination raw (post-compression)
     batches: int
     duration_ms: int
-
-
-def _ensure_arrow_env() -> None:
-    """Set Arrow-mode env vars if not already present."""
-    for key, val in _ARROW_ENV.items():
-        if key not in os.environ:
-            os.environ[key] = val
 
 
 def stream_to_raw(
@@ -54,20 +71,22 @@ def stream_to_raw(
     This is the ELT ingest path — no dlt normalization, no disk staging.
     Destination adapters handle the final landing strategy.
     """
-    _ensure_arrow_env()
-
     start_ms = int(time.time() * 1000)
 
     from datanika.services.destinations import get_lander
 
     lander = get_lander(destination_type)
 
-    # Use dlt's source readers in Arrow mode for extraction
+    # Use dlt's source readers in Arrow mode for extraction.
     from datanika.services.dlt_runner import DltRunnerService
 
     runner = DltRunnerService()
     dlt_config = {
         "mode": "single_table" if ir.source.table else "full_database",
+        # E6: Arrow backend for SQL sources — yields pa.Table per chunk
+        # instead of dict rows. dlt_runner.build_source() passes this
+        # through to sql_table()/sql_database().
+        "backend": "pyarrow",
     }
     if ir.source.table:
         dlt_config["table"] = ir.source.table
@@ -76,7 +95,7 @@ def stream_to_raw(
 
     source = runner.build_source(source_type, source_config, dlt_config, batch_size=10000)
 
-    # Land to raw via destination adapter
+    # Land to raw via destination adapter.
     stats = lander.land(
         source=source,
         ir=ir,

--- a/tests/test_services/test_destinations.py
+++ b/tests/test_services/test_destinations.py
@@ -1,0 +1,86 @@
+"""Destination landers — PostgresLander file-size guard (E7).
+
+Arrow-mode (E6) tests live in test_elt_runner.py; this file focuses on
+adapter-internal behavior.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from datanika.services.destinations.postgres import _split_by_bytes, _table_to_csv_bytes
+
+
+@pytest.fixture
+def sample_table() -> pa.Table:
+    """10k rows × 2 int64 columns ≈ 160 KB in Arrow memory."""
+    n = 10_000
+    return pa.table(
+        {
+            "id": pa.array(range(n), type=pa.int64()),
+            "val": pa.array(range(n), type=pa.int64()),
+        }
+    )
+
+
+class TestSplitByBytes:
+    """E7 — _split_by_bytes splits Arrow tables at a size threshold."""
+
+    def test_small_table_returns_single_chunk(self, sample_table):
+        # Threshold much larger than table — single chunk.
+        chunks = _split_by_bytes(sample_table, max_bytes=1_000_000)
+        assert len(chunks) == 1
+        assert chunks[0].num_rows == sample_table.num_rows
+
+    def test_large_table_splits_into_multiple_chunks(self, sample_table):
+        # Threshold a quarter of the table size — expect ~4 chunks.
+        max_bytes = sample_table.nbytes // 4
+        chunks = _split_by_bytes(sample_table, max_bytes=max_bytes)
+        assert len(chunks) >= 3  # 3-5 depending on row math
+        total_rows = sum(c.num_rows for c in chunks)
+        assert total_rows == sample_table.num_rows
+        # Each chunk should be at or under the threshold.
+        for c in chunks:
+            assert c.nbytes <= max_bytes * 2  # allow 2x slack for metadata
+
+    def test_empty_table_returns_empty_list_like(self):
+        empty = pa.table({"id": pa.array([], type=pa.int64())})
+        chunks = _split_by_bytes(empty, max_bytes=1_000_000)
+        assert len(chunks) == 1
+        assert chunks[0].num_rows == 0
+
+    def test_single_row_never_splits_below_one(self, sample_table):
+        # Pathologically tiny max_bytes — still yields at-least-1-row chunks.
+        chunks = _split_by_bytes(sample_table, max_bytes=1)
+        assert all(c.num_rows >= 1 for c in chunks)
+        total = sum(c.num_rows for c in chunks)
+        assert total == sample_table.num_rows
+
+
+class TestTableToCsvBytes:
+    def test_roundtrip(self, sample_table):
+        csv_bytes = _table_to_csv_bytes(sample_table)
+        # Header + 10k lines.
+        assert csv_bytes.count(b"\n") == sample_table.num_rows + 1
+        # pyarrow CSV quotes column names by default.
+        assert csv_bytes.startswith(b'"id","val"\n')
+
+
+class TestFileMaxBytesConstant:
+    """E6/E7 — FILE_MAX_BYTES is set from env and used by landers."""
+
+    def test_default_is_100mb(self):
+        from datanika.services.elt_runner import FILE_MAX_BYTES
+
+        # Default from _ARROW_ENV in elt_runner.py.
+        assert FILE_MAX_BYTES == 100_000_000
+
+    def test_env_vars_applied_at_import(self):
+        import os
+
+        # All three Arrow env vars should be in os.environ after
+        # elt_runner import (which happens via the test imports above).
+        assert os.environ.get("DATA_WRITER__FILE_MAX_BYTES") == "100000000"
+        assert os.environ.get("DATA_WRITER__FILE_MAX_ITEMS") == "10000"
+        assert os.environ.get("LOAD__DELETE_COMPLETED_JOBS") == "true"

--- a/tests/test_services/test_elt_runner.py
+++ b/tests/test_services/test_elt_runner.py
@@ -1,0 +1,159 @@
+"""ELT runner — Arrow mode wiring (E6) + stream_to_raw orchestration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from datanika.services.elt_runner import StreamStats, stream_to_raw
+from datanika.services.ir.schema import IR, IRColumn, IRSource, IRTarget
+
+
+def _make_ir() -> IR:
+    return IR(
+        ir_version=1,
+        source=IRSource(kind="sql_table", connection_id=1, table="orders"),
+        columns=[
+            IRColumn(source_ref="id", target_name="id", type="bigint", nullable=False),
+        ],
+        primary_key=["id"],
+        target=IRTarget(connection_id=2, raw_schema="raw", table="orders"),
+    )
+
+
+class TestArrowModeWiring:
+    """E6 — stream_to_raw sets backend='pyarrow' when building SQL sources."""
+
+    def test_stream_to_raw_passes_arrow_backend_to_build_source(self):
+        ir = _make_ir()
+
+        fake_lander = MagicMock()
+        fake_lander.land.return_value = {
+            "rows": 0,
+            "bytes_in": 0,
+            "bytes_out": 0,
+            "batches": 0,
+        }
+
+        with (
+            patch(
+                "datanika.services.destinations.get_lander",
+                return_value=fake_lander,
+            ),
+            patch(
+                "datanika.services.dlt_runner.DltRunnerService.build_source",
+                return_value=object(),
+            ) as mock_build_source,
+        ):
+            stats = stream_to_raw(
+                ir=ir,
+                run_id=1,
+                source_config={},
+                destination_config={},
+                source_type="postgres",
+                destination_type="postgres",
+            )
+
+        assert isinstance(stats, StreamStats)
+        # E6: Arrow backend is wired.
+        call_args = mock_build_source.call_args
+        # build_source(source_type, source_config, dlt_config, batch_size=...)
+        if len(call_args.args) >= 3:
+            dlt_config = call_args.args[2]
+        else:
+            dlt_config = call_args.kwargs["dlt_config"]
+        assert dlt_config["backend"] == "pyarrow"
+        assert dlt_config["table"] == "orders"
+        assert dlt_config["mode"] == "single_table"
+
+    def test_stream_to_raw_captures_stats_from_lander(self):
+        ir = _make_ir()
+
+        fake_lander = MagicMock()
+        fake_lander.land.return_value = {
+            "rows": 1000,
+            "bytes_in": 50_000,
+            "bytes_out": 20_000,
+            "batches": 2,
+        }
+
+        with (
+            patch(
+                "datanika.services.destinations.get_lander",
+                return_value=fake_lander,
+            ),
+            patch(
+                "datanika.services.dlt_runner.DltRunnerService.build_source",
+                return_value=object(),
+            ),
+        ):
+            stats = stream_to_raw(
+                ir=ir,
+                run_id=42,
+                source_config={},
+                destination_config={},
+                source_type="postgres",
+                destination_type="postgres",
+            )
+
+        assert stats.rows == 1000
+        assert stats.bytes_out == 20_000
+        assert stats.batches == 2
+        assert stats.duration_ms >= 0
+
+
+class TestDltRunnerBackendPassthrough:
+    """E6 — DltRunnerService.build_source forwards backend to sql_table/sql_database."""
+
+    def test_single_table_passes_backend(self):
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.dlt_runner.sql_table") as mock_sql_table:
+            mock_sql_table.return_value = object()
+            runner.build_source(
+                "postgres",
+                {"host": "h", "port": 5432, "user": "u", "password": "p", "database": "d"},
+                {"mode": "single_table", "table": "t", "backend": "pyarrow"},
+                batch_size=1000,
+            )
+
+            kwargs = mock_sql_table.call_args.kwargs
+            assert kwargs["backend"] == "pyarrow"
+            assert kwargs["table"] == "t"
+            assert kwargs["chunk_size"] == 1000
+
+    def test_full_database_passes_backend(self):
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.dlt_runner.sql_database") as mock_sql_database:
+            mock_sql_database.return_value = object()
+            runner.build_source(
+                "postgres",
+                {"host": "h", "port": 5432, "user": "u", "password": "p", "database": "d"},
+                {"mode": "full_database", "backend": "pyarrow"},
+                batch_size=1000,
+            )
+
+            kwargs = mock_sql_database.call_args.kwargs
+            assert kwargs["backend"] == "pyarrow"
+
+    def test_backend_is_optional(self):
+        """ETL path doesn't set backend — must not be forwarded as None."""
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.dlt_runner.sql_table") as mock_sql_table:
+            mock_sql_table.return_value = object()
+            runner.build_source(
+                "postgres",
+                {"host": "h", "port": 5432, "user": "u", "password": "p", "database": "d"},
+                {"mode": "single_table", "table": "t"},  # no backend
+                batch_size=1000,
+            )
+
+            kwargs = mock_sql_table.call_args.kwargs
+            assert "backend" not in kwargs


### PR DESCRIPTION
## Summary

Closes **E6** and **E7** from `PLAN_ENGINEERING.md` §ELT Optimizations. Ports the two highest-leverage patterns from the Whisk production architecture into Datanika's ELT engine.

### E6 — Arrow mode in `stream_to_raw()`
- Apply `DATA_WRITER__FILE_MAX_ITEMS=10000`, `DATA_WRITER__FILE_MAX_BYTES=100_000_000`, and `LOAD__DELETE_COMPLETED_JOBS=true` at **module import time** via `os.environ.setdefault()` — dlt reads these before any source is built. (Previous code set them inside `stream_to_raw()`, which is too late if dlt was imported elsewhere first.)
- Pass `backend="pyarrow"` through `DltRunnerService.build_source()` to dlt's `sql_table`/`sql_database`. SQL sources now yield `pa.Table` per chunk instead of dict rows, bypassing JSON normalization entirely.
- Add `"backend"` to `INTERNAL_CONFIG_KEYS` so it's not forwarded to `pipeline.run()` on the ETL path.

**Measured impact (Whisk prod data):** 5.8× speedup on 54M-row MySQL (174min → 17min), 3.5× on 8.6M-doc Mongo.

### E7 — File-size guard in `PostgresLander`
- New `_split_by_bytes()` slices `pa.Table` into sub-tables whose `nbytes` ≤ `FILE_MAX_BYTES` (100 MB) before CSV serialization + COPY FROM STDIN.
- Prevents the multi-GB upload timeout mode documented in Whisk §"Critical fix".
- `FILE_MAX_BYTES` constant exported from `elt_runner` so other adapters can reuse the same threshold.

### Why `DATA_WRITER__` not `NORMALIZE__`
Arrow direct-import skips dlt's normalize step. `NORMALIZE__*` env vars are ignored for Arrow tables — only the global `DATA_WRITER__` prefix applies during extract. Documented in the module docstring.

## Test plan
- [x] 1980 tests passing (+12 new), ruff clean
- [x] 12 new tests: 4 split-by-bytes, 1 CSV roundtrip, 2 env-var assertion, 5 backend-wiring
- [ ] CI green
- [ ] Post-promote: observe Whisk-class throughput on next large SQL source run on staging

Closes E6 + E7 in PLAN_ENGINEERING.md §ELT Optimizations.