### PR TITLE
[Infra] GHCR hotfix: drop paths filter on build-push-image workflow

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -15,11 +15,11 @@ name: Build & push image
 on:
   push:
     branches: [dev, master]
-    paths:
-      - "datanika/**"
-      - "Dockerfile"
-      - ".github/workflows/build-push-image.yml"
   workflow_dispatch:
+  # No paths filter: deploy jobs wait on the build-push check completing
+  # on the exact commit SHA, so every push to dev/master MUST produce
+  # an image (even if only docker-compose.yml or ci.yml changed).
+  # The gha cache keeps unchanged-source rebuilds to ~30-60s.
 
 concurrency:
   group: build-push-${{ github.ref }}


### PR DESCRIPTION
Phase 2 (#256) surfaced a bug immediately on merge — paths filter only triggered build-push on datanika/** / Dockerfile / build-push-image.yml changes. Deploys wait on build-push for the same SHA; any push that only touches ci.yml or docker-compose.yml hangs.

Dropping the filter. Every dev/master push produces an image. `cache-to: type=gha,mode=max` keeps unchanged-source rebuilds to ~30-60s.

Manually dispatched build-push for current dev HEAD via `gh workflow run` to unblock the in-flight CI.