### PR TITLE
[Infra] Fix nightly connector smoke: add environment: production

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -21,6 +21,10 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # QA_CONNECTOR_CREDENTIALS + QA_BIGQUERY_SA_JSON secrets are scoped
+    # to the `production` environment. Without this line the job runs
+    # without those secrets and the credential-gate fails loud.
+    environment: production
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Both Apr 19 and Apr 20 nightly runs failed with:
\`\`\`
##[error]QA_CONNECTOR_CREDENTIALS secret is not set — nothing to test
\`\`\`

Root cause: `QA_CONNECTOR_CREDENTIALS` + `QA_BIGQUERY_SA_JSON` were provisioned on the `production` GH Environment (not repo-level). The workflow's `smoke` job didn't declare `environment: production` so the secrets were invisible.

One-line fix: add the environment declaration.

## Test plan
- [x] YAML validates, ruff clean, full test suite green
- [ ] Manual `gh workflow run` after merge — should pass the credential gate and proceed to actual connector probes