### PR TITLE
[QA] Upload raw e2e test-results on failure (closes #117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,19 @@ jobs:
         with:
           name: playwright-report
           path: e2e/playwright-report/
+          retention-days: 14
+
+      # Raw test-results fallback. The HTML report can fail to render when
+      # the trace JSON is truncated (process killed mid-write, OOM, etc.) —
+      # the raw traces + screenshots + videos survive that class of failure.
+      - name: Upload raw test-results (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Telegram alert on failure
         if: failure()
@@ -532,7 +544,16 @@ jobs:
         with:
           name: sso-playwright-report
           path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload SSO raw test-results (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sso-test-results
+          path: e2e/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Cleanup Authentik
         if: always()


### PR DESCRIPTION
## Summary

Adds \`actions/upload-artifact@v4\` for \`e2e/test-results/\` to both \`e2e-staging\` and \`e2e-sso\` jobs, gated on \`if: failure()\`. Retention 7 days.

Existing \`playwright-report/\` upload stays on \`if: always()\` because green-run reports are useful for drift investigations; its retention bumps from 7 → 14 days to match the core#117 spec.

## Why both

- **\`playwright-report/\`** is the rendered HTML report. Great when it works, but when Playwright's trace JSON is truncated (process killed mid-write, OOM, crash before \`onEnd\`), the report fails to render and shows \"Failed to load results\".
- **\`test-results/\`** is the raw output dir — individual trace zips, screenshots, videos. Survives the class of failures that break the HTML report. Belt-and-suspenders.

## Shape

\`\`\`yaml
- name: Upload Playwright report
  if: always()
  uses: actions/upload-artifact@v4
  with:
    name: playwright-report  # (or sso-playwright-report)
    path: e2e/playwright-report/
    retention-days: 14

- name: Upload raw test-results (failure only)
  if: failure()
  uses: actions/upload-artifact@v4
  with:
    name: test-results  # (or sso-test-results)
    path: e2e/test-results/
    retention-days: 7
    if-no-files-found: ignore
\`\`\`

\`if-no-files-found: ignore\` is load-bearing: some failure modes (setup failure before any spec runs) leave \`test-results/\` empty. Without \`ignore\`, the upload step itself would fail and hide the underlying failure signal.

## Test plan

- [x] YAML syntax validated (yaml.safe_load)
- [x] Pre-push hook — 2 line-level changes, no affected tests
- [ ] Next push-to-dev run: verify green runs still surface \`playwright-report-*\` artifacts as before; forced failure surfaces both \`playwright-report-*\` and \`test-results-*\`

## Other core#117 checklist items

Most are already done (pre-existing work not in this PR):
- [x] CI job running e2e — \`e2e-staging\` + \`e2e-sso\` jobs exist
- [x] \`@slow\` gate — handled via \`grepInvert\` in playwright.config.ts
- [x] Runner capacity — resolved by running against staging (not local compose)
- [x] This PR — \`test-results/\` upload
- [ ] Optional: GitHub reporter annotations — separate follow-up if desired

Closes #117.