### PR TITLE
perf: E10 SQL filter pushdown via query_adapter_callback

### DIFF
--- a/datanika/services/_sql_filter_pushdown.py
+++ b/datanika/services/_sql_filter_pushdown.py
@@ -1,0 +1,71 @@
+"""SQL filter pushdown — translate Datanika ``FILTER_OPS`` to SQLAlchemy WHERE.
+
+E10 — makes ``filters:`` config server-side for SQL sources. Before this,
+``source.add_filter(fn)`` dropped rows in memory AFTER the source yielded,
+so we pulled the whole table over the network and discarded 99% of it.
+
+Surface: one factory ``make_query_adapter(filters)`` returns a callable
+matching dlt's ``query_adapter_callback`` contract. Sources in the SQL
+path pass it straight to ``sql_table``/``sql_database``.
+
+Non-SQL sources (REST, Mongo, SaaS, Kafka) continue to use the existing
+in-memory ``source.add_filter`` path — see ``DltRunnerService.execute``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import sqlalchemy as sa
+
+
+class FilterPushdownError(ValueError):
+    """Raised when a filter spec can't be translated to SQL."""
+
+
+def _filter_to_where(table: sa.Table, op: str, column: str, value: Any) -> sa.ColumnElement:
+    """Translate a single ``{op, column, value}`` spec to a SQLAlchemy WHERE."""
+    if column not in table.c:
+        raise FilterPushdownError(f"filter column {column!r} not found on table {table.name!r}")
+    col = table.c[column]
+
+    if op == "eq":
+        return col == value
+    if op == "ne":
+        return col != value
+    if op == "gt":
+        return col > value
+    if op == "gte":
+        return col >= value
+    if op == "lt":
+        return col < value
+    if op == "lte":
+        return col <= value
+    if op == "in":
+        return col.in_(value)
+    if op == "not_in":
+        return sa.not_(col.in_(value))
+    raise FilterPushdownError(f"unsupported filter op {op!r}")
+
+
+def make_query_adapter(filters: list[dict]) -> Callable:
+    """Build a ``query_adapter_callback`` that applies ``filters`` as WHERE.
+
+    Contract matches dlt's ``TableLoader.make_query`` call site:
+    the callback receives ``(query, table)`` and returns a modified query.
+
+    dlt preserves any WHERE already added by ``incremental`` — we ``.where()``
+    on top of it, which SQLAlchemy translates to ``AND``. Filters compose
+    freely with incremental cursors.
+    """
+
+    def adapter(query, table):
+        wheres = [_filter_to_where(table, f["op"], f["column"], f["value"]) for f in filters]
+        if not wheres:
+            return query
+        if len(wheres) == 1:
+            return query.where(wheres[0])
+        return query.where(sa.and_(*wheres))
+
+    return adapter

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -69,6 +69,16 @@ INTERNAL_CONFIG_KEYS = {
     "merge_config",
 }
 
+# Client-side row-filter lambdas — applied AFTER source yield.
+#
+# Used only for non-SQL sources (REST, Mongo, SaaS, Kafka) where server-side
+# filtering isn't uniformly available. For SQL sources in single_table mode,
+# the same (op, column, value) specs are translated to a SQLAlchemy WHERE via
+# ``_sql_filter_pushdown.make_query_adapter`` — no in-memory filtering.
+#
+# If you add a new op here, add the equivalent SQL translation in
+# ``_sql_filter_pushdown._filter_to_where`` too so SQL users don't lose the
+# pushdown.
 FILTER_OPS = {
     "eq": lambda col, val: lambda row: row.get(col) == val,
     "ne": lambda col, val: lambda row: row.get(col) != val,
@@ -246,12 +256,26 @@ class DltRunnerService:
         # Bypasses JSON normalization — 5.8x speedup on large MySQL loads.
         backend = dlt_config.get("backend")
 
+        # E10 — SQL filter pushdown. Translate FILTER_OPS entries to a
+        # query_adapter_callback so WHERE runs on the source DB, not after
+        # fetch. Full-database mode doesn't support per-table filters here
+        # (a callback binds to a single table); we fall through to the
+        # in-memory add_filter path for that case.
+        from datanika.services._sql_filter_pushdown import make_query_adapter
+
+        filters_cfg = dlt_config.get("filters")
+        query_adapter = None
+        if filters_cfg and mode == "single_table":
+            query_adapter = make_query_adapter(filters_cfg)
+
         if mode == "single_table":
             kwargs = {"credentials": creds, "table": dlt_config["table"], "chunk_size": batch_size}
             if schema is not None:
                 kwargs["schema"] = schema
             if backend is not None:
                 kwargs["backend"] = backend
+            if query_adapter is not None:
+                kwargs["query_adapter_callback"] = query_adapter
             incremental_cfg = dlt_config.get("incremental")
             if incremental_cfg is not None:
                 inc_kwargs = {"cursor_path": incremental_cfg["cursor_path"]}
@@ -847,9 +871,14 @@ class DltRunnerService:
         )
         source = self.build_source(source_type, source_config, dlt_config, batch_size=batch_size)
 
