### PR TITLE
[Infra] Nightly smoke: strip quotes + tolerate CRLF-free env

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -61,6 +61,10 @@ jobs:
           while IFS= read -r line; do
             # Skip comments + blanks
             case "$line" in ''|\#*) continue ;; esac
+            # Strip surrounding double-quotes from value — $GITHUB_ENV
+            # parser treats quotes as literal chars (unlike bash/python-dotenv).
+            # Without this, httpx rejects URLs like ""https://..."" (core#270).
+            line=$(echo "$line" | sed -E 's/^([A-Z_]+)="(.*)"$/\1=\2/')
             echo "$line" >> "$GITHUB_ENV"
           done < /tmp/creds.env
           rm /tmp/creds.env


### PR DESCRIPTION
Follow-up to #270 — credentials now visible to the workflow, but Databricks tests failed:
\`\`\`
httpx.UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.
\`\`\`

Source env bundle had quoted values:
\`\`\`
DATABRICKS_HOST=\"https://dbc-adc397cf-f20a.cloud.databricks.com\"
\`\`\`

`$GITHUB_ENV` parser keeps literal quotes (unlike bash or python-dotenv), so httpx saw `\"https://...\"` with leading `\"` and rejected as "missing protocol".

## Fix
- Strip surrounding `\"...\"` in the export loop (one sed on each line)
- Dequoted the source file in `secrets/qa-connectors.env` for cleanliness (defensive — same behaviour after fix)
- Re-uploaded QA_CONNECTOR_CREDENTIALS + QA_BIGQUERY_SA_JSON with CRLF stripped (initial upload was Windows CRLF, every value ended with `\r`)

## Current state after the two fixes
Last manual run had 4 PASS + 2 SKIPPED + 2 FAILED (both Databricks, quote issue). With this PR + re-uploaded secrets, expect 6 PASS + 2 SKIPPED.