### PR TITLE
[Infra] Promote dev → master (V2 P5 VARCHAR widen + QA migration probe)

### DIFF
--- a/datanika/migrations/versions/c9d4e5f6g7h8_widen_notification_type_varchar.py
+++ b/datanika/migrations/versions/c9d4e5f6g7h8_widen_notification_type_varchar.py
@@ -1,0 +1,68 @@
+"""Widen notifications.type column from VARCHAR(14) to VARCHAR(50).
+
+V2 P5 re-dry-run (2026-04-20) surfaced a silent-failure bug: the
+original notifications-table migration (``x3t0u1v2w4q5``) declared
+``type`` as ``sa.Enum(..., native_enum=False)`` without an explicit
+``length``. SQLAlchemy sized the column to the longest enum value at
+migration time — ``"quota_exceeded"`` (14 chars). When core#254 added
+``charge_incoming`` (15 chars) the new value exceeded the column
+width. Postgres raised ``DataError: value too long for type character
+varying(14)``, but the notification subscriber's ``_with_session``
+decorator caught and logged the exception (by design — notifier
+failures must not break the emitting task). Net effect: cloud's
+charge_cycle_overages reported success, ``usage_ledger.charge_incoming_sent``
+flipped to True, but the user never saw the in-app banner or email.
+
+Widening to VARCHAR(50) (not 32 — the model was updated to 50 for
+headroom so we don't need another migration next time a longer type
+name lands).
+
+SQLite maps VARCHAR to TEXT regardless of length, so tests never saw
+this. core#276 tracks a realistic-Postgres INSERT probe that would
+have caught this class of bug.
+
+Revision ID: c9d4e5f6g7h8
+Revises: b8c3d4e5f6g7
+Create Date: 2026-04-20 22:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c9d4e5f6g7h8"
+down_revision: str | None = "b8c3d4e5f6g7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Metadata-only ALTER on Postgres — widening a VARCHAR's max length
+    # does not rewrite existing rows. No lock beyond the brief ACCESS
+    # EXCLUSIVE for the DDL itself. Safe to run live.
+    op.alter_column(
+        "notifications",
+        "type",
+        existing_type=sa.String(length=14),
+        type_=sa.String(length=50),
+        existing_nullable=False,
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    # Narrowing back would fail if any row has a value longer than 14
+    # chars — which is why this migration exists. Downgrade is only
+    # safe after purging or rewriting those rows manually. Test suite
+    # round-trips on an empty DB.
+    op.alter_column(
+        "notifications",
+        "type",
+        existing_type=sa.String(length=50),
+        type_=sa.String(length=14),
+        existing_nullable=False,
+    )
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/notification.py
+++ b/datanika/models/notification.py
@@ -28,7 +28,10 @@ class Notification(Base, TenantMixin, TimestampMixin):
         Enum(
             NotificationType,
             native_enum=False,
-            length=30,
+            # length=50 matches migration c9d4e5f6g7h8 (core#279). Kept
+            # generous so a new 20-char enum name doesn't force another
+            # column migration.
+            length=50,
             values_callable=lambda e: [i.value for i in e],
         ),
         nullable=False,

--- a/tests/test_migrations/test_c9d4_widen_notification_type.py
+++ b/tests/test_migrations/test_c9d4_widen_notification_type.py
@@ -1,0 +1,79 @@
+"""Regression test for the ``notifications.type`` VARCHAR widening
+(core#279). Guards against accidental reversion to VARCHAR(14) that
+would silently drop any notification whose type name is ≥15 chars.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_VERSIONS = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
+_MIGRATION = _VERSIONS / "c9d4e5f6g7h8_widen_notification_type_varchar.py"
+
+
+@pytest.fixture(scope="module")
+def migration_source() -> str:
+    assert _MIGRATION.exists(), f"Missing migration file: {_MIGRATION}"
+    return _MIGRATION.read_text(encoding="utf-8")
+
+
+class TestWidenNotificationTypeMigration:
+    def test_revision_id_and_parent(self, migration_source):
+        assert 'revision: str = "c9d4e5f6g7h8"' in migration_source
+        assert 'down_revision: str | None = "b8c3d4e5f6g7"' in migration_source
+
+    def test_upgrade_widens_to_varchar50(self, migration_source):
+        upgrade_match = re.search(r"def upgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL)
+        assert upgrade_match
+        upgrade_body = upgrade_match.group(0)
+        assert '"notifications"' in upgrade_body
+        assert '"type"' in upgrade_body
+        assert "type_=sa.String(length=50)" in upgrade_body
+        assert "existing_type=sa.String(length=14)" in upgrade_body
+
+    def test_downgrade_narrows_back(self, migration_source):
+        downgrade_match = re.search(
+            r"def downgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL
+        )
+        assert downgrade_match
+        downgrade_body = downgrade_match.group(0)
+        assert "type_=sa.String(length=14)" in downgrade_body
+        assert "existing_type=sa.String(length=50)" in downgrade_body
+
+
+class TestNotificationModelTypeLength:
+    """Model-level assert that catches the reverse mistake: migration
+    widened but model still declares the old length. Future auto-generated
+    migrations would then narrow the column again without anyone noticing.
+    """
+
+    def test_model_column_length_matches_migration(self):
+        from datanika.models.notification import Notification
+
+        col = Notification.__table__.c.type
+        # SQLAlchemy's Enum type exposes length via ``.length`` when
+        # ``native_enum=False``. We widened both the migration and the
+        # model to 50.
+        assert col.type.length == 50, (
+            f"Notification.type column length is {col.type.length}, "
+            f"expected 50. Model must match migration c9d4e5f6g7h8 "
+            "(core#279). If you added a longer NotificationType value, "
+            "bump both together."
+        )
+
+    def test_all_type_names_fit_declared_length(self):
+        """Trip-wire for the class of bug that motivated core#279: a
+        new enum value longer than the column width ships silently.
+        """
+        from datanika.models.notification import Notification, NotificationType
+
+        limit = Notification.__table__.c.type.type.length
+        too_long = [v.value for v in NotificationType if len(v.value) > limit]
+        assert not too_long, (
+            f"These NotificationType values exceed the column limit "
+            f"({limit}): {too_long}. Widen the migration + model "
+            "together before shipping."
+        )

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -197,3 +197,150 @@ def _diff(a: dict[str, list[str]], b: dict[str, list[str]]) -> dict[str, list[st
         if missing:
             out[table] = missing
     return out
+
+
+# Probe values chosen to fit int64 and bust int32 (max 2_147_483_647 ≈ 2 GB).
+# Each value is a realistic real-world size for the column's semantic:
+#   - plans.bytes_included: 100 GB (current Pro tier spec — core#249)
+#   - usage_ledger.quantity: 3 GB (single day of Pro-scale ingestion)
+#   - charges.overage_quantity: 50 GB (one month of mild Pro overage)
+_GB = 1024**3
+_PROBE_PLAN_BYTES = 100 * _GB  # 107_374_182_400
+_PROBE_USAGE_BYTES = 3 * _GB  # 3_221_225_472
+_PROBE_OVERAGE_BYTES = 50 * _GB  # 53_687_091_200
+
+
+def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
+    """Insert real-world byte sizes into bigint columns; catch int32 regressions.
+
+    Would-have-caught: **core#272**. The existing schema-equivalence test
+    only compares column names — type-width regressions are invisible
+    because SQLite maps both Integer and BigInteger to a dynamic-width
+    INTEGER. Postgres enforces fixed widths, so inserting a value above
+    `int32.max` (≈ 2 GB) surfaces any silent regression immediately.
+
+    Columns probed:
+      - `plans.bytes_included` at 100 GB — the Pro tier's included
+        allotment; every Pro plan row stores this value.
+      - `usage_ledger.quantity` at 3 GB — a single day of Pro-scale
+        ingestion. This was the column core#272 fixed; this test locks
+        that fix in.
+      - `charges.overage_quantity` at 50 GB — a month of mild Pro
+        overage. V2 P5 Option B writes this column on every cycle close.
+
+    If any of these columns ever silently reverts to int32, this test
+    fails with `NumericValueOutOfRange: integer out of range` and the
+    PR is blocked.
+    """
+    _reset_db(roundtrip_db_url)
+    r = _run_alembic(["upgrade", "head"], roundtrip_db_url)
+    assert r.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+    engine = create_engine(roundtrip_db_url)
+    try:
+        with engine.begin() as conn:
+            org_id = conn.execute(
+                text("INSERT INTO organizations (name, slug) VALUES (:n, :s) RETURNING id"),
+                {"n": "QA bigint probe", "s": "qa-bigint-probe"},
+            ).scalar_one()
+
+            plan_id = conn.execute(
+                text(
+                    "INSERT INTO plans (name, slug, paddle_price_id, "
+                    "paddle_product_id, price_cents, interval, bytes_included) "
+                    "VALUES (:n, :s, :ppi, :ppp, :pc, :i, :bi) RETURNING id"
+                ),
+                {
+                    "n": "QA Probe Plan",
+                    "s": "qa-probe",
+                    "ppi": "pri_qa_probe_001",
+                    "ppp": "pro_qa_probe_001",
+                    "pc": 0,
+                    "i": "month",
+                    "bi": _PROBE_PLAN_BYTES,
+                },
+            ).scalar_one()
+
+            sub_id = conn.execute(
+                text(
+                    "INSERT INTO subscriptions (org_id, plan_id, "
+                    "paddle_customer_id, paddle_subscription_id) "
+                    "VALUES (:o, :p, :c, :s) RETURNING id"
+                ),
+                {
+                    "o": org_id,
+                    "p": plan_id,
+                    "c": "ctm_qa_probe",
+                    "s": "sub_qa_probe_001",
+                },
+            ).scalar_one()
+
+            ul_id = conn.execute(
+                text(
+                    "INSERT INTO usage_ledger "
+                    "(org_id, period_start, period_end, metric, quantity) "
+                    "VALUES (:o, :ps, :pe, 'bytes_processed', :q) RETURNING id"
+                ),
+                {
+                    "o": org_id,
+                    "ps": "2026-04-01 00:00:00+00",
+                    "pe": "2026-05-01 00:00:00+00",
+                    "q": _PROBE_USAGE_BYTES,
+                },
+            ).scalar_one()
+
+            charge_id = conn.execute(
+                text(
+                    "INSERT INTO charges "
+                    "(org_id, idempotency_key, subscription_id, period_start, "
+                    "period_end, metric, overage_quantity, amount_cents) "
+                    "VALUES (:o, :k, :s, :ps, :pe, 'bytes_processed', :oq, :ac) "
+                    "RETURNING id"
+                ),
+                {
+                    "o": org_id,
+                    "k": "sub_qa_probe_001:2026-04-01:bytes_processed",
+                    "s": sub_id,
+                    "ps": "2026-04-01 00:00:00+00",
+                    "pe": "2026-05-01 00:00:00+00",
+                    "oq": _PROBE_OVERAGE_BYTES,
+                    "ac": 50000,
+                },
+            ).scalar_one()
+
+            # Assert round-trip — if the column is int32, the INSERT would
+            # have already raised NumericValueOutOfRange. Assertions below
+            # guard against less-obvious regressions (e.g., a migration that
+            # silently truncates, or future ORM drift).
+            assert (
+                conn.execute(
+                    text("SELECT bytes_included FROM plans WHERE id = :i"),
+                    {"i": plan_id},
+                ).scalar()
+                == _PROBE_PLAN_BYTES
+            )
+            assert (
+                conn.execute(
+                    text("SELECT quantity FROM usage_ledger WHERE id = :i"),
+                    {"i": ul_id},
+                ).scalar()
+                == _PROBE_USAGE_BYTES
+            )
+            assert (
+                conn.execute(
+                    text("SELECT overage_quantity FROM charges WHERE id = :i"),
+                    {"i": charge_id},
+                ).scalar()
+                == _PROBE_OVERAGE_BYTES
+            )
+
+            # Delete in FK-order so the DB is clean for any following test.
+            conn.execute(text("DELETE FROM charges"))
+            conn.execute(text("DELETE FROM usage_ledger"))
+            conn.execute(text("DELETE FROM subscriptions"))
+            conn.execute(text("DELETE FROM plans"))
+            conn.execute(text("DELETE FROM organizations"))
+    finally:
+        engine.dispose()

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -204,10 +204,15 @@ def _diff(a: dict[str, list[str]], b: dict[str, list[str]]) -> dict[str, list[st
 #   - plans.bytes_included: 100 GB (current Pro tier spec — core#249)
 #   - usage_ledger.quantity: 3 GB (single day of Pro-scale ingestion)
 #   - charges.overage_quantity: 50 GB (one month of mild Pro overage)
+#   - uploaded_files.file_size: 5 GB (realistic Enterprise single upload)
+#   - runs.rows_loaded: 3 * 10**9 rows (Enterprise backfill — currently
+#     int32, tracked by core#283; probe is xfailed until the widening migration ships)
 _GB = 1024**3
 _PROBE_PLAN_BYTES = 100 * _GB  # 107_374_182_400
 _PROBE_USAGE_BYTES = 3 * _GB  # 3_221_225_472
 _PROBE_OVERAGE_BYTES = 50 * _GB  # 53_687_091_200
+_PROBE_FILE_SIZE_BYTES = 5 * _GB  # 5_368_709_120
+_PROBE_ROWS_LOADED = 3_000_000_000  # Busts int32.max (2_147_483_647)
 
 
 def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
@@ -310,6 +315,25 @@ def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
                 },
             ).scalar_one()
 
+            # uploaded_files.file_size — 5 GB. Bigint since u0q7r8s9t1n2;
+            # this probe locks that guarantee in place for Enterprise uploads.
+            file_id = conn.execute(
+                text(
+                    "INSERT INTO uploaded_files "
+                    "(original_name, content_type, file_size, file_hash, "
+                    "archive_path, org_id) "
+                    "VALUES (:n, :t, :sz, :h, :p, :o) RETURNING id"
+                ),
+                {
+                    "n": "qa_probe_5gb.csv",
+                    "t": "text/csv",
+                    "sz": _PROBE_FILE_SIZE_BYTES,
+                    "h": "0" * 64,
+                    "p": "/tmp/qa-probe",
+                    "o": org_id,
+                },
+            ).scalar_one()
+
             # Assert round-trip — if the column is int32, the INSERT would
             # have already raised NumericValueOutOfRange. Assertions below
             # guard against less-obvious regressions (e.g., a migration that
@@ -335,12 +359,78 @@ def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
                 ).scalar()
                 == _PROBE_OVERAGE_BYTES
             )
+            assert (
+                conn.execute(
+                    text("SELECT file_size FROM uploaded_files WHERE id = :i"),
+                    {"i": file_id},
+                ).scalar()
+                == _PROBE_FILE_SIZE_BYTES
+            )
 
             # Delete in FK-order so the DB is clean for any following test.
+            conn.execute(text("DELETE FROM uploaded_files"))
             conn.execute(text("DELETE FROM charges"))
             conn.execute(text("DELETE FROM usage_ledger"))
             conn.execute(text("DELETE FROM subscriptions"))
             conn.execute(text("DELETE FROM plans"))
+            conn.execute(text("DELETE FROM organizations"))
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "runs.rows_loaded is currently Integer (int32). Enterprise backfills "
+        "routinely exceed 2.14B rows; this probe inserts 3B and overflows. "
+        "Tracked by core#283 — flip to strict=True after the bigint migration "
+        "lands."
+    ),
+)
+def test_runs_rows_loaded_bigint_roundtrip(roundtrip_db_url: str) -> None:
+    """3-billion-row probe for `runs.rows_loaded` — xfails until core#283 ships.
+
+    Enterprise customers run one-shot backfills of clickstream / event /
+    log data that routinely exceed 2^31 rows. dlt extracts the row count
+    and we persist it into `runs.rows_loaded`; the column is currently
+    int32 and any ingestion over 2.14B rows raises `NumericValueOutOfRange`.
+
+    Once Engineering ships the `runs.rows_loaded` → bigint migration
+    (core#283), this test starts passing. Flip the marker to
+    `strict=True` so XPASS forces its removal and locks in the guarantee.
+    """
+    _reset_db(roundtrip_db_url)
+    r = _run_alembic(["upgrade", "head"], roundtrip_db_url)
+    assert r.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+    engine = create_engine(roundtrip_db_url)
+    try:
+        with engine.begin() as conn:
+            org_id = conn.execute(
+                text("INSERT INTO organizations (name, slug) VALUES (:n, :s) RETURNING id"),
+                {"n": "QA rows_loaded probe", "s": "qa-rows-loaded-probe"},
+            ).scalar_one()
+
+            run_id = conn.execute(
+                text(
+                    "INSERT INTO runs "
+                    "(target_type, target_id, status, rows_loaded, org_id) "
+                    "VALUES ('pipeline', 1, 'success', :r, :o) RETURNING id"
+                ),
+                {"r": _PROBE_ROWS_LOADED, "o": org_id},
+            ).scalar_one()
+
+            assert (
+                conn.execute(
+                    text("SELECT rows_loaded FROM runs WHERE id = :i"),
+                    {"i": run_id},
+                ).scalar()
+                == _PROBE_ROWS_LOADED
+            )
+
+            conn.execute(text("DELETE FROM runs"))
             conn.execute(text("DELETE FROM organizations"))
     finally:
         engine.dispose()


### PR DESCRIPTION
Promotes:
- **core#281** — Engineering: `notifications.type` VARCHAR(14) → VARCHAR(50) + model match + regression guard (closes #279)
- **core#282** — QA: realistic-size INSERT probe in migration-roundtrip CI (closes #276 — gap that let #272 slip through)

Paired with cloud#58 (cloud#56 retry fix + cloud#57 sandbox contract test), already on cloud master.

## Deploy sequence
1. Cloud master has retry fix + sandbox contract test ✅
2. Core master deploy: rebuild GHCR image + alembic runs VARCHAR widen migration at startup
3. smoke-prod verifies