### PR TITLE
[Infra] e2e-sso: fix spec assertions for Authentik login-flow wrapping

### DIFF
--- a/e2e/tests/sso-oidc.spec.ts
+++ b/e2e/tests/sso-oidc.spec.ts
@@ -32,7 +32,10 @@ test.describe("SSO OIDC: Authentik @slow", () => {
     // Navigate via backend to get the real 302 redirect (Vite proxy blocks it)
     await page.goto(`${BACKEND_URL}/api/auth/sso/login/${ORG_SLUG}`);
 
-    const finalUrl = page.url();
+    // Authentik wraps /application/o/authorize in a login flow when no session:
+    //   /if/flow/default-authentication-flow/?next=%2Fapplication%2Fo%2Fauthorize%2F%3F...
+    // Decode the URL so our substring checks match either direct or wrapped form.
+    const finalUrl = decodeURIComponent(page.url());
     expect(finalUrl).toContain("/application/o/authorize/");
     expect(finalUrl).toContain("client_id=datanika-oidc-e2e");
     expect(finalUrl).toContain("response_type=code");
@@ -43,8 +46,8 @@ test.describe("SSO OIDC: Authentik @slow", () => {
     // 1. Navigate to SSO login via backend — redirects to Authentik
     await page.goto(`${BACKEND_URL}/api/auth/sso/login/${ORG_SLUG}`);
 
-    // 2. Authentik login form
-    await page.waitForURL(/.*\/application\/o\/authorize\/.*/);
+    // 2. Authentik login form — fresh session always goes through the login flow
+    await page.waitForURL(/\/if\/flow\/default-authentication-flow\//);
     await page.getByLabel(/username|email/i).fill(SSO_USER_EMAIL);
     await page.getByLabel(/password/i).fill(SSO_USER_PASSWORD);
     await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
@@ -85,7 +88,9 @@ test.describe("SSO OIDC: Authentik @slow", () => {
   });
 
   test("OIDC with invalid org slug returns error", async ({ playwright }) => {
-    const api = await playwright.request.newContext(backendContextOptions());
+    // maxRedirects: 0 — the backend responds with a 302 error redirect;
+    // following it would land on a 200 error page and fail the assertion.
+    const api = await playwright.request.newContext(backendContextOptions({ maxRedirects: 0 }));
     const response = await api.get("/api/auth/sso/login/nonexistent-org-slug");
     expect(response.status()).not.toBe(200);
     expect(response.status()).toBeLessThan(500);
@@ -95,7 +100,8 @@ test.describe("SSO OIDC: Authentik @slow", () => {
   test("OIDC state tampering is rejected", async ({ page, context }) => {
     // Start a legitimate OIDC flow to get a state cookie via backend
     await page.goto(`${BACKEND_URL}/api/auth/sso/login/${ORG_SLUG}`);
-    await page.waitForURL(/.*\/application\/o\/authorize\/.*/);
+    // Authentik wraps /application/o/authorize in a login flow for fresh sessions
+    await page.waitForURL(/\/if\/flow\/default-authentication-flow\//);
 
     // Tamper with the sso_state cookie
     const cookies = await context.cookies();

--- a/e2e/tests/sso-saml.spec.ts
+++ b/e2e/tests/sso-saml.spec.ts
@@ -30,7 +30,9 @@ test.describe("SSO SAML: Authentik @slow", () => {
     const loginUrl = `${BACKEND_URL}/api/auth/sso/login/${SAML_ORG_SLUG}`;
     const response = await page.goto(loginUrl);
 
-    const finalUrl = page.url();
+    // Decode — Authentik may wrap /application/saml/.../sso in a login flow
+    // where the SAMLRequest param ends up URL-encoded inside ?next=
+    const finalUrl = decodeURIComponent(page.url());
     // SP-initiated SAML: should redirect to Authentik with SAMLRequest param
     expect(
       finalUrl.includes("SAMLRequest=") || (response?.status() ?? 0) === 302,
@@ -41,7 +43,8 @@ test.describe("SSO SAML: Authentik @slow", () => {
   test("SAML full flow: login via Authentik → session created", async ({ page }) => {
     await page.goto(`${BACKEND_URL}/api/auth/sso/login/${SAML_ORG_SLUG}`);
 
-    // Authentik login form
+    // Fresh session: Authentik wraps SAML SSO in the login flow first
+    await page.waitForURL(/\/if\/flow\/default-authentication-flow\//);
     await page.getByLabel(/username|email/i).fill(SSO_USER_EMAIL);
     await page.getByLabel(/password/i).fill(SSO_USER_PASSWORD);
     await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
@@ -75,7 +78,8 @@ test.describe("SSO SAML: Authentik @slow", () => {
   });
 
   test("SAML assertion with wrong audience is rejected", async ({ playwright }) => {
-    const api = await playwright.request.newContext(backendContextOptions());
+    // maxRedirects: 0 — we want to observe the 302 error redirect, not follow it
+    const api = await playwright.request.newContext(backendContextOptions({ maxRedirects: 0 }));
     const response = await api.post("/api/auth/sso/callback", {
       form: {
         SAMLResponse: Buffer.from("<invalid-xml>").toString("base64"),


### PR DESCRIPTION
With the network bridge (core#228) working, Authentik now correctly receives SSO requests from both staging and the Playwright browser. The remaining 10 spec failures were all assertion bugs — Authentik wraps the OIDC `/application/o/authorize/` and SAML `/application/saml/.../sso/` URLs inside a login flow when there's no active session:

```
http://e2e-authentik-server:9000/if/flow/default-authentication-flow/?next=%2Fapplication%2Fo%2Fauthorize%2F%3F...
```

The target URL ends up URL-encoded inside `next=`, and fresh CI sessions never have an active Authentik session, so specs looking for the direct authorize/sso URL never see it.

## Fixes

### URL substring checks — decode before matching
- `sso-oidc.spec.ts` "OIDC login redirects": `decodeURIComponent(page.url())` before `.toContain("/application/o/authorize/")`
- `sso-saml.spec.ts` "SAML login redirects": same, so `SAMLRequest=` matches even when wrapped

### waitForURL — wait for the login flow URL
Fresh CI sessions ALWAYS hit the login flow first. Changed 3 regexes from `/.*\/application\/o\/authorize\/.*/` to `/\/if\/flow\/default-authentication-flow\//`:
- "OIDC full flow"
- "OIDC state tampering"
- "SAML full flow"

### maxRedirects: 0 for error-path API tests
These were getting 200 because the backend responds with a 302 error redirect and Playwright followed it to the 200 error page:
- "OIDC with invalid org slug returns error"
- "SAML assertion with wrong audience is rejected"

## Test plan

- [ ] CI green
- [ ] Next e2e-sso run: all 16 specs pass

Closes #230