### PR TITLE
test: add errors='ignore' to analytics-leak guard read_text

### DIFF
--- a/tests/test_no_analytics_leak.py
+++ b/tests/test_no_analytics_leak.py
@@ -34,7 +34,7 @@ class TestNoAnalyticsLeakIntoCore:
         core_root = Path(core_module.__file__).resolve().parent
         offenders: list[tuple[Path, str]] = []
         for py_file in core_root.rglob("*.py"):
-            text = py_file.read_text(encoding="utf-8")
+            text = py_file.read_text(encoding="utf-8", errors="ignore")
             for needle in FORBIDDEN_STRINGS:
                 if needle in text:
                     offenders.append((py_file.relative_to(core_root), needle))


### PR DESCRIPTION
1-line nit from #116. If a future file contains a non-UTF-8 byte the guard would crash; with errors='ignore' it just skips the byte. Same FORBIDDEN_STRINGS scan. Test still passes. Closes #116.