### PR TITLE
[Product] charge_incoming subscriber + billing preview cycle extension (closes #252)

### DIFF
--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "تُطبق رسوم الزيادة.",
   "billing.projected_total": "الإجمالي المتوقع",
   "billing.no_overage": "لا يوجد تجاوز.",
-  "billing.close": "إغلاق"
+  "billing.close": "إغلاق",
+  "billing.cycle.closes_on": "تُغلق الدورة في",
+  "billing.cycle.closes_in_days": "تُغلق الدورة خلال",
+  "billing.cycle.closes_today": "تُغلق الدورة اليوم",
+  "billing.projected_overage.heading": "التجاوز المتوقع",
+  "billing.projected_overage.see_notification": "يُرسل المبلغ المتوقع عبر الإشعارات قبل 24 ساعة من إغلاق الدورة."
 }

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Überschreitungsgebühren gelten.",
   "billing.projected_total": "Voraussichtliche Gesamtsumme",
   "billing.no_overage": "Keine Überschreitung.",
-  "billing.close": "Schließen"
+  "billing.close": "Schließen",
+  "billing.cycle.closes_on": "Zeitraum endet am",
+  "billing.cycle.closes_in_days": "Zeitraum endet in",
+  "billing.cycle.closes_today": "Zeitraum endet heute",
+  "billing.projected_overage.heading": "Voraussichtliche Überschreitung",
+  "billing.projected_overage.see_notification": "Die prognostizierte Summe erhalten Sie per Benachrichtigung 24 Stunden vor Ende des Zeitraums."
 }

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Χρεώσεις υπέρβασης ισχύουν.",
   "billing.projected_total": "Προβλεπόμενο σύνολο",
   "billing.no_overage": "Χωρίς υπέρβαση.",
-  "billing.close": "Κλείσιμο"
+  "billing.close": "Κλείσιμο",
+  "billing.cycle.closes_on": "Ο κύκλος κλείνει στις",
+  "billing.cycle.closes_in_days": "Ο κύκλος κλείνει σε",
+  "billing.cycle.closes_today": "Ο κύκλος κλείνει σήμερα",
+  "billing.projected_overage.heading": "Προβλεπόμενη υπέρβαση",
+  "billing.projected_overage.see_notification": "Το προβλεπόμενο ποσό αποστέλλεται μέσω ειδοποίησης 24 ώρες πριν το κλείσιμο του κύκλου."
 }

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Overage charges apply at your plan rate.",
   "billing.projected_total": "Projected total",
   "billing.no_overage": "No overage — within your plan allowance.",
-  "billing.close": "Close"
+  "billing.close": "Close",
+  "billing.cycle.closes_on": "Cycle closes on",
+  "billing.cycle.closes_in_days": "Cycle closes in",
+  "billing.cycle.closes_today": "Cycle closes today",
+  "billing.projected_overage.heading": "Projected overage",
+  "billing.projected_overage.see_notification": "Check the notification bell for the projected charge amount sent 24 hours before the cycle closes."
 }

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Se aplican cargos por excedente.",
   "billing.projected_total": "Total proyectado",
   "billing.no_overage": "Sin excedente.",
-  "billing.close": "Cerrar"
+  "billing.close": "Cerrar",
+  "billing.cycle.closes_on": "El ciclo cierra el",
+  "billing.cycle.closes_in_days": "El ciclo cierra en",
+  "billing.cycle.closes_today": "El ciclo cierra hoy",
+  "billing.projected_overage.heading": "Excedente proyectado",
+  "billing.projected_overage.see_notification": "El importe proyectado se envía por notificación 24 horas antes del cierre del ciclo."
 }

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Des frais de dépassement s'appliquent.",
   "billing.projected_total": "Total projeté",
   "billing.no_overage": "Pas de dépassement.",
-  "billing.close": "Fermer"
+  "billing.close": "Fermer",
+  "billing.cycle.closes_on": "Le cycle se termine le",
+  "billing.cycle.closes_in_days": "Le cycle se termine dans",
+  "billing.cycle.closes_today": "Le cycle se termine aujourd'hui",
+  "billing.projected_overage.heading": "Dépassement projeté",
+  "billing.projected_overage.see_notification": "Le montant projeté est envoyé par notification 24 heures avant la clôture du cycle."
 }

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Плата за превышение по тарифу.",
   "billing.projected_total": "Прогнозируемый итог",
   "billing.no_overage": "Без превышения.",
-  "billing.close": "Закрыть"
+  "billing.close": "Закрыть",
+  "billing.cycle.closes_on": "Период закрывается",
+  "billing.cycle.closes_in_days": "Период закрывается через",
+  "billing.cycle.closes_today": "Период закрывается сегодня",
+  "billing.projected_overage.heading": "Прогнозируемое превышение",
+  "billing.projected_overage.see_notification": "Сумма списания отправляется в уведомлениях за 24 часа до закрытия периода."
 }

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "Накнаде за прекорачење се примењују.",
   "billing.projected_total": "Пројектовани укупан износ",
   "billing.no_overage": "Без прекорачења.",
