### PR TITLE
feat: E8 YAML pipeline config via POST /api/v1/pipelines/yaml

### DIFF
--- a/datanika/services/_yaml_import.py
+++ b/datanika/services/_yaml_import.py
@@ -1,0 +1,55 @@
+"""YAML import — parse YAML pipeline configs for /api/v1/pipelines/yaml (E8).
+
+Thin format-layer over the existing JSON v2 bulk-import schema. YAML is
+a hand-friendlier alternative to JSON for power users + CLI workflows; the
+on-disk schema is identical (same ``version: 2`` contract, same
+connections/uploads/pipelines/transformations keys), only the
+serialization differs.
+
+Why not just accept YAML in the existing /api/v1/import endpoint?
+Content-type negotiation on Starlette is doable but splits the docs story
+("POST /api/v1/import accepts JSON OR YAML depending on Content-Type")
+and adds a failure mode where JSON parse errors look like YAML parse
+errors. A separate endpoint keeps the API stability tiers clean: JSON
+import is stable, YAML is the power-user entry.
+
+Ref: SPEC in PLAN_ENGINEERING.md §ELT Optimizations E8; Whisk YAML
+shape at D:/Projects/whisk/data_repos/DB data transfer architecture.md
+§"YAML Table Configuration".
+"""
+
+from __future__ import annotations
+
+import yaml
+
+
+class YamlImportError(ValueError):
+    """Raised when YAML cannot be parsed or has the wrong top-level shape."""
+
+
+def parse_yaml_import(body: bytes | str) -> dict:
+    """Parse a YAML import body and return the dict the bulk_import path expects.
+
+    Raises YamlImportError on parse errors or invalid top-level types.
+    The caller is responsible for running the JSON-path validator
+    (``_validate_import_payload``) on the result.
+    """
+    if isinstance(body, bytes):
+        try:
+            body = body.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise YamlImportError(f"YAML body is not valid UTF-8: {exc}") from exc
+
+    try:
+        data = yaml.safe_load(body)
+    except yaml.YAMLError as exc:
+        # yaml.YAMLError includes MarkedYAMLError — line/column when available.
+        raise YamlImportError(f"YAML parse error: {exc}") from exc
+
+    if data is None:
+        raise YamlImportError("YAML body is empty")
+
+    if not isinstance(data, dict):
+        raise YamlImportError(f"YAML top-level must be a mapping, got {type(data).__name__}")
+
+    return data

--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -1300,29 +1300,16 @@ def _validate_import_payload(data: dict, existing_conn_names: dict[str, int]) ->
     return errors
 
 
-@api_endpoint(required_scope=None)
-async def bulk_import(request, api_key, session):
-    """POST /api/v1/import — create connections, uploads, pipelines,
-    and transformations from a single JSON payload.
+def _execute_validated_import(session, org_id: int, data: dict) -> dict[str, list[int]]:
+    """Phase-1..4 creation shared by JSON and YAML import endpoints.
 
