### PR TITLE
Promote dev → master: release auth-read txn early (core#293)

### DIFF
--- a/datanika/db.py
+++ b/datanika/db.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncGenerator
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from datanika.config import settings
 
@@ -46,7 +46,16 @@ sync_engine = create_engine(
     **_pool_kwargs,
 )
 
+# Mirror the async factory: loaded ORM attributes stay valid after commit
+# so handlers can commit mid-body (releasing the read txn before response
+# serialization) without triggering lazy re-queries on attribute access.
+sync_session_factory = sessionmaker(
+    sync_engine,
+    class_=Session,
+    expire_on_commit=False,
+)
+
 
 def get_sync_session() -> Session:
     """Return a sync Session bound to the shared sync engine."""
-    return Session(sync_engine)
+    return sync_session_factory()

--- a/datanika/services/api_middleware.py
+++ b/datanika/services/api_middleware.py
@@ -111,6 +111,11 @@ async def _run_async_handler(
         api_key = _api_key_svc.authenticate_api_key(session, raw_key, required_scope=required_scope)
         if api_key is None:
             return _error(401, "Invalid or expired API key")
+        # Release the auth-read txn before Redis rate-limit/idempotency
+        # work and before the handler runs (#292). Keeps `idle in
+        # transaction` out of pg_stat_activity across the Redis/Python
+        # gap; handler re-opens a fresh txn on its first query.
+        session.commit()
 
         limit_rpm = _rate_limit_svc.get_limit_for_org(api_key.org_id)
         result = _rate_limit_svc.check_rate_limit(
@@ -173,6 +178,9 @@ def _run_sync_handler(
         api_key = _api_key_svc.authenticate_api_key(session, raw_key, required_scope=required_scope)
         if api_key is None:
             return _error(401, "Invalid or expired API key")
+        # Release the auth-read txn before Redis rate-limit/idempotency
+        # work and before the handler runs (#292).
+        session.commit()
 
         limit_rpm = _rate_limit_svc.get_limit_for_org(api_key.org_id)
         result = _rate_limit_svc.check_rate_limit(

--- a/tests/test_services/test_api_middleware.py
+++ b/tests/test_services/test_api_middleware.py
@@ -191,8 +191,10 @@ class TestApiEndpointSyncHandler:
             assert resp.status_code == 429
 
     def test_sync_handler_commits_session(self, fake_api_key, rate_limit_ok):
-        """Successful sync handler triggers session.commit() (write-path
-        correctness guarantee unchanged from the async path)."""
+        """Successful sync handler triggers session.commit() twice:
+        once after auth (release the auth-read txn before rate-limit/Redis
+        work) and once after the handler (write-path correctness).
+        """
         mock_sess = MagicMock()
         with (
             patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
@@ -209,10 +211,14 @@ class TestApiEndpointSyncHandler:
             client = TestClient(app)
             resp = client.get("/sync", headers={"Authorization": "Bearer etf_validkey"})
             assert resp.status_code == 200
-            mock_sess.commit.assert_called_once()
+            assert mock_sess.commit.call_count == 2
 
     def test_sync_handler_rolls_back_on_exception(self, fake_api_key, rate_limit_ok):
-        """A raised exception rolls back and returns 500."""
+        """A raised exception rolls back the handler txn and returns 500.
+
+        The post-auth commit still fires (auth-read txn released before the
+        handler ran); only the handler's txn is rolled back.
+        """
         mock_sess = MagicMock()
 
         @api_endpoint()
@@ -235,7 +241,7 @@ class TestApiEndpointSyncHandler:
             resp = client.get("/boom", headers={"Authorization": "Bearer etf_validkey"})
             assert resp.status_code == 500
             mock_sess.rollback.assert_called_once()
-            mock_sess.commit.assert_not_called()
+            assert mock_sess.commit.call_count == 1
 
     def test_async_handler_path_unchanged(self, fake_api_key, rate_limit_ok):
         """Regression: async-def handlers still take the original path."""
@@ -313,3 +319,162 @@ class TestApiEndpointSyncHandler:
             assert len(set(handler_calls)) == 2
             # Overlap: total < 2 × 0.2 + margin. Serialized would be ~0.4s.
             assert elapsed < 0.35, f"handlers serialized (elapsed={elapsed:.2f}s)"
+
+
+# ---------------------------------------------------------------------------
+# Release auth-read txn before rate-limit / handler work (#292)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthReadTxnRelease:
+    """The middleware must release the auth-read transaction before the
+    Redis-only rate-limit + idempotency work and before the handler runs.
+
+    Root cause of k6 Run 10's ``idle in transaction`` peak (up to 26 conns
+    at 100 VU sustain): ``authenticate_api_key`` opens a read txn on the
+    middleware's session; that txn is then held idle across the Redis rate
+    limit check and idempotency lookup, and across whatever gap exists
+    between the handler's first and last queries. Committing after auth
+    confines the auth-read txn to a ~1 ms window instead of the full
+    request duration.
+    """
+
+    def test_sync_commits_after_auth_before_rate_limit(self, fake_api_key, rate_limit_ok):
+        """Sync path: commit fires before ``check_rate_limit`` is called.
+
+        Ordering matters because ``check_rate_limit`` runs after the auth
+        step and we want the auth-read txn released before any further
+        work — including the Redis probe.
+        """
+        mock_sess = MagicMock()
+        call_order: list[str] = []
+
+        def record_commit():
+            call_order.append("commit")
+
+        mock_sess.commit.side_effect = record_commit
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_sess_ctor,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+
+            def record_rl(*a, **kw):
+                call_order.append("check_rate_limit")
+                return rate_limit_ok
+
+            mock_rl.check_rate_limit.side_effect = record_rl
+            mock_sess_ctor.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_sess_ctor.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/sync", sync_sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/sync", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 200
+            # commit comes before the rate-limit Redis probe, and again after
+            # the handler. At minimum, the first 'commit' precedes
+            # 'check_rate_limit'.
+            assert call_order[0] == "commit"
+            assert "check_rate_limit" in call_order
+            first_commit_idx = call_order.index("commit")
+            first_rl_idx = call_order.index("check_rate_limit")
+            assert first_commit_idx < first_rl_idx
+
+    def test_sync_rate_limited_path_still_commits_auth_txn(self, fake_api_key, rate_limit_exceeded):
+        """Sync path, 429 rejection: the auth-read txn is still committed.
+
+        Pre-#292, a rate-limited request carried the auth-read txn all the
+        way to context-exit rollback. Now the middleware commits it
+        explicitly after auth, independent of rate-limit outcome.
+        """
+        mock_sess = MagicMock()
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_sess_ctor,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_exceeded
+            mock_sess_ctor.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_sess_ctor.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/sync", sync_sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/sync", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 429
+            # Exactly one commit — the auth-read release. No handler ran,
+            # so no second commit.
+            assert mock_sess.commit.call_count == 1
+
+    def test_async_commits_after_auth_before_rate_limit(self, fake_api_key, rate_limit_ok):
+        """Async path: same contract as sync — commit before rate-limit work."""
+        mock_sess = MagicMock()
+        call_order: list[str] = []
+        mock_sess.commit.side_effect = lambda: call_order.append("commit")
+
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_sess_ctor,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+
+            def record_rl(*a, **kw):
+                call_order.append("check_rate_limit")
+                return rate_limit_ok
+
+            mock_rl.check_rate_limit.side_effect = record_rl
+            mock_sess_ctor.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_sess_ctor.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/async", sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/async", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 200
+            assert call_order[0] == "commit"
+            assert call_order.index("commit") < call_order.index("check_rate_limit")
+
+    def test_async_rate_limited_path_still_commits_auth_txn(
+        self, fake_api_key, rate_limit_exceeded
+    ):
+        """Async path, 429 rejection: auth-read txn is committed."""
+        mock_sess = MagicMock()
+        with (
+            patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+            patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+            patch("datanika.services.api_middleware._get_session") as mock_sess_ctor,
+        ):
+            mock_svc.authenticate_api_key.return_value = fake_api_key
+            mock_rl.get_limit_for_org.return_value = 60
+            mock_rl.check_rate_limit.return_value = rate_limit_exceeded
+            mock_sess_ctor.return_value.__enter__ = MagicMock(return_value=mock_sess)
+            mock_sess_ctor.return_value.__exit__ = MagicMock(return_value=False)
+
+            app = Starlette(routes=[Route("/async", sample_handler)])
+            client = TestClient(app)
+            resp = client.get("/async", headers={"Authorization": "Bearer etf_validkey"})
+            assert resp.status_code == 429
+            assert mock_sess.commit.call_count == 1
+
+
+class TestSyncSessionExpireOnCommit:
+    """``get_sync_session`` returns sessions with ``expire_on_commit=False``
+    — matches the async factory (``db.py:33``). Post-commit ORM attribute
+    access stays valid without a lazy re-query, which unblocks future
+    per-handler mid-request commits in the hot-path list endpoints without
+    a response-serialization refactor.
+    """
+
+    def test_sync_session_has_expire_on_commit_false(self):
+        from datanika.db import get_sync_session
+
+        session = get_sync_session()
+        try:
+            assert session.expire_on_commit is False
+        finally:
+            session.close()


### PR DESCRIPTION
## Summary

Single-PR promotion of Engineering's fix for the Run 10 postgres `idle in transaction` finding:

- **core#293** (closes #292) — Release auth-read txn before rate-limit/handler work. Commits the session right after `authenticate_api_key` in both sync + async middleware paths, confining the auth-read txn to a sub-ms window instead of carrying it across the Redis/Python gap. Also switches `get_sync_session()` to `sessionmaker(expire_on_commit=False)` mirroring the async factory — unblocks future per-handler mid-body commits without a serialization refactor. 4 new tests, 2 existing updated, 2157 tests pass.

## CI

Source PR green (lint + test + migration-roundtrip + helm-lint).

## Deploy impact

Triggers GHA deploy to Hetzner on push to master. `datanika-app` + `datanika-celery` pull new GHCR image + restart. ~30s health-check window. No data migrations in this PR.

## Unblocks

k6 Run 11 — verify `idle in transaction` drops under sustained 100-VU load and p95 holds vs Run 10.

## Fixture fix (Infra, parallel)

`transformation_compile` 0% pass rate across Runs 1–10 diagnosed as stale fixture — org#19's transformation#1 had no `destination_connection_id`. Connection#2 wired on prod 2026-04-23 before this promotion. Compile now returns 200 on probe. Not in this PR; documented in `plans/infra/scripts/`.