### PR TITLE
[QA] Migration round-trip: realistic-size INSERT (closes #276)

### DIFF
--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -197,3 +197,150 @@ def _diff(a: dict[str, list[str]], b: dict[str, list[str]]) -> dict[str, list[st
         if missing:
             out[table] = missing
     return out
+
+
+# Probe values chosen to fit int64 and bust int32 (max 2_147_483_647 ≈ 2 GB).
+# Each value is a realistic real-world size for the column's semantic:
+#   - plans.bytes_included: 100 GB (current Pro tier spec — core#249)
+#   - usage_ledger.quantity: 3 GB (single day of Pro-scale ingestion)
+#   - charges.overage_quantity: 50 GB (one month of mild Pro overage)
+_GB = 1024**3
+_PROBE_PLAN_BYTES = 100 * _GB  # 107_374_182_400
+_PROBE_USAGE_BYTES = 3 * _GB  # 3_221_225_472
+_PROBE_OVERAGE_BYTES = 50 * _GB  # 53_687_091_200
+
+
+def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
+    """Insert real-world byte sizes into bigint columns; catch int32 regressions.
+
+    Would-have-caught: **core#272**. The existing schema-equivalence test
+    only compares column names — type-width regressions are invisible
+    because SQLite maps both Integer and BigInteger to a dynamic-width
+    INTEGER. Postgres enforces fixed widths, so inserting a value above
+    `int32.max` (≈ 2 GB) surfaces any silent regression immediately.
+
+    Columns probed:
+      - `plans.bytes_included` at 100 GB — the Pro tier's included
+        allotment; every Pro plan row stores this value.
+      - `usage_ledger.quantity` at 3 GB — a single day of Pro-scale
+        ingestion. This was the column core#272 fixed; this test locks
+        that fix in.
+      - `charges.overage_quantity` at 50 GB — a month of mild Pro
+        overage. V2 P5 Option B writes this column on every cycle close.
+
+    If any of these columns ever silently reverts to int32, this test
+    fails with `NumericValueOutOfRange: integer out of range` and the
+    PR is blocked.
+    """
+    _reset_db(roundtrip_db_url)
+    r = _run_alembic(["upgrade", "head"], roundtrip_db_url)
+    assert r.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+    engine = create_engine(roundtrip_db_url)
+    try:
+        with engine.begin() as conn:
+            org_id = conn.execute(
+                text("INSERT INTO organizations (name, slug) VALUES (:n, :s) RETURNING id"),
+                {"n": "QA bigint probe", "s": "qa-bigint-probe"},
+            ).scalar_one()
+
+            plan_id = conn.execute(
+                text(
+                    "INSERT INTO plans (name, slug, paddle_price_id, "
+                    "paddle_product_id, price_cents, interval, bytes_included) "
+                    "VALUES (:n, :s, :ppi, :ppp, :pc, :i, :bi) RETURNING id"
+                ),
+                {
+                    "n": "QA Probe Plan",
+                    "s": "qa-probe",
+                    "ppi": "pri_qa_probe_001",
+                    "ppp": "pro_qa_probe_001",
+                    "pc": 0,
+                    "i": "month",
+                    "bi": _PROBE_PLAN_BYTES,
+                },
+            ).scalar_one()
+
+            sub_id = conn.execute(
+                text(
+                    "INSERT INTO subscriptions (org_id, plan_id, "
+                    "paddle_customer_id, paddle_subscription_id) "
+                    "VALUES (:o, :p, :c, :s) RETURNING id"
+                ),
+                {
+                    "o": org_id,
+                    "p": plan_id,
+                    "c": "ctm_qa_probe",
+                    "s": "sub_qa_probe_001",
+                },
+            ).scalar_one()
+
+            ul_id = conn.execute(
+                text(
+                    "INSERT INTO usage_ledger "
+                    "(org_id, period_start, period_end, metric, quantity) "
+                    "VALUES (:o, :ps, :pe, 'bytes_processed', :q) RETURNING id"
+                ),
+                {
+                    "o": org_id,
+                    "ps": "2026-04-01 00:00:00+00",
+                    "pe": "2026-05-01 00:00:00+00",
+                    "q": _PROBE_USAGE_BYTES,
+                },
+            ).scalar_one()
+
+            charge_id = conn.execute(
+                text(
+                    "INSERT INTO charges "
+                    "(org_id, idempotency_key, subscription_id, period_start, "
+                    "period_end, metric, overage_quantity, amount_cents) "
+                    "VALUES (:o, :k, :s, :ps, :pe, 'bytes_processed', :oq, :ac) "
+                    "RETURNING id"
+                ),
+                {
+                    "o": org_id,
+                    "k": "sub_qa_probe_001:2026-04-01:bytes_processed",
+                    "s": sub_id,
+                    "ps": "2026-04-01 00:00:00+00",
+                    "pe": "2026-05-01 00:00:00+00",
+                    "oq": _PROBE_OVERAGE_BYTES,
+                    "ac": 50000,
+                },
+            ).scalar_one()
+
+            # Assert round-trip — if the column is int32, the INSERT would
+            # have already raised NumericValueOutOfRange. Assertions below
+            # guard against less-obvious regressions (e.g., a migration that
+            # silently truncates, or future ORM drift).
+            assert (
+                conn.execute(
+                    text("SELECT bytes_included FROM plans WHERE id = :i"),
+                    {"i": plan_id},
+                ).scalar()
+                == _PROBE_PLAN_BYTES
+            )
+            assert (
+                conn.execute(
+                    text("SELECT quantity FROM usage_ledger WHERE id = :i"),
+                    {"i": ul_id},
+                ).scalar()
+                == _PROBE_USAGE_BYTES
+            )
+            assert (
+                conn.execute(
+                    text("SELECT overage_quantity FROM charges WHERE id = :i"),
+                    {"i": charge_id},
+                ).scalar()
+                == _PROBE_OVERAGE_BYTES
+            )
+
+            # Delete in FK-order so the DB is clean for any following test.
+            conn.execute(text("DELETE FROM charges"))
+            conn.execute(text("DELETE FROM usage_ledger"))
+            conn.execute(text("DELETE FROM subscriptions"))
+            conn.execute(text("DELETE FROM plans"))
+            conn.execute(text("DELETE FROM organizations"))
+    finally:
+        engine.dispose()

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -204,10 +204,15 @@ def _diff(a: dict[str, list[str]], b: dict[str, list[str]]) -> dict[str, list[st
 #   - plans.bytes_included: 100 GB (current Pro tier spec — core#249)
 #   - usage_ledger.quantity: 3 GB (single day of Pro-scale ingestion)
 #   - charges.overage_quantity: 50 GB (one month of mild Pro overage)
+#   - uploaded_files.file_size: 5 GB (realistic Enterprise single upload)
+#   - runs.rows_loaded: 3 * 10**9 rows (Enterprise backfill — currently
+#     int32, tracked by core#283; probe is xfailed until the widening migration ships)
 _GB = 1024**3
 _PROBE_PLAN_BYTES = 100 * _GB  # 107_374_182_400
 _PROBE_USAGE_BYTES = 3 * _GB  # 3_221_225_472
 _PROBE_OVERAGE_BYTES = 50 * _GB  # 53_687_091_200
+_PROBE_FILE_SIZE_BYTES = 5 * _GB  # 5_368_709_120
+_PROBE_ROWS_LOADED = 3_000_000_000  # Busts int32.max (2_147_483_647)
 
 
 def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
@@ -310,6 +315,25 @@ def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
                 },
             ).scalar_one()
 
+            # uploaded_files.file_size — 5 GB. Bigint since u0q7r8s9t1n2;
+            # this probe locks that guarantee in place for Enterprise uploads.
+            file_id = conn.execute(
+                text(
+                    "INSERT INTO uploaded_files "
+                    "(original_name, content_type, file_size, file_hash, "
+                    "archive_path, org_id) "
+                    "VALUES (:n, :t, :sz, :h, :p, :o) RETURNING id"
+                ),
+                {
+                    "n": "qa_probe_5gb.csv",
+                    "t": "text/csv",
+                    "sz": _PROBE_FILE_SIZE_BYTES,
+                    "h": "0" * 64,
+                    "p": "/tmp/qa-probe",
+                    "o": org_id,
+                },
+            ).scalar_one()
+
             # Assert round-trip — if the column is int32, the INSERT would
             # have already raised NumericValueOutOfRange. Assertions below
             # guard against less-obvious regressions (e.g., a migration that
@@ -335,12 +359,78 @@ def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
                 ).scalar()
                 == _PROBE_OVERAGE_BYTES
             )
+            assert (
+                conn.execute(
+                    text("SELECT file_size FROM uploaded_files WHERE id = :i"),
+                    {"i": file_id},
+                ).scalar()
+                == _PROBE_FILE_SIZE_BYTES
+            )
 
             # Delete in FK-order so the DB is clean for any following test.
+            conn.execute(text("DELETE FROM uploaded_files"))
             conn.execute(text("DELETE FROM charges"))
             conn.execute(text("DELETE FROM usage_ledger"))
             conn.execute(text("DELETE FROM subscriptions"))
             conn.execute(text("DELETE FROM plans"))
+            conn.execute(text("DELETE FROM organizations"))
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "runs.rows_loaded is currently Integer (int32). Enterprise backfills "
+        "routinely exceed 2.14B rows; this probe inserts 3B and overflows. "
+        "Tracked by core#283 — flip to strict=True after the bigint migration "
+        "lands."
+    ),
+)
+def test_runs_rows_loaded_bigint_roundtrip(roundtrip_db_url: str) -> None:
+    """3-billion-row probe for `runs.rows_loaded` — xfails until core#283 ships.
+
+    Enterprise customers run one-shot backfills of clickstream / event /
+    log data that routinely exceed 2^31 rows. dlt extracts the row count
+    and we persist it into `runs.rows_loaded`; the column is currently
+    int32 and any ingestion over 2.14B rows raises `NumericValueOutOfRange`.
+
+    Once Engineering ships the `runs.rows_loaded` → bigint migration
+    (core#283), this test starts passing. Flip the marker to
+    `strict=True` so XPASS forces its removal and locks in the guarantee.
+    """
+    _reset_db(roundtrip_db_url)
+    r = _run_alembic(["upgrade", "head"], roundtrip_db_url)
+    assert r.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+    engine = create_engine(roundtrip_db_url)
+    try:
+        with engine.begin() as conn:
+            org_id = conn.execute(
+                text("INSERT INTO organizations (name, slug) VALUES (:n, :s) RETURNING id"),
+                {"n": "QA rows_loaded probe", "s": "qa-rows-loaded-probe"},
+            ).scalar_one()
+
+            run_id = conn.execute(
+                text(
+                    "INSERT INTO runs "
+                    "(target_type, target_id, status, rows_loaded, org_id) "
+                    "VALUES ('pipeline', 1, 'success', :r, :o) RETURNING id"
+                ),
+                {"r": _PROBE_ROWS_LOADED, "o": org_id},
+            ).scalar_one()
+
+            assert (
+                conn.execute(
+                    text("SELECT rows_loaded FROM runs WHERE id = :i"),
+                    {"i": run_id},
+                ).scalar()
+                == _PROBE_ROWS_LOADED
+            )
+
+            conn.execute(text("DELETE FROM runs"))
             conn.execute(text("DELETE FROM organizations"))
     finally:
         engine.dispose()