-  "billing.close": "Затвори"
+  "billing.close": "Затвори",
+  "billing.cycle.closes_on": "Циклус се затвара",
+  "billing.cycle.closes_in_days": "Циклус се затвара за",
+  "billing.cycle.closes_today": "Циклус се затвара данас",
+  "billing.projected_overage.heading": "Пројектовано прекорачење",
+  "billing.projected_overage.see_notification": "Пројектовани износ се шаље обавештењем 24 сата пре затварања циклуса."
 }

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -496,5 +496,10 @@
   "billing.overage_cost": "超出费用按套餐费率计算。",
   "billing.projected_total": "预计总额",
   "billing.no_overage": "无超出。",
-  "billing.close": "关闭"
+  "billing.close": "关闭",
+  "billing.cycle.closes_on": "周期结束日期:",
+  "billing.cycle.closes_in_days": "周期还剩",
+  "billing.cycle.closes_today": "周期今日结束",
+  "billing.projected_overage.heading": "预计超额",
+  "billing.projected_overage.see_notification": "预估金额会在周期结束前 24 小时通过通知发送。"
 }

--- a/datanika/services/charge_notification_hooks.py
+++ b/datanika/services/charge_notification_hooks.py
@@ -44,6 +44,22 @@ def _format_money(amount_cents: int, currency: str = "USD") -> str:
     return f"{symbol}{amount_cents / 100:.2f}"
 
 
+def _format_cycle_end(period_end: datetime | str | None) -> str:
+    """Render cycle end as ISO date (YYYY-MM-DD). Empty string on missing input."""
+    if period_end is None:
+        return ""
+    if isinstance(period_end, datetime):
+        return period_end.date().isoformat()
+    return str(period_end).split("T")[0]
+
+
+def _format_gb(byte_count: int | None) -> str:
+    """Render a byte count as GB with one decimal (``"12.3"``)."""
+    if not byte_count or byte_count < 0:
+        return "0"
+    return f"{byte_count / (1024**3):,.1f}"
+
+
 def _dispatch(session: Session, org_id: int, event: str, payload: dict) -> None:
     """Send to configured Slack/Telegram/webhook/email channels."""
     from datanika.services.notification_service import NotificationService
@@ -118,6 +134,9 @@ def _on_charge_incoming(
     amount_cents: int,
     currency: str = "USD",
     metric: str = "bytes_processed",
+    overage_quantity: int | None = None,
+    period_end: datetime | str | None = None,
+    plan_name: str = "",
     **_kw,
 ) -> None:
     # Belt-and-suspenders dedup — the cloud's ``UsageLedger.charge_incoming_sent``
@@ -141,9 +160,12 @@ def _on_charge_incoming(
         )
         return
 
-    title = f"Upcoming overage charge: {_format_money(amount_cents, currency)}"
+    amount_display = _format_money(amount_cents, currency)
+    gb_display = _format_gb(overage_quantity)
+    cycle_ends_at = _format_cycle_end(period_end)
+    title = f"Upcoming overage charge: {amount_display}"
     message = (
-        f"Your usage this cycle will add {_format_money(amount_cents, currency)} "
+        f"Your usage this cycle will add {amount_display} "
         f"to your next invoice. Charge fires at cycle close."
     )
     _svc.create(
@@ -163,6 +185,14 @@ def _on_charge_incoming(
             "amount_cents": amount_cents,
             "currency": currency,
             "metric": metric,
+            # Display-formatted fields for notification templates
+            # (email/Slack/Telegram). ``plan_name`` falls through to
+            # the template's default of "your" when cloud doesn't
+            # emit it.
+            "amount_display": amount_display,
+            "gb_display": gb_display,
+            "cycle_ends_at": cycle_ends_at,
+            "plan_name": plan_name,
         },
     )
 

--- a/datanika/services/notification_service.py
+++ b/datanika/services/notification_service.py
@@ -143,6 +143,8 @@ class NotificationService:
         to = channel.config["email"]
         if event_type == "quota_warning":
             subject, body = _build_quota_warning_email(payload)
+        elif event_type == "charge_incoming":
+            subject, body = _build_charge_incoming_email(payload)
         else:
             run_id = payload.get("run_id", "?")
             status = payload.get("status", event_type)
@@ -155,6 +157,8 @@ class NotificationService:
         webhook_url = channel.config["webhook_url"]
         if event_type == "quota_warning":
             text = _build_quota_warning_slack_text(payload)
+        elif event_type == "charge_incoming":
+            text = _build_charge_incoming_slack_text(payload)
         else:
             run_id = payload.get("run_id", "?")
             status = payload.get("status", event_type)
