### PR TITLE
[Engineering] Register all core hook subscribers in the Celery worker too (closes #287)

### DIFF
--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -258,30 +258,12 @@ for _route in metrics_routes:
     app._api.routes.append(_route)
 app._api.add_middleware(PrometheusMiddleware)
 
-# Wire notification hooks (dispatch on run completion)
-from datanika.services.notification_service import NotificationService, register_hooks  # noqa: E402
+# Register every core-side hook subscriber (runs + quota + V2 P5 charge
+# events + external-channel dispatch). Delegated to
+# ``services._register_hooks`` so the Celery worker can call the same
+# function from ``datanika/tasks/celery_app.py`` — without that, hooks
+# emitted from Celery tasks (e.g. ``charge_cycle_overages``) would fire
+# into an empty handler dict in the worker process. See #287.
+from datanika.services._register_hooks import register_all_core_hooks  # noqa: E402
 
-register_hooks(NotificationService())
-
-# Wire in-app notification hooks (create Notification records on run completion)
-from datanika.services.in_app_notification_hooks import (  # noqa: E402
-    register_in_app_notification_hooks,
-)
-
-register_in_app_notification_hooks()
-
-# Wire quota warning hooks — in-app notification + external channel dispatch
-# on quota.warning_threshold_reached (emitted by cloud plugin's BillingService).
-from datanika.services.quota_notification_hooks import (  # noqa: E402
-    register_quota_notification_hooks,
-)
-
-register_quota_notification_hooks()
-
-# Charge events (V2 P5 Option B, core#249) — emitted by cloud plugin's
-# cycle-boundary billing task.
-from datanika.services.charge_notification_hooks import (  # noqa: E402
-    register_charge_notification_hooks,
-)
-
-register_charge_notification_hooks()
+register_all_core_hooks()

--- a/datanika/services/_register_hooks.py
+++ b/datanika/services/_register_hooks.py
@@ -1,0 +1,58 @@
+"""Idempotent one-shot registration for all core hook handlers (#287).
+
+``datanika.hooks._handlers`` is a module-level dict — one instance per
+Python process. Registrations don't cross process boundaries. Before
+this module, all ``register_*_notification_hooks()`` calls lived in
+``datanika/datanika.py`` (the Reflex app module), which is never
+imported by the Celery worker — so cloud's ``charge_cycle_overages``
+could emit ``charge_*`` hooks all day long into an empty handler dict.
+
+This module centralises registration. Both entrypoints call
+``register_all_core_hooks()``:
+
+- ``datanika/datanika.py`` — Reflex app (web process).
+- ``datanika/tasks/celery_app.py`` — Celery worker + beat processes.
+
+The function is **idempotent** via a module-level sentinel; calling it
+twice from the same process is a no-op, so if someone later wires it
+into a third entrypoint there's no double-registration risk.
+"""
+
+from __future__ import annotations
+
+_already_registered = False
+
+
+def register_all_core_hooks() -> None:
+    """Subscribe all core-side hook handlers. Idempotent per process."""
+    global _already_registered
+    if _already_registered:
+        return
+
+    # Import inside the function to avoid import cycles at module load and
+    # to keep the Celery worker's cold-start surface minimal.
+    from datanika.services.charge_notification_hooks import (
+        register_charge_notification_hooks,
+    )
+    from datanika.services.in_app_notification_hooks import (
+        register_in_app_notification_hooks,
+    )
+    from datanika.services.notification_service import (
+        NotificationService,
+        register_hooks,
+    )
+    from datanika.services.quota_notification_hooks import (
+        register_quota_notification_hooks,
+    )
+
+    # External-channel dispatch (Slack/Telegram/webhook/email) on
+    # ``run.{upload,models,transformation}_completed``.
+    register_hooks(NotificationService())
+    # In-app Notification rows on run completion.
+    register_in_app_notification_hooks()
+    # Quota warning — in-app + external dispatch.
+    register_quota_notification_hooks()
+    # V2 P5 Option B — cycle-boundary charge events.
+    register_charge_notification_hooks()
+
+    _already_registered = True

--- a/datanika/tasks/celery_app.py
+++ b/datanika/tasks/celery_app.py
@@ -2,8 +2,15 @@ from celery import Celery
 
 from datanika.config import settings
 from datanika.logging_config import setup_logging
+from datanika.services._register_hooks import register_all_core_hooks
 
 setup_logging(debug=settings.debug)
+
+# Register every core-side hook subscriber in this process. Without this,
+# cloud tasks running in the Celery worker (e.g. ``charge_cycle_overages``
+# emitting ``charge_*`` events) would fire into an empty handler dict and
+# the user-facing Notification rows would silently never land. See #287.
+register_all_core_hooks()
 
 celery_app = Celery(
     "datanika",

--- a/tests/test_services/test_register_hooks.py
+++ b/tests/test_services/test_register_hooks.py
@@ -1,0 +1,145 @@
+"""Regression test for core#287.
+
+Both the Reflex app and the Celery worker must register the same
+hook subscribers. Before #287, registrations lived only in
+``datanika/datanika.py`` (the Reflex app module), so Celery's
+``charge_cycle_overages`` emitted ``charge_*`` hooks into an empty
+handler dict in the worker process.
+
+This test does two things:
+
+1. Unit: import ``datanika.services._register_hooks`` and call
+   ``register_all_core_hooks()`` against a cleared ``hooks._handlers``
+   dict, then assert every expected event has a handler.
+2. Subprocess guard: fire ``python -c "import datanika.tasks.celery_app;
+   ..."`` and check the worker's real startup surface registers all
+   the same events. Catches someone removing the
+   ``register_all_core_hooks()`` import from ``celery_app.py`` in
+   the future.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+EXPECTED_EVENTS = (
+    "charge_incoming",
+    "charge_issued",
+    "charge_failed",
+    "quota.warning_threshold_reached",
+    "run.upload_completed",
+    "run.models_completed",
+    "run.transformation_completed",
+)
+
+
+class TestRegisterAllCoreHooks:
+    def test_registers_every_expected_event(self, monkeypatch):
+        """Unit: direct call registers every event the subscribers own."""
+        from datanika import hooks
+        from datanika.services import _register_hooks
+
+        monkeypatch.setattr(hooks, "_handlers", {})
+        monkeypatch.setattr(_register_hooks, "_already_registered", False)
+
+        _register_hooks.register_all_core_hooks()
+
+        for event in EXPECTED_EVENTS:
+            assert hooks._handlers.get(event), (
+                f"{event!r} has no handler after register_all_core_hooks(). "
+                "See #287 — cloud emits these from the Celery worker; if "
+                "registration drops, Notification rows never land."
+            )
+
+    def test_idempotent_within_a_process(self, monkeypatch):
+        """Second call must not double-register (would dispatch twice)."""
+        from datanika import hooks
+        from datanika.services import _register_hooks
+
+        monkeypatch.setattr(hooks, "_handlers", {})
+        monkeypatch.setattr(_register_hooks, "_already_registered", False)
+
+        _register_hooks.register_all_core_hooks()
+        first_counts = {e: len(hooks._handlers.get(e, [])) for e in EXPECTED_EVENTS}
+
+        _register_hooks.register_all_core_hooks()
+        second_counts = {e: len(hooks._handlers.get(e, [])) for e in EXPECTED_EVENTS}
+
+        assert first_counts == second_counts, (
+            "register_all_core_hooks() double-registered on second call. "
+            "Sentinel is broken — a future second import (Celery + Reflex "
+            "sharing the same process in tests) would fire every subscriber "
+            "twice per emit."
+        )
+
+
+class TestCeleryWorkerRegistersHooks:
+    """Subprocess guard: `datanika.tasks.celery_app` must populate the
+    full handler dict at import time. This catches someone removing the
+    ``register_all_core_hooks()`` call from the Celery entrypoint.
+    """
+
+    def test_celery_worker_import_populates_hooks(self):
+        # setup_logging writes structured JSON logs to stdout when the
+        # celery entrypoint is imported, so we prefix output with a known
+        # marker and filter on that — otherwise the parse picks up log
+        # lines and fails with an unhelpful ValueError.
+        marker = "HOOKS_CHECK:"
+        script = (
+            "import datanika.tasks.celery_app  # noqa: F401\n"
+            "from datanika import hooks\n"
+            f"for e in {list(EXPECTED_EVENTS)!r}:\n"
+            "    n = len(hooks._handlers.get(e, []))\n"
+            f"    print('{marker}' + e + '=' + str(n))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"Celery worker import failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        found: dict[str, int] = {}
+        for line in result.stdout.splitlines():
+            if not line.startswith(marker):
+                continue
+            event, _, count = line.removeprefix(marker).partition("=")
+            found[event] = int(count)
+
+        missing = [e for e in EXPECTED_EVENTS if e not in found]
+        assert not missing, (
+            f"Marker-tagged output missing events {missing!r}.\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        for event, count in found.items():
+            assert count >= 1, (
+                f"{event!r} has no handler after `import datanika.tasks.celery_app`. "
+                "If ``register_all_core_hooks()`` was removed from "
+                "``celery_app.py``, cloud tasks emitting this event will be "
+                "silently ignored — see #287."
+            )
+
+
+@pytest.mark.parametrize("event", EXPECTED_EVENTS)
+def test_expected_events_list_matches_registry(event):
+    """Documentation test: if a new hook subscriber is added (e.g. a future
+    ``tenant_suspended`` event), this list must be updated alongside the
+    registration function. Fails loud if someone forgets to wire both ends.
+    """
+    from datanika.services import _register_hooks
+
+    source = _register_hooks.__file__
+    with open(source, encoding="utf-8") as fp:
+        body = fp.read()
+    # Every registered hook function should be mentioned in the module.
+    # Weak check — just asserts the three new charge_* registrations are
+    # still called out; stronger enforcement lives in the unit test above.
+    assert "register_charge_notification_hooks" in body
+    assert "register_quota_notification_hooks" in body
+    assert "register_in_app_notification_hooks" in body
+    assert "NotificationService" in body


### PR DESCRIPTION
## Finding (from V2 P5 dry-run #3)

Dry-run #3 against staging (2026-04-20 late-evening) surfaced a process-isolation bug that my stale-closure of #274 missed:

```
$ docker exec datanika-staging-celery /app/.venv/bin/python -c \
    "from datanika import hooks; import datanika.tasks.celery_app
for evt in ('charge_incoming', 'charge_issued', 'charge_failed',
            'quota.warning_threshold_reached', 'run.upload_completed'):
    print(f'{evt}: {len(hooks._handlers.get(evt, []))} handler(s)')"
charge_incoming: 0 handler(s)
charge_issued: 0 handler(s)
charge_failed: 0 handler(s)
quota.warning_threshold_reached: 0 handler(s)
run.upload_completed: 0 handler(s)
```

## Root cause

All `register_*_notification_hooks()` calls lived in `datanika/datanika.py` — the Reflex app module. That module is never imported by the Celery worker. `hooks._handlers` is process-scoped, so the worker had zero handlers for every event cloud emits from Celery tasks.

Impact: cloud's `charge_cycle_overages` + `emit_charge_incoming_notices` emit into the void. Charge rows transition state correctly (fix from cloud#56 works — DB confirms FAILED), but **no Notification row ever lands** and **no external channel dispatch fires**. The pre-charge banner, the FAILED ops alert, everything — silent.

**I closed #274 stale after verifying registrations existed in `datanika.py`. I only verified the Reflex process path, not the Celery process path. That closure was wrong — this is the re-open.**

## Fix

- New `datanika/services/_register_hooks.py` — idempotent `register_all_core_hooks()` that bundles all 4 existing registrations (NotificationService dispatch, in-app, quota, charge) behind a sentinel.
- `datanika/tasks/celery_app.py` imports + calls it at module load.
- `datanika/datanika.py` now delegates to the same function.

25 lines of per-subscriber wiring in the Reflex init collapse to 1 call; Celery worker gets the same handlers for free.

## Dry-run #3 evidence

| Scenario | Before this PR |
|---|---|
| 1. Pre-charge banner (charge_incoming → Notification row) | ❌ FAIL (no subscriber in worker) |
| 2. `/charge` payload shape (includes `product_id`) | ✅ PASS (independent of subscriber) |
| 3. PENDING → FAILED → charge_failed Notification | ❌ FAIL (charge does flip to FAILED, but no Notification) |
| 4. `runs.rows_loaded` bigint round-trip | ✅ PASS (independent of subscriber) |

After this PR promotes: scenarios 1 + 3 should pass. Infra re-runs dry-run #3 post-promotion.

## Handoff

Per the task-split clarification: master promotion + re-dry-run are Infra-only. This PR targets `dev` and stops there — green CI + ready to merge. Infra takes it through promotion + dry-run #3 rerun.

## Test plan

- [x] `ruff check datanika tests` + `ruff format` — clean
- [x] `pytest tests/ --ignore=tests/test_e2e` — **2152 passed** (+4 new tests)
- [x] Pre-push hook green (includes lint + test + helm-lint)
- [x] New tests:
  - Unit: `register_all_core_hooks()` populates all 7 expected events (3 charge + quota + 3 run.*)
  - Unit: idempotency sentinel — double-call doesn't double-register
  - **Subprocess guard**: `python -c "import datanika.tasks.celery_app"` and greps `hooks._handlers` — catches future removal of the registration from `celery_app.py`
  - Source-check documentation trip-wire