### PR TITLE
[Engineering] feat: V2 P5 Option B — charges migration + core-side hooks

### DIFF
--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -277,3 +277,11 @@ from datanika.services.quota_notification_hooks import (  # noqa: E402
 )
 
 register_quota_notification_hooks()
+
+# Charge events (V2 P5 Option B, core#249) — emitted by cloud plugin's
+# cycle-boundary billing task.
+from datanika.services.charge_notification_hooks import (  # noqa: E402
+    register_charge_notification_hooks,
+)
+
+register_charge_notification_hooks()

--- a/datanika/migrations/helpers.py
+++ b/datanika/migrations/helpers.py
@@ -29,6 +29,7 @@ PUBLIC_TABLES: set[str] = {
     "plans",
     "subscriptions",
     "usage_ledger",
+    "charges",
 }
 
 # Tables managed by Alembic but not belonging to either category

--- a/datanika/migrations/versions/a7b1c2d3e4f5_add_charges_table_and_charge_incoming_sent.py
+++ b/datanika/migrations/versions/a7b1c2d3e4f5_add_charges_table_and_charge_incoming_sent.py
@@ -1,0 +1,111 @@
+"""V2 P5 Option B — charges table + usage_ledger.charge_incoming_sent
+
+Adds the ``charges`` table used by the cloud plugin's cycle-boundary
+overage-billing task (V2 P5 Option B — core#249). Idempotency key on
+``(subscription_id, period_start, metric)`` is enforced via a unique
+index on ``charges.idempotency_key`` so a concurrent task run or retry
+hits ``IntegrityError`` rather than double-charging the customer.
+
+Also adds ``usage_ledger.charge_incoming_sent`` — the pre-charge
+notification idempotency latch (~24h before cycle close, fires once
+per cycle per org).
+
+Revision ID: a7b1c2d3e4f5
+Revises: z6a1b2c3d4e5
+Create Date: 2026-04-18 13:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7b1c2d3e4f5"
+down_revision: str | None = "z6a1b2c3d4e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "usage_ledger",
+        sa.Column(
+            "charge_incoming_sent",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    op.create_table(
+        "charges",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.BigInteger(), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=120), nullable=False),
+        sa.Column(
+            "subscription_id",
+            sa.BigInteger(),
+            sa.ForeignKey("subscriptions.id"),
+            nullable=False,
+        ),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metric", sa.String(length=50), nullable=False),
+        sa.Column("overage_quantity", sa.BigInteger(), nullable=False),
+        sa.Column("amount_cents", sa.Integer(), nullable=False),
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default=sa.text("'USD'"),
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("paddle_transaction_id", sa.String(length=50), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_error", sa.String(length=500), nullable=True),
+        sa.Column("issued_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("paid_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Hard idempotency barrier — a second insert on the same cycle raises
+    # IntegrityError and the task aborts before calling Paddle.
+    op.create_index(
+        "ix_charges_idempotency_key",
+        "charges",
+        ["idempotency_key"],
+        unique=True,
+    )
+    op.create_index("ix_charges_subscription_id", "charges", ["subscription_id"])
+    op.create_index("ix_charges_org_id", "charges", ["org_id"])
+
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    op.drop_index("ix_charges_org_id", table_name="charges")
+    op.drop_index("ix_charges_subscription_id", table_name="charges")
+    op.drop_index("ix_charges_idempotency_key", table_name="charges")
+    op.drop_table("charges")
+    op.drop_column("usage_ledger", "charge_incoming_sent")
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/notification.py
+++ b/datanika/models/notification.py
@@ -13,6 +13,10 @@ class NotificationType(enum.StrEnum):
     RUN_SUCCEEDED = "run_succeeded"
     QUOTA_WARNING = "quota_warning"
     QUOTA_EXCEEDED = "quota_exceeded"
+    # V2 P5 Option B — cycle-boundary overage billing (core#249)
+    CHARGE_INCOMING = "charge_incoming"
+    CHARGE_ISSUED = "charge_issued"
+    CHARGE_FAILED = "charge_failed"
 
 
 class Notification(Base, TenantMixin, TimestampMixin):

--- a/datanika/services/charge_notification_hooks.py
+++ b/datanika/services/charge_notification_hooks.py
@@ -1,0 +1,194 @@
+"""Charge notification hooks — V2 P5 Option B (core#249).
+
+Subscribes to the three cycle-boundary charge events emitted by the cloud
+plugin's ``datanika_cloud/billing/tasks.py``:
+
+- ``charge_incoming``: ~24h before cycle close, customer has crossed
+  ``plan.bytes_included`` → warn them so they can top up or adjust usage
+  before the charge fires.
+- ``charge_issued``: Paddle accepted the one-off charge; invoice receipt.
+- ``charge_failed``: API retries exhausted (after CHARGE_MAX_RETRIES);
+  ops alert + customer email asking to contact support.
+
+Same shape as ``quota_notification_hooks.py`` — creates in-app
+Notification rows and dispatches to user-configured external channels.
+Handlers are pure subscribers: in an open-source build with no cloud
+plugin loaded, these events never emit and the module is inert.
+"""
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from datanika import hooks
+from datanika.models.notification import NotificationType
+from datanika.services.in_app_notification_service import InAppNotificationService
+from datanika.ui.state.base_state import get_sync_session
+
+logger = logging.getLogger(__name__)
+
+_svc = InAppNotificationService()
+
+
+def _format_money(amount_cents: int, currency: str = "USD") -> str:
+    symbol = "$" if currency == "USD" else currency + " "
+    return f"{symbol}{amount_cents / 100:.2f}"
+
+
+def _dispatch(session: Session, org_id: int, event: str, payload: dict) -> None:
+    """Send to configured Slack/Telegram/webhook/email channels."""
+    from datanika.services.notification_service import NotificationService
+
+    NotificationService().notify(session, org_id, event, payload)
+
+
+def _with_session(fn):
+    """Open a session, run ``fn(session)``, commit/rollback/close.
+
+    Swallows all exceptions so notification delivery failures can't break
+    the emit path — the event source is a Celery task, we don't want a
+    transient notification-service error to fail the charge task too.
+    """
+
+    def _wrapped(**kw):
+        session = get_sync_session()
+        try:
+            fn(session, **kw)
+            session.commit()
+        except Exception:  # noqa: BLE001
+            session.rollback()
+            logger.exception(
+                "Failed to handle charge notification (event=%s, org_id=%s)",
+                fn.__name__,
+                kw.get("org_id"),
+            )
+        finally:
+            session.close()
+
+    return _wrapped
+
+
+@_with_session
+def _on_charge_incoming(
+    session: Session,
+    *,
+    org_id: int,
+    subscription_id: int,
+    amount_cents: int,
+    currency: str = "USD",
+    metric: str = "bytes_processed",
+    **_kw,
+) -> None:
+    title = f"Upcoming overage charge: {_format_money(amount_cents, currency)}"
+    message = (
+        f"Your usage this cycle will add {_format_money(amount_cents, currency)} "
+        f"to your next invoice. Charge fires at cycle close."
+    )
+    _svc.create(
+        session,
+        org_id,
+        NotificationType.CHARGE_INCOMING,
+        title=title,
+        resource_type="subscription",
+        resource_id=subscription_id,
+        message=message,
+    )
+    _dispatch(
+        session,
+        org_id,
+        "charge_incoming",
+        {
+            "amount_cents": amount_cents,
+            "currency": currency,
+            "metric": metric,
+        },
+    )
+
+
+@_with_session
+def _on_charge_issued(
+    session: Session,
+    *,
+    org_id: int,
+    subscription_id: int,
+    charge_id: int,
+    amount_cents: int,
+    currency: str = "USD",
+    metric: str = "bytes_processed",
+    **_kw,
+) -> None:
+    title = f"Overage charge: {_format_money(amount_cents, currency)}"
+    message = (
+        f"A one-off charge of {_format_money(amount_cents, currency)} "
+        f"has been added to your subscription for this cycle's usage."
+    )
+    _svc.create(
+        session,
+        org_id,
+        NotificationType.CHARGE_ISSUED,
+        title=title,
+        resource_type="charge",
+        resource_id=charge_id,
+        message=message,
+    )
+    _dispatch(
+        session,
+        org_id,
+        "charge_issued",
+        {
+            "amount_cents": amount_cents,
+            "currency": currency,
+            "metric": metric,
+            "charge_id": charge_id,
+        },
+    )
+
+
+@_with_session
+def _on_charge_failed(
+    session: Session,
+    *,
+    org_id: int,
+    subscription_id: int,
+    charge_id: int,
+    amount_cents: int,
+    currency: str = "USD",
+    metric: str = "bytes_processed",
+    attempts: int = 0,
+    last_error: str = "",
+    **_kw,
+) -> None:
+    title = "Overage charge failed — action needed"
+    message = (
+        f"We couldn't collect {_format_money(amount_cents, currency)} for this cycle "
+        f"after {attempts} attempts. Please contact support or check your payment method."
+    )
+    _svc.create(
+        session,
+        org_id,
+        NotificationType.CHARGE_FAILED,
+        title=title,
+        resource_type="charge",
+        resource_id=charge_id,
+        message=message,
+    )
+    _dispatch(
+        session,
+        org_id,
+        "charge_failed",
+        {
+            "amount_cents": amount_cents,
+            "currency": currency,
+            "metric": metric,
+            "charge_id": charge_id,
+            "attempts": attempts,
+            "last_error": last_error,
+        },
+    )
+
+
+def register_charge_notification_hooks() -> None:
+    """Subscribe to the 3 cycle-boundary charge events."""
+    hooks.on("charge_incoming", _on_charge_incoming)
+    hooks.on("charge_issued", _on_charge_issued)
+    hooks.on("charge_failed", _on_charge_failed)

--- a/tests/test_services/test_charge_notification_hooks.py
+++ b/tests/test_services/test_charge_notification_hooks.py
@@ -1,0 +1,217 @@
+"""Tests for V2 P5 Option B charge-event subscribers (core#249).
+
+The hooks create in-app ``Notification`` rows + dispatch to external
+channels via ``NotificationService``. Subscriber wiring is pure — if
+the cloud plugin never emits these events, the core tree is inert.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datanika import hooks
+from datanika.models.notification import NotificationType
+from datanika.services.charge_notification_hooks import (
+    _format_money,
+    _on_charge_failed,
+    _on_charge_incoming,
+    _on_charge_issued,
+    register_charge_notification_hooks,
+)
+
+
+class TestFormatMoney:
+    def test_usd_default_symbol(self):
+        assert _format_money(1299) == "$12.99"
+
+    def test_exact_dollar(self):
+        assert _format_money(5000) == "$50.00"
+
+    def test_zero(self):
+        assert _format_money(0) == "$0.00"
+
+    def test_non_usd_falls_back_to_code(self):
+        assert _format_money(1299, "EUR") == "EUR 12.99"
+
+
+class _FakeNotificationSvc:
+    """In-memory stand-in for ``NotificationService.notify`` and
+    ``InAppNotificationService.create``. Each call appends to ``records``.
+    """
+
+    def __init__(self):
+        self.in_app: list[dict] = []
+        self.external: list[dict] = []
+
+    def create(self, session, org_id, notif_type, *, title, resource_type, resource_id, message):
+        self.in_app.append(
+            {
+                "org_id": org_id,
+                "type": notif_type,
+                "title": title,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "message": message,
+            }
+        )
+
+    def notify(self, session, org_id, event, payload):
+        self.external.append({"org_id": org_id, "event": event, "payload": payload})
+
+
+@pytest.fixture
+def fake_session():
+    sess = MagicMock()
+    sess.commit = MagicMock()
+    sess.rollback = MagicMock()
+    sess.close = MagicMock()
+    return sess
+
+
+@pytest.fixture
+def fake_svc(monkeypatch):
+    svc = _FakeNotificationSvc()
+    # Replace both the module-level in-app service and the ad-hoc
+    # NotificationService instantiation inside _dispatch.
+    import datanika.services.charge_notification_hooks as m
+
+    monkeypatch.setattr(m, "_svc", svc)
+    monkeypatch.setattr(
+        "datanika.services.notification_service.NotificationService",
+        lambda: svc,
+    )
+    return svc
+
+
+@pytest.fixture
+def fake_session_context(fake_session, monkeypatch):
+    """Patch ``get_sync_session`` in the hooks module so the decorator
+    opens the mock session instead of a real DB.
+    """
+    monkeypatch.setattr(
+        "datanika.services.charge_notification_hooks.get_sync_session",
+        lambda: fake_session,
+    )
+    return fake_session
+
+
+class TestChargeIncoming:
+    def test_creates_in_app_notification(self, fake_session_context, fake_svc):
+        _on_charge_incoming(
+            org_id=42,
+            subscription_id=7,
+            amount_cents=1500,
+            currency="USD",
+            metric="bytes_processed",
+        )
+        assert len(fake_svc.in_app) == 1
+        row = fake_svc.in_app[0]
+        assert row["org_id"] == 42
+        assert row["type"] == NotificationType.CHARGE_INCOMING
+        assert "$15.00" in row["title"]
+        assert row["resource_type"] == "subscription"
+        assert row["resource_id"] == 7
+
+    def test_dispatches_to_external_channels(self, fake_session_context, fake_svc):
+        _on_charge_incoming(
+            org_id=42,
+            subscription_id=7,
+            amount_cents=1500,
+            currency="USD",
+            metric="bytes_processed",
+        )
+        assert len(fake_svc.external) == 1
+        call = fake_svc.external[0]
+        assert call["event"] == "charge_incoming"
+        assert call["payload"]["amount_cents"] == 1500
+        assert call["payload"]["metric"] == "bytes_processed"
+
+    def test_commit_called_on_success(self, fake_session_context, fake_svc, fake_session):
+        _on_charge_incoming(org_id=42, subscription_id=7, amount_cents=1500)
+        fake_session.commit.assert_called_once()
+        fake_session.rollback.assert_not_called()
+
+
+class TestChargeIssued:
+    def test_creates_notification_with_charge_id(self, fake_session_context, fake_svc):
+        _on_charge_issued(
+            org_id=42,
+            subscription_id=7,
+            charge_id=99,
+            amount_cents=2500,
+            currency="USD",
+            metric="bytes_processed",
+        )
+        assert fake_svc.in_app[0]["type"] == NotificationType.CHARGE_ISSUED
+        assert fake_svc.in_app[0]["resource_type"] == "charge"
+        assert fake_svc.in_app[0]["resource_id"] == 99
+
+    def test_external_payload_includes_charge_id(self, fake_session_context, fake_svc):
+        _on_charge_issued(org_id=42, subscription_id=7, charge_id=99, amount_cents=2500)
+        assert fake_svc.external[0]["payload"]["charge_id"] == 99
+
+
+class TestChargeFailed:
+    def test_creates_failed_notification(self, fake_session_context, fake_svc):
+        _on_charge_failed(
+            org_id=42,
+            subscription_id=7,
+            charge_id=99,
+            amount_cents=2500,
+            attempts=6,
+            last_error="Paddle API 500",
+        )
+        row = fake_svc.in_app[0]
+        assert row["type"] == NotificationType.CHARGE_FAILED
+        assert "action needed" in row["title"].lower()
+        assert "6 attempts" in row["message"]
+
+    def test_external_payload_includes_error_details(self, fake_session_context, fake_svc):
+        _on_charge_failed(
+            org_id=42,
+            subscription_id=7,
+            charge_id=99,
+            amount_cents=2500,
+            attempts=6,
+            last_error="Paddle API 500",
+        )
+        payload = fake_svc.external[0]["payload"]
+        assert payload["attempts"] == 6
+        assert payload["last_error"] == "Paddle API 500"
+
+
+class TestDecoratorErrorSafety:
+    """The _with_session decorator must never let subscriber errors escape
+    into emit() — the Celery task emitting the event should never fail
+    because a notification couldn't be delivered.
+    """
+
+    def test_create_raises_rollback_not_commit(self, fake_session_context, fake_svc, fake_session):
+        import datanika.services.charge_notification_hooks as m
+
+        # Make the in-app service raise.
+        bad = MagicMock()
+        bad.create.side_effect = RuntimeError("DB down")
+
+        with patch.object(m, "_svc", bad):
+            _on_charge_incoming(org_id=42, subscription_id=7, amount_cents=1500)
+
+        # rollback + close both called, commit NOT called.
+        fake_session.rollback.assert_called_once()
+        fake_session.close.assert_called_once()
+        fake_session.commit.assert_not_called()
+
+
+class TestRegistration:
+    def test_register_subscribes_all_three_events(self, monkeypatch):
+        # Fresh handler dict for the test so we don't pollute global state.
+        fresh = {}
+        monkeypatch.setattr(hooks, "_handlers", fresh)
+
+        register_charge_notification_hooks()
+
+        assert set(fresh.keys()) == {"charge_incoming", "charge_issued", "charge_failed"}
+        for event in ("charge_incoming", "charge_issued", "charge_failed"):
+            assert len(fresh[event]) == 1


### PR DESCRIPTION
## Summary

Core-side half of V2 P5 Option B (Paddle cycle-boundary overage charges, core#249). Cloud-side PR lands separately.

### Changes
- **Migration `a7b1c2d3e4f5`**: new `charges` table with unique `idempotency_key` (hard barrier against double-charge), plus `usage_ledger.charge_incoming_sent` latch for the 24h pre-charge warning.
- **3 new `NotificationType` values**: `CHARGE_INCOMING`, `CHARGE_ISSUED`, `CHARGE_FAILED`.
- **`services/charge_notification_hooks.py`**: subscribes to all 3 events emitted by cloud's Celery task. Creates in-app `Notification` rows + dispatches to Slack/Telegram/webhook/email channels. Decorated with `_with_session` that swallows exceptions so notification delivery can never fail the emitting task.
- Registered via `register_charge_notification_hooks()` in `datanika.py`.
- `charges` added to `PUBLIC_TABLES`.

### Ship gates closed
Per PLAN §V2 P5 Paddle Option B:
1. ✅ Idempotency barrier (unique index on `idempotency_key`)
2. ✅ Pre-charge notification event wired (`charge_incoming` subscriber)
3. Failed-payment policy doc ships in the cloud-side PR at `datanika-cloud/docs/billing-failed-payment-policy.md`.

## Test plan
- [x] 13 new tests for the subscriber (format_money, 3 handlers, decorator error safety, registration)
- [x] Alembic round-trip test passes (migration upgrade+downgrade clean)
- [x] 2069 total tests passing, 1 skipped (unchanged), ruff clean
- [ ] CI green

Pairs with (forthcoming) cloud-side PR. Closes #249 on merge when combined.