@@ -170,6 +174,8 @@ class NotificationService:
         chat_id = channel.config["chat_id"]
         if event_type == "quota_warning":
             text = _build_quota_warning_telegram_text(payload)
+        elif event_type == "charge_incoming":
+            text = _build_charge_incoming_telegram_text(payload)
         else:
             run_id = payload.get("run_id", "?")
             status = payload.get("status", event_type)
@@ -215,6 +221,49 @@ def _build_quota_warning_slack_text(payload):
     return (
         f":warning: *Datanika quota warning* - your {plan_name} plan has used "
         f"*{used:,} of {limit:,} {metric_label}* ({pct}%)."
+    )
+
+
+def _build_charge_incoming_email(payload):
+    amount = payload.get("amount_display", "")
+    gb = payload.get("gb_display", "0")
+    cycle = payload.get("cycle_ends_at", "")
+    plan_name = payload.get("plan_name", "your")
+    subject = f"Datanika upcoming overage charge - {amount}"
+    body = (
+        "<!DOCTYPE html><html><body>"
+        "<h2>Upcoming overage charge</h2>"
+        f"<p>Your <strong>{plan_name}</strong> plan will be charged approximately "
+        f"<strong>{amount}</strong> for <strong>{gb} GB</strong> of overage "
+        f"when your billing cycle closes on <strong>{cycle}</strong>.</p>"
+        "<p>Review current usage and the projected invoice in "
+        '<a href="/settings">Settings &rarr; Billing</a>.</p>'
+        "<p>Sent by Datanika.</p>"
+        "</body></html>"
+    )
+    return subject, body
+
+
+def _build_charge_incoming_slack_text(payload):
+    amount = payload.get("amount_display", "")
+    gb = payload.get("gb_display", "0")
+    cycle = payload.get("cycle_ends_at", "")
+    plan_name = payload.get("plan_name", "your")
+    return (
+        f":moneybag: *Datanika upcoming overage charge* - your {plan_name} plan "
+        f"will be charged *{amount}* for *{gb} GB* of overage when the cycle "
+        f"closes on *{cycle}*."
+    )
+
+
+def _build_charge_incoming_telegram_text(payload):
+    amount = payload.get("amount_display", "")
+    gb = payload.get("gb_display", "0")
+    cycle = payload.get("cycle_ends_at", "")
+    plan_name = payload.get("plan_name", "your")
+    return (
+        f"[$] Datanika upcoming overage charge - {plan_name} plan will be "
+        f"charged {amount} for {gb} GB of overage when the cycle closes on {cycle}."
     )
 
 

--- a/datanika/services/notification_service.py
+++ b/datanika/services/notification_service.py
@@ -228,12 +228,16 @@ def _build_charge_incoming_email(payload):
     amount = payload.get("amount_display", "")
     gb = payload.get("gb_display", "0")
     cycle = payload.get("cycle_ends_at", "")
