### PR TITLE
[Infra] Promote dev → master (GHCR rollout)

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -15,11 +15,11 @@ name: Build & push image
 on:
   push:
     branches: [dev, master]
-    paths:
-      - "datanika/**"
-      - "Dockerfile"
-      - ".github/workflows/build-push-image.yml"
   workflow_dispatch:
+  # No paths filter: deploy jobs wait on the build-push check completing
+  # on the exact commit SHA, so every push to dev/master MUST produce
+  # an image (even if only docker-compose.yml or ci.yml changed).
+  # The gha cache keeps unchanged-source rebuilds to ~30-60s.
 
 concurrency:
   group: build-push-${{ github.ref }}

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,86 @@
+name: Build & push image
+
+# Builds the combined core+cloud Docker image on GHA and pushes to
+# ghcr.io/datanika-io/datanika-core. Downstream deploys pull this image
+# instead of building on the Hetzner host (saves ~2 GB RAM + ~30s CPU
+# spike on every deploy, which landed on live users under Granian).
+#
+# Phase 1: builds + pushes only. Deploy jobs still build on Hetzner.
+# Phase 2 (separate PR): flip deploy jobs to `docker compose pull`.
+#
+# Tagging:
+#   push to dev    → :dev and :dev-<short-sha>
+#   push to master → :latest and :<short-sha>
+
+on:
+  push:
+    branches: [dev, master]
+    paths:
+      - "datanika/**"
+      - "Dockerfile"
+      - ".github/workflows/build-push-image.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: build-push-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout core (this repo)
+        uses: actions/checkout@v6
+        with:
+          path: core
+
+      - name: Checkout cloud (private)
+        uses: actions/checkout@v6
+        with:
+          repository: datanika-io/datanika-cloud
+          token: ${{ secrets.CLOUD_REPO_TOKEN }}
+          ref: ${{ github.ref_name }}
+          path: cloud
+
+      # Dockerfile assumes monorepo layout with datanika/ + datanika-cloud/
+      # at the root. Reshape checkout paths to match.
+      - name: Reshape build context
+        run: |
+          mkdir -p build-context
+          mv core build-context/datanika
+          mv cloud build-context/datanika-cloud
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          if [ "${GITHUB_REF_NAME}" = "master" ]; then
+            TAGS="ghcr.io/datanika-io/datanika-core:latest,ghcr.io/datanika-io/datanika-core:${SHORT_SHA}"
+          else
+            TAGS="ghcr.io/datanika-io/datanika-core:dev,ghcr.io/datanika-io/datanika-core:dev-${SHORT_SHA}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "Computed tags: ${TAGS}"
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: build-context
+          file: build-context/datanika/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,17 +109,32 @@ jobs:
         run: helm template test-release deploy/helm/datanika > /dev/null
 
   deploy:
+    # Waits for build-push-image.yml to finish on the same SHA so GHCR has
+    # the :<sha> tag available when the Hetzner deploy tries to pull.
     needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Wait for image push to finish
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: build-push
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
       - name: Deploy to Hetzner
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN,IMAGE_TAG
           script: |
             set -e
 
@@ -134,8 +149,13 @@ jobs:
             # Source env vars for docker-compose interpolation
             set -a && source .env.docker && set +a
 
-            # Build and restart with zero-downtime (one at a time)
-            docker compose build app celery
+            # Pull the pre-built image from GHCR (built on GHA, no CPU/RAM
+            # spike on prod during deploy). Fallback: if pull fails we can
+            # re-run with local build by removing DATANIKA_IMAGE_TAG.
+            SHORT_SHA="${IMAGE_TAG:0:7}"
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export DATANIKA_IMAGE_TAG="$SHORT_SHA"
+            docker compose pull app celery
 
             # Restart app first, wait for health, then celery
             docker compose up -d --no-deps app
@@ -158,12 +178,25 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Wait for image push to finish
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: build-push
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
       - name: Deploy to Hetzner staging
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN,IMAGE_TAG
           script: |
             set -e
 
@@ -177,7 +210,12 @@ jobs:
 
             cd /opt/datanika-staging
 
-            docker compose -p datanika-staging --env-file .env.docker -f docker-compose.yml up -d --build app celery
+            # Pull dev-tagged pre-built image from GHCR
+            SHORT_SHA="${IMAGE_TAG:0:7}"
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export DATANIKA_IMAGE_TAG="dev-$SHORT_SHA"
+            docker compose -p datanika-staging --env-file .env.docker -f docker-compose.yml pull app celery
+            docker compose -p datanika-staging --env-file .env.docker -f docker-compose.yml up -d app celery
 
             echo "Waiting for staging app to be healthy..."
             timeout 180 bash -c 'until docker inspect --format="{{.State.Health.Status}}" datanika-staging-app 2>/dev/null | grep -q healthy; do sleep 3; done' || {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,10 +62,13 @@ services:
     restart: unless-stopped
 
   app:
+    # In CI/CD, the image is pulled from GHCR (built by build-push-image.yml).
+    # For local dev, `docker compose build` still works — it builds from source
+    # and tags with the same image name so subsequent `up` finds it.
+    image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}
     build:
       context: ..
       dockerfile: datanika/Dockerfile
-    image: datanika-io/app:latest
     container_name: datanika-app
     ports:
       - "127.0.0.1:3000:3000"
@@ -94,10 +97,11 @@ services:
     restart: unless-stopped
 
   celery:
+    # Uses the same image as `app` — single Dockerfile, different CMD.
+    image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}
     build:
       context: ..
       dockerfile: datanika/Dockerfile
-    image: datanika-io/celery:latest
     container_name: datanika-celery
     env_file:
       - .env.docker


### PR DESCRIPTION
Promotes the GHCR rollout:

- **#255** — GHCR phase 1: build-push workflow pushes `:dev`, `:dev-<sha>`, `:latest`, `:<sha>` tags
- **#256** — GHCR phase 2: deploy jobs pull from GHCR instead of building on Hetzner
- **#258** — Hotfix: removed paths filter so every dev/master push triggers build-push

## Why

Freed resources on prod during deploy (~2 GB RAM + ~30s CPU spike + ~45 GB accumulated build cache). Highest-priority infra change from 2026-04-18 capacity analysis, zero-cost.

## CD verification on dev

All green on staging after first real GHCR-pull deploy (run 24603387325):
- deploy-staging ✅ (pulled `ghcr.io/datanika-io/datanika-core:dev-547d668`)
- e2e-staging ✅
- e2e-sso ✅
- smoke-staging ✅

Staging container confirmed running the GHCR image, healthy.

## Prod deploy sequence

When this merges to master:
1. build-push workflow fires → pushes `:latest` + `:<sha>` for the merge commit
2. deploy job waits for build-push check (`wait-on-check-action`)
3. SSHes Hetzner, `git pull origin master` brings the new docker-compose.yml
4. `docker login ghcr.io` using workflow GITHUB_TOKEN
5. `docker compose pull app celery` pulls pre-built image
6. `docker compose up -d --no-deps app` + health check, then celery

## Rollback

Revert this promotion. The docker-compose.yml still has `build:` alongside `image:` so reverting restores the pre-GHCR path cleanly.

## Prod compose fixup

Prod `/opt/datanika/datanika/docker-compose.yml` currently has old `datanika-io/app:latest` refs — will be auto-updated by `git pull origin master` in the deploy script before `docker compose pull` runs.