### PR TITLE
[QA] template-prefill spec: link Plausible soft-assert to landing#212

### DIFF
--- a/e2e/tests/template-prefill.spec.ts
+++ b/e2e/tests/template-prefill.spec.ts
@@ -42,12 +42,14 @@ test.describe("Pipeline template prefill via ?template=", () => {
     // The event may have fired during the click-to-navigate transition.
     // On open-source builds (no cloud plugin), the event script is empty
     // so this assertion is conditional.
+    //
+    // Soft assertion for now — see landing#212. As of 2026-04-18 Plausible
+    // CE records 0 custom events across 30d (despite the tracking script
+    // loading on every page), so even on staging/prod this event is silently
+    // dropped. Tighten to a hard assert once Plausible config is fixed.
     const hasPrefill = events.some((e) => e.includes("template_selected"));
-    // In staging (cloud edition), this should be true.
-    // In open-source CI, the plugin isn't loaded so no event fires.
-    // Mark as soft assertion — the real gate is the prefill working.
     if (!hasPrefill) {
-      console.log("template_selected event not captured (expected in open-source builds)");
+      console.log("template_selected event not captured (see landing#212)");
     }
   });
 });


### PR DESCRIPTION
Tiny comment update on `e2e/tests/template-prefill.spec.ts`. The soft assertion on the Plausible event was hiding a real config bug — Plausible CE has 0 custom events in 30d across all sites despite the script being loaded and CTAs tagged correctly. Comment now points at landing#212 so the pattern isn't rediscovered as 'expected'.

No behavior change. No test added or removed. Lint + format pending.

Closes #250