### PR TITLE
Add smoke-prod CI job — pytest shape checks against prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,11 +499,12 @@ jobs:
           **Report:** playwright-report-sso artifact on the run page" \
             --label "e2e-failure"
 
-  # Post-deploy smoke gate. Fails loud if any curated URL 404s, returns an
-  # empty body, or serves the wrong content-type/body substring. See
-  # plans/growth/SMOKE_URLS.md (Growth-owned SoT) for the curation rationale.
-  # Non-empty body check is the critical guard — core#124 returned
-  # 404 Content-Length: 0, which a status-only check would have missed.
+  # Post-deploy smoke gate — shallow URL check. Fails loud if any curated
+  # URL 404s, returns an empty body, or serves the wrong content-type/body
+  # substring. See plans/growth/SMOKE_URLS.md (Growth-owned SoT) for the
+  # curation rationale. Non-empty body check is the critical guard —
+  # core#124 returned 404 Content-Length: 0, which a status-only check
+  # would have missed.
   smoke:
     needs: deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -512,3 +513,52 @@ jobs:
       - uses: actions/checkout@v6
       - name: Smoke gate — app.datanika.io
         run: bash .github/smoke-check.sh https://app.datanika.io .github/smoke-urls-core.txt
+
+  # Post-deploy pytest smoke — deeper shape assertions against prod.
+  # Complements the URL gate above: catches 200-with-wrong-payload bugs
+  # (tier_count changed, agent-guide.md shrunk, openapi.json shape broke)
+  # that the URL gate can't distinguish from correct responses.
+  # See plans/qa/PLAN_QA.md → P0 Pre-Promotion Smoke (core#107 Phase 1).
+  smoke-prod:
+    needs: [deploy, smoke]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Run smoke probes against prod
+        id: smoke
+        env:
+          DATANIKA_SMOKE_CORE_URL: https://app.datanika.io
+          DATANIKA_SMOKE_LANDING_URL: https://datanika.io
+        # No CF Access headers — prod is public. Conftest's _core_headers()
+        # is a no-op when the env vars are unset.
+        run: pytest scripts/smoke/ -v --tb=short
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          SHORT_SHA=${COMMIT_SHA:0:7}
+          FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+          TEXT=$(printf '\xf0\x9f\x94\xa5 *PROD smoke failed* (shape regression)\n\n*Commit:* `%s`\n*Message:* %s\n*Run:* %s\n\n*Rollback:* see plans/infra/RUNBOOK_DEV_TO_MASTER.md' \
+            "$SHORT_SHA" "$FIRST_LINE" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=1201995" \
+            --data-urlencode "text=${TEXT}" \
+            --data-urlencode "parse_mode=Markdown"


### PR DESCRIPTION
## Summary

Adds a `smoke-prod` CI job that runs `scripts/smoke/` (pytest + httpx) against `app.datanika.io` + `datanika.io` after every push to `master`. Complements the existing shallow `smoke` bash gate.

**Phase 1 of core#107.** Phase 2 (staging pytest smoke) already shipped as `smoke-staging`.

## What the new job catches

The bash gate asserts HTTP 200 + non-empty body + content-type + literal substring. It can't distinguish shape regressions from correct responses. The pytest suite adds:

- `tier_count == 5` / `capability_count == 8` on `/api/v1/meta/agent-tiers` (SoT pin)
- `agent-guide.md` body > 500 chars + contains "golden path"
- `openapi.json` has `openapi`, `paths` keys, and at least one `/api/v1/` route
- `llms.txt` contains "Tenant Isolation"
- landing `/pricing` contains Free, Pro, Enterprise
- landing `/sitemap-index.xml` is valid XML

## How it runs

```yaml
smoke-prod:
  needs: [deploy, smoke]
  if: github.event_name == 'push' && github.ref == 'refs/heads/master'
```

Waits for both `deploy` and `smoke` green before running (avoids dogpiling Telegram on deep 404s). Telegram alert on failure with rollback pointer to `RUNBOOK_DEV_TO_MASTER.md`.

## Rollback path

New section in `plans/infra/RUNBOOK_DEV_TO_MASTER.md` covers both fix-forward and revert paths, with Alembic migration caveats.

## Test plan

- [x] Ran smoke suite against prod locally: **10/10 passed in 2.67s** (well under the 2-min budget per #107 constraints)
- [x] CF Access headers are no-op on prod (conftest checks env vars, skips if unset)
- [x] No schema changes, no cross-team coupling

Refs #107