### PR TITLE
Promote dev → master: QA raw test-results upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,19 @@ jobs:
         with:
           name: playwright-report
           path: e2e/playwright-report/
+          retention-days: 14
+
+      # Raw test-results fallback. The HTML report can fail to render when
+      # the trace JSON is truncated (process killed mid-write, OOM, etc.) —
+      # the raw traces + screenshots + videos survive that class of failure.
+      - name: Upload raw test-results (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Telegram alert on failure
         if: failure()
@@ -532,7 +544,16 @@ jobs:
         with:
           name: sso-playwright-report
           path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload SSO raw test-results (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sso-test-results
+          path: e2e/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Cleanup Authentik
         if: always()


### PR DESCRIPTION
## Summary

Single merged dev PR:

- **core#290** — Upload raw `e2e/test-results/` on E2E failure (closes core#117). Adds `actions/upload-artifact@v4` for the raw output dir to both `e2e-staging` and `e2e-sso` jobs gated on `if: failure()`, retention 7 days. Existing `playwright-report/` upload keeps `if: always()` with retention bumped 7 → 14. Belt-and-suspenders: when Playwright's trace JSON is truncated and the HTML report fails to render, the raw test-results dir survives.

## CI

Source PR green (lint + test + migration-roundtrip + helm-lint). Promotion PR runs the same plus deploy-gated jobs (e2e-staging / e2e-sso / smoke-staging) on master.

## Deploy impact

Triggers GHA deploy to Hetzner on push to master. `datanika-app` + `datanika-celery` pull new GHCR image + restart. ~30s health-check window. No data migrations in this batch.

No new alembic migrations in this PR.