### PR DESCRIPTION
## Summary

Adds `test_realistic_byte_size_roundtrip` + `test_runs_rows_loaded_bigint_roundtrip` to `tests/test_migrations/test_roundtrip.py`. After `alembic upgrade head`, inserts real-world byte/row sizes into each known int-width-sensitive column:

| Column | Probe size | Status |
|---|---|---|
| `plans.bytes_included` | 100 GB | ✅ bigint — Pro tier spec (core#249) |
| `usage_ledger.quantity` | 3 GB | ✅ bigint after core#272 — single day Pro ingestion |
| `charges.overage_quantity` | 50 GB | ✅ bigint — one-month Pro overage |
| `uploaded_files.file_size` | 5 GB | ✅ bigint since u0q7r8s9t1n2 — Enterprise single upload |
| `runs.rows_loaded` | 3 B rows | ⚠️ **int32 today** — xfailed, flips green on core#283 |

The green probes fit int64 and bust int32; Postgres raises `NumericValueOutOfRange` on any silent reversion, failing CI on the PR.

The xfailed probe (`runs.rows_loaded`) is a **red-test-first** for [core#283](https://github.com/datanika-io/datanika-core/issues/283), surfaced during the audit the user asked for. Enterprise clickstream/event backfills routinely exceed 2^31 rows; dlt extracts the count and `execution_service.complete_run` persists it unchanged — same shape as core#272 but on `runs`. Flip to `strict=True` after the widening migration ships.

## Would-have-caught

core#272. SQLite maps both `Integer` and `BigInteger` to a dynamic-width INTEGER, so the existing schema-equivalence test can't see type regressions. Postgres enforces fixed widths — inserting 3 GB worth of bytes against a reverted int32 column overflows immediately.

## Runs in existing CI

No new workflow. Uses the `migration-roundtrip` job's Postgres service container. Local runs skip when Docker is down.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] Pre-push hook — 2133 passed + 11 skipped (roundtrip tests skip locally, no Docker)
- [x] Pytest collects 3 tests cleanly (2 green probes + 1 xfail for rows_loaded)
- [ ] CI `migration-roundtrip` job green against real Postgres (4 green probes pass, 1 xfail stays xfailed until core#283)

## Related

- [core#276](https://github.com/datanika-io/datanika-core/issues/276) — parent issue
- [core#272](https://github.com/datanika-io/datanika-core/issues/272) — `usage_ledger.quantity` precedent
- [core#283](https://github.com/datanika-io/datanika-core/issues/283) — `runs.rows_loaded` int32 widening, surfaced by this audit

Closes #276.