-        # Apply row-level filters
+        # Apply row-level filters. SQL sources in single_table mode (E10)
+        # have already pushed filters to the DB via query_adapter_callback
+        # in build_source — don't re-apply them in memory.
         filters_cfg = dlt_config.get("filters")
-        if filters_cfg:
+        pushed_down = source_type in self.SUPPORTED_SOURCE_TYPES and (
+            dlt_config.get("mode", "full_database") == "single_table"
+        )
+        if filters_cfg and not pushed_down:
             for f in filters_cfg:
                 filter_fn = FILTER_OPS[f["op"]](f["column"], f["value"])
                 source.add_filter(filter_fn)

--- a/tests/test_services/test_sql_filter_pushdown.py
+++ b/tests/test_services/test_sql_filter_pushdown.py
@@ -1,0 +1,179 @@
+"""E10 — SQL filter pushdown via query_adapter_callback."""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from datanika.services._sql_filter_pushdown import (
+    FilterPushdownError,
+    make_query_adapter,
+)
+
+
+@pytest.fixture
+def sample_table():
+    """A SQLAlchemy Table we can build WHERE clauses against."""
+    metadata = sa.MetaData()
+    return sa.Table(
+        "orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.DateTime),
+        sa.Column("status", sa.String),
+        sa.Column("amount", sa.Numeric),
+    )
+
+
+def _compile(query, dialect_name="postgresql"):
+    """Compile a SQLAlchemy query to a literal-bound SQL string for assertion."""
+    dialect = sa.dialects.registry.load(dialect_name)()
+    return str(query.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+class TestMakeQueryAdapter:
+    def test_no_filters_returns_query_unchanged(self, sample_table):
+        adapter = make_query_adapter([])
+        original = sample_table.select()
+        assert adapter(original, sample_table) is original
+
+    def test_single_eq_filter(self, sample_table):
+        adapter = make_query_adapter([{"op": "eq", "column": "status", "value": "active"}])
+        query = adapter(sample_table.select(), sample_table)
+        sql = _compile(query).lower()
+        assert "where" in sql
+        assert "status = 'active'" in sql
+
+    def test_gt_filter_translates_to_greater_than(self, sample_table):
+        adapter = make_query_adapter([{"op": "gt", "column": "amount", "value": 100}])
+        query = adapter(sample_table.select(), sample_table)
+        sql = _compile(query).lower()
+        assert "amount > 100" in sql
+
+    def test_gte_lt_lte_ne(self, sample_table):
+        for op, sql_op in [("gte", ">="), ("lt", "<"), ("lte", "<="), ("ne", "!=")]:
+            adapter = make_query_adapter([{"op": op, "column": "id", "value": 42}])
+            query = adapter(sample_table.select(), sample_table)
+            sql = _compile(query).lower()
+            assert f"id {sql_op} 42" in sql, f"op {op} did not produce {sql_op}"
+
+    def test_in_filter(self, sample_table):
+        adapter = make_query_adapter(
+            [{"op": "in", "column": "status", "value": ["active", "paid"]}]
+        )
+        query = adapter(sample_table.select(), sample_table)
+        sql = _compile(query).lower()
+        assert "status in " in sql
+        assert "'active'" in sql
+        assert "'paid'" in sql
+
+    def test_not_in_filter(self, sample_table):
+        adapter = make_query_adapter([{"op": "not_in", "column": "status", "value": ["cancelled"]}])
+        query = adapter(sample_table.select(), sample_table)
+        sql = _compile(query).lower()
+        # SQLAlchemy renders NOT IN as a single "not in" operator
+        assert "not in" in sql
+        assert "'cancelled'" in sql
+
+    def test_multiple_filters_combine_with_and(self, sample_table):
+        adapter = make_query_adapter(
+            [
+                {"op": "eq", "column": "status", "value": "active"},
+                {"op": "gt", "column": "amount", "value": 100},
+            ]
+        )
+        query = adapter(sample_table.select(), sample_table)
+        sql = _compile(query).lower()
+        assert "where" in sql
+        assert "status = 'active'" in sql
+        assert "amount > 100" in sql
+        assert " and " in sql
+
+    def test_filter_composes_with_existing_where(self, sample_table):
+        """Incremental already added a WHERE — our filter ANDs on top."""
+        adapter = make_query_adapter([{"op": "eq", "column": "status", "value": "active"}])
+        query_with_incremental = sample_table.select().where(sample_table.c.id > 1000)
+        query = adapter(query_with_incremental, sample_table)
+        sql = _compile(query).lower()
+        # Both conditions present
+        assert "id > 1000" in sql
+        assert "status = 'active'" in sql
+        assert " and " in sql
+
+    def test_unknown_column_raises(self, sample_table):
+        adapter = make_query_adapter([{"op": "eq", "column": "nonexistent", "value": "x"}])
+        with pytest.raises(FilterPushdownError, match="not found"):
+            adapter(sample_table.select(), sample_table)
+
+    def test_unknown_op_raises(self, sample_table):
+        adapter = make_query_adapter([{"op": "like", "column": "status", "value": "%active%"}])
+        with pytest.raises(FilterPushdownError, match="unsupported filter op"):
+            adapter(sample_table.select(), sample_table)
+
+
+class TestDltRunnerPushdownWiring:
+    """DltRunnerService.build_source passes query_adapter_callback for SQL."""
+
+    def test_single_table_with_filters_passes_query_adapter(self):
+        from unittest.mock import patch
+
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.dlt_runner.sql_table") as mock_sql_table:
+            mock_sql_table.return_value = object()
+            runner.build_source(
+                "postgres",
+                {"host": "h", "port": 5432, "user": "u", "password": "p", "database": "d"},
+                {
+                    "mode": "single_table",
+                    "table": "orders",
+                    "filters": [{"op": "gt", "column": "created_at", "value": "2024-01-01"}],
+                },
+                batch_size=1000,
+            )
+            kwargs = mock_sql_table.call_args.kwargs
+            assert callable(kwargs.get("query_adapter_callback"))
+
+    def test_single_table_no_filters_no_adapter(self):
+        from unittest.mock import patch
+
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.dlt_runner.sql_table") as mock_sql_table:
+            mock_sql_table.return_value = object()
+            runner.build_source(
+                "postgres",
+                {"host": "h", "port": 5432, "user": "u", "password": "p", "database": "d"},
+                {"mode": "single_table", "table": "orders"},
+                batch_size=1000,
+            )
+            kwargs = mock_sql_table.call_args.kwargs
+            assert "query_adapter_callback" not in kwargs
+
+    def test_full_database_filters_stay_client_side(self):
+        """full_database mode doesn't get pushdown — filters apply in memory."""
+        from unittest.mock import patch
+
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.dlt_runner.sql_database") as mock_sql_db:
+            mock_sql_db.return_value = object()
+            runner.build_source(
+                "postgres",
+                {"host": "h", "port": 5432, "user": "u", "password": "p", "database": "d"},
+                {
+                    "mode": "full_database",
+                    "filters": [{"op": "gt", "column": "created_at", "value": "2024-01-01"}],
+                },
+                batch_size=1000,
+            )
+            kwargs = mock_sql_db.call_args.kwargs
+            # full_database mode — no per-table pushdown since a callback
+            # binds to a single table.
+            assert "query_adapter_callback" not in kwargs


### PR DESCRIPTION
## Summary

Closes **E10** from PLAN_ENGINEERING.md §ELT Optimizations — the high-impact outcome of the 2026-04-17 condition-pushdown audit.

### Before
`filters: [{op, column, value}]` config compiled to `source.add_filter(fn)` — a **client-side** row-by-row lambda applied AFTER the source yielded. A \"filtered\" SQL query that matched 1% of a 100M-row table pulled all 100M rows over the network and dropped 99M in memory.

### After
For SQL sources in `single_table` mode, filters translate to a SQLAlchemy `WHERE` via `query_adapter_callback`. WHERE runs on the source DB. Filters compose with `dlt.sources.incremental`'s existing WHERE (dlt adds its own; we `.where()` on top → SQLAlchemy emits `AND`).

| Source / mode | Pushdown? |
|---|---|
| SQL `single_table` | ✅ WHERE server-side via adapter |
| SQL `full_database` | ❌ client-side (adapter binds to one table) |
| REST / Mongo / SaaS / Kafka | ❌ client-side (unchanged) |

### Changes
- `services/_sql_filter_pushdown.py` (new) — `make_query_adapter(filters)` factory + `_filter_to_where` translator for all 8 existing ops (eq/ne/gt/gte/lt/lte/in/not_in)
- `services/dlt_runner.py` — `build_source()` passes `query_adapter_callback` when SQL single_table + filters present; `execute()` skips the add_filter loop when pushdown is active; `FILTER_OPS` docstring clarifies it's the non-SQL fallback
- **Zero user-facing API change** — same `filters:` config, just now actually filters where it matters

## Test plan
- [x] 13 new tests (SQL translation for 8 ops + AND composition + incremental interop + wiring)
- [x] 1993 total tests passing, ruff clean
- [ ] CI green

Closes E10.