-    Validates the entire payload first; if any errors are found, nothing
-    is created (atomic). Uses the same JSON v2 format as AI_IMPORT_GUIDE.md.
+    Caller must have already validated ``data`` via
+    ``_validate_import_payload`` — this function assumes the payload is
+    shape-correct and proceeds atomically (SQLAlchemy session manages the
+    transaction). Returns a ``{"connections": [ids], ...}`` dict.
     """
-    data = await _body(request)
-
-    # --- version check ---
-    version = data.get("version")
-    if version != 2:
-        return _error(400, "version 2 is required")
-
-    # --- build existing connection name→id map ---
-    existing_conns = _get_conn_svc().list_connections(session, api_key.org_id)
+    existing_conns = _get_conn_svc().list_connections(session, org_id)
     existing_conn_names: dict[str, int] = {c.name: c.id for c in existing_conns}
-
-    # --- validate everything before creating anything ---
-    errors = _validate_import_payload(data, existing_conn_names)
-    if errors:
-        return JSONResponse({"errors": errors}, status_code=400)
 
     created: dict[str, list[int]] = {
         "connections": [],
@@ -1332,12 +1319,11 @@ async def bulk_import(request, api_key, session):
     }
 
     # --- Phase 1: create connections ---
-    # Maps connection name → id (payload + existing)
     conn_name_to_id: dict[str, int] = dict(existing_conn_names)
     for c in data.get("connections", []):
         conn = _get_conn_svc().create_connection(
             session,
-            api_key.org_id,
+            org_id,
             name=c["name"],
             connection_type=ConnectionType(c["connection_type"]),
             config=c["config"],
@@ -1350,7 +1336,7 @@ async def bulk_import(request, api_key, session):
     for u in data.get("uploads", []):
         upload = _get_upload_svc().create_upload(
             session,
-            api_key.org_id,
+            org_id,
             name=u["name"],
             description=u.get("description"),
             source_connection_id=conn_name_to_id[u["source_connection_name"]],
@@ -1367,7 +1353,7 @@ async def bulk_import(request, api_key, session):
             command = DbtCommand(p["command"])
         pipeline = _pipeline_svc.create_pipeline(
             session,
-            api_key.org_id,
+            org_id,
             name=p["name"],
             description=p.get("description"),
             destination_connection_id=conn_name_to_id[p["destination_connection_name"]],
@@ -1389,7 +1375,7 @@ async def bulk_import(request, api_key, session):
             dest_conn_id = conn_name_to_id.get(t["destination_connection_name"])
         transformation = _transform_svc.create_transformation(
             session,
-            api_key.org_id,
+            org_id,
             name=t["name"],
             sql_body=t["sql_body"],
             materialization=mat,
@@ -1403,6 +1389,89 @@ async def bulk_import(request, api_key, session):
         session.flush()
         created["transformations"].append(transformation.id)
 
+    return created
+
+
+@api_endpoint(required_scope=None)
+async def bulk_import(request, api_key, session):
+    """POST /api/v1/import — create connections, uploads, pipelines,
+    and transformations from a single JSON payload.
+
+    Validates the entire payload first; if any errors are found, nothing
+    is created (atomic). Uses the same JSON v2 format as AI_IMPORT_GUIDE.md.
+    """
+    data = await _body(request)
+
+    # --- version check ---
+    version = data.get("version")
+    if version != 2:
+        return _error(400, "version 2 is required")
+
+    existing_conns = _get_conn_svc().list_connections(session, api_key.org_id)
+    existing_conn_names: dict[str, int] = {c.name: c.id for c in existing_conns}
+
+    errors = _validate_import_payload(data, existing_conn_names)
+    if errors:
+        return JSONResponse({"errors": errors}, status_code=400)
+
+    created = _execute_validated_import(session, api_key.org_id, data)
+    return JSONResponse({"created": created}, status_code=201)
+
+
+@api_endpoint(required_scope=None)
+async def bulk_import_yaml(request, api_key, session):
+    """POST /api/v1/pipelines/yaml — YAML-formatted alternative to /api/v1/import.
+
+    Accepts the same ``version: 2`` schema as the JSON endpoint, just
+    serialized as YAML (more hand-editable, CLI-friendly). Per E8 /
+    SPEC §"ELT Optimizations": power-user entry for declarative
+    pipeline configs.
+
+    YAML parse errors return 400 with ``{"error": "YAML parse error: ..."}``.
+    Schema validation errors return 400 with the same
+    ``{"errors": [...]}`` shape as JSON import.
+
+    Payload example:
+      version: 2
+      connections:
+        - name: source_pg
+          connection_type: postgres
+          config: {host: localhost, port: 5432, user: ..., password: ..., database: ...}
+      uploads:
+        - name: orders_sync
+          source_connection_name: source_pg
+          destination_connection_name: dest_bq
+          dlt_config:
+            mode: single_table
+            table: orders
+            chunk_size: 10000
+            backend: pyarrow
+            filters:
+              - {op: gt, column: created_at, value: "2024-01-01"}
+            incremental:
+              cursor_path: updated_at
+              initial_value: "2024-01-01"
+    """
+    from datanika.services._yaml_import import YamlImportError, parse_yaml_import
+
+    raw = await request.body()
+
+    try:
+        data = parse_yaml_import(raw)
+    except YamlImportError as exc:
+        return _error(400, str(exc))
+
+    if data.get("version") != 2:
+        return _error(400, "version 2 is required")
+
+    existing_conns = _get_conn_svc().list_connections(session, api_key.org_id)
+    existing_conn_names: dict[str, int] = {c.name: c.id for c in existing_conns}
+
+    errors = _validate_import_payload(data, existing_conn_names)
+    if errors:
+        return JSONResponse({"errors": errors}, status_code=400)
+
+    created = _execute_validated_import(session, api_key.org_id, data)
     return JSONResponse({"created": created}, status_code=201)
 
 
@@ -1491,6 +1560,8 @@ api_v1_routes = [
     Route("/api/v1/notifications/{id:int}", dismiss_notification, methods=["DELETE"]),
     # Bulk import
     Route("/api/v1/import", bulk_import, methods=["POST"]),
+    # YAML pipeline config (E8) — same schema as JSON import, YAML serialization
+    Route("/api/v1/pipelines/yaml", bulk_import_yaml, methods=["POST"]),
     # Notification channels
     Route("/api/v1/notifications/channels", list_notification_channels, methods=["GET"]),
     Route("/api/v1/notifications/channels/{id:int}", get_notification_channel, methods=["GET"]),

--- a/tests/test_services/test_yaml_import.py
+++ b/tests/test_services/test_yaml_import.py
@@ -1,0 +1,360 @@
+"""E8 — YAML pipeline import (POST /api/v1/pipelines/yaml).
+
+Thin format-layer over the JSON bulk_import path. Tests cover:
+- Parse helper (_yaml_import.parse_yaml_import) — parse errors, wrong
+  top-level type, empty body, UTF-8 decode
+- Endpoint — happy path, validation errors surface as JSON, same shape
+  as /api/v1/import
+- Semantic parity — the same YAML payload YAML-serialized from a JSON
+  payload produces the same response
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import datanika.models.invitation  # noqa: F401
+import datanika.models.notification_channel  # noqa: F401
+import datanika.models.sso_config  # noqa: F401
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+# ---------------------------------------------------------------------------
+# Unit tests — parse_yaml_import helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseYamlImport:
+    def test_valid_yaml_returns_dict(self):
+        from datanika.services._yaml_import import parse_yaml_import
+
+        body = "version: 2\nconnections: []\n"
+        result = parse_yaml_import(body)
+        assert result == {"version": 2, "connections": []}
+
+    def test_accepts_bytes(self):
+        from datanika.services._yaml_import import parse_yaml_import
+
+        body = b"version: 2\n"
+        result = parse_yaml_import(body)
+        assert result == {"version": 2}
+
+    def test_parse_error_raises(self):
+        from datanika.services._yaml_import import YamlImportError, parse_yaml_import
+
+        # Unclosed flow sequence
+        body = "version: 2\nconnections: [\n"
+        with pytest.raises(YamlImportError, match="parse error"):
+            parse_yaml_import(body)
+
+    def test_empty_body_raises(self):
+        from datanika.services._yaml_import import YamlImportError, parse_yaml_import
+
+        with pytest.raises(YamlImportError, match="empty"):
+            parse_yaml_import("")
+
+    def test_top_level_list_raises(self):
+        from datanika.services._yaml_import import YamlImportError, parse_yaml_import
+
+        body = "- foo\n- bar\n"
+        with pytest.raises(YamlImportError, match="must be a mapping"):
+            parse_yaml_import(body)
+
+    def test_top_level_scalar_raises(self):
+        from datanika.services._yaml_import import YamlImportError, parse_yaml_import
+
+        with pytest.raises(YamlImportError, match="must be a mapping"):
+            parse_yaml_import("just-a-string\n")
+
+    def test_invalid_utf8_raises(self):
+        from datanika.services._yaml_import import YamlImportError, parse_yaml_import
+
+        with pytest.raises(YamlImportError, match="UTF-8"):
+            parse_yaml_import(b"\xff\xfe\xff")
+
+    def test_nested_structures_preserved(self):
+        from datanika.services._yaml_import import parse_yaml_import
+
+        body = """
+version: 2
+uploads:
+  - name: orders
+    dlt_config:
+      mode: single_table
+      table: orders
+      filters:
+        - op: gt
+          column: created_at
+          value: "2024-01-01"
+      incremental:
+        cursor_path: updated_at
+        initial_value: "2024-01-01"
+"""
+        result = parse_yaml_import(body)
+        assert result["version"] == 2
+        upload = result["uploads"][0]
+        assert upload["dlt_config"]["mode"] == "single_table"
+        assert upload["dlt_config"]["filters"][0]["op"] == "gt"
+        assert upload["dlt_config"]["incremental"]["cursor_path"] == "updated_at"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests — POST /api/v1/pipelines/yaml
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_api_key():
+    key = MagicMock()
+    key.id = 1
+    key.org_id = 10
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def app():
+    return Starlette(routes=api_v1_routes)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def _auth_headers_yaml():
+    return {
+        "Authorization": "Bearer etf_testkey",
+        "Content-Type": "application/yaml",
+    }
+
+
+def _patch_auth(fake_api_key, rate_limit_ok):
+    """Same auth patch used in test_import_endpoint.py."""
+    import contextlib
+
+    from cryptography.fernet import Fernet
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from datanika.models.base import Base
+    from datanika.services.connection_service import ConnectionService
+    from datanika.services.encryption import EncryptionService
+    from datanika.services.pipeline_service import PipelineService
+    from datanika.services.schedule_service import ScheduleService
+    from datanika.services.transformation_service import TransformationService
+    from datanika.services.upload_service import UploadService
+
+    @contextlib.contextmanager
+    def _ctx():
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=__import__("sqlalchemy.pool", fromlist=["StaticPool"]).StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session = SASession(engine)
+
+        enc = EncryptionService(Fernet.generate_key().decode())
+        conn_svc = ConnectionService(enc)
+        upload_svc = UploadService(conn_svc)
+        pipeline_svc = PipelineService()
+        transform_svc = TransformationService()
+        schedule_svc = ScheduleService(upload_svc, transform_svc, pipeline_service=pipeline_svc)
+
+        @contextlib.contextmanager
+        def fake_session():
+            yield session
+
+        import datanika.services.api_v1_routes as routes_mod
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session", fake_session),
+            patch.object(routes_mod, "_get_conn_svc", return_value=conn_svc),
+            patch.object(routes_mod, "_get_upload_svc", return_value=upload_svc),
+            patch.object(routes_mod, "_get_schedule_svc", return_value=schedule_svc),
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+
+            yield session
+
+        session.close()
+        engine.dispose()
+
+    return _ctx()
+
+
+_PAYLOAD = {
+    "version": 2,
+    "connections": [
+        {
+            "name": "Src PG",
+            "connection_type": "postgres",
+            "config": {
+                "host": "localhost",
+                "port": 5432,
+                "user": "u",
+                "password": "p",
+                "database": "db",
+            },
+        },
+        {
+            "name": "Src MySQL",
+            "connection_type": "mysql",
+            "config": {
+                "host": "mysql.local",
+                "port": 3306,
+                "user": "u",
+                "password": "p",
+                "database": "db",
+            },
+        },
+    ],
+    "uploads": [
+        {
+            "name": "Orders sync",
+            "source_connection_name": "Src MySQL",
+            "destination_connection_name": "Src PG",
+            "dlt_config": {
+                "mode": "single_table",
+                "table": "orders",
+                "backend": "pyarrow",
+            },
+        }
+    ],
+}
+
+
+class TestYamlImportEndpoint:
+    def test_happy_path_creates_resources(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            body = yaml.safe_dump(_PAYLOAD)
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content=body,
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 201, resp.json()
+            data = resp.json()
+            assert "created" in data
+            assert len(data["created"]["connections"]) == 2
+            assert len(data["created"]["uploads"]) == 1
+
+    def test_yaml_parse_error_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content="version: 2\nconnections: [\n",  # unclosed
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 400
+            assert "YAML parse error" in resp.json()["error"]["message"]
+
+    def test_missing_version_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            body = yaml.safe_dump({"connections": []})
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content=body,
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 400
+            assert "version 2" in resp.json()["error"]["message"]
+
+    def test_wrong_version_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            body = yaml.safe_dump({"version": 1, "connections": []})
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content=body,
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 400
+
+    def test_validation_errors_surface_as_json(self, client, fake_api_key, rate_limit_ok):
+        """Schema validation errors surface the same way as JSON import."""
+        bad_payload = {
+            "version": 2,
+            "connections": [
+                {"name": "bad", "connection_type": "not-a-real-type", "config": {}},
+            ],
+        }
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            body = yaml.safe_dump(bad_payload)
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content=body,
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 400
+            assert "errors" in resp.json()
+
+    def test_top_level_list_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content="- item1\n- item2\n",
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 400
+            assert "mapping" in resp.json()["error"]["message"]
+
+    def test_empty_body_returns_400(self, client, fake_api_key, rate_limit_ok):
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content="",
+                headers=_auth_headers_yaml(),
+            )
+            assert resp.status_code == 400
+            assert "empty" in resp.json()["error"]["message"]
+
+    def test_yaml_and_json_produce_identical_result(self, client, fake_api_key, rate_limit_ok):
+        """Same payload, JSON vs YAML serialization → identical created shape."""
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            json_resp = client.post(
+                "/api/v1/import",
+                json=_PAYLOAD,
+                headers={"Authorization": "Bearer etf_testkey"},
+            )
+            assert json_resp.status_code == 201
+
+        # Fresh session for YAML — avoid name collisions with the JSON run.
+        with _patch_auth(fake_api_key, rate_limit_ok):
+            yaml_resp = client.post(
+                "/api/v1/pipelines/yaml",
+                content=yaml.safe_dump(_PAYLOAD),
+                headers=_auth_headers_yaml(),
+            )
+            assert yaml_resp.status_code == 201
+
+        json_created = json_resp.json()["created"]
+        yaml_created = yaml_resp.json()["created"]
+        # Same counts in each bucket (IDs differ because sessions are different).
+        assert len(json_created["connections"]) == len(yaml_created["connections"])
+        assert len(json_created["uploads"]) == len(yaml_created["uploads"])
+        assert len(json_created["pipelines"]) == len(yaml_created["pipelines"])
+        assert len(json_created["transformations"]) == len(yaml_created["transformations"])


