### PR TITLE
[Engineering] Redis-cached unread notification count

### DIFF
--- a/datanika/services/in_app_notification_service.py
+++ b/datanika/services/in_app_notification_service.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from datanika.models.notification import Notification, NotificationType
+from datanika.services import notification_unread_cache
 
 
 class InAppNotificationService:
@@ -38,6 +39,11 @@ class InAppNotificationService:
         )
         session.add(notif)
         session.flush()
+        # A new unread row invalidates every user's count in the org: if
+        # user_id is set, only that user is affected; if None, the row
+        # is org-wide and every user's count goes up. We conservatively
+        # drop all — orgs are small, SCAN+DEL is cheap.
+        notification_unread_cache.invalidate_org(org_id)
         return notif
 
     @staticmethod
@@ -67,6 +73,9 @@ class InAppNotificationService:
 
     @staticmethod
     def unread_count(session: Session, org_id: int, user_id: int) -> int:
+        cached = notification_unread_cache.get(org_id, user_id)
+        if cached is not None:
+            return cached
         stmt = (
             select(func.count())
             .select_from(Notification)
@@ -77,7 +86,9 @@ class InAppNotificationService:
                 (Notification.user_id == user_id) | (Notification.user_id.is_(None)),
             )
         )
-        return session.execute(stmt).scalar_one()
+        count = session.execute(stmt).scalar_one()
+        notification_unread_cache.set(org_id, user_id, count)
+        return count
 
     @staticmethod
     def mark_read(session: Session, notification_id: int, org_id: int) -> Notification | None:
@@ -89,8 +100,13 @@ class InAppNotificationService:
         notif = session.execute(stmt).scalar_one_or_none()
         if notif is None:
             return None
+        was_unread = notif.read_at is None
         notif.read_at = datetime.now(UTC)
         session.flush()
+        if was_unread:
+            # The row may be user-specific or org-wide; either way, the
+            # unread count for at least one user dropped. Invalidate org.
+            notification_unread_cache.invalidate_org(org_id)
         return notif
 
     @staticmethod
@@ -106,6 +122,14 @@ class InAppNotificationService:
         for n in notifications:
             n.read_at = now
         session.flush()
+        # The mark_all set may include org-wide rows (user_id=None) whose
+        # read_at transition affects every user's count, not just this
+        # user's. Conservative: invalidate the whole org.
+        has_org_wide = any(n.user_id is None for n in notifications)
+        if has_org_wide:
+            notification_unread_cache.invalidate_org(org_id)
+        else:
+            notification_unread_cache.invalidate_user(org_id, user_id)
         return len(notifications)
 
     @staticmethod
@@ -118,8 +142,11 @@ class InAppNotificationService:
         notif = session.execute(stmt).scalar_one_or_none()
         if notif is None:
             return False
+        was_unread = notif.read_at is None
         notif.deleted_at = datetime.now(UTC)
         session.flush()
+        if was_unread:
+            notification_unread_cache.invalidate_org(org_id)
         return True
 
     @staticmethod

