### PR TITLE
[QA] Nightly connector smoke matrix against 5 verified sandboxes

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -1,0 +1,87 @@
+name: Nightly Connector Smoke
+
+# Lightweight live-API probe against every paid connector sandbox with
+# provisioned credentials. See tests/test_connector_smoke/ for the checks
+# and PLAN_QA.md §P1 Connector Smoke Matrix for the rationale.
+#
+# Fails loud (Telegram) when a vendor API change, credential rotation,
+# or account expiry would silently break Datanika's connector code.
+
+on:
+  schedule:
+    # 03:00 UTC daily — off-peak in EU, US, and APAC. Vendor APIs are
+    # least likely to be under maintenance windows at this time.
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-connector-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          uv pip install -e ".[dev]" --system
+          # Connector-specific libs not in core deps
+          uv pip install --system "google-cloud-bigquery>=3.0" "kafka-python>=2.0"
+
+      - name: Materialize connector credentials
+        env:
+          # Aggregate base64'd env file — set in GitHub secrets from
+          # secrets/qa-connectors.env on the dev host. Rotate bundle
+          # whenever any individual cred rotates.
+          QA_CONNECTOR_CREDENTIALS: ${{ secrets.QA_CONNECTOR_CREDENTIALS }}
+          QA_BIGQUERY_SA_JSON: ${{ secrets.QA_BIGQUERY_SA_JSON }}
+        run: |
+          if [ -z "$QA_CONNECTOR_CREDENTIALS" ]; then
+            echo "::error::QA_CONNECTOR_CREDENTIALS secret is not set — nothing to test"
+            exit 1
+          fi
+          mkdir -p secrets
+          # Decode env file and export every KEY=VALUE pair into $GITHUB_ENV
+          printf '%s' "$QA_CONNECTOR_CREDENTIALS" | base64 -d > /tmp/creds.env
+          while IFS= read -r line; do
+            # Skip comments + blanks
+            case "$line" in ''|\#*) continue ;; esac
+            echo "$line" >> "$GITHUB_ENV"
+          done < /tmp/creds.env
+          rm /tmp/creds.env
+
+          # BigQuery service-account JSON is a separate secret (multi-line
+          # JSON doesn't fit cleanly in the aggregate env file).
+          if [ -n "$QA_BIGQUERY_SA_JSON" ]; then
+            printf '%s' "$QA_BIGQUERY_SA_JSON" > secrets/qa-bigquery-sa.json
+            chmod 600 secrets/qa-bigquery-sa.json
+          fi
+
+      - name: Run connector smoke tests
+        id: smoke
+        env:
+          DATANIKA_CONNECTOR_SMOKE: "1"
+        run: pytest tests/test_connector_smoke/ -v --tb=short
+
+      - name: Telegram alert on failure
+        if: failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          TEXT=$(printf '\xf0\x9f\x94\xa5 *Nightly connector smoke failed*\n\nOne or more paid-connector sandboxes failed auth + metadata probe.\n\n*Triage*: open the run link, look for the first FAILED test. Likely causes (in order of frequency):\n- Credential rotated / expired (Stripe, HubSpot PATs rotate silently)\n- Sandbox/trial expired (Databricks 14-day trial)\n- Vendor API shape changed (rare but catches it early)\n\n*Run*: %s\n\nSee PLAN_HUMAN_LOCKERS.md §"QA test credentials" for how to reprovision.' "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=1201995" \
+            --data-urlencode "text=${TEXT}" \
+            --data-urlencode "parse_mode=Markdown"

--- a/tests/test_connector_smoke/conftest.py
+++ b/tests/test_connector_smoke/conftest.py
@@ -1,0 +1,53 @@
+"""Gate for the live-connector smoke suite.
+
+These tests hit real third-party APIs with sandbox credentials. They
+are skipped unless ``DATANIKA_CONNECTOR_SMOKE=1`` — the nightly CI
+workflow sets it; regular PR CI does not, so adding these tests does
+not slow the PR feedback loop.
+
+Per-connector creds come from env vars (see individual test modules for
+the vars each expects). In CI, the workflow decodes the
+``QA_CONNECTOR_CREDENTIALS`` GitHub secret (base64-encoded env file)
+and exports all ``*`` pairs before pytest runs. Locally:
+
+    set -a && source secrets/qa-connectors.env && set +a
+    DATANIKA_CONNECTOR_SMOKE=1 uv run pytest tests/test_connector_smoke/ -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_GATE_ENV = "DATANIKA_CONNECTOR_SMOKE"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip the whole directory unless the gate env var is set.
+
+    Done at collection time so the skip reason is visible in `pytest --collect-only`
+    and doesn't count toward "slow test" budget in normal PR runs.
+    """
+    if os.environ.get(_GATE_ENV) == "1":
+        return
+    skip_marker = pytest.mark.skip(
+        reason=f"Live connector smoke tests skipped. Set {_GATE_ENV}=1 to enable."
+    )
+    for item in items:
+        if "test_connector_smoke" in str(item.fspath):
+            item.add_marker(skip_marker)
+
+
+def _require_env(*names: str) -> dict[str, str]:
+    """Fetch required env vars or skip with a clear message."""
+    missing = [n for n in names if not os.environ.get(n)]
+    if missing:
+        pytest.skip(f"Missing env vars: {', '.join(missing)}")
+    return {n: os.environ[n] for n in names}
+
+
+@pytest.fixture
+def require_env():
+    """Fixture wrapper so tests read `env = require_env('FOO', 'BAR')`."""
+    return _require_env

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -1,0 +1,265 @@
+"""Nightly live-connector smoke matrix (PLAN_QA.md §P1).
+
+One test per verified paid-connector sandbox. Each probe is the
+lightest auth + metadata call that catches:
+
+1. Our credentials being revoked / rotated / expired
+2. The vendor's API shape changing in a way our code cares about
+3. Regional/network issues (DNS, TLS, firewall)
+
+Failure → Telegram alert from the nightly workflow. Not wired into
+PR CI (gated by ``DATANIKA_CONNECTOR_SMOKE=1``; see conftest.py).
+
+## Status of the 9 paid connectors in PLAN_QA.md
+
+| Connector      | Tested here? | Reason |
+|----------------|:-:|-|
+| BigQuery       | ✅ |   |
+| Databricks     | ✅ |   |
+| Stripe         | ✅ |   |
+| Kafka/Redpanda | ✅ |   |
+| HubSpot        | ✅ |   |
+| Shopify        | ⬜ | creds not yet provisioned |
+| GA4            | ⬜ | creds not yet provisioned |
+| Salesforce     | ⬜ | creds not yet provisioned |
+| Snowflake      | ⬜ | signup blocked (see `PLAN_HUMAN_LOCKERS.md`) |
+
+When the remaining 4 land in `qa-connectors.env`, add a test here and
+the nightly workflow picks it up automatically.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+
+def _log(msg: str) -> None:
+    """Print with a stable prefix so the nightly log is scannable."""
+    print(f"[smoke] {msg}")
+
+
+# ---------- BigQuery ----------
+
+
+def test_bigquery_auth_and_list_datasets(require_env):
+    """Service-account auth + list datasets in the QA project.
+
+    Catches: key revoked, project ID changed, API disabled, IAM scope drift.
+    """
+    env = require_env("BIGQUERY_PROJECT_ID", "BIGQUERY_CREDENTIALS_FILE")
+
+    from google.cloud import bigquery  # type: ignore[import-untyped]
+    from google.oauth2 import service_account
+
+    t0 = time.monotonic()
+    creds = service_account.Credentials.from_service_account_file(env["BIGQUERY_CREDENTIALS_FILE"])
+    client = bigquery.Client(project=env["BIGQUERY_PROJECT_ID"], credentials=creds)
+    # list_datasets is the cheapest call that exercises both auth and project access.
+    datasets = list(client.list_datasets(max_results=5))
+    _log(
+        f"bigquery: email={creds.service_account_email} datasets={len(datasets)} "
+        f"elapsed={int((time.monotonic() - t0) * 1000)}ms"
+    )
+    # An empty project is fine (no datasets yet) — what matters is the call succeeded.
+    assert datasets is not None
+
+
+# ---------- Databricks ----------
+
+
+def test_databricks_auth_and_list_warehouses(require_env):
+    """PAT auth + list SQL warehouses (BI Tools scope).
+
+    Catches: PAT revoked, workspace URL changed, scope downgrade, trial expiry.
+    """
+    env = require_env("DATABRICKS_HOST", "DATABRICKS_TOKEN")
+
+    t0 = time.monotonic()
+    r = httpx.get(
+        f"{env['DATABRICKS_HOST']}/api/2.0/sql/warehouses",
+        headers={"Authorization": f"Bearer {env['DATABRICKS_TOKEN']}"},
+        timeout=15.0,
+    )
+    elapsed = int((time.monotonic() - t0) * 1000)
+    assert r.status_code == 200, (
+        f"Databricks warehouses list returned {r.status_code}: {r.text[:200]}"
+    )
+    warehouses = r.json().get("warehouses", [])
+    _log(f"databricks: warehouses={len(warehouses)} elapsed={elapsed}ms")
+    assert warehouses, "No SQL warehouses found — trial workspace may have expired"
+
+
+def test_databricks_auth_and_list_uc_catalogs(require_env):
+    """Unity Catalog list (Other APIs scope).
+
+    Catches: UC scope dropped from PAT. Second call so a partial scope
+    revoke is caught specifically, not hidden behind warehouses.
+    """
+    env = require_env("DATABRICKS_HOST", "DATABRICKS_TOKEN")
+
+    r = httpx.get(
+        f"{env['DATABRICKS_HOST']}/api/2.1/unity-catalog/catalogs",
+        headers={"Authorization": f"Bearer {env['DATABRICKS_TOKEN']}"},
+        timeout=15.0,
+    )
+    assert r.status_code == 200, f"UC catalogs returned {r.status_code}: {r.text[:200]}"
+    catalogs = r.json().get("catalogs", [])
+    _log(f"databricks: uc_catalogs={len(catalogs)}")
+    assert len(catalogs) >= 1, "No UC catalogs — workspace/scope may be broken"
+
+
+# ---------- Stripe ----------
+
+
+def test_stripe_auth_and_livemode_guard(require_env):
+    """Restricted key auth + verify we're in test mode.
+
+    Catches: key revoked, accidentally live-mode key replaces test-mode
+    (we'd never want `livemode: true` in a smoke run — that would mean a
+    production key was copied to the test secret).
+    """
+    env = require_env("STRIPE_API_KEY")
+    assert env["STRIPE_API_KEY"].startswith("rk_test_") or env["STRIPE_API_KEY"].startswith(
+        "sk_test_"
+    ), "STRIPE_API_KEY must be a test-mode key (rk_test_ or sk_test_)"
+
+    t0 = time.monotonic()
+    r = httpx.get(
+        "https://api.stripe.com/v1/balance",
+        auth=(env["STRIPE_API_KEY"], ""),
+        timeout=15.0,
+    )
+    elapsed = int((time.monotonic() - t0) * 1000)
+    assert r.status_code == 200, f"Stripe balance returned {r.status_code}: {r.text[:200]}"
+    payload = r.json()
+    _log(f"stripe: livemode={payload.get('livemode')} elapsed={elapsed}ms")
+    assert payload.get("livemode") is False, (
+        "Stripe smoke hit LIVE MODE — rotate the key immediately; a live key "
+        "has replaced the test-mode restricted key in qa-connectors.env"
+    )
+
+
+def test_stripe_list_charges_read_scope(require_env):
+    """Exercise the `charges.read` scope on the restricted key.
+
+    Catches: scope narrowing on the key (if someone rotated it with
+    fewer scopes, this catches it before the smoke matrix runs blind).
+    """
+    env = require_env("STRIPE_API_KEY")
+    r = httpx.get(
+        "https://api.stripe.com/v1/charges",
+        params={"limit": 1},
+        auth=(env["STRIPE_API_KEY"], ""),
+        timeout=15.0,
+    )
+    assert r.status_code == 200, f"Stripe charges returned {r.status_code}: {r.text[:200]}"
+    data = r.json()
+    _log(f"stripe: charges_has_more={data.get('has_more')} charges={len(data.get('data', []))}")
+    # Empty list is fine — key must just be permitted to ask.
+
+
+# ---------- Kafka / Redpanda ----------
+
+
+def test_kafka_auth_and_list_topics(require_env):
+    """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
+
+    Catches: credentials rotated, cluster paused, network block,
+    SASL mechanism change (Redpanda occasionally tightens defaults).
+
+    Runs fine from GHA Ubuntu runners. Will **fail from networks that
+    block outbound 9092** (some ISPs do — see PLAN_HUMAN_LOCKERS.md
+    Kafka entry). If you see ENOTFOUND or timeout locally, that's an
+    ISP issue, not a credential issue.
+    """
+    env = require_env(
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "KAFKA_SASL_USERNAME",
+        "KAFKA_SASL_PASSWORD",
+        "KAFKA_TOPIC",
+    )
+
+    try:
+        from kafka.admin import KafkaAdminClient  # type: ignore[import-untyped]
+    except ImportError:
+        pytest.skip("kafka-python not installed — add to nightly workflow requirements")
+
+    t0 = time.monotonic()
+    admin = KafkaAdminClient(
+        bootstrap_servers=env["KAFKA_BOOTSTRAP_SERVERS"],
+        security_protocol="SASL_SSL",
+        sasl_mechanism="SCRAM-SHA-256",
+        sasl_plain_username=env["KAFKA_SASL_USERNAME"],
+        sasl_plain_password=env["KAFKA_SASL_PASSWORD"],
+        request_timeout_ms=20000,
+        api_version_auto_timeout_ms=20000,
+        client_id="qa-nightly-smoke",
+    )
+    try:
+        topics = admin.list_topics()
+        elapsed = int((time.monotonic() - t0) * 1000)
+        _log(f"kafka: topics={topics} elapsed={elapsed}ms")
+        assert env["KAFKA_TOPIC"] in topics, (
+            f"Expected topic {env['KAFKA_TOPIC']!r} missing; topics visible to "
+            f"qa-smoke user: {topics}. Topic may have been deleted, or the ACL "
+            f"grant was removed."
+        )
+    finally:
+        admin.close()
+
+
+# ---------- HubSpot ----------
+
+
+def test_hubspot_auth_and_account_details(require_env):
+    """Private App PAT auth + account type check.
+
+    Catches: token revoked, portal deleted, account type downgraded
+    (a real account would break the smoke expectations silently; we
+    want the smoke to fail loud).
+    """
+    env = require_env("HUBSPOT_ACCESS_TOKEN")
+    assert env["HUBSPOT_ACCESS_TOKEN"].startswith("pat-"), (
+        "HUBSPOT_ACCESS_TOKEN must be a Private App PAT (pat-*)"
+    )
+
+    t0 = time.monotonic()
+    r = httpx.get(
+        "https://api.hubapi.com/account-info/v3/details",
+        headers={"Authorization": f"Bearer {env['HUBSPOT_ACCESS_TOKEN']}"},
+        timeout=15.0,
+    )
+    elapsed = int((time.monotonic() - t0) * 1000)
+    assert r.status_code == 200, f"HubSpot account details returned {r.status_code}: {r.text[:200]}"
+    payload = r.json()
+    _log(
+        f"hubspot: portalId={payload.get('portalId')} accountType={payload.get('accountType')} "
+        f"elapsed={elapsed}ms"
+    )
+    assert payload.get("accountType") == "DEVELOPER_TEST", (
+        f"HubSpot accountType is {payload.get('accountType')!r}, expected DEVELOPER_TEST. "
+        "A real/standard account may have replaced the test portal in the secret."
+    )
+
+
+def test_hubspot_contacts_schema_introspectable(require_env):
+    """List contact property definitions — the introspect() coverage check.
+
+    Catches: CRM scope dropped, property-definitions endpoint shape change.
+    """
+    env = require_env("HUBSPOT_ACCESS_TOKEN")
+    r = httpx.get(
+        "https://api.hubapi.com/crm/v3/properties/contacts",
+        headers={"Authorization": f"Bearer {env['HUBSPOT_ACCESS_TOKEN']}"},
+        timeout=15.0,
+    )
+    assert r.status_code == 200, f"HubSpot properties returned {r.status_code}: {r.text[:200]}"
+    properties = r.json().get("results", [])
+    _log(f"hubspot: contact_properties={len(properties)}")
+    assert len(properties) >= 50, (
+        f"Only {len(properties)} contact properties returned — HubSpot usually ships "
+        "300+ by default. Scope or API-shape change?"
+    )


### PR DESCRIPTION
## Summary

Wires the nightly connector smoke matrix from PLAN_QA.md §P1. Live-API probe against the 5 paid-connector sandboxes with provisioned creds. Failure → Telegram alert.

## Coverage (8 tests across 5 connectors)

| Connector | Tests | What each catches |
|-----------|-------|------|
| BigQuery | `list_datasets` | Service-account key revoked, project ID changed, API disabled, IAM scope drift |
| Databricks | warehouses + UC catalogs | PAT revoked, scope downgrade (BI Tools vs Other APIs), trial expiry |
| Stripe | balance + charges | Key revoked, **live-mode key accidentally replaces test-mode** (the biggest footgun), scope narrowing |
| Kafka/Redpanda | SASL-SCRAM + list_topics | Credentials rotated, cluster paused, SASL mechanism change, expected topic deleted |
| HubSpot | account details + contact schema | Token revoked, account type downgraded, CRM scope dropped |

## How it runs

- `.github/workflows/nightly-connector-smoke.yml` — cron `0 3 * * *` (03:00 UTC daily) + `workflow_dispatch`
- Gated by `DATANIKA_CONNECTOR_SMOKE=1` so regular PR CI skips
- Reads `QA_CONNECTOR_CREDENTIALS` (base64 env bundle) + `QA_BIGQUERY_SA_JSON` GH secrets
- Telegram alert on failure with triage guidance (credential rotation, trial expiry, vendor API shape change)

## Infra ask (post-merge)

Two new GH Actions secrets:
- `QA_CONNECTOR_CREDENTIALS` — `base64 -w0 secrets/qa-connectors.env`
- `QA_BIGQUERY_SA_JSON` — full contents of `secrets/qa-bigquery-sa.json`

Rotate both together when any individual cred rotates on the dev host.

## Test plan

- [x] Skip path: 8 tests skip cleanly without `DATANIKA_CONNECTOR_SMOKE=1`
- [x] Live run locally: 7 passed, 1 skipped (Kafka — needs `kafka-python` which the workflow installs explicitly)
- [x] Ruff clean
- [ ] First nightly run green (will know tomorrow 03:00 UTC, or via `workflow_dispatch` once secrets land)

## Still deferred

4 of 9 paid connectors without creds yet: Shopify, GA4, Salesforce, Snowflake (blocked on signup). Tests land here when their creds do.

Refs PLAN_QA.md §P1 Connector Smoke Matrix.

---

Closes #245 (retroactively filed — branch was created before the issue, noting for audit trail)