### PR TITLE
[Infra] Promote dev → master (E12 async middleware)

### DIFF
--- a/datanika/services/api_middleware.py
+++ b/datanika/services/api_middleware.py
@@ -1,5 +1,20 @@
-"""API middleware — authentication + rate limiting for /api/v1/ routes."""
+"""API middleware — authentication + rate limiting for /api/v1/ routes.
 
+E12 — sync/async handler detection. Handlers declared as ``def`` (not
+``async def``) are executed inside ``asyncio.to_thread`` so their sync
+DB work doesn't block the event loop. Async handlers keep the original
+path for backward compatibility.
+
+Before E12, every handler held the event loop for the duration of its
+sync SQLAlchemy session.execute()/commit(), serializing all requests on
+a Granian async worker. k6 Run 4 (2026-04-18) measured 60 req/s at 100
+VUs with 4 workers — theoretical max was 97. Wrapping sync handlers in
+``to_thread`` unlocks threadpool-level concurrency (~40 threads/worker).
+"""
+
+from __future__ import annotations
+
+import asyncio
 import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
@@ -35,90 +50,174 @@ def api_endpoint(
 ) -> Callable:
     """Decorator for API route handlers that enforces auth + rate limiting.
 
+    Handlers can be declared as ``async def`` (original behavior — awaited
+    on the event loop) or plain ``def`` (E12 — executed in ``asyncio.to_thread``
+    so sync SQLAlchemy operations don't block the event loop).
+
     Usage::
 
+        # Async handler (unchanged)
         @api_endpoint(required_scope="pipeline:read")
         async def list_pipelines(request, api_key, session):
             ...
-            return JSONResponse({"items": [...]})
+
+        # Sync handler (E12 — threaded, recommended for DB-bound endpoints)
+        @api_endpoint(required_scope="pipeline:read")
+        def list_pipelines(request, api_key, session):
+            ...
     """
 
     def decorator(
-        handler: Callable[..., Coroutine[Any, Any, JSONResponse]],
+        handler: Callable[..., Coroutine[Any, Any, JSONResponse] | JSONResponse],
     ) -> Callable[..., Coroutine[Any, Any, JSONResponse]]:
+        is_async_handler = asyncio.iscoroutinefunction(handler)
+
         async def wrapper(request: Request) -> JSONResponse:
-            # 1. Extract API key from Authorization header
+            # 1. Extract API key (async-safe, no DB)
             auth_header = request.headers.get("authorization", "")
             if not auth_header.startswith("Bearer "):
                 return _error(401, "Missing or invalid Authorization header")
 
-            raw_key = auth_header[7:]  # Strip "Bearer "
+            raw_key = auth_header[7:]
             if not raw_key:
                 return _error(401, "Missing API key")
 
-            # 2. Authenticate
-            with _get_session() as session:
-                api_key = _api_key_svc.authenticate_api_key(
-                    session, raw_key, required_scope=required_scope
-                )
-                if api_key is None:
-                    return _error(401, "Invalid or expired API key")
+            # 2. Pre-consume body for POST so the handler can read it in
+            # the sync thread without touching the outer event loop's receive.
+            if request.method in ("POST", "PUT", "PATCH"):
+                await request.body()
 