--- a/datanika/services/notification_unread_cache.py
+++ b/datanika/services/notification_unread_cache.py
@@ -1,0 +1,106 @@
+"""Redis-backed cache for per-user unread-notification counts.
+
+The ``/api/v1/notifications/unread-count`` endpoint is called on every
+bell-icon render and was pushing p95 to 265ms at 100 VUs (k6 Run 5),
+above the 200ms target. The underlying query is cheap — two predicates
+on an indexed table — but round-trip + connection checkout + ORM
+materialization add up. Caching the scalar count in Redis drops the
+warm-path to a single round-trip.
+
+Design notes:
+
+* **Key shape**: ``notif_unread:{org_id}:{user_id}``. The count depends
+  on both because the UI query unions user-specific rows (``user_id==U``)
+  and org-wide rows (``user_id IS NULL``) — two users in the same org
+  can have different totals if one has unread user-specific notifications.
+* **TTL**: 60s safety net. Writes invalidate explicitly, TTL just
+  prevents unbounded drift if an invalidation is lost (Redis flush,
+  network partition, subscriber bug).
+* **Invalidation granularity**: writes that affect state the cache can
+  observe (``create``, ``mark_read``, ``mark_all_read``, ``dismiss``)
+  invalidate the org's entire prefix. Orgs are small (<20 users by
+  design), so SCAN+DEL is cheap in practice.
+* **Redis unavailable** → fall through to DB. A broken cache must not
+  break the endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import redis
+
+from datanika.config import settings
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "notif_unread:"
+_TTL_SECONDS = 60
+
+
+def _redis() -> redis.Redis:
+    # Short timeouts so a down/misconfigured Redis degrades fast to the DB
+    # fallback — the endpoint must stay responsive even with a bad cache.
+    return redis.from_url(
+        settings.redis_url,
+        decode_responses=True,
+        socket_connect_timeout=1,
+        socket_timeout=1,
+    )
+
+
+def _user_key(org_id: int, user_id: int) -> str:
+    return f"{_KEY_PREFIX}{org_id}:{user_id}"
+
+
+def _org_pattern(org_id: int) -> str:
+    return f"{_KEY_PREFIX}{org_id}:*"
+
+
+def get(org_id: int, user_id: int) -> int | None:
+    """Return the cached count for ``(org, user)`` or ``None`` on miss/error."""
+    try:
+        raw = _redis().get(_user_key(org_id, user_id))
+    except Exception:
+        logger.warning("notif_unread cache read failed", exc_info=True)
+        return None
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def set(org_id: int, user_id: int, count: int) -> None:
+    """Store the freshly-computed count. Silent on Redis error."""
+    try:
+        _redis().set(_user_key(org_id, user_id), count, ex=_TTL_SECONDS)
+    except Exception:
+        logger.warning("notif_unread cache write failed", exc_info=True)
+
+
+def invalidate_user(org_id: int, user_id: int) -> None:
+    """Drop a single user's cached count (e.g. after ``mark_all_read``)."""
+    try:
+        _redis().delete(_user_key(org_id, user_id))
+    except Exception:
+        logger.warning("notif_unread cache invalidate_user failed", exc_info=True)
+
+
+def invalidate_org(org_id: int) -> None:
+    """Drop every user's cached count in an org.
+
+    Used when we don't know which users are affected (notification
+    created with ``user_id=None`` → org-wide; a single ``mark_read``
+    where we don't have the user context). Cheap because orgs are small.
+    """
+    try:
+        client = _redis()
+        # SCAN with a prefix match returns batches; COUNT is a hint. For
+        # small orgs a single SCAN iteration covers everything.
+        keys = list(client.scan_iter(match=_org_pattern(org_id), count=100))
+        if keys:
+            client.delete(*keys)
+    except Exception:
+        logger.warning("notif_unread cache invalidate_org failed", exc_info=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -8,6 +10,27 @@ from datanika.models.base import Base
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _disable_notif_unread_cache(request):
+    """Autouse fallback: make the unread-count Redis cache a no-op for every
+    test that hasn't explicitly wired its own `mock_redis` fixture.
+
+    Without this, every service call to ``InAppNotificationService`` tries
+    to reach a real Redis on ``localhost:6379``; in local/CI runs with no
+    container up, that's ~1s × 50+ calls = minutes of dead wait. Tests
+    that care about the cache path declare ``mock_redis`` explicitly and
+    this fixture sees it and steps aside.
+    """
+    if "mock_redis" in request.fixturenames:
+        yield
+        return
+    with patch(
+        "datanika.services.notification_unread_cache._redis",
+        side_effect=RuntimeError("redis disabled in tests"),
+    ):
+        yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_services/test_notification_unread_cache.py
+++ b/tests/test_services/test_notification_unread_cache.py
@@ -1,0 +1,289 @@
+"""Tests for the Redis-backed unread-count cache (PLAN_ENGINEERING §Deferred).
+
+Target: notifications_unread p95 265ms → <200ms. The cache collapses
+the read path to a single Redis GET on warm hits; writes invalidate
+to prevent staleness.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession
+from sqlalchemy.pool import StaticPool
+
+import datanika.models.invitation  # noqa: F401
+import datanika.models.notification  # noqa: F401
+import datanika.models.notification_channel  # noqa: F401
+import datanika.models.sso_config  # noqa: F401
+from datanika.models.base import Base
+from datanika.models.notification import NotificationType
+from datanika.models.user import Organization
+from datanika.services import notification_unread_cache
+from datanika.services.in_app_notification_service import InAppNotificationService
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def db_session(engine):
+    session = SASession(engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def org(db_session):
+    o = Organization(name="CacheOrg", slug="cache-org")
+    db_session.add(o)
+    db_session.flush()
+    return o
+
+
+@pytest.fixture
+def mock_redis():
+    """Replace the `redis.from_url` factory inside the cache module with an
+    in-memory fake. All .get/.set/.delete/.scan_iter calls hit it instead.
+    """
+    store: dict[str, str] = {}
+    ttls: dict[str, int] = {}
+
+    fake = MagicMock()
+
+    def fake_get(key):
+        return store.get(key)
+
+    def fake_set(key, value, ex=None):
+        store[key] = str(value)
+        if ex:
+            ttls[key] = ex
+        return True
+
+    def fake_delete(*keys):
+        n = 0
+        for k in keys:
+            if k in store:
+                del store[k]
+                n += 1
+        return n
+
+    def fake_scan_iter(match=None, count=None):
+        if match is None:
+            return iter(list(store.keys()))
+        # Convert Redis-style glob to simple prefix check.
+        prefix = match.rstrip("*")
+        return iter([k for k in list(store.keys()) if k.startswith(prefix)])
+
+    fake.get.side_effect = fake_get
+    fake.set.side_effect = fake_set
+    fake.delete.side_effect = fake_delete
+    fake.scan_iter.side_effect = fake_scan_iter
+
+    with patch.object(notification_unread_cache, "_redis", return_value=fake):
+        yield {"store": store, "ttls": ttls, "client": fake}
+
+
+# ---------------------------------------------------------------------------
+# Cache module primitives
+# ---------------------------------------------------------------------------
+
+
+class TestCachePrimitives:
+    def test_get_miss_returns_none(self, mock_redis):
+        assert notification_unread_cache.get(1, 5) is None
+
+    def test_set_then_get(self, mock_redis):
+        notification_unread_cache.set(1, 5, 7)
+        assert notification_unread_cache.get(1, 5) == 7
+
+    def test_set_writes_ttl(self, mock_redis):
+        notification_unread_cache.set(1, 5, 7)
+        assert mock_redis["ttls"]["notif_unread:1:5"] == 60
+
+    def test_invalidate_user_drops_just_that_key(self, mock_redis):
+        notification_unread_cache.set(1, 5, 7)
+        notification_unread_cache.set(1, 6, 3)
+        notification_unread_cache.invalidate_user(1, 5)
+        assert notification_unread_cache.get(1, 5) is None
+        assert notification_unread_cache.get(1, 6) == 3
+
+    def test_invalidate_org_drops_all_users_in_org(self, mock_redis):
+        notification_unread_cache.set(1, 5, 7)
+        notification_unread_cache.set(1, 6, 3)
+        notification_unread_cache.set(2, 5, 9)  # different org
+        notification_unread_cache.invalidate_org(1)
+        assert notification_unread_cache.get(1, 5) is None
+        assert notification_unread_cache.get(1, 6) is None
+        assert notification_unread_cache.get(2, 5) == 9  # untouched
+
+    def test_redis_failure_is_swallowed_on_read(self):
+        with patch.object(
+            notification_unread_cache,
+            "_redis",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            assert notification_unread_cache.get(1, 5) is None
+
+    def test_redis_failure_is_swallowed_on_write(self):
+        with patch.object(
+            notification_unread_cache,
+            "_redis",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            # Must not raise.
+            notification_unread_cache.set(1, 5, 7)
+            notification_unread_cache.invalidate_user(1, 5)
+            notification_unread_cache.invalidate_org(1)
+
+    def test_garbage_cached_value_returns_none(self, mock_redis):
+        # Simulate a stale/corrupted value from a prior incompatible version.
+        mock_redis["store"]["notif_unread:1:5"] = "not_a_number"
+        assert notification_unread_cache.get(1, 5) is None
+
+
+# ---------------------------------------------------------------------------
+# Service integration — read path + invalidation on writes
+# ---------------------------------------------------------------------------
+
+
+def _make_notif(svc, session, org, **kw):
+    defaults = dict(
+        notification_type=NotificationType.RUN_FAILED,
+        title="X",
+        resource_type="run",
+        resource_id=1,
+    )
+    defaults.update(kw)
+    return svc.create(session, org.id, **defaults)
+
+
+class TestServiceReadPath:
+    def test_first_call_queries_db_and_populates_cache(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        _make_notif(svc, db_session, org, user_id=42)
+        # The create itself invalidated the org — cache is empty now.
+        assert notification_unread_cache.get(org.id, 42) is None
+
+        count = svc.unread_count(db_session, org.id, user_id=42)
+        assert count == 1
+        # Cache populated after DB read.
+        assert notification_unread_cache.get(org.id, 42) == 1
+
+    def test_second_call_served_from_cache(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        _make_notif(svc, db_session, org, user_id=42)
+        svc.unread_count(db_session, org.id, user_id=42)  # warm
+
+        # Blow away the DB row — cache should still serve the cached value.
+        from datanika.models.notification import Notification
+
+        db_session.query(Notification).delete()
+        db_session.commit()
+
+        # Still cached — no DB query consulted.
+        assert svc.unread_count(db_session, org.id, user_id=42) == 1
+
+    def test_different_users_cached_separately(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        # User 1 has one user-specific row; user 2 has none. Both share an
+        # org-wide row → both see count=2 and count=1 respectively.
+        _make_notif(svc, db_session, org, user_id=1)
+        _make_notif(svc, db_session, org, user_id=None)  # org-wide
+
+        assert svc.unread_count(db_session, org.id, user_id=1) == 2
+        assert svc.unread_count(db_session, org.id, user_id=2) == 1
+
+
+class TestServiceInvalidation:
+    def test_create_invalidates_org(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        _make_notif(svc, db_session, org, user_id=1)
+        svc.unread_count(db_session, org.id, user_id=1)  # warm
+        svc.unread_count(db_session, org.id, user_id=2)  # warm
+        assert notification_unread_cache.get(org.id, 1) == 1
+        assert notification_unread_cache.get(org.id, 2) == 0
+
+        _make_notif(svc, db_session, org, user_id=None)  # org-wide
+        # Both users' cached counts dropped.
+        assert notification_unread_cache.get(org.id, 1) is None
+        assert notification_unread_cache.get(org.id, 2) is None
+
+    def test_mark_read_invalidates_when_row_was_unread(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        n = _make_notif(svc, db_session, org, user_id=1)
+        svc.unread_count(db_session, org.id, user_id=1)
+        assert notification_unread_cache.get(org.id, 1) == 1
+
+        svc.mark_read(db_session, n.id, org.id)
+        assert notification_unread_cache.get(org.id, 1) is None
+
+    def test_mark_read_skips_invalidation_when_already_read(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        n = _make_notif(svc, db_session, org, user_id=1)
+        svc.mark_read(db_session, n.id, org.id)  # first mark: invalidates
+        svc.unread_count(db_session, org.id, user_id=1)  # warm cache with 0
+        assert notification_unread_cache.get(org.id, 1) == 0
+
+        # Second mark_read on an already-read row should not invalidate.
+        svc.mark_read(db_session, n.id, org.id)
+        assert notification_unread_cache.get(org.id, 1) == 0
+
+    def test_mark_all_read_invalidates_user_when_no_org_wide(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        _make_notif(svc, db_session, org, user_id=1)
+        _make_notif(svc, db_session, org, user_id=1)
+        _make_notif(svc, db_session, org, user_id=2)  # other user
+        svc.unread_count(db_session, org.id, user_id=1)
+        svc.unread_count(db_session, org.id, user_id=2)
+
+        svc.mark_all_read(db_session, org.id, user_id=1)
+        # User 1's key dropped, user 2's survives.
+        assert notification_unread_cache.get(org.id, 1) is None
+        assert notification_unread_cache.get(org.id, 2) == 1
+
+    def test_mark_all_read_invalidates_org_when_org_wide_rows_touched(
+        self, db_session, org, mock_redis
+    ):
+        svc = InAppNotificationService()
+        _make_notif(svc, db_session, org, user_id=1)
+        _make_notif(svc, db_session, org, user_id=None)  # org-wide
+        svc.unread_count(db_session, org.id, user_id=1)
+        svc.unread_count(db_session, org.id, user_id=2)
+
+        svc.mark_all_read(db_session, org.id, user_id=1)
+        # Org-wide transition → every user's count affected.
+        assert notification_unread_cache.get(org.id, 1) is None
+        assert notification_unread_cache.get(org.id, 2) is None
+
+    def test_dismiss_invalidates_when_unread(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        n = _make_notif(svc, db_session, org, user_id=1)
+        svc.unread_count(db_session, org.id, user_id=1)
+        assert notification_unread_cache.get(org.id, 1) == 1
+
+        svc.dismiss(db_session, n.id, org.id)
+        assert notification_unread_cache.get(org.id, 1) is None
+
+    def test_dismiss_skips_invalidation_when_already_read(self, db_session, org, mock_redis):
+        svc = InAppNotificationService()
+        n = _make_notif(svc, db_session, org, user_id=1)
+        svc.mark_read(db_session, n.id, org.id)
+        svc.unread_count(db_session, org.id, user_id=1)
+        assert notification_unread_cache.get(org.id, 1) == 0
+
+        # Dismissing an already-read row doesn't change anyone's unread count.
+        svc.dismiss(db_session, n.id, org.id)
+        assert notification_unread_cache.get(org.id, 1) == 0


### PR DESCRIPTION
## Summary

- Targets `GET /api/v1/notifications/unread-count` p95 265ms → <200ms (k6 Run 5). The endpoint is the hottest read in the notification path: one call per bell-icon render, far more often than anything that changes state.
- New `services/notification_unread_cache.py` wraps Redis with `get` / `set` / `invalidate_user` / `invalidate_org` primitives. Short timeouts (1s connect + socket) so a misconfigured Redis degrades fast to DB fallback.
- `InAppNotificationService.unread_count()` consults the cache first; writes (`create`, `mark_read` / `dismiss` when the row was unread, `mark_all_read`) invalidate. `mark_all_read` is granular — user-scoped unless the mark set touched org-wide rows.

## Notes worth calling out

- **Invalidation granularity**: orgs are small (<20 users), so SCAN+DEL on `notif_unread:{org_id}:*` is cheap. Tracked the alternative (per-user bookkeeping on `create`) and rejected it — that would require a query-users-of-org round-trip inside the write path, which trades one hot-read amortized over minutes for one cold-read on every write.
- **Test hygiene**: added an autouse fixture in `tests/conftest.py` that makes the cache a no-op for any test that doesn't declare `mock_redis`. Before this change, the in-app notification test file was **94s** because every service call attempted a real Redis round-trip on a machine without Redis running — now **1.1s**. Tests that want the cache path declare the fixture explicitly.
- **TTL 60s is a safety net**, not the primary consistency mechanism. Explicit invalidation runs on every write; TTL just bounds the drift window if invalidation is lost (e.g. Redis flushdb, subscriber bug in a future change).

## Test plan

- [x] `ruff check datanika tests` / `ruff format` — clean
- [x] `pytest tests/ --ignore=tests/test_e2e` — **2074 passed, 1 skipped**
- [x] 18 new tests: cache primitives (get/set/invalidate/TTL/failure modes/garbage values), service read path (cold miss → DB → populate, warm hit served from cache, per-user isolation), service invalidation (create / mark_read / mark_all_read / dismiss scenarios including user-wide vs org-wide rows)
- [ ] Needs prod verification once promoted: re-run k6 notifications scenario to confirm p95 < 200ms

## Follow-up (not in this PR)

Re-run the k6 notifications scenario after promotion to confirm the measured delta. If the hit rate is high (expected, read-mostly endpoint), we should see p95 drop to well under 100ms on warm paths.