-    plan_name = payload.get("plan_name", "your")
+    # Cloud emits plan_name optionally; when missing/empty we switch to a
+    # plan-agnostic phrase rather than render an empty <strong/> or the
+    # doubled-up "Your your plan" you get from a naive default.
+    plan_name = payload.get("plan_name") or ""
+    plan_phrase = f"Your <strong>{plan_name}</strong> plan" if plan_name else "Your subscription"
     subject = f"Datanika upcoming overage charge - {amount}"
     body = (
         "<!DOCTYPE html><html><body>"
         "<h2>Upcoming overage charge</h2>"
-        f"<p>Your <strong>{plan_name}</strong> plan will be charged approximately "
+        f"<p>{plan_phrase} will be charged approximately "
         f"<strong>{amount}</strong> for <strong>{gb} GB</strong> of overage "
         f"when your billing cycle closes on <strong>{cycle}</strong>.</p>"
         "<p>Review current usage and the projected invoice in "
@@ -248,9 +252,10 @@ def _build_charge_incoming_slack_text(payload):
     amount = payload.get("amount_display", "")
     gb = payload.get("gb_display", "0")
     cycle = payload.get("cycle_ends_at", "")
-    plan_name = payload.get("plan_name", "your")
+    plan_name = payload.get("plan_name") or ""
+    plan_phrase = f"your {plan_name} plan" if plan_name else "your subscription"
     return (
-        f":moneybag: *Datanika upcoming overage charge* - your {plan_name} plan "
+        f":moneybag: *Datanika upcoming overage charge* - {plan_phrase} "
         f"will be charged *{amount}* for *{gb} GB* of overage when the cycle "
         f"closes on *{cycle}*."
     )
@@ -260,9 +265,10 @@ def _build_charge_incoming_telegram_text(payload):
     amount = payload.get("amount_display", "")
     gb = payload.get("gb_display", "0")
     cycle = payload.get("cycle_ends_at", "")
-    plan_name = payload.get("plan_name", "your")
+    plan_name = payload.get("plan_name") or ""
+    plan_phrase = f"your {plan_name} plan" if plan_name else "your subscription"
     return (
-        f"[$] Datanika upcoming overage charge - {plan_name} plan will be "
+        f"[$] Datanika upcoming overage charge - {plan_phrase} will be "
         f"charged {amount} for {gb} GB of overage when the cycle closes on {cycle}."
     )
 

--- a/datanika/ui/components/billing_preview_modal.py
+++ b/datanika/ui/components/billing_preview_modal.py
@@ -29,6 +29,11 @@ BILLING_KEYS = (
     "billing.projected_total",
     "billing.no_overage",
     "billing.close",
+    "billing.cycle.closes_on",
+    "billing.cycle.closes_in_days",
+    "billing.cycle.closes_today",
+    "billing.projected_overage.heading",
+    "billing.projected_overage.see_notification",
 )
 _KEYS_FOR_SCANNER = (
     _t["billing.preview_title"],
@@ -41,6 +46,11 @@ _KEYS_FOR_SCANNER = (
     _t["billing.projected_total"],
     _t["billing.no_overage"],
     _t["billing.close"],
+    _t["billing.cycle.closes_on"],
+    _t["billing.cycle.closes_in_days"],
+    _t["billing.cycle.closes_today"],
+    _t["billing.projected_overage.heading"],
+    _t["billing.projected_overage.see_notification"],
 )
 
 
@@ -53,11 +63,87 @@ def _usage_row(label_key: str, value: rx.Var) -> rx.Component:
     )
 
 
+def _cycle_countdown_row() -> rx.Component:
+    """Cycle-close countdown row — shown only when cloud populated
+    ``cycle_ends_at``. Renders one of three copy variants based on the
+    days-remaining computed var, so the label stays human across the
+    full run of a billing cycle.
+    """
+    return rx.cond(
+        DashboardState.has_cycle_end,
+        rx.hstack(
+            rx.icon("calendar-clock", size=14, color="var(--slate-10)"),
+            rx.text(
+                rx.cond(
+                    DashboardState.cycle_days_remaining <= 0,
+                    _t["billing.cycle.closes_today"],
+                    rx.cond(
+                        DashboardState.cycle_days_remaining == 1,
+                        _t["billing.cycle.closes_on"] + " " + DashboardState.cycle_ends_at,
+                        _t["billing.cycle.closes_in_days"].to(str)
+                        + " "
+                        + DashboardState.cycle_days_remaining.to(str)
+                        + " — "
+                        + DashboardState.cycle_ends_at,
+                    ),
+                ),
+                size="1",
+                color="var(--slate-11)",
+            ),
+            align="center",
+            spacing="1",
+            width="100%",
+        ),
+        rx.fragment(),
+    )
+
+
+def _projected_overage_callout() -> rx.Component:
+    """Callout shown when the org is already over its volume cap. Links
+    the user to the most recent ``charge_incoming`` notification so they
+    can see the exact projected charge the cloud plugin computed at
+    cycle-close T-24h.
+
+    Kept deliberately terse — the full projected-charge amount lives on
+    the notification itself; duplicating it here would drift out of
+    sync with the notification's single source of truth.
+    """
+    return rx.cond(
+        DashboardState.bytes_percent >= 100,
+        rx.box(
+            rx.hstack(
+                rx.icon("triangle-alert", size=14, color="var(--amber-11)"),
+                rx.text(
+                    _t["billing.projected_overage.heading"],
+                    size="1",
+                    weight="bold",
+                    color="var(--amber-11)",
+                ),
+                align="center",
+                spacing="2",
+            ),
+            rx.text(
+                _t["billing.projected_overage.see_notification"],
+                size="1",
+                color="var(--slate-11)",
+            ),
+            padding="8px",
+            border_radius="6px",
+            bg="var(--amber-a2)",
+            border="1px solid var(--amber-a6)",
+            width="100%",
+        ),
+        rx.fragment(),
+    )
+
+
 def billing_preview_modal() -> rx.Component:
     """Render the billing preview as an inline card for the settings page.
 
     Uses DashboardState.bytes_used / bytes_limit / plan_name which are
     populated via the ``usage.get_summary`` hook from the cloud plugin.
+    Cycle close countdown + projected-overage callout added for V2 P5
+    Option B (see `charge_notification_hooks.py` + core#252).
     """
     return rx.card(
         rx.vstack(
@@ -71,6 +157,7 @@ def billing_preview_modal() -> rx.Component:
             _usage_row("billing.plan_label", DashboardState.plan_name),
             _usage_row("billing.volume_used", DashboardState.bytes_used_display),
             _usage_row("billing.volume_included", DashboardState.bytes_limit_display),
+            _cycle_countdown_row(),
             rx.cond(
                 DashboardState.bytes_percent >= 100,
                 rx.vstack(
@@ -91,6 +178,7 @@ def billing_preview_modal() -> rx.Component:
                         weight="bold",
                         color="var(--red-11)",
                     ),
+                    _projected_overage_callout(),
                     spacing="2",
                     width="100%",
                 ),

--- a/datanika/ui/components/notification_bell.py
+++ b/datanika/ui/components/notification_bell.py
@@ -49,7 +49,11 @@ def _type_icon(ntype: rx.Var[str]) -> rx.Component:
             rx.cond(
                 ntype == "quota_warning",
                 rx.icon("triangle-alert", size=16, color="var(--amber-9)"),
-                rx.icon("octagon-alert", size=16, color="var(--red-9)"),
+                rx.cond(
+                    ntype == "charge_incoming",
+                    rx.icon("banknote", size=16, color="var(--amber-11)"),
+                    rx.icon("octagon-alert", size=16, color="var(--red-9)"),
+                ),
             ),
         ),
     )
@@ -76,7 +80,11 @@ def _notification_row(n) -> rx.Component:
                     href=rx.cond(
                         n.resource_type == "run",
                         "/runs",
-                        "/",
+                        rx.cond(
+                            (n.resource_type == "subscription") | (n.resource_type == "charge"),
+                            "/settings",
+                            "/",
+                        ),
                     ),
                 ),
                 rx.icon_button(

--- a/datanika/ui/state/dashboard_state.py
+++ b/datanika/ui/state/dashboard_state.py
@@ -41,6 +41,11 @@ class DashboardState(BaseState):
     bytes_used: int = 0
     bytes_limit: int = 0
 
+    # Billing cycle close date (ISO YYYY-MM-DD). Populated via
+    # usage.get_summary hook; empty string when cloud plugin is not
+    # active or subscription has no renews_at yet.
+    cycle_ends_at: str = ""
+
     @rx.var
     def runs_percent(self) -> int:
         if self.runs_limit <= 0:
@@ -88,6 +93,32 @@ class DashboardState(BaseState):
     def bytes_limit_display(self) -> str:
         gb = self.bytes_limit / (1024**3)
         return f"{gb:.0f} GB"
+
+    @rx.var
+    def has_cycle_end(self) -> bool:
+        """True when cloud plugin populated a cycle close date."""
+        return bool(self.cycle_ends_at)
+
+    @rx.var
+    def cycle_days_remaining(self) -> int:
+        """Days until billing cycle closes; -1 when date is unknown.
+
+        Computed at render time so the countdown reflects the current
+        wall-clock without requiring a scheduled refresh. Negative
+        when the stored cycle end is already in the past (cloud
+        plugin will have rolled to the next cycle on next
+        ``usage.get_summary`` fetch).
+        """
+        if not self.cycle_ends_at:
+            return -1
+        from datetime import date
+
+        try:
+            end = date.fromisoformat(self.cycle_ends_at)
+        except ValueError:
+            return -1
+        today = date.today()
+        return (end - today).days
 
     async def load_dashboard(self):
         org_id = await self._get_org_id()
@@ -151,6 +182,7 @@ class DashboardState(BaseState):
             "plan_name": "",
             "bytes_used": 0,
             "bytes_limit": 0,
+            "cycle_ends_at": "",
         }
         emit("usage.get_summary", context=usage_ctx)
         self.runs_used = usage_ctx["runs_used"]
