### PR TITLE
[Infra] Promote dev → master (V2 P5 bigint migration + cloud fixes)

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -21,6 +21,10 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # QA_CONNECTOR_CREDENTIALS + QA_BIGQUERY_SA_JSON secrets are scoped
+    # to the `production` environment. Without this line the job runs
+    # without those secrets and the credential-gate fails loud.
+    environment: production
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -61,6 +61,10 @@ jobs:
           while IFS= read -r line; do
             # Skip comments + blanks
             case "$line" in ''|\#*) continue ;; esac
+            # Strip surrounding double-quotes from value — $GITHUB_ENV
+            # parser treats quotes as literal chars (unlike bash/python-dotenv).
+            # Without this, httpx rejects URLs like ""https://..."" (core#270).
+            line=$(echo "$line" | sed -E 's/^([A-Z_]+)="(.*)"$/\1=\2/')
             echo "$line" >> "$GITHUB_ENV"
           done < /tmp/creds.env
           rm /tmp/creds.env

--- a/datanika/migrations/versions/b8c3d4e5f6g7_bigint_usage_ledger_quantity.py
+++ b/datanika/migrations/versions/b8c3d4e5f6g7_bigint_usage_ledger_quantity.py
@@ -1,0 +1,60 @@
+"""Widen usage_ledger.quantity from int32 → int64.
+
+V2 P5 Option B dry-run (2026-04-20) surfaced an overflow in staging:
+Pro's ``bytes_included`` is 100 GB (≈ 107,374,182,400 bytes), well above
+the int32 max of 2,147,483,647. Any real customer row overflowed on
+insert with ``NumericValueOutOfRange``.
+
+Other byte columns were already correctly sized:
+- ``plans.bytes_included`` is ``bigint`` from z5v2w3x4y6a7 ✓
+- ``charges.overage_quantity`` is ``bigint`` from a7b1c2d3e4f5 ✓
+
+This migration only needs to widen the one column.
+
+Revision ID: b8c3d4e5f6g7
+Revises: a7b1c2d3e4f5
+Create Date: 2026-04-20 16:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b8c3d4e5f6g7"
+down_revision: str | None = "a7b1c2d3e4f5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Metadata-only change on Postgres when the column has no indexes that
+    # depend on its type — a full table rewrite is not required. Safe to run
+    # live (no lock beyond a brief ACCESS EXCLUSIVE for the DDL).
+    op.alter_column(
+        "usage_ledger",
+        "quantity",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        existing_server_default=sa.text("0"),
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    # The reverse narrowing would fail on rows where quantity > 2^31 - 1
+    # (which is exactly the scenario this migration exists to unblock).
+    # If a rollback is ever needed, callers must first purge or zero out
+    # offending rows manually.
+    op.alter_column(
+        "usage_ledger",
+        "quantity",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        existing_server_default=sa.text("0"),
+    )
+    connection = op.get_bind()
+    connection.commit()

--- a/tests/test_migrations/test_b8c3_bigint_quantity.py
+++ b/tests/test_migrations/test_b8c3_bigint_quantity.py
@@ -1,0 +1,87 @@
+"""Regression test for the ``usage_ledger.quantity`` BigInt widening
+(core#272). Asserts both that the migration calls ``alter_column`` with
+``type_=sa.BigInteger()`` and that the head revision actually lists it.
+
+Live-DB round-trip is covered by ``test_roundtrip.py``; this is a cheap
+static check so an accidental reversion shows up in CI without spinning
+up Postgres.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_VERSIONS = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
+_MIGRATION = _VERSIONS / "b8c3d4e5f6g7_bigint_usage_ledger_quantity.py"
+
+
+@pytest.fixture(scope="module")
+def migration_source() -> str:
+    assert _MIGRATION.exists(), f"Missing migration file: {_MIGRATION}"
+    return _MIGRATION.read_text(encoding="utf-8")
+
+
+class TestBigIntQuantityMigration:
+    def test_revision_id_and_parent(self, migration_source):
+        assert 'revision: str = "b8c3d4e5f6g7"' in migration_source
+        assert 'down_revision: str | None = "a7b1c2d3e4f5"' in migration_source
+
+    def test_upgrade_widens_to_bigint(self, migration_source):
+        """Must call ``alter_column`` with ``type_=sa.BigInteger()`` on
+        ``usage_ledger.quantity``.
+        """
+        upgrade_match = re.search(r"def upgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL)
+        assert upgrade_match
+        upgrade_body = upgrade_match.group(0)
+        assert 'alter_column(\n        "usage_ledger"' in upgrade_body
+        assert '"quantity"' in upgrade_body
+        assert "type_=sa.BigInteger()" in upgrade_body
+        assert "existing_type=sa.Integer()" in upgrade_body
+
+    def test_downgrade_reverses_the_widening(self, migration_source):
+        """Downgrade should narrow back to Integer — even though narrowing
+        may fail on rows that prompted the widening, the symmetry is what
+        ``test_roundtrip.py`` exercises on an empty DB.
+        """
+        downgrade_match = re.search(
+            r"def downgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL
+        )
+        assert downgrade_match
+        downgrade_body = downgrade_match.group(0)
+        assert "type_=sa.Integer()" in downgrade_body
+        assert "existing_type=sa.BigInteger()" in downgrade_body
+
+    def test_migration_is_reachable_from_head(self):
+        """Walking the revision chain, b8c3d4e5f6g7 must lead to the head
+        (or be the head). Prevents an orphan migration that sits in the
+        folder but is never applied.
+        """
+        revisions: dict[str, str | None] = {}
+        for f in _VERSIONS.glob("*.py"):
+            if f.name == "__init__.py":
+                continue
+            src = f.read_text(encoding="utf-8")
+            rev_match = re.search(r'revision:\s*str\s*=\s*"(\w+)"', src)
+            down_match = re.search(r'down_revision:\s*str\s*\|\s*None\s*=\s*"(\w+)"', src)
+            if not rev_match:
+                continue
+            revisions[rev_match.group(1)] = down_match.group(1) if down_match else None
+
+        # Build child lookup: {parent: child}
+        children: dict[str, str] = {}
+        for rev, parent in revisions.items():
+            if parent is not None:
+                children[parent] = rev
+
+        # Walk children from b8c3… forward. If we run off the end, we were
+        # at the head.
+        cur: str | None = "b8c3d4e5f6g7"
+        assert cur in revisions, "b8c3d4e5f6g7 not registered as a revision"
+        while cur in children:
+            cur = children[cur]
+        # cur is now the head. That's fine — we just needed to confirm the
+        # chain is intact.
+        assert cur is not None


### PR DESCRIPTION
Promotes core#275 — bigint migration \`b8c3d4e5f6g7\` widens \`usage_ledger.quantity\` from int32 to bigint (closes #272).

Paired with cloud#54 (UsageLedger.quantity BigInteger in model, already on cloud master via cloud#55) + cloud#53 (PaddleClient product_id fix).

## Deploy sequence
1. Cloud master has BigInteger model ✅ (cloud#55 merged first)
2. Core master deploy: \`git pull\` both repos → rebuild GHCR image → container startup runs \`alembic upgrade head\` → bigint widening applied before any new usage_ledger writes
3. smoke + smoke-prod verify

## CD verification
Latest dev CD all green: lint ✅ test ✅ helm-lint ✅ migration-roundtrip ✅ deploy-staging ✅ e2e-staging ✅ e2e-sso ✅ smoke-staging ✅

Closes #272