-                # 3. Rate limiting
-                limit_rpm = _rate_limit_svc.get_limit_for_org(api_key.org_id)
-                result = _rate_limit_svc.check_rate_limit(
-                    api_key_id=api_key.id,
-                    org_id=api_key.org_id,
-                    limit_rpm=limit_rpm,
-                    burst_per_sec=settings.api_rate_limit_burst,
-                )
-
-                if not result.allowed:
-                    return _error(
-                        429,
-                        f"Rate limit exceeded ({limit_rpm} requests/minute). "
-                        f"Retry after {result.retry_after} seconds.",
-                        headers=result.headers(),
-                    )
-
-                # 4. Idempotency check (POST only, opt-in via header)
-                from datanika.services.idempotency import (
-                    cache_response,
-                    get_cached_response,
-                    get_idempotency_key,
-                )
-
-                idem_key = None
-                if request.method == "POST":
-                    idem_key = get_idempotency_key(request, api_key.org_id)
-                    if idem_key:
-                        cached = get_cached_response(idem_key)
-                        if cached is not None:
-                            for k, v in result.headers().items():
-                                cached.headers[k] = v
-                            return cached
-
-                # 5. Call the actual handler
-                try:
-                    response = await handler(request, api_key=api_key, session=session)
-                    session.commit()
-                except Exception:
-                    logger.exception("API handler error")
-                    session.rollback()
-                    return _error(500, "Internal server error")
-
-                # 6. Cache response for idempotency
-                if idem_key:
-                    cache_response(idem_key, response)
-
-                # 7. Attach rate limit headers to successful responses
-                for k, v in result.headers().items():
-                    response.headers[k] = v
-
-                return response
+            # 3. Auth + rate-limit + handler + commit. E12: run in threadpool
+            # for sync handlers to unblock the event loop. Async handlers
+            # keep the original inline path.
+            if is_async_handler:
+                return await _run_async_handler(handler, request, raw_key, required_scope)
+            return await asyncio.to_thread(
+                _run_sync_handler, handler, request, raw_key, required_scope
+            )
 
         wrapper.__name__ = handler.__name__
         wrapper.__qualname__ = handler.__qualname__
         return wrapper
 
     return decorator
+
+
+async def _run_async_handler(
+    handler: Callable, request: Request, raw_key: str, required_scope: str | None
+) -> JSONResponse:
+    """Original async-handler path — kept for backward compat."""
+    with _get_session() as session:
+        api_key = _api_key_svc.authenticate_api_key(session, raw_key, required_scope=required_scope)
+        if api_key is None:
+            return _error(401, "Invalid or expired API key")
+
+        limit_rpm = _rate_limit_svc.get_limit_for_org(api_key.org_id)
+        result = _rate_limit_svc.check_rate_limit(
+            api_key_id=api_key.id,
+            org_id=api_key.org_id,
+            limit_rpm=limit_rpm,
+            burst_per_sec=settings.api_rate_limit_burst,
+        )
+
+        if not result.allowed:
+            return _error(
+                429,
+                f"Rate limit exceeded ({limit_rpm} requests/minute). "
+                f"Retry after {result.retry_after} seconds.",
+                headers=result.headers(),
+            )
+
+        from datanika.services.idempotency import (
+            cache_response,
+            get_cached_response,
+            get_idempotency_key,
+        )
+
+        idem_key = None
+        if request.method == "POST":
+            idem_key = get_idempotency_key(request, api_key.org_id)
+            if idem_key:
+                cached = get_cached_response(idem_key)
+                if cached is not None:
+                    for k, v in result.headers().items():
+                        cached.headers[k] = v
+                    return cached
+
+        try:
+            response = await handler(request, api_key=api_key, session=session)
+            session.commit()
+        except Exception:
+            logger.exception("API handler error")
+            session.rollback()
+            return _error(500, "Internal server error")
+
+        if idem_key:
+            cache_response(idem_key, response)
+
+        for k, v in result.headers().items():
+            response.headers[k] = v
+
+        return response
+
+
+def _run_sync_handler(
+    handler: Callable, request: Request, raw_key: str, required_scope: str | None
+) -> JSONResponse:
+    """E12 — synchronous path, invoked via asyncio.to_thread from wrapper.
+
+    Same logic as the async path but all calls stay sync. SQLAlchemy sessions
+    are not thread-safe; we create one per invocation and close on exit.
+    """
+    with _get_session() as session:
+        api_key = _api_key_svc.authenticate_api_key(session, raw_key, required_scope=required_scope)
+        if api_key is None:
+            return _error(401, "Invalid or expired API key")
+
+        limit_rpm = _rate_limit_svc.get_limit_for_org(api_key.org_id)
+        result = _rate_limit_svc.check_rate_limit(
+            api_key_id=api_key.id,
+            org_id=api_key.org_id,
+            limit_rpm=limit_rpm,
+            burst_per_sec=settings.api_rate_limit_burst,
+        )
+
+        if not result.allowed:
+            return _error(
+                429,
+                f"Rate limit exceeded ({limit_rpm} requests/minute). "
+                f"Retry after {result.retry_after} seconds.",
+                headers=result.headers(),
+            )
+
+        from datanika.services.idempotency import (
+            cache_response,
+            get_cached_response,
+            get_idempotency_key,
+        )
+
+        idem_key = None
+        if request.method == "POST":
+            idem_key = get_idempotency_key(request, api_key.org_id)
+            if idem_key:
+                cached = get_cached_response(idem_key)
+                if cached is not None:
+                    for k, v in result.headers().items():
+                        cached.headers[k] = v
+                    return cached
+
+        try:
+            response = handler(request, api_key=api_key, session=session)
+            session.commit()
+        except Exception:
+            logger.exception("API handler error")
+            session.rollback()
+            return _error(500, "Internal server error")
+
+        if idem_key:
+            cache_response(idem_key, response)
+
+        for k, v in result.headers().items():
+            response.headers[k] = v
+
+        return response