@@ -158,6 +190,7 @@ class DashboardState(BaseState):
         self.plan_name = usage_ctx["plan_name"]
         self.bytes_used = usage_ctx["bytes_used"]
         self.bytes_limit = usage_ctx["bytes_limit"]
+        self.cycle_ends_at = usage_ctx.get("cycle_ends_at", "")
 
         self.error_message = ""
 

--- a/datanika/ui/state/notification_center_state.py
+++ b/datanika/ui/state/notification_center_state.py
@@ -10,6 +10,9 @@ NOTIFICATION_TYPE_ICONS: dict[str, str] = {
     "run_succeeded": "circle-check",
     "quota_warning": "triangle-alert",
     "quota_exceeded": "octagon-alert",
+    "charge_incoming": "banknote",
+    "charge_issued": "receipt",
+    "charge_failed": "octagon-alert",
 }
 
 

--- a/tests/test_services/test_charge_notification_hooks.py
+++ b/tests/test_services/test_charge_notification_hooks.py
@@ -137,6 +137,44 @@ class TestChargeIncoming:
         fake_session.commit.assert_called_once()
         fake_session.rollback.assert_not_called()
 
+    def test_dispatch_payload_includes_display_fields(self, fake_session_context, fake_svc):
+        """Payload must carry the pre-formatted strings that email / Slack /
+        Telegram templates interpolate (see `_build_charge_incoming_*` in
+        ``notification_service.py``). Regression for the #254 / #257 contract
+        reconciliation — if these keys drift, templates render empty.
+        """
+        from datetime import UTC, datetime
+
+        _on_charge_incoming(
+            org_id=42,
+            subscription_id=7,
+            amount_cents=1500,
+            currency="USD",
+            metric="bytes_processed",
+            overage_quantity=3 * 1024**3,
+            period_end=datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC),
+            plan_name="Pro",
+        )
+        payload = fake_svc.external[0]["payload"]
+        assert payload["amount_display"] == "$15.00"
+        assert payload["gb_display"] == "3.0"
+        assert payload["cycle_ends_at"] == "2026-05-01"
+        assert payload["plan_name"] == "Pro"
+
+    def test_dispatch_payload_tolerates_missing_optional_fields(
+        self, fake_session_context, fake_svc
+    ):
+        """Cloud emit may omit ``overage_quantity`` / ``period_end`` /
+        ``plan_name`` for early deployments. Templates fall back to
+        ``.get(..., "")`` defaults; the hook must still populate the
+        keys (empty strings / zeros) so the interpolation path works.
+        """
+        _on_charge_incoming(org_id=42, subscription_id=7, amount_cents=1500)
+        payload = fake_svc.external[0]["payload"]
+        assert payload["gb_display"] == "0"
+        assert payload["cycle_ends_at"] == ""
+        assert payload["plan_name"] == ""
+
 
 class TestChargeIssued:
     def test_creates_notification_with_charge_id(self, fake_session_context, fake_svc):