### PR DESCRIPTION
## Summary

Closes **E8** — the final P2 item in PLAN_ENGINEERING.md §ELT Optimizations. Thin format-layer over the existing JSON `/api/v1/import` endpoint: same `version: 2` schema, same validation, same atomic creation semantics — just YAML serialization for hand-editable / CLI / version-controlled declarative configs.

### Design decision: separate endpoint, not content-type negotiation on `/api/v1/import`

Content-type negotiation splits the docs story (\"/api/v1/import accepts JSON OR YAML depending on Content-Type\") and makes JSON parse errors indistinguishable from YAML parse errors in logs. A separate route keeps API stability tiers clean: JSON import stays `x-stability: stable`, YAML is the power-user entry.

### Shared core, two entry points
Refactored `bulk_import` into `_execute_validated_import()` — JSON and YAML endpoints both parse, validate, then call the same create logic. No duplicate validation, no duplicate creation phases.

### Error handling
| Condition | Status | Body |
|---|---|---|
| YAML parse error (unclosed bracket, bad syntax) | 400 | `{\"error\": {\"code\": 400, \"message\": \"YAML parse error: ...\"}}` |
| Empty body | 400 | `{\"error\": {...\"message\": \"YAML body is empty\"}}` |
| Top-level not a mapping (list/scalar) | 400 | `{\"error\": {...\"message\": \"YAML top-level must be a mapping, got list\"}}` |
| Non-UTF-8 bytes | 400 | `{\"error\": {...\"message\": \"YAML body is not valid UTF-8: ...\"}}` |
| Missing `version: 2` | 400 | `{\"error\": {...\"message\": \"version 2 is required\"}}` |
| Schema validation | 400 | `{\"errors\": [...]}` (same shape as JSON `/api/v1/import`) |

### Example
```yaml
version: 2
connections:
  - name: Src PG
    connection_type: postgres
    config:
      host: localhost
      port: 5432
      user: u
      password: p
      database: db
uploads:
  - name: Orders sync
    source_connection_name: Src PG
    destination_connection_name: Dest BQ
    dlt_config:
      mode: single_table
      table: orders
      backend: pyarrow  # E6
      filters:  # E10 — now server-side WHERE
        - {op: gt, column: created_at, value: \"2024-01-01\"}
      incremental:
        cursor_path: updated_at
        initial_value: \"2024-01-01\"
```

### No new dependency
PyYAML 6.0.3 already available transitively (pulled by dlt/pydantic).

## Test plan
- [x] 16 new tests (8 parse helper + 8 endpoint)
- [x] YAML↔JSON parity test: same payload serialized both ways produces same `created` shape
- [x] 2034 total tests passing (+29), ruff clean
- [ ] CI green

Closes E8.