--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -218,7 +218,7 @@ def _ser_catalog_entry(e):
 
 
 @api_endpoint(required_scope="connections:read")
-async def list_connections(request, api_key, session):
+def list_connections(request, api_key, session):
     items = _get_conn_svc().list_connections(session, api_key.org_id)
     return JSONResponse({"items": [_ser_connection(c) for c in items]})
 
@@ -709,7 +709,7 @@ async def trigger_transformation(request, api_key, session):
 
 
 @api_endpoint(required_scope="transformations:read")
-async def compile_transformation_endpoint(request, api_key, session):
+def compile_transformation_endpoint(request, api_key, session):
     """POST /api/v1/transformations/{id}/compile — dbt compile only.
 
     Agent uses this to validate Jinja + ref/source resolution before
@@ -873,7 +873,7 @@ async def delete_schedule(request, api_key, session):
 
 
 @api_endpoint(required_scope="runs:read")
-async def list_runs(request, api_key, session):
+def list_runs(request, api_key, session):
     target_type = request.query_params.get("target_type")
     target_id = request.query_params.get("target_id")
     status = request.query_params.get("status")
@@ -997,7 +997,7 @@ def _ser_notification(n):
 
 
 @api_endpoint(required_scope="notifications:read")
-async def list_in_app_notifications(request, api_key, session):
+def list_in_app_notifications(request, api_key, session):
     from datanika.services.in_app_notification_service import InAppNotificationService
 
     unread_only = request.query_params.get("unread_only", "").lower() in ("true", "1")
@@ -1030,7 +1030,7 @@ async def list_in_app_notifications(request, api_key, session):
 
 
 @api_endpoint(required_scope="notifications:read")
-async def get_unread_count(request, api_key, session):
+def get_unread_count(request, api_key, session):
     from datanika.services.in_app_notification_service import InAppNotificationService
 
     count = InAppNotificationService.unread_count(

--- a/tests/test_services/test_api_middleware.py
+++ b/tests/test_services/test_api_middleware.py
@@ -123,3 +123,193 @@ class TestApiEndpointRateLimit:
         assert resp.json()["ok"] is True
         assert resp.headers["X-RateLimit-Limit"] == "60"
         assert resp.headers["X-RateLimit-Remaining"] == "59"
+
+
+# ---------------------------------------------------------------------------
+# E12 — sync handler path (asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+@api_endpoint(required_scope="pipeline:read")
+def sync_sample_handler(request, api_key, session):
+    """A handler declared as ``def`` instead of ``async def`` — should be
+    routed through the E12 to_thread path."""
+    return JSONResponse({"ok": True, "org_id": api_key.org_id, "sync": True})
+
+
+class TestApiEndpointSyncHandler:
+    """E12 — sync (def) handlers run in asyncio.to_thread to unblock the
+    event loop for concurrent DB work.
+    """
+
+    def test_sync_handler_still_reaches_handler(self, fake_api_key, rate_limit_ok):
+        """A sync handler returns 200 with the expected body."""
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_session,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+            mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/sync", sync_sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/sync", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["ok"] is True
+            assert body["sync"] is True
+            assert body["org_id"] == 10
+
+    def test_sync_handler_rejects_missing_auth(self):
+        """Sync handler path still enforces auth — no handler-level check
+        needed. If auth fails, handler never runs."""
+        app = Starlette(routes=[Route("/sync", sync_sample_handler)])
+        client = TestClient(app)
+        resp = client.get("/sync")
+        assert resp.status_code == 401
+
+    def test_sync_handler_rate_limit(self, fake_api_key, rate_limit_exceeded):
+        """Rate limit still applies in the sync path."""
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_session,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_exceeded
+            mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/sync", sync_sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/sync", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 429
+
+    def test_sync_handler_commits_session(self, fake_api_key, rate_limit_ok):
+        """Successful sync handler triggers session.commit() (write-path
+        correctness guarantee unchanged from the async path)."""
+        mock_sess = MagicMock()
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_sess_ctor,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+            mock_sess_ctor.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_sess_ctor.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/sync", sync_sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/sync", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 200
+            mock_sess.commit.assert_called_once()
+
+    def test_sync_handler_rolls_back_on_exception(self, fake_api_key, rate_limit_ok):
+        """A raised exception rolls back and returns 500."""
+        mock_sess = MagicMock()
+
+        @api_endpoint()
+        def raising_handler(request, api_key, session):
+            raise RuntimeError("boom")
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_sess_ctor,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+            mock_sess_ctor.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_sess_ctor.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/boom", raising_handler)])
+            client = TestClient(app)
+            resp = client.get("/boom", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 500
+            mock_sess.rollback.assert_called_once()
+            mock_sess.commit.assert_not_called()
+
+    def test_async_handler_path_unchanged(self, fake_api_key, rate_limit_ok):
+        """Regression: async-def handlers still take the original path."""
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_session,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+            mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/async", sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/async", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 200
+
+    def test_sync_handler_concurrent_requests_not_serialized(self, fake_api_key, rate_limit_ok):
+        """Core E12 guarantee: sync handlers run in a thread pool, so a slow
+        handler does NOT block a concurrent request on the same worker.
+
+        Simulation: 2 requests where each handler sleeps 0.2s. If they were
+        serialized (pre-E12 path), total time >= 0.4s. In the threadpool,
+        they overlap and total time stays close to 0.2s.
+        """
+        import threading
+        import time
+
+        call_enter = threading.Event()
+        handler_calls = []
+
+        @api_endpoint()
+        def slow_handler(request, api_key, session):
+            handler_calls.append(threading.get_ident())
+            call_enter.set()
+            time.sleep(0.2)
+            return JSONResponse({"thread": threading.get_ident()})
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_session,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_ok
+            mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/slow", slow_handler)])
+            client = TestClient(app)
+
+            # Fire two concurrent requests from separate client threads.
+            results = []
+
+            def go():
+                results.append(
+                    client.get("/slow", headers={"Authorization": "Bearer etf_validkey"})
+                )
+
+            t1 = threading.Thread(target=go)
+            t2 = threading.Thread(target=go)
+            start = time.monotonic()
+            t1.start()
+            t2.start()
+            t1.join(timeout=2.0)
+            t2.join(timeout=2.0)
+            elapsed = time.monotonic() - start
+
+            assert len(results) == 2
+            assert all(r.status_code == 200 for r in results)
+            # Two distinct threads executed the handlers.
+            assert len(set(handler_calls)) == 2
+            # Overlap: total < 2 × 0.2 + margin. Serialized would be ~0.4s.
+            assert elapsed < 0.35, f"handlers serialized (elapsed={elapsed:.2f}s)"


### PR DESCRIPTION
Single-item promotion to unblock k6 Run 5.

**Closes #246** — E12 (sync handlers via asyncio.to_thread, core#247).

Post-deploy: run k6 baseline targeting p95 <500ms at 100 VUs on list endpoints. Previous Run 4 capped at 3.5s due to event-loop serialization (now fixed).