### PR TITLE
[Infra] GHCR phase 1: build & push image on push to dev/master

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,86 @@
+name: Build & push image
+
+# Builds the combined core+cloud Docker image on GHA and pushes to
+# ghcr.io/datanika-io/datanika-core. Downstream deploys pull this image
+# instead of building on the Hetzner host (saves ~2 GB RAM + ~30s CPU
+# spike on every deploy, which landed on live users under Granian).
+#
+# Phase 1: builds + pushes only. Deploy jobs still build on Hetzner.
+# Phase 2 (separate PR): flip deploy jobs to `docker compose pull`.
+#
+# Tagging:
+#   push to dev    → :dev and :dev-<short-sha>
+#   push to master → :latest and :<short-sha>
+
+on:
+  push:
+    branches: [dev, master]
+    paths:
+      - "datanika/**"
+      - "Dockerfile"
+      - ".github/workflows/build-push-image.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: build-push-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout core (this repo)
+        uses: actions/checkout@v6
+        with:
+          path: core
+
+      - name: Checkout cloud (private)
+        uses: actions/checkout@v6
+        with:
+          repository: datanika-io/datanika-cloud
+          token: ${{ secrets.CLOUD_REPO_TOKEN }}
+          ref: ${{ github.ref_name }}
+          path: cloud
+
+      # Dockerfile assumes monorepo layout with datanika/ + datanika-cloud/
+      # at the root. Reshape checkout paths to match.
+      - name: Reshape build context
+        run: |
+          mkdir -p build-context
+          mv core build-context/datanika
+          mv cloud build-context/datanika-cloud
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          if [ "${GITHUB_REF_NAME}" = "master" ]; then
+            TAGS="ghcr.io/datanika-io/datanika-core:latest,ghcr.io/datanika-io/datanika-core:${SHORT_SHA}"
+          else
+            TAGS="ghcr.io/datanika-io/datanika-core:dev,ghcr.io/datanika-io/datanika-core:dev-${SHORT_SHA}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "Computed tags: ${TAGS}"
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: build-context
+          file: build-context/datanika/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-push-image.yml` — builds the combined core+cloud Docker image on GHA and pushes to `ghcr.io/datanika-io/datanika-core` on every push to `dev` or `master`.

**Phase 1 of 2.** This PR is strictly additive — no deploy behavior change, deploys still build on Hetzner. Splitting into two phases so we can verify the GHCR push works cleanly before flipping deploys to pull from it.

## Why

Current deploy does `docker compose build` on Hetzner prod, consuming ~2 GB RAM + ~30s CPU spike on every deploy. Per peak-RAM analysis (2026-04-18), this is the highest-impact zero-cost infra change before Launch Week.

## Tagging

- push to `dev` → `:dev` + `:dev-<short-sha>`
- push to `master` → `:latest` + `:<short-sha>`

Both tags are pushed so we can pin deploys to an exact SHA (phase 2) or track rolling `dev`/`latest` for local dev.

## Cross-repo checkout

Uses existing `CLOUD_REPO_TOKEN` secret to check out the private `datanika-cloud` repo. The Dockerfile expects `datanika/` + `datanika-cloud/` side-by-side at the build context root, so the workflow reshapes the two checkouts into `build-context/` before invoking buildx.

## Cache

`cache-from: type=gha, cache-to: type=gha,mode=max` — first build takes ~3-5 min, subsequent builds reuse layers for ~30-60s builds.

## Phase 2 (separate PR, after verifying phase 1)

- docker-compose.yml: replace `build:` with `image:` + `DATANIKA_IMAGE_TAG` env
- ci.yml deploy/deploy-staging: `docker login ghcr.io` + `docker compose pull`
- `wait-on-check-action` gate so deploy waits for image push to finish

## Test plan

- [ ] CI gates green (lint/test/helm-lint)
- [ ] After merge to dev: build-push workflow runs, image appears at `ghcr.io/datanika-io/datanika-core:dev`
- [ ] Manual pull test from Hetzner: `docker pull ghcr.io/datanika-io/datanika-core:dev` works with GITHUB_TOKEN-style auth