### PR TITLE
[QA] Harden e2e_seed prod-host guard to check frontend_url (closes #296)

### DIFF
--- a/datanika/scripts/e2e_seed.py
+++ b/datanika/scripts/e2e_seed.py
@@ -150,13 +150,22 @@ class UnsafeTargetError(RuntimeError):
 def _assert_safe_target() -> None:
     if os.environ.get("E2E_SEED_ALLOW_ANY_HOST") == "1":
         return
-    url = settings.database_url_sync.lower()
-    for marker in PROD_HOST_MARKERS:
-        if marker in url:
-            raise UnsafeTargetError(
-                f"Refusing to seed: DATABASE_URL contains {marker!r}. "
-                "Set E2E_SEED_ALLOW_ANY_HOST=1 to override (CI only)."
-            )
+    # Inspect both the DB URL and the app's public URL. Inside a container the
+    # DB URL is a compose-service host (e.g. ``@postgres:5432/datanika``) that
+    # reveals nothing about the environment, but ``frontend_url`` is the real
+    # deployment identity (``https://app.datanika.io`` in prod). Checking only
+    # the DB URL let a prod seed through on the pointer.gr box (core#296).
+    candidates = {
+        "DATABASE_URL": settings.database_url_sync.lower(),
+        "FRONTEND_URL": settings.frontend_url.lower(),
+    }
+    for source, value in candidates.items():
+        for marker in PROD_HOST_MARKERS:
+            if marker in value:
+                raise UnsafeTargetError(
+                    f"Refusing to seed: {source} contains {marker!r}. "
+                    "Set E2E_SEED_ALLOW_ANY_HOST=1 to override (CI only)."
+                )
 
 
 def _tear_down_fixture(session: Session) -> None:

--- a/tests/test_scripts/test_e2e_seed.py
+++ b/tests/test_scripts/test_e2e_seed.py
@@ -197,6 +197,40 @@ def test_assert_safe_target_allows_localhost():
         _assert_safe_target()  # must not raise
 
 
+def test_assert_safe_target_blocks_prod_frontend_url_with_safe_db():
+    """Guard must catch prod even when DATABASE_URL is a compose-service host.
+
+    Regression for core#296: inside the prod container DATABASE_URL is a
+    compose service host (e.g. ``@postgres:5432/datanika``) that contains no
+    prod marker, so checking it alone lets a prod seed through. ``frontend_url``
+    is the real deployment identity (``https://app.datanika.io`` in prod), so
+    the guard must inspect it too.
+    """
+    with (
+        patch.object(
+            e2e_seed.settings,
+            "database_url_sync",
+            "postgresql://datanika:pw@postgres:5432/datanika",
+        ),
+        patch.object(e2e_seed.settings, "frontend_url", "https://app.datanika.io"),
+        pytest.raises(UnsafeTargetError),
+    ):
+        _assert_safe_target()
+
+
+def test_assert_safe_target_allows_localhost_frontend_url():
+    """A localhost frontend_url must not trip the guard (dev/CI stacks)."""
+    with (
+        patch.object(
+            e2e_seed.settings,
+            "database_url_sync",
+            "postgresql://u:p@localhost:5432/datanika",
+        ),
+        patch.object(e2e_seed.settings, "frontend_url", "http://localhost:3000"),
+    ):
+        _assert_safe_target()  # must not raise
+
+
 def test_seed_result_shape():
     """The JSON contract with Playwright — keys must not silently drift."""
     # Check via the dataclass field names rather than running the script.


### PR DESCRIPTION
## What
`_assert_safe_target()` in `datanika/scripts/e2e_seed.py` only inspected `DATABASE_URL`. Inside the app container the DB URL is a compose-service host (`@postgres:5432/datanika`) with no prod marker, so the guard **let a prod seed through** on the new pointer.gr box. Now it also inspects `settings.frontend_url`, which is the real deployment identity (`https://app.datanika.io` in prod).

## Why
Surfaced by the 2026-07-17 post-restore verification — QA had to set `E2E_SEED_ALLOW_ANY_HOST=1` to seed prod because the guard didn't fire on its own. The guard is supposed to be the safety net against an accidental `docker exec ... e2e_seed` against production; it wasn't.

## Tests (TDD)
- `test_assert_safe_target_blocks_prod_frontend_url_with_safe_db` — safe compose DB URL + prod `frontend_url` → now raises `UnsafeTargetError` (was red before the fix).
- `test_assert_safe_target_allows_localhost_frontend_url` — localhost `frontend_url` still allowed (dev/CI).
- Existing guard + override + localhost tests unchanged and green.

Full suite green via pre-push hook (2162 passed, 8 skipped).

Closes #296.
