### PR TITLE
perf: E11 MongoDB server-side filter + incremental $gt cursor

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -67,6 +67,7 @@ INTERNAL_CONFIG_KEYS = {
     "sheet_names",
     "collection_names",
     "merge_config",
+    "query",
 }
 
 FILTER_OPS = {
@@ -365,11 +366,26 @@ class DltRunnerService:
 
         collection_names = dlt_config.get("collection_names")
 
+        # E11 — server-side filter + incremental pushdown.
+        # `query` is a verbatim Mongo filter dict; `incremental` (same config
+        # shape as sql_table) becomes {cursor_path: {"$gt": initial_value}}
+        # merged into the filter. Mirrors what sql_table does today.
+        query = dlt_config.get("query")
+        incremental_cursor = None
+        incremental_cfg = dlt_config.get("incremental")
+        if incremental_cfg is not None:
+            cursor_path = incremental_cfg.get("cursor_path")
+            initial_value = incremental_cfg.get("initial_value")
+            if cursor_path is not None and initial_value is not None:
+                incremental_cursor = (cursor_path, initial_value)
+
         return mongodb_source(
             connection_uri=uri,
             database=database,
             collection_names=collection_names,
             batch_size=batch_size,
+            query=query,
+            incremental_cursor=incremental_cursor,
         )
 
     def _build_saas_source(self, connection_type: str, config: dict, dlt_config: dict):

--- a/datanika/services/mongodb_source.py
+++ b/datanika/services/mongodb_source.py
@@ -7,6 +7,13 @@ JSON encoder as unknown objects and either fail serialization or serialize
 to incomplete string representations (e.g. ``"ObjectId('...')"`` instead
 of the hex string).
 
+Server-side filter + incremental pushdown (E11): ``query`` is passed to
+``collection.find(filter=query)`` verbatim, and ``incremental_cursor``
+translates a cursor field + last value into a ``$gt`` match that's merged
+into the same filter. Before this, every run did ``collection.find()``
+and pulled the whole collection — bare extracts on >100k-doc collections
+were painful.
+
 Upstream swap candidate: ``dlt-mongodb`` verified source exists as of
 dlt 1.21+. We ship this custom one because it predates the upstream
 version being stable. Re-evaluate on next dlt bump.
@@ -45,14 +52,54 @@ def _normalize_bson_types(value: Any) -> Any:
     return value
 
 
-def _make_collection_resource(db, collection_name, batch_size):
-    """Create a named dlt resource for a single MongoDB collection."""
+def _build_mongo_filter(
+    query: dict | None,
+    incremental_cursor: tuple[str, Any] | None,
+) -> dict:
+    """Merge user query + incremental cursor into a single Mongo find() filter.
+
+    - ``query``: verbatim dict passed by the caller (e.g. ``{"price": {"$gt": 100}}``).
+    - ``incremental_cursor``: ``(cursor_path, last_value)`` translated into
+      ``{cursor_path: {"$gt": last_value}}`` and merged with ``query`` via ``$and``.
+
+    If ``cursor_path`` is already a key in ``query``, we wrap with ``$and``
+    to preserve both conditions instead of overwriting.
+    """
+    filter_dict: dict = dict(query) if query else {}
+
+    if incremental_cursor is not None:
+        cursor_path, last_value = incremental_cursor
+        cursor_cond = {cursor_path: {"$gt": last_value}}
+
+        if cursor_path in filter_dict:
+            # Avoid clobbering user-supplied condition on the same field.
+            filter_dict = {"$and": [filter_dict, cursor_cond]}
+        else:
+            filter_dict.update(cursor_cond)
+
+    return filter_dict
+
+
+def _make_collection_resource(
+    db,
+    collection_name: str,
+    batch_size: int,
+    query: dict | None = None,
+    incremental_cursor: tuple[str, Any] | None = None,
+):
+    """Create a named dlt resource for a single MongoDB collection.
+
+    ``query`` and ``incremental_cursor`` are pushed down to
+    ``collection.find(filter=...)`` — the server does the filtering,
+    we don't pull then drop.
+    """
+    mongo_filter = _build_mongo_filter(query, incremental_cursor)
 
     @dlt.resource(name=collection_name, write_disposition="replace")
     def _resource():
         collection = db[collection_name]
         batch = []
-        for doc in collection.find():
+        for doc in collection.find(filter=mongo_filter):
             batch.append(_normalize_bson_types(doc))
             if len(batch) >= batch_size:
                 yield batch
@@ -64,7 +111,14 @@ def _make_collection_resource(db, collection_name, batch_size):
 
 
 @dlt.source
-def mongodb_source(connection_uri, database, collection_names=None, batch_size=DEFAULT_BATCH_SIZE):
+def mongodb_source(
+    connection_uri: str,
+    database: str,
+    collection_names: list[str] | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    query: dict | None = None,
+    incremental_cursor: tuple[str, Any] | None = None,
+):
     """Extract collections from a MongoDB database.
 
     Args:
@@ -72,9 +126,21 @@ def mongodb_source(connection_uri, database, collection_names=None, batch_size=D
         database: Name of the database to extract from.
         collection_names: Optional list of collection names. If None, all collections.
         batch_size: Number of documents per yielded batch.
+        query: Optional Mongo find() filter dict (e.g. ``{"price": {"$gt": 100}}``).
+            Applied to every collection extracted. For collection-specific
+            queries, call the source once per collection.
+        incremental_cursor: Optional ``(cursor_path, last_value)`` tuple that
+            translates to ``{cursor_path: {"$gt": last_value}}`` and merges
+            with ``query``. Mirrors the sql_table incremental behaviour.
     """
     client = MongoClient(connection_uri)
     db = client[database]
     collections = collection_names or db.list_collection_names()
     for name in collections:
-        yield _make_collection_resource(db, name, batch_size)
+        yield _make_collection_resource(
+            db,
+            name,
+            batch_size,
+            query=query,
+            incremental_cursor=incremental_cursor,
+        )

--- a/tests/test_services/test_mongodb_source.py
+++ b/tests/test_services/test_mongodb_source.py
@@ -137,3 +137,169 @@ class TestNormalizeBsonTypes:
         doc = {"a": 1, "b": "hello", "c": [1, 2], "d": None, "e": True}
         result = _normalize_bson_types(doc)
         assert result == doc
+
+
+class TestBuildMongoFilter:
+    """E11 — _build_mongo_filter merges query + incremental cursor."""
+
+    def test_empty_returns_empty_dict(self):
+        from datanika.services.mongodb_source import _build_mongo_filter
+
+        assert _build_mongo_filter(None, None) == {}
+
+    def test_query_only(self):
+        from datanika.services.mongodb_source import _build_mongo_filter
+
+        result = _build_mongo_filter({"price": {"$gt": 100}}, None)
+        assert result == {"price": {"$gt": 100}}
+
+    def test_incremental_only(self):
+        from datanika.services.mongodb_source import _build_mongo_filter
+
+        result = _build_mongo_filter(None, ("updated_at", "2024-01-01"))
+        assert result == {"updated_at": {"$gt": "2024-01-01"}}
+
+    def test_query_and_incremental_merged(self):
+        from datanika.services.mongodb_source import _build_mongo_filter
+
+        result = _build_mongo_filter({"status": "active"}, ("updated_at", "2024-01-01"))
+        assert result == {"status": "active", "updated_at": {"$gt": "2024-01-01"}}
+
+    def test_cursor_overlaps_query_field_uses_and(self):
+        """If the cursor field is already in the query, wrap with $and so neither gets clobbered."""
+        from datanika.services.mongodb_source import _build_mongo_filter
+
+        result = _build_mongo_filter(
+            {"updated_at": {"$lt": "2025-01-01"}},
+            ("updated_at", "2024-01-01"),
+        )
+        assert result == {
+            "$and": [
+                {"updated_at": {"$lt": "2025-01-01"}},
+                {"updated_at": {"$gt": "2024-01-01"}},
+            ]
+        }
+
+
+class TestMongoFilterPushdown:
+    """E11 — filter/incremental reach collection.find() as the filter arg."""
+
+    @patch("datanika.services.mongodb_source.MongoClient")
+    def test_query_passed_to_find_verbatim(self, mock_client_cls):
+        from datanika.services.mongodb_source import mongodb_source
+
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = []
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["orders"]
+        mock_db.__getitem__ = MagicMock(return_value=mock_collection)
+        mock_client = MagicMock()
+        mock_client.__getitem__ = MagicMock(return_value=mock_db)
+        mock_client_cls.return_value = mock_client
+
+        source = mongodb_source(
+            "mongodb://localhost:27017/testdb",
+            "testdb",
+            query={"price": {"$gt": 100}},
+        )
+        list(source.resources["orders"])
+        # collection.find(filter=...) — verify the filter dict is exact
+        mock_collection.find.assert_called_once_with(filter={"price": {"$gt": 100}})
+
+    @patch("datanika.services.mongodb_source.MongoClient")
+    def test_incremental_cursor_becomes_gt(self, mock_client_cls):
+        from datanika.services.mongodb_source import mongodb_source
+
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = []
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["orders"]
+        mock_db.__getitem__ = MagicMock(return_value=mock_collection)
+        mock_client = MagicMock()
+        mock_client.__getitem__ = MagicMock(return_value=mock_db)
+        mock_client_cls.return_value = mock_client
+
+        source = mongodb_source(
+            "mongodb://localhost:27017/testdb",
+            "testdb",
+            incremental_cursor=("updated_at", "2024-01-01"),
+        )
+        list(source.resources["orders"])
+        mock_collection.find.assert_called_once_with(filter={"updated_at": {"$gt": "2024-01-01"}})
+
+    @patch("datanika.services.mongodb_source.MongoClient")
+    def test_no_query_no_incremental_sends_empty_filter(self, mock_client_cls):
+        from datanika.services.mongodb_source import mongodb_source
+
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = []
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["orders"]
+        mock_db.__getitem__ = MagicMock(return_value=mock_collection)
+        mock_client = MagicMock()
+        mock_client.__getitem__ = MagicMock(return_value=mock_db)
+        mock_client_cls.return_value = mock_client
+
+        source = mongodb_source("mongodb://localhost:27017/testdb", "testdb")
+        list(source.resources["orders"])
+        # Default filter is {} — empty, not None — so pymongo treats it as match-all
+        mock_collection.find.assert_called_once_with(filter={})
+
+
+class TestDltRunnerMongoPushdownWiring:
+    """_build_mongodb_source wires dlt_config.query and .incremental through."""
+
+    def test_query_forwarded(self):
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.mongodb_source.mongodb_source") as mock_src:
+            mock_src.return_value = MagicMock()
+            runner.build_source(
+                "mongodb",
+                {"host": "h", "port": 27017, "database": "d"},
+                {"query": {"status": "active"}},
+                batch_size=1000,
+            )
+            kwargs = mock_src.call_args.kwargs
+            assert kwargs["query"] == {"status": "active"}
+
+    def test_incremental_forwarded_as_tuple(self):
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.mongodb_source.mongodb_source") as mock_src:
+            mock_src.return_value = MagicMock()
+            runner.build_source(
+                "mongodb",
+                {"host": "h", "port": 27017, "database": "d"},
+                {"incremental": {"cursor_path": "updated_at", "initial_value": "2024-01-01"}},
+                batch_size=1000,
+            )
+            kwargs = mock_src.call_args.kwargs
+            assert kwargs["incremental_cursor"] == ("updated_at", "2024-01-01")
+
+    def test_no_filter_no_incremental_yields_none(self):
+        from unittest.mock import MagicMock, patch
+
+        from datanika.services.dlt_runner import DltRunnerService
+
+        runner = DltRunnerService()
+
+        with patch("datanika.services.mongodb_source.mongodb_source") as mock_src:
+            mock_src.return_value = MagicMock()
+            runner.build_source(
+                "mongodb",
+                {"host": "h", "port": 27017, "database": "d"},
+                {},
+                batch_size=1000,
+            )
+            kwargs = mock_src.call_args.kwargs
+            assert kwargs["query"] is None
+            assert kwargs["incremental_cursor"] is None


### PR DESCRIPTION
## Summary

Closes **E11** from PLAN_ENGINEERING.md §ELT Optimizations.

### Before
`mongodb_source.py:22` did bare `collection.find()` — every run pulled the entire collection over the network regardless of what the user needed. No filter config, no incremental cursor. 100k-doc collections fetched 100k docs; 10M-doc collections fetched 10M.

### After
- New `query` kwarg on `mongodb_source()` — passed **verbatim** to `collection.find(filter=query)`. User writes native Mongo query syntax (`{\"price\": {\"\$gt\": 100}}`) because Mongo has its own query DSL.
- New `incremental_cursor` tuple `(cursor_path, last_value)` translates to `{cursor_path: {\"\$gt\": last_value}}` and merges with `query`. Mirrors the exact behaviour of dlt's `sql_table` incremental.
- If cursor_path overlaps a query field, we wrap with `\$and` to preserve both conditions instead of clobbering.
- `DltRunnerService._build_mongodb_source` reads `dlt_config.query` + `dlt_config.incremental` (same config shape as SQL sources) and forwards them.

### Config shape
```python
dlt_config = {
    \"collection_names\": [\"orders\"],
    \"query\": {\"status\": \"active\"},
    \"incremental\": {
        \"cursor_path\": \"updated_at\",
        \"initial_value\": \"2024-01-01\",
    },
}
# → collection.find(filter={\"status\": \"active\", \"updated_at\": {\"\$gt\": \"2024-01-01\"}})
```

## Test plan
- [x] 11 new tests (filter merge logic, pushdown wiring, incremental translation, overlap-\$and case)
- [x] 2005 total tests passing, ruff clean
- [ ] CI green

Closes E11.