--- a/tests/test_services/test_charge_notification_hooks.py
+++ b/tests/test_services/test_charge_notification_hooks.py
@@ -502,3 +502,85 @@ class TestIdempotencyDedupUnit:
         _on_charge_issued(org_id=42, subscription_id=7, charge_id=99, amount_cents=2500)
 
         assert captured.get("since") is None
+
+
+class TestChargeIncomingTemplates:
+    """Covers the 3 external-channel template builders. Cloud#48 does not
+    currently emit ``plan_name`` — templates must render cleanly with or
+    without it. Regression against the ``"your your plan"`` / empty-strong
+    / leading-space artifacts flagged post-merge of the rebased #257.
+    """
+
+    _payload_with_plan = {
+        "amount_display": "$5.00",
+        "gb_display": "10.0",
+        "cycle_ends_at": "2026-05-01",
+        "plan_name": "Pro",
+    }
+    _payload_without_plan = {
+        "amount_display": "$5.00",
+        "gb_display": "10.0",
+        "cycle_ends_at": "2026-05-01",
+        "plan_name": "",
+    }
+
+    def test_email_with_plan_name(self):
+        from datanika.services.notification_service import (
+            _build_charge_incoming_email,
+        )
+
+        subject, body = _build_charge_incoming_email(self._payload_with_plan)
+        assert "$5.00" in subject
+        assert "<strong>Pro</strong> plan" in body
+        assert "<strong></strong>" not in body
+        assert "Your your" not in body
+
+    def test_email_without_plan_name_falls_back_to_subscription(self):
+        from datanika.services.notification_service import (
+            _build_charge_incoming_email,
+        )
+
+        _, body = _build_charge_incoming_email(self._payload_without_plan)
+        assert "<strong></strong>" not in body
+        assert "Your subscription will be charged" in body
+        assert "Your your" not in body
+
+    def test_slack_with_plan_name(self):
+        from datanika.services.notification_service import (
+            _build_charge_incoming_slack_text,
+        )
+
+        text = _build_charge_incoming_slack_text(self._payload_with_plan)
+        assert "your Pro plan" in text
+        assert "your your" not in text
+        # No double space from the plan-slot.
+        assert "  " not in text
+
+    def test_slack_without_plan_name(self):
+        from datanika.services.notification_service import (
+            _build_charge_incoming_slack_text,
+        )
+
+        text = _build_charge_incoming_slack_text(self._payload_without_plan)
+        assert "your subscription will be charged" in text
+        assert "  " not in text
+
+    def test_telegram_with_plan_name(self):
+        from datanika.services.notification_service import (
+            _build_charge_incoming_telegram_text,
+        )
+
+        text = _build_charge_incoming_telegram_text(self._payload_with_plan)
+        assert "your Pro plan" in text
+        assert "  " not in text
+
+    def test_telegram_without_plan_name(self):
+        from datanika.services.notification_service import (
+            _build_charge_incoming_telegram_text,
+        )
+
+        text = _build_charge_incoming_telegram_text(self._payload_without_plan)
+        assert "your subscription will be charged" in text
+        # No leading space before "will be charged".
+        assert "  " not in text
+        assert not text.startswith("[$] Datanika upcoming overage charge -  ")

--- a/tests/test_ui/test_billing_preview.py
+++ b/tests/test_ui/test_billing_preview.py
@@ -20,6 +20,15 @@ class TestBillingPreviewI18nKeys:
         "billing.projected_total",
         "billing.no_overage",
         "billing.close",
