### PR TITLE
Promote dev → master: core#285 (runs.rows_loaded bigint)

### DIFF
--- a/datanika/migrations/versions/d0e5f6g7h8i9_bigint_runs_rows_loaded.py
+++ b/datanika/migrations/versions/d0e5f6g7h8i9_bigint_runs_rows_loaded.py
@@ -1,0 +1,66 @@
+"""Widen runs.rows_loaded from int32 → int64.
+
+Third of the V2 P5 int32-overflow fixes (core#283). Same shape as
+b8c3d4e5f6g7 (usage_ledger.quantity, core#272) and c9d4e5f6g7h8
+(notifications.type width, core#279). Surfaced by core#282's
+realistic-size INSERT probe which had been landed as an xfail
+against 3 billion rows — Enterprise clickstream / event / log
+backfills routinely exceed 2^31 rows in a single pipeline run.
+
+Chain of custody:
+- ``dlt_runner._extract_rows_loaded(pipeline)`` returns the row count
+- ``upload_tasks.run_upload_task`` passes it to
+  ``execution_service.complete_run(..., rows_loaded=...)``
+- ``complete_run`` writes ``run.rows_loaded = rows_loaded``
+- INSERT → ``NumericValueOutOfRange: integer out of range`` on any
+  count ≥ 2^31.
+
+Audit of other ``runs`` columns (same pass):
+- ``id``: Integer autoincrement PK — ~10 yrs headroom at current
+  trajectory; widening deferred.
+- ``target_id``: BigInteger ✓
+- ``org_id``: BigInteger ✓ (via TenantMixin)
+
+Metadata-only ``ALTER COLUMN`` on Postgres; no table rewrite.
+
+Revision ID: d0e5f6g7h8i9
+Revises: c9d4e5f6g7h8
+Create Date: 2026-04-20 23:45:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d0e5f6g7h8i9"
+down_revision: str | None = "c9d4e5f6g7h8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "runs",
+        "rows_loaded",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    # Narrowing back would fail on any row whose rows_loaded > 2^31 - 1
+    # (the scenario that prompted the widening). Safe only on an empty
+    # or purged DB — which is what ``test_roundtrip.py`` exercises.
+    op.alter_column(
+        "runs",
+        "rows_loaded",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=True,
+    )
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/run.py
+++ b/datanika/models/run.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, Enum, Integer, Text
+from sqlalchemy import BigInteger, DateTime, Enum, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from datanika.models.base import Base, TenantMixin, TimestampMixin
@@ -32,5 +32,9 @@ class Run(Base, TenantMixin, TimestampMixin):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     logs: Mapped[str | None] = mapped_column(Text, nullable=True)
-    rows_loaded: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # BigInteger: Enterprise clickstream/event/log backfills routinely
+    # exceed 2^31 rows in a single pipeline run. int32 would overflow on
+    # insert with ``NumericValueOutOfRange``. See core#283 — same class
+    # as the usage_ledger.quantity widening in core#272.
+    rows_loaded: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/tests/test_migrations/test_d0e5_bigint_rows_loaded.py
+++ b/tests/test_migrations/test_d0e5_bigint_rows_loaded.py
@@ -1,0 +1,67 @@
+"""Regression test for the ``runs.rows_loaded`` BigInt widening
+(core#283). Guards against accidental reversion to int32 that would
+silently reject any Enterprise backfill ≥ 2^31 rows.
+
+Live-DB round-trip is covered by ``test_roundtrip.py`` (the probe that
+shipped xfailed in core#282 and is now a passing test here in core#283).
+This is a cheap static check so a reversion surfaces in CI without
+Postgres.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_VERSIONS = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
+_MIGRATION = _VERSIONS / "d0e5f6g7h8i9_bigint_runs_rows_loaded.py"
+
+
+@pytest.fixture(scope="module")
+def migration_source() -> str:
+    assert _MIGRATION.exists(), f"Missing migration file: {_MIGRATION}"
+    return _MIGRATION.read_text(encoding="utf-8")
+
+
+class TestBigIntRowsLoadedMigration:
+    def test_revision_id_and_parent(self, migration_source):
+        assert 'revision: str = "d0e5f6g7h8i9"' in migration_source
+        assert 'down_revision: str | None = "c9d4e5f6g7h8"' in migration_source
+
+    def test_upgrade_widens_to_bigint(self, migration_source):
+        upgrade_match = re.search(r"def upgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL)
+        assert upgrade_match
+        upgrade_body = upgrade_match.group(0)
+        assert 'alter_column(\n        "runs"' in upgrade_body
+        assert '"rows_loaded"' in upgrade_body
+        assert "type_=sa.BigInteger()" in upgrade_body
+        assert "existing_type=sa.Integer()" in upgrade_body
+
+    def test_downgrade_narrows_back(self, migration_source):
+        downgrade_match = re.search(
+            r"def downgrade\(\).*?(?=\ndef |\Z)", migration_source, re.DOTALL
+        )
+        assert downgrade_match
+        downgrade_body = downgrade_match.group(0)
+        assert "type_=sa.Integer()" in downgrade_body
+        assert "existing_type=sa.BigInteger()" in downgrade_body
+
+
+class TestRunModelColumnType:
+    """Model-level regression. SQLite maps both Integer and BigInteger
+    to one INTEGER type so insertion tests can't see the boundary; the
+    declaration is the authoritative statement.
+    """
+
+    def test_rows_loaded_is_bigint(self):
+        from sqlalchemy import BigInteger
+
+        from datanika.models.run import Run
+
+        col = Run.__table__.c.rows_loaded
+        assert isinstance(col.type, BigInteger), (
+            f"Run.rows_loaded must be BigInteger (got {type(col.type).__name__}). "
+            "Enterprise backfills overflow int32 — see core#283."
+        )

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -378,26 +378,19 @@ def test_realistic_byte_size_roundtrip(roundtrip_db_url: str) -> None:
         engine.dispose()
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "runs.rows_loaded is currently Integer (int32). Enterprise backfills "
-        "routinely exceed 2.14B rows; this probe inserts 3B and overflows. "
-        "Tracked by core#283 — flip to strict=True after the bigint migration "
-        "lands."
-    ),
-)
 def test_runs_rows_loaded_bigint_roundtrip(roundtrip_db_url: str) -> None:
-    """3-billion-row probe for `runs.rows_loaded` — xfails until core#283 ships.
+    """3-billion-row probe for `runs.rows_loaded` (core#283 — shipped).
 
     Enterprise customers run one-shot backfills of clickstream / event /
     log data that routinely exceed 2^31 rows. dlt extracts the row count
-    and we persist it into `runs.rows_loaded`; the column is currently
-    int32 and any ingestion over 2.14B rows raises `NumericValueOutOfRange`.
+    and we persist it into `runs.rows_loaded`; before core#283 the
+    column was int32 and any ingestion over 2.14B rows raised
+    `NumericValueOutOfRange`.
 
-    Once Engineering ships the `runs.rows_loaded` → bigint migration
-    (core#283), this test starts passing. Flip the marker to
-    `strict=True` so XPASS forces its removal and locks in the guarantee.
+    Migration `d0e5f6g7h8i9` widens to bigint. This test was authored
+    xfailed in core#282 as a red-test pointing at the gap; the xfail
+    marker is removed now that the widening ships — a passing probe
+    that regressions back to int32 would trip.
     """
     _reset_db(roundtrip_db_url)
     r = _run_alembic(["upgrade", "head"], roundtrip_db_url)


### PR DESCRIPTION
## Summary

Single-commit promotion wave carrying **core#285** — `runs.rows_loaded` int32 → bigint widening.

Third of the V2 P5 int32-overflow fixes (pair with cloud#55/#58 already on master). Enterprise backfills of clickstream / event / log data ≥ 2^31 rows would have raised `NumericValueOutOfRange` on `INSERT INTO runs ...`. Surfaced by QA's realistic-size probe (core#282) — the first bug we caught via our own CI probe rather than a staging dry-run.

## Migration

`d0e5f6g7h8i9_bigint_runs_rows_loaded.py`. Metadata-only `ALTER COLUMN` on Postgres — no table rewrite. Safe to run live.

## Deploy expectations

- `datanika-app` + `datanika-celery` rebuild + restart via GHCR.
- Alembic auto-runs on app startup → widens `runs.rows_loaded`.
- No downtime beyond the brief container restart window.

## What unblocks next

Re-dry-run #3 (Infra) needs all of:
- core#281 (notifications.type width) — ✅ on master
- cloud#56 (retry flow) — ✅ on master
- core#285 (this PR) — promoting now

Then scenarios 1-4 of the dry-run are exercisable end-to-end.

## Test plan (post-promotion)

- [ ] CI runs + deploys cleanly
- [ ] `docker exec datanika-postgres psql ... -c "\d+ runs" | grep rows_loaded` → shows `bigint`
- [ ] Health endpoints respond 200 within 60s
- [ ] Grafana shows `pg_up: 1`
- [ ] V2 P5 dry-run #3 starts next