### PR TITLE
[Engineering] Widen notifications.type VARCHAR(14) → 50 (closes #279)

### DIFF
--- a/datanika/migrations/versions/c9d4e5f6g7h8_widen_notification_type_varchar.py
+++ b/datanika/migrations/versions/c9d4e5f6g7h8_widen_notification_type_varchar.py
@@ -1,0 +1,68 @@
+"""Widen notifications.type column from VARCHAR(14) to VARCHAR(50).
+
+V2 P5 re-dry-run (2026-04-20) surfaced a silent-failure bug: the
+original notifications-table migration (``x3t0u1v2w4q5``) declared
+``type`` as ``sa.Enum(..., native_enum=False)`` without an explicit
+``length``. SQLAlchemy sized the column to the longest enum value at
+migration time — ``"quota_exceeded"`` (14 chars). When core#254 added
+``charge_incoming`` (15 chars) the new value exceeded the column
+width. Postgres raised ``DataError: value too long for type character
+varying(14)``, but the notification subscriber's ``_with_session``
+decorator caught and logged the exception (by design — notifier
+failures must not break the emitting task). Net effect: cloud's
+charge_cycle_overages reported success, ``usage_ledger.charge_incoming_sent``
+flipped to True, but the user never saw the in-app banner or email.
+
+Widening to VARCHAR(50) (not 32 — the model was updated to 50 for
+headroom so we don't need another migration next time a longer type
+name lands).
+
+SQLite maps VARCHAR to TEXT regardless of length, so tests never saw
+this. core#276 tracks a realistic-Postgres INSERT probe that would
+have caught this class of bug.
+
+Revision ID: c9d4e5f6g7h8
+Revises: b8c3d4e5f6g7
+Create Date: 2026-04-20 22:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c9d4e5f6g7h8"
+down_revision: str | None = "b8c3d4e5f6g7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Metadata-only ALTER on Postgres — widening a VARCHAR's max length
+    # does not rewrite existing rows. No lock beyond the brief ACCESS
+    # EXCLUSIVE for the DDL itself. Safe to run live.
+    op.alter_column(
+        "notifications",
+        "type",
+        existing_type=sa.String(length=14),
+        type_=sa.String(length=50),
+        existing_nullable=False,
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    # Narrowing back would fail if any row has a value longer than 14
+    # chars — which is why this migration exists. Downgrade is only
+    # safe after purging or rewriting those rows manually. Test suite
+    # round-trips on an empty DB.
+    op.alter_column(
+        "notifications",
+        "type",
+        existing_type=sa.String(length=50),
+        type_=sa.String(length=14),
+        existing_nullable=False,
+    )
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/notification.py
+++ b/datanika/models/notification.py
@@ -28,7 +28,10 @@ class Notification(Base, TenantMixin, TimestampMixin):
         Enum(
             NotificationType,
             native_enum=False,
-            length=30,
+            # length=50 matches migration c9d4e5f6g7h8 (core#279). Kept
+            # generous so a new 20-char enum name doesn't force another
+            # column migration.
+            length=50,
             values_callable=lambda e: [i.value for i in e],
         ),
         nullable=False,

--- a/tests/test_migrations/test_c9d4_widen_notification_type.py
+++ b/tests/test_migrations/test_c9d4_widen_notification_type.py
@@ -1,0 +1,79 @@
+"""Regression test for the ``notifications.type`` VARCHAR widening
+(core#279). Guards against accidental reversion to VARCHAR(14) that
+would silently drop any notification whose type name is ≥15 chars.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_VERSIONS = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
+_MIGRATION = _VERSIONS / "c9d4e5f6g7h8_widen_notification_type_varchar.py"
+
+
+@pytest.fixture(scope="module")
+def migration_source() -> str:
+    assert _MIGRATION.exists(), f"Missing migration file: {_MIGRATION}"
+    return _MIGRATION.read_text(encoding="utf-8")
+
+
+class TestWidenNotificationTypeMigration:
+    def test_revision_id_and_parent(self, migration_source):
+        assert 'revision: str = "c9d4e5f6g7h8"' in migration_source
+        assert 'down_revision: str | None = "b8c3d4e5f6g7"' in migration_source
+
+    def test_upgrade_widens_to_varchar50(self, migration_source):
+        upgrade_match = re.search(r"def upgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL)
+        assert upgrade_match
+        upgrade_body = upgrade_match.group(0)
+        assert '"notifications"' in upgrade_body
+        assert '"type"' in upgrade_body
+        assert "type_=sa.String(length=50)" in upgrade_body
+        assert "existing_type=sa.String(length=14)" in upgrade_body
+
+    def test_downgrade_narrows_back(self, migration_source):
+        downgrade_match = re.search(
+            r"def downgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL
+        )
+        assert downgrade_match
+        downgrade_body = downgrade_match.group(0)
+        assert "type_=sa.String(length=14)" in downgrade_body
+        assert "existing_type=sa.String(length=50)" in downgrade_body
+
+
+class TestNotificationModelTypeLength:
+    """Model-level assert that catches the reverse mistake: migration
+    widened but model still declares the old length. Future auto-generated
+    migrations would then narrow the column again without anyone noticing.
+    """
+
+    def test_model_column_length_matches_migration(self):
+        from datanika.models.notification import Notification
+
+        col = Notification.__table__.c.type
+        # SQLAlchemy's Enum type exposes length via ``.length`` when
+        # ``native_enum=False``. We widened both the migration and the
+        # model to 50.
+        assert col.type.length == 50, (
+            f"Notification.type column length is {col.type.length}, "
+            f"expected 50. Model must match migration c9d4e5f6g7h8 "
+            "(core#279). If you added a longer NotificationType value, "
+            "bump both together."
+        )
+
+    def test_all_type_names_fit_declared_length(self):
+        """Trip-wire for the class of bug that motivated core#279: a
+        new enum value longer than the column width ships silently.
+        """
+        from datanika.models.notification import Notification, NotificationType
+
+        limit = Notification.__table__.c.type.type.length
+        too_long = [v.value for v in NotificationType if len(v.value) > limit]
+        assert not too_long, (
+            f"These NotificationType values exceed the column limit "
+            f"({limit}): {too_long}. Widen the migration + model "
+            "together before shipping."
+        )


### PR DESCRIPTION
## Summary

V2 P5 re-dry-run blocker. The original notifications migration (`x3t0u1v2w4q5`) used `sa.Enum(..., native_enum=False)` without an explicit `length`, so SQLAlchemy sized the column to the longest enum at migration time — `"quota_exceeded"` (14 chars). Core#254 added `charge_incoming` (15 chars), which overruns. Postgres raises `DataError: value too long for type character varying(14)` but the subscriber's `_with_session` decorator swallows the exception (by design — notifier failures must not break the emitting task). Net effect: **`charge_cycle_overages` reports success, `usage_ledger.charge_incoming_sent` flips to True, but the user never sees the pre-charge banner or email.**

Only `charge_incoming` is affected (15 chars). `charge_issued` + `charge_failed` are 13.

## Fix

- New migration `c9d4e5f6g7h8` runs `ALTER COLUMN type TYPE VARCHAR(50)`. Metadata-only on Postgres — no table rewrite.
- `Notification.type` model declares `length=50` to match. (Was `length=30` previously — never regenerated post-migration so model and schema drifted. This aligns them.)

## Why 50, not 32

Headroom. A future 20-char enum name won't force another migration. Cheap.

## Why unit tests missed it

SQLite maps VARCHAR(14) to TEXT — no length enforcement. Only Postgres truncates/rejects. Same class as core#272. core#276 tracks the realistic-Postgres INSERT probe that would have caught both.

## Test plan

- [x] `ruff check datanika tests` + `ruff format` — clean
- [x] `pytest tests/ --ignore=tests/test_e2e` — **2138 passed**
- [x] 5 new regressions in `test_migrations/test_c9d4_widen_notification_type.py`:
  - Revision id + parent chain
  - Upgrade shape (`alter_column` with `String(length=50)`)
  - Downgrade reverses
  - Model length matches migration (catches reverse drift — model widened but migration still narrow)
  - Trip-wire: every current `NotificationType` value fits the declared column limit