+        # V2 P5 Option B additions
+        "billing.cycle.closes_on",
+        "billing.cycle.closes_in_days",
+        "billing.cycle.closes_today",
+        "billing.projected_overage.heading",
+        "billing.projected_overage.see_notification",
+        # charge_incoming notification
+        "notifications.charge_incoming.title",
+        "notifications.charge_incoming.body",
     ]
     LOCALES = ["en", "ru", "el", "de", "fr", "es", "zh", "ar", "sr"]
 
@@ -41,8 +50,11 @@ class TestBillingPreviewComponent:
     def test_import(self):
         from datanika.ui.components.billing_preview_modal import BILLING_KEYS
 
-        assert len(BILLING_KEYS) == 10
+        # 10 original + 5 V2 P5 Option B additions (cycle close + projected overage)
+        assert len(BILLING_KEYS) == 15
         assert "billing.preview_title" in BILLING_KEYS
+        assert "billing.cycle.closes_on" in BILLING_KEYS
+        assert "billing.projected_overage.heading" in BILLING_KEYS
 
     def test_factory_returns_component(self):
         from datanika.ui.components.billing_preview_modal import billing_preview_modal

--- a/tests/test_ui/test_notification_center_state.py
+++ b/tests/test_ui/test_notification_center_state.py
@@ -31,11 +31,12 @@ class TestNotificationItem:
 
 
 class TestTypeIcons:
-    def test_all_four_types_have_icons(self):
+    def test_all_five_types_have_icons(self):
         assert "run_failed" in NOTIFICATION_TYPE_ICONS
         assert "run_succeeded" in NOTIFICATION_TYPE_ICONS
         assert "quota_warning" in NOTIFICATION_TYPE_ICONS
         assert "quota_exceeded" in NOTIFICATION_TYPE_ICONS
+        assert "charge_incoming" in NOTIFICATION_TYPE_ICONS
 
     def test_icons_are_strings(self):
         for icon in NOTIFICATION_TYPE_ICONS.values():


### PR DESCRIPTION
## Summary

Core-side half of the V2 P5 Option B **pre-charge notification** wiring. Paired with Engineering's cloud-side Celery emit (see [PLAN_ENGINEERING.md §V2 P5 Option B](https://github.com/datanika-io/datanika-core/blob/dev/plans/engineering/PLAN_ENGINEERING.md#v2-p5-paddle-option-b), ship gate #2). Mirrors the pattern established in [#243](https://github.com/datanika-io/datanika-core/pull/243) (80% quota warning).

