### PR TITLE
[Infra] e2e-sso: bootstrap scopes + login form + consent — 13/13 passing locally

### DIFF
--- a/e2e/scripts/bootstrap-authentik.sh
+++ b/e2e/scripts/bootstrap-authentik.sh
@@ -95,7 +95,19 @@ log "API token verified."
 AUTH_FLOW_PK=$(api GET '/flows/instances/?slug=default-provider-authorization-implicit-consent' | py "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
 INVAL_FLOW_PK=$(api GET '/flows/instances/?slug=default-provider-invalidation-flow' | py "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
 SIGNING_KEY_PK=$(api GET '/crypto/certificatekeypairs/' | py "import json,sys; r=json.load(sys.stdin)['results']; print(r[0]['pk'] if r else '')")
+
+# Scope mappings — required for userinfo to return claims. Without these
+# the OIDC provider issues a token but /userinfo returns 403 because
+# Authentik has nothing to map into the response.
+SCOPE_PKS=$(api GET '/propertymappings/provider/scope/' | py "
+import json, sys
+data = json.load(sys.stdin)
+wanted = {'openid', 'email', 'profile'}
+pks = [p['pk'] for p in data['results'] if p.get('scope_name') in wanted]
+print(','.join(pks))
+")
 log "Flows: auth=${AUTH_FLOW_PK} inval=${INVAL_FLOW_PK} key=${SIGNING_KEY_PK}"
+log "Scope mappings (openid+email+profile): ${SCOPE_PKS}"
 
 # --- 5. Create test user ---
 log "Creating test user sso-user@datanika.test..."
@@ -115,9 +127,19 @@ SSO_USER_ID=$(echo "$SSO_USER" | py "import json,sys; print(json.load(sys.stdin)
 log "Test user ID: ${SSO_USER_ID}"
 
 api POST "/core/users/${SSO_USER_ID}/set_password/" -d '{"password": "SsoTestPassword-2026"}' > /dev/null
+# set_password via API sometimes doesn't apply (2024.12 quirk) — belt-and-suspenders
+# via `ak changepassword` inside the server container.
+docker exec -i e2e-authentik-server-1 ak changepassword sso-user <<< $'SsoTestPassword-2026\nSsoTestPassword-2026' > /dev/null 2>&1 || true
 
 # --- 6. Create OIDC provider + application ---
 log "Creating OIDC provider..."
+# Build property_mappings JSON array from comma-separated PKs
+SCOPE_JSON=$(echo "${SCOPE_PKS}" | py "
+import sys
+pks = [p.strip() for p in sys.stdin.read().strip().split(',') if p.strip()]
+import json
+print(json.dumps(pks))
+")
 OIDC_PROVIDER=$(api POST /providers/oauth2/ -d "{
   \"name\": \"datanika-oidc-e2e\",
   \"authorization_flow\": \"${AUTH_FLOW_PK}\",
@@ -127,7 +149,8 @@ OIDC_PROVIDER=$(api POST /providers/oauth2/ -d "{
   \"client_secret\": \"oidc-e2e-secret-not-for-production\",
   \"redirect_uris\": [{\"matching_mode\": \"strict\", \"url\": \"${OIDC_REDIRECT_URI}\"}],
   \"signing_key\": \"${SIGNING_KEY_PK}\",
-  \"sub_mode\": \"user_email\"
+  \"sub_mode\": \"user_email\",
+  \"property_mappings\": ${SCOPE_JSON}
 }" 2>/dev/null || true)
 
 if [ -z "$OIDC_PROVIDER" ]; then

--- a/e2e/tests/sso-oidc.spec.ts
+++ b/e2e/tests/sso-oidc.spec.ts
@@ -46,20 +46,21 @@ test.describe("SSO OIDC: Authentik @slow", () => {
     // 1. Navigate to SSO login via backend — redirects to Authentik
     await page.goto(`${BACKEND_URL}/api/auth/sso/login/${ORG_SLUG}`);
 
-    // 2. Authentik login form — fresh session always goes through the login flow
+    // 2. Authentik 2-step login: username → submit → password → submit.
+    // Authentik 2024.12 UI is lit-element based; form inputs live inside
+    // shadow DOM. Use getByRole (pierces shadow DOM) and match on the
+    // accessible name from aria-label/placeholder, not input[name].
     await page.waitForURL(/\/if\/flow\/default-authentication-flow\//);
-    await page.getByLabel(/username|email/i).fill(SSO_USER_EMAIL);
-    await page.getByLabel(/password/i).fill(SSO_USER_PASSWORD);
+    await page.getByRole("textbox", { name: /email|username/i }).fill(SSO_USER_EMAIL);
+    await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
+    await page.getByRole("textbox", { name: /password/i }).fill(SSO_USER_PASSWORD);
     await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
 
-    // 3. Authentik may show a consent screen — auto-approve if present
-    const consentButton = page.getByRole("button", { name: /continue|allow|approve/i });
-    if (await consentButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await consentButton.click();
-    }
-
-    // 4. Callback redirects back to Datanika with tokens
-    await page.waitForURL(/.*\/(connections|dashboard|pipelines|login).*/i, { timeout: 15000 });
+    // 3. Bootstrap uses default-provider-authorization-implicit-consent flow,
+    //    so no consent step. Callback lands on /auth/complete?token=...
+    await page.waitForURL(/\/(auth\/complete|connections|dashboard|pipelines|login)/, {
+      timeout: 15000,
+    });
 
     // 5. Verify session — user should be logged in (or at least past the SSO flow)
     const url = page.url();
@@ -112,12 +113,15 @@ test.describe("SSO OIDC: Authentik @slow", () => {
       ]);
     }
 
-    // Simulate callback with tampered state
-    const callbackResp = await page.goto(
-      `${BACKEND_URL}/api/auth/sso/callback?code=fake&state=tampered`,
-    );
-    // Should reject with redirect to error or 400, never 200
-    const status = callbackResp?.status() ?? 0;
-    expect(status === 302 || status >= 400, `Expected 302 or 400+, got ${status}`).toBe(true);
+    // Simulate callback with tampered state. page.goto follows redirects
+    // through to a 200 page, so check the final URL instead — rejection
+    // redirects to /login?error=..., success would stay on /auth/complete.
+    await page.goto(`${BACKEND_URL}/api/auth/sso/callback?code=fake&state=tampered`);
+    const finalUrl = page.url();
+    expect(
+      finalUrl.includes("error=") || finalUrl.includes("/login"),
+      `Expected redirect to error page, got ${finalUrl}`,
+    ).toBe(true);
+    expect(finalUrl).not.toContain("/auth/complete");
   });
 });

--- a/e2e/tests/sso-saml.spec.ts
+++ b/e2e/tests/sso-saml.spec.ts
@@ -43,20 +43,21 @@ test.describe("SSO SAML: Authentik @slow", () => {
   test("SAML full flow: login via Authentik → session created", async ({ page }) => {
     await page.goto(`${BACKEND_URL}/api/auth/sso/login/${SAML_ORG_SLUG}`);
 
-    // Fresh session: Authentik wraps SAML SSO in the login flow first
+    // Fresh session: Authentik wraps SAML SSO in the login flow first.
+    // 2-step: username → submit → password → submit (Authentik 2024.12).
+    // Form inputs live inside lit-element shadow DOM — use getByRole which
+    // pierces shadow DOM.
     await page.waitForURL(/\/if\/flow\/default-authentication-flow\//);
-    await page.getByLabel(/username|email/i).fill(SSO_USER_EMAIL);
-    await page.getByLabel(/password/i).fill(SSO_USER_PASSWORD);
+    await page.getByRole("textbox", { name: /email|username/i }).fill(SSO_USER_EMAIL);
+    await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
+    await page.getByRole("textbox", { name: /password/i }).fill(SSO_USER_PASSWORD);
     await page.getByRole("button", { name: /log in|sign in|continue/i }).click();
 
-    // Authentik may show consent — auto-approve
-    const consentButton = page.getByRole("button", { name: /continue|allow|approve/i });
-    if (await consentButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await consentButton.click();
-    }
-
-    // SAMLResponse POST to callback → redirect to app
-    await page.waitForURL(/.*\/(connections|dashboard|pipelines|login).*/i, { timeout: 15000 });
+    // Implicit consent flow: no consent screen.
+    // SAMLResponse POST to callback → /auth/complete?token=... or app route
+    await page.waitForURL(/\/(auth\/complete|connections|dashboard|pipelines|login)/, {
+      timeout: 15000,
+    });
 
     const url = page.url();
     expect(url).not.toContain("/api/auth/sso");


### PR DESCRIPTION
**Verified end-to-end locally.** 13/13 runnable SSO specs pass in 32s. 3 skipped are intentional (JIT provisioning needs extended seed; OIDC misconfig + quota gating are TBD).

## How I verified
Set up the full stack the same way CI does — Authentik on Hetzner via SSH, bridge networks, SSH tunnel 9000 to local, run Playwright on Windows. No Docker needed locally (staging Datanika already runs on Hetzner, Authentik runs on Hetzner).

Faster than CI push-wait loops; next session's SSO work should do this from day one.

## Fixes

### `bootstrap-authentik.sh`
- **Scope mappings**: fetch openid+email+profile PKs, attach via `property_mappings`. Without these Authentik issues tokens but `/userinfo` returns 403 (root cause of 5 consecutive CI failures).
- **Explicit password reset**: `ak changepassword sso-user` inside container after `set_password` API call. API-based password set doesn't always apply in 2024.12.

### `sso-oidc.spec.ts` / `sso-saml.spec.ts`
- **2-step login form**: Authentik 2024.12 shows username → submit → password → submit, not single-page. Split the fills + clicks.
- **Shadow DOM selectors**: use `getByRole("textbox", { name: /email|username/i })` instead of `getByLabel`. Authentik's lit-element form inputs don't expose labels via associated `<label>` tags.
- **Remove consent handling**: bootstrap uses `default-provider-authorization-implicit-consent` flow — no consent screen. The old consent check was clicking the password-form "Continue" button during navigation, breaking the flow.
- **Callback URL check**: wait for `/auth/complete` (or fallback app routes) instead of `/connections|dashboard|...` which only appears after the `/auth/complete` JWT exchange.
- **Tamper test assertion**: `page.goto` follows redirects, so the 302 error → 200 login page. Check `page.url()` contains `/error=` or `/login` instead.

Closes #230