### PR TITLE
[Infra] GHCR phase 2: flip deploy to pull from GHCR instead of building on prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,17 +109,32 @@ jobs:
         run: helm template test-release deploy/helm/datanika > /dev/null
 
   deploy:
+    # Waits for build-push-image.yml to finish on the same SHA so GHCR has
+    # the :<sha> tag available when the Hetzner deploy tries to pull.
     needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Wait for image push to finish
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: build-push
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
       - name: Deploy to Hetzner
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN,IMAGE_TAG
           script: |
             set -e
 
@@ -134,8 +149,13 @@ jobs:
             # Source env vars for docker-compose interpolation
             set -a && source .env.docker && set +a
 
-            # Build and restart with zero-downtime (one at a time)
-            docker compose build app celery
+            # Pull the pre-built image from GHCR (built on GHA, no CPU/RAM
+            # spike on prod during deploy). Fallback: if pull fails we can
+            # re-run with local build by removing DATANIKA_IMAGE_TAG.
+            SHORT_SHA="${IMAGE_TAG:0:7}"
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export DATANIKA_IMAGE_TAG="$SHORT_SHA"
+            docker compose pull app celery
 
             # Restart app first, wait for health, then celery
             docker compose up -d --no-deps app
@@ -158,12 +178,25 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Wait for image push to finish
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: build-push
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
       - name: Deploy to Hetzner staging
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN,IMAGE_TAG
           script: |
             set -e
 
@@ -177,7 +210,12 @@ jobs:
 
             cd /opt/datanika-staging
 
-            docker compose -p datanika-staging --env-file .env.docker -f docker-compose.yml up -d --build app celery
+            # Pull dev-tagged pre-built image from GHCR
+            SHORT_SHA="${IMAGE_TAG:0:7}"
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export DATANIKA_IMAGE_TAG="dev-$SHORT_SHA"
+            docker compose -p datanika-staging --env-file .env.docker -f docker-compose.yml pull app celery
+            docker compose -p datanika-staging --env-file .env.docker -f docker-compose.yml up -d app celery
 
             echo "Waiting for staging app to be healthy..."
             timeout 180 bash -c 'until docker inspect --format="{{.State.Health.Status}}" datanika-staging-app 2>/dev/null | grep -q healthy; do sleep 3; done' || {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,10 +62,13 @@ services:
     restart: unless-stopped
 
   app:
+    # In CI/CD, the image is pulled from GHCR (built by build-push-image.yml).
+    # For local dev, `docker compose build` still works — it builds from source
+    # and tags with the same image name so subsequent `up` finds it.
+    image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}
     build:
       context: ..
       dockerfile: datanika/Dockerfile
-    image: datanika-io/app:latest
     container_name: datanika-app
     ports:
       - "127.0.0.1:3000:3000"
@@ -94,10 +97,11 @@ services:
     restart: unless-stopped
 
   celery:
+    # Uses the same image as `app` — single Dockerfile, different CMD.
+    image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}
     build:
       context: ..
       dockerfile: datanika/Dockerfile
-    image: datanika-io/celery:latest
     container_name: datanika-celery
     env_file:
       - .env.docker


### PR DESCRIPTION
## Summary

Phase 2 of the GHCR rollout. Phase 1 ([#255](https://github.com/datanika-io/datanika-core/pull/255)) shipped the build-push workflow; this PR flips the deploy jobs to pull the pre-built image instead of building on Hetzner.

## Phase 1 verification

First GHCR build on dev push succeeded (run 24603160002):
- Duration: **114s total** (cold cache), 10.1s layer push
- Tags pushed: `ghcr.io/datanika-io/datanika-core:dev` + `:dev-4d480bf`
- Manifest digest: `sha256:be0ff81a9c6bf1e76c446b83d45c0456452f69fd42cc73ab2577d582b8e99d2c`

Subsequent builds hit buildx gha cache → expected ~30-60s.

## Changes

### `docker-compose.yml`
```diff
 app:
-  build:
-    context: ..
-    dockerfile: datanika/Dockerfile
-  image: datanika-io/app:latest
+  image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}
+  build:
+    context: ..
+    dockerfile: datanika/Dockerfile
```

Same diff applied to `celery` service. Keeps `build:` for local dev — both actions work, compose tags the build output with the image name.

### `.github/workflows/ci.yml`

Both `deploy` (master) and `deploy-staging` (dev) jobs now:
1. Wait for `build-push` to complete on the same SHA via `lewagon/wait-on-check-action@v1.3.4`
2. SSH to Hetzner with `GHCR_USER` + `GHCR_TOKEN` + `IMAGE_TAG` forwarded via `envs:`
3. `docker login ghcr.io` using the ephemeral workflow `GITHUB_TOKEN`
4. `docker compose pull app celery` with `DATANIKA_IMAGE_TAG` set to the SHA tag
5. `docker compose up -d --no-deps app celery`

## Why

Freed resources on prod during deploy:
- **~2 GB RAM** that was going to `docker build` layers
- **~30s CPU spike** during build
- No more 45 GB build cache accumulating on `/var/lib/docker`

Directly addresses the highest-priority infra recommendation from the 2026-04-18 capacity analysis.

## Rollback

Revert this commit. Since `docker-compose.yml` still has `build:`, prod can fall back to local build on the next deploy without any other changes.

## Risk

Staging deploy runs first (when this merges to dev) and exercises the full pull-auth-up path. If staging fails, prod is not affected (runs old master which still builds locally). Only promotes to prod after we verify staging works.

## Test plan

- [x] YAML validates
- [ ] CI gates pass on this PR
- [ ] After merge to dev: deploy-staging pulls successfully, staging app healthy
- [ ] After promotion to master: prod pull succeeds, no build artifacts added to `/var/lib/docker`