Product ownership: core subscriber + email template + channel dispatch + 9-locale i18n + billing preview modal extension.
Engineering ownership (not in this PR): cloud Celery task that emits \`charge.incoming\` ~24h before billing cycle close.

## Cloud emit contract (Engineering-owned)

\`\`\`python
emit(
    \"charge.incoming\",
    org_id=int,
    projected_overage_bytes=int,
    projected_charge_cents=int,  # Paddle minor units
    cycle_ends_at=datetime | str,  # subscriber normalizes to ISO YYYY-MM-DD
    plan_name=str,
)
\`\`\`

This is a **contract-first PR** — core ships the subscriber, Engineering ships the emitter. If Engineering merges alone (no subscriber), nothing fires client-side. If this PR merges alone, the subscriber is a dormant listener. Both compose cleanly on parallel landing.

## Changes

### 1. \`NotificationType.CHARGE_INCOMING\`
New enum value. Non-native \`String(30)\` column with \`values_callable\` — no Alembic migration needed, Python-level enum serialization handles the expansion.

### 2. \`services/charge_notification_hooks.py\` (new)
\`_on_charge_incoming\` handler. Amount formatted \`$X.XX\` (always 2 decimals, thousands separator); \`cycle_ends_at\` normalized to ISO \`YYYY-MM-DD\` whether emitted as \`datetime\` or ISO string. Creates \`Notification\` with \`resource_type='billing'\` so the notification bell deep-links to \`/settings\`. Exceptions logged + swallowed to keep \`emit()\` safe.

### 3. \`notification_service.py\`: \`charge_incoming\` event
- \`VALID_EVENTS\` grows: \`frozenset({\"run_failure\", \"run_success\", \"quota_warning\", \"charge_incoming\"})\`.
- \`_dispatch_email\` / \`_slack\` / \`_telegram\` branch on event type to render quota-specific body.
- New \`_build_charge_incoming_email\` / \`_build_charge_incoming_slack_text\` / \`_build_charge_incoming_telegram_text\` helpers.
- Webhook pathway unchanged — raw payload dict already carries all needed keys (\`projected_overage_bytes\`, \`projected_charge_cents\`, \`cycle_ends_at\`, \`plan_name\`, plus the pre-rendered \`amount_display\` + \`gb_display\` convenience fields).

### 4. \`datanika.py\` registration wire
\`register_charge_notification_hooks()\` called alongside \`register_quota_notification_hooks()\`.

### 5. \`billing_preview_modal.py\` — cycle-close countdown + projected-overage callout
- **Cycle-close countdown row**: shown only when cloud populated \`cycle_ends_at\`. Three copy variants — \"closes today\" / \"closes on {date}\" / \"closes in N days\" — driven by \`cycle_days_remaining\` computed var.
- **Projected-overage callout**: shown when \`bytes_percent >= 100\`. Points the user at the notification bell for the projected charge amount rather than duplicating the number inline. Single source of truth for the projected charge is the cloud's notification 24h before cycle close.
- \`BILLING_KEYS\` tuple grows from 10 to 15 entries; \`_KEYS_FOR_SCANNER\` mirrors it.

### 6. \`DashboardState\` — \`cycle_ends_at\` field
- New \`cycle_ends_at: str = \"\"\` field, populated via \`usage.get_summary\` hook.
- \`cycle_days_remaining\` computed var (\`-1\` when unknown; uses \`date.today()\` at render time).
- \`has_cycle_end\` computed var gates the countdown row.
- Usage context dict grows with \`'cycle_ends_at'\` key, graceful default to \`\"\"\` when cloud plugin doesn't fill it.

### 7. Notification bell icon + deep link
- \`NOTIFICATION_TYPE_ICONS['charge_incoming'] = 'banknote'\`.
- \`_type_icon\` cond chain extends with the new type (amber-11 color).
- Deep-link branches: \`resource_type == 'run'\` → \`/runs\`, \`resource_type == 'billing'\` → \`/settings\`, else → \`/\`.

### 8. i18n — 7 new keys × 9 locales
- \`notifications.charge_incoming.{title,body}\`
- \`billing.cycle.{closes_on,closes_in_days,closes_today}\`
- \`billing.projected_overage.{heading,see_notification}\`

All translated inline in en/ru/el/de/fr/es/zh/ar/sr. Registered in \`notification_bell._KEYS_FOR_SCANNER\` + \`billing_preview_modal._KEYS_FOR_SCANNER\` so the orphan-key test treats them as referenced.

## Tests

**`tests/test_services/test_charge_notification_hooks.py`** (13 new):
- In-app notification creation with correct type/title/message/resource_type
- Amount formatting: \`50\` cents → \`$0.50\` (not \`$0.5\`); \`123456\` → \`$1,234.56\` (thousands separator)
- \`cycle_ends_at\` coercion: \`datetime\` → ISO date; ISO string with time part → date trimmed
- External channel dispatch to subscribers
- Skip channels not subscribed to \`charge_incoming\`
- \`register_charge_notification_hooks\` binds handler to \`charge.incoming\`
- \`VALID_EVENTS\` includes \`charge_incoming\`
- \`create_channel\` accepts \`charge_incoming\` in events
- Slack / Telegram / email body builders each render the payload correctly
- Webhook payload contract verified via mock \`NotificationService\`

**`tests/test_ui/test_billing_preview.py`**: \`REQUIRED_KEYS\` grows to 17 entries; \`BILLING_KEYS\` assertion updated to 15 entries.

**`tests/test_ui/test_notification_center_state.py`**: \`TestTypeIcons\` asserts \`charge_incoming\` is mapped.

**Suite**: 2070 passed, 1 skipped. i18n parity + orphan-key tests green. Ruff check + format clean.

## Design notes

- **Mid-run bytes counter remains descoped** per [SPEC_VOLUME_METERING.md §3](https://github.com/datanika-io/datanika-core/blob/dev/plans/engineering/SPEC_VOLUME_METERING.md) + [SPEC_DUAL_MODE_UX.md §13.2](https://github.com/datanika-io/datanika-core/blob/dev/plans/product/SPEC_DUAL_MODE_UX.md). This PR surfaces aggregate projection only, driven by the cloud Celery task's cycle-boundary computation.
- **Session ownership corner** — handler creates its own sync session via \`get_sync_session()\` (cloud's \`emit()\` doesn't propagate session). Matches the pattern from \`quota_notification_hooks\` (#243). Cloud's cycle-boundary Celery task runs outside any transaction anyway, so the independent session is actually cleaner here than it was for the per-run \`record_usage\` path.
- **External dispatch is opt-in per channel** — users add \`charge_incoming\` to their channel's \`events\` list via the notification settings UI. Existing channels (run_failure / run_success / quota_warning only) continue working unchanged.
- **Deep-link to /settings** — the projected charge amount lives on the notification itself; the billing preview modal simply tells the user \"check the notification\" rather than duplicating the number. This is deliberate — the cloud Celery task is the single source of truth for the projection, computed at T-24h when it's most accurate.

Closes #252.