### PR TITLE
[Engineering] Gate viewer-role visibility of create/destructive controls (closes #313)

### DIFF
--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -7,6 +7,7 @@ from datanika.ui.components.connection_config_fields import type_fields
 from datanika.ui.components.layout import page_layout
 from datanika.ui.components.quota_callout import error_or_quota_callout
 from datanika.ui.components.searchable_select import searchable_select
+from datanika.ui.state.auth_state import AuthState
 from datanika.ui.state.connection_state import ConnectionState
 from datanika.ui.state.i18n_state import I18nState
 
@@ -192,23 +193,32 @@ def connections_table() -> rx.Component:
                                 size="1",
                                 on_click=ConnectionState.test_saved_connection(conn.id),
                             ),
-                            rx.button(
-                                _t["common.edit"],
-                                variant="outline",
-                                size="1",
-                                on_click=ConnectionState.edit_connection(conn.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.edit"],
+                                    variant="outline",
+                                    size="1",
+                                    on_click=ConnectionState.edit_connection(conn.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.copy"],
-                                variant="outline",
-                                size="1",
-                                on_click=ConnectionState.copy_connection(conn.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.copy"],
+                                    variant="outline",
+                                    size="1",
+                                    on_click=ConnectionState.copy_connection(conn.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.delete"],
-                                color_scheme="red",
-                                size="1",
-                                on_click=ConnectionState.delete_connection(conn.id),
+                            rx.cond(
+                                AuthState.can_delete,
+                                rx.button(
+                                    _t["common.delete"],
+                                    color_scheme="red",
+                                    size="1",
+                                    on_click=ConnectionState.delete_connection(conn.id),
+                                ),
                             ),
                             spacing="2",
                             align="center",
@@ -224,7 +234,7 @@ def connections_table() -> rx.Component:
 def connections_page() -> rx.Component:
     return page_layout(
         rx.vstack(
-            connection_form(),
+            rx.cond(AuthState.can_edit, connection_form()),
             connections_table(),
             # Plugin-contributed scripts (e.g. cloud-edition Plausible
             # ``template_prefill_applied`` event on ?template=slug

--- a/datanika/ui/pages/pipelines.py
+++ b/datanika/ui/pages/pipelines.py
@@ -9,6 +9,7 @@ from datanika.ui.components.pipeline_mode_selector import pipeline_mode_selector
 from datanika.ui.components.quota_callout import error_or_quota_callout
 from datanika.ui.components.searchable_select import searchable_select
 from datanika.ui.components.volume_quota_modal import volume_quota_modal
+from datanika.ui.state.auth_state import AuthState
 from datanika.ui.state.i18n_state import I18nState
 from datanika.ui.state.pipeline_state import PipelineState
 
@@ -315,29 +316,41 @@ def pipelines_table() -> rx.Component:
                     ),
                     rx.table.cell(
                         rx.hstack(
-                            rx.button(
-                                _t["common.edit"],
-                                size="1",
-                                variant="outline",
-                                on_click=PipelineState.edit_pipeline(p.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.edit"],
+                                    size="1",
+                                    variant="outline",
+                                    on_click=PipelineState.edit_pipeline(p.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.copy"],
-                                size="1",
-                                variant="outline",
-                                on_click=PipelineState.copy_pipeline(p.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.copy"],
+                                    size="1",
+                                    variant="outline",
+                                    on_click=PipelineState.copy_pipeline(p.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.run"],
-                                size="1",
-                                color_scheme=_run_button_color(p.last_run_status),
-                                on_click=PipelineState.run_pipeline(p.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.run"],
+                                    size="1",
+                                    color_scheme=_run_button_color(p.last_run_status),
+                                    on_click=PipelineState.run_pipeline(p.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.delete"],
-                                color_scheme="red",
-                                size="1",
-                                on_click=PipelineState.delete_pipeline(p.id),
+                            rx.cond(
+                                AuthState.can_delete,
+                                rx.button(
+                                    _t["common.delete"],
+                                    color_scheme="red",
+                                    size="1",
+                                    on_click=PipelineState.delete_pipeline(p.id),
+                                ),
                             ),
                             spacing="2",
                         ),
@@ -390,7 +403,7 @@ def pipelines_page() -> rx.Component:
                 pipelines_empty_state(),
                 rx.fragment(),
             ),
-            pipeline_form(),
+            rx.cond(AuthState.can_edit, pipeline_form()),
             pipelines_table(),
             spacing="6",
             width="100%",

--- a/datanika/ui/pages/schedules.py
+++ b/datanika/ui/pages/schedules.py
@@ -4,6 +4,7 @@ import reflex as rx
 
 from datanika.ui.components.layout import page_layout
 from datanika.ui.components.quota_callout import error_or_quota_callout
+from datanika.ui.state.auth_state import AuthState
 from datanika.ui.state.i18n_state import I18nState
 from datanika.ui.state.schedule_state import ScheduleState
 
@@ -192,33 +193,45 @@ def schedules_table() -> rx.Component:
                     ),
                     rx.table.cell(
                         rx.hstack(
-                            rx.button(
-                                _t["common.edit"],
-                                size="1",
-                                variant="outline",
-                                on_click=ScheduleState.edit_schedule(s.id),
-                            ),
-                            rx.button(
-                                _t["common.copy"],
-                                size="1",
-                                variant="outline",
-                                on_click=ScheduleState.copy_schedule(s.id),
-                            ),
-                            rx.button(
-                                rx.cond(
-                                    s.is_active,
-                                    _t["schedules.pause"],
-                                    _t["schedules.resume"],
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.edit"],
+                                    size="1",
+                                    variant="outline",
+                                    on_click=ScheduleState.edit_schedule(s.id),
                                 ),
-                                size="1",
-                                variant="outline",
-                                on_click=ScheduleState.toggle_schedule(s.id),
                             ),
-                            rx.button(
-                                _t["common.delete"],
-                                color_scheme="red",
-                                size="1",
-                                on_click=ScheduleState.delete_schedule(s.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.copy"],
+                                    size="1",
+                                    variant="outline",
+                                    on_click=ScheduleState.copy_schedule(s.id),
+                                ),
+                            ),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    rx.cond(
+                                        s.is_active,
+                                        _t["schedules.pause"],
+                                        _t["schedules.resume"],
+                                    ),
+                                    size="1",
+                                    variant="outline",
+                                    on_click=ScheduleState.toggle_schedule(s.id),
+                                ),
+                            ),
+                            rx.cond(
+                                AuthState.can_delete,
+                                rx.button(
+                                    _t["common.delete"],
+                                    color_scheme="red",
+                                    size="1",
+                                    on_click=ScheduleState.delete_schedule(s.id),
+                                ),
                             ),
                             spacing="2",
                         ),
@@ -232,6 +245,11 @@ def schedules_table() -> rx.Component:
 
 def schedules_page() -> rx.Component:
     return page_layout(
-        rx.vstack(schedule_form(), schedules_table(), spacing="6", width="100%"),
+        rx.vstack(
+            rx.cond(AuthState.can_edit, schedule_form()),
+            schedules_table(),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.schedules"],
     )

--- a/datanika/ui/pages/transformations.py
+++ b/datanika/ui/pages/transformations.py
@@ -10,6 +10,7 @@ from datanika.ui.components.sql_autocomplete import (
     ref_hidden_buttons,
     ref_popover,
 )
+from datanika.ui.state.auth_state import AuthState
 from datanika.ui.state.i18n_state import I18nState
 from datanika.ui.state.transformation_state import TransformationState
 
@@ -324,17 +325,23 @@ def transformations_table() -> rx.Component:
                         rx.table.cell(t.tags),
                         rx.table.cell(
                             rx.hstack(
-                                rx.button(
-                                    _t["common.edit"],
-                                    size="1",
-                                    variant="outline",
-                                    on_click=TransformationState.edit_transformation(t.id),
+                                rx.cond(
+                                    AuthState.can_edit,
+                                    rx.button(
+                                        _t["common.edit"],
+                                        size="1",
+                                        variant="outline",
+                                        on_click=TransformationState.edit_transformation(t.id),
+                                    ),
                                 ),
-                                rx.button(
-                                    _t["common.copy"],
-                                    size="1",
-                                    variant="outline",
-                                    on_click=TransformationState.copy_transformation(t.id),
+                                rx.cond(
+                                    AuthState.can_edit,
+                                    rx.button(
+                                        _t["common.copy"],
+                                        size="1",
+                                        variant="outline",
+                                        on_click=TransformationState.copy_transformation(t.id),
+                                    ),
                                 ),
                                 rx.button(
                                     _t["transformations.preview_sql"],
@@ -348,11 +355,14 @@ def transformations_table() -> rx.Component:
                                     variant="outline",
                                     on_click=TransformationState.preview_result(t.id),
                                 ),
-                                rx.button(
-                                    _t["common.delete"],
-                                    color_scheme="red",
-                                    size="1",
-                                    on_click=TransformationState.delete_transformation(t.id),
+                                rx.cond(
+                                    AuthState.can_delete,
+                                    rx.button(
+                                        _t["common.delete"],
+                                        color_scheme="red",
+                                        size="1",
+                                        on_click=TransformationState.delete_transformation(t.id),
+                                    ),
                                 ),
                                 spacing="2",
                             ),
@@ -370,7 +380,7 @@ def transformations_table() -> rx.Component:
 def transformations_page() -> rx.Component:
     return page_layout(
         rx.vstack(
-            transformation_form(),
+            rx.cond(AuthState.can_edit, transformation_form()),
             transformations_table(),
             preview_display(),
             spacing="6",

--- a/datanika/ui/pages/uploads.py
+++ b/datanika/ui/pages/uploads.py
@@ -6,6 +6,7 @@ from datanika.ui.components.info_tooltip import info_tooltip
 from datanika.ui.components.layout import page_layout
 from datanika.ui.components.quota_callout import error_or_quota_callout
 from datanika.ui.components.searchable_select import searchable_select
+from datanika.ui.state.auth_state import AuthState
 from datanika.ui.state.i18n_state import I18nState
 from datanika.ui.state.upload_state import UploadState
 
@@ -365,29 +366,41 @@ def uploads_table() -> rx.Component:
                     rx.table.cell(u.destination_connection_name),
                     rx.table.cell(
                         rx.hstack(
-                            rx.button(
-                                _t["common.edit"],
-                                size="1",
-                                variant="outline",
-                                on_click=UploadState.edit_upload(u.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.edit"],
+                                    size="1",
+                                    variant="outline",
+                                    on_click=UploadState.edit_upload(u.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.copy"],
-                                size="1",
-                                variant="outline",
-                                on_click=UploadState.copy_upload(u.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.copy"],
+                                    size="1",
+                                    variant="outline",
+                                    on_click=UploadState.copy_upload(u.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.run"],
-                                size="1",
-                                color_scheme=_run_button_color(u.last_run_status),
-                                on_click=UploadState.run_upload(u.id),
+                            rx.cond(
+                                AuthState.can_edit,
+                                rx.button(
+                                    _t["common.run"],
+                                    size="1",
+                                    color_scheme=_run_button_color(u.last_run_status),
+                                    on_click=UploadState.run_upload(u.id),
+                                ),
                             ),
-                            rx.button(
-                                _t["common.delete"],
-                                color_scheme="red",
-                                size="1",
-                                on_click=UploadState.delete_upload(u.id),
+                            rx.cond(
+                                AuthState.can_delete,
+                                rx.button(
+                                    _t["common.delete"],
+                                    color_scheme="red",
+                                    size="1",
+                                    on_click=UploadState.delete_upload(u.id),
+                                ),
                             ),
                             spacing="2",
                         ),
@@ -401,6 +414,11 @@ def uploads_table() -> rx.Component:
 
 def uploads_page() -> rx.Component:
     return page_layout(
-        rx.vstack(upload_form(), uploads_table(), spacing="6", width="100%"),
+        rx.vstack(
+            rx.cond(AuthState.can_edit, upload_form()),
+            uploads_table(),
+            spacing="6",
+            width="100%",
+        ),
         title=_t["nav.uploads"],
     )

--- a/datanika/ui/state/auth_state.py
+++ b/datanika/ui/state/auth_state.py
@@ -11,7 +11,7 @@ from datanika.hooks import collect_events
 from datanika.services.auth import AuthService
 from datanika.services.captcha_service import CaptchaService
 from datanika.services.user_service import UserService, UserServiceError
-from datanika.ui.state.base_state import get_sync_session
+from datanika.ui.state.base_state import check_role_hierarchy, get_sync_session
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,24 @@ class AuthState(rx.State):
     @rx.var
     def org_id(self) -> int:
         return self.current_org.id if self.current_org.id else 0
+
+    @rx.var
+    def can_edit(self) -> bool:
+        """Whether the current member may create/edit/run resources (editor+).
+
+        Mirrors the ``_check_role("editor")`` gate on the create/edit/run/toggle
+        state handlers so the UI hides controls the member cannot use. Enforcement
+        still lives in the handlers — this only governs visibility (see #313).
+        """
+        return check_role_hierarchy(self.current_role, "editor")
+
+    @rx.var
+    def can_delete(self) -> bool:
+        """Whether the current member may delete resources (admin+).
+
+        Mirrors the ``_check_role("admin")`` gate on the delete handlers.
+        """
+        return check_role_hierarchy(self.current_role, "admin")
 
     def _get_user_service(self) -> UserService:
         auth = AuthService(settings.secret_key)

--- a/tests/test_ui/test_rbac_ui_visibility.py
+++ b/tests/test_ui/test_rbac_ui_visibility.py
@@ -1,0 +1,248 @@
+"""RBAC UI-visibility: destructive/create controls are gated by membership role.
+
+Companion to ``test_rbac_enforcement.py`` (which locks the *handler* ``_check_role``
+gates). This module locks the *visibility* gates: a viewer must not SEE the
+create / edit / delete controls whose handlers they cannot invoke — "a viewer
+that gets to a delete button by accident is a regression".
+
+Uses AST source-inspection (no Reflex state instantiation, matching the repo's
+RBAC test convention) so the invariant survives refactors of the page markup.
+
+Regression guard for datanika-core#313.
+"""
+
+import ast
+import inspect
+
+import pytest
+
+# visibility computed-var -> the minimum role its check_role_hierarchy call must require
+VIS_VARS = {"can_edit": "editor", "can_delete": "admin"}
+
+# The five tenant resource pages whose list rows expose create/destructive controls.
+RESOURCE_PAGES = [
+    "datanika.ui.pages.connections",
+    "datanika.ui.pages.uploads",
+    "datanika.ui.pages.pipelines",
+    "datanika.ui.pages.transformations",
+    "datanika.ui.pages.schedules",
+]
+
+# handler-name prefix -> the visibility var that must gate that control.
+# save_* (the form submit) is gated at the form's call site, not inline, and is
+# verified separately by ``test_create_form_is_gated``.
+GATE_FOR_PREFIX = {
+    "delete_": "can_delete",
+    "edit_": "can_edit",
+    "copy_": "can_edit",
+    "run_": "can_edit",
+    "toggle_": "can_edit",
+}
+
+
+# --------------------------------------------------------------------------- #
+# AST helpers
+# --------------------------------------------------------------------------- #
+
+
+def _module_source(dotted: str) -> str:
+    mod = __import__(dotted, fromlist=[dotted.rsplit(".", 1)[-1]])
+    with open(inspect.getfile(mod), encoding="utf-8") as f:
+        return f.read()
+
+
+def _attr_names(node: ast.AST) -> set[str]:
+    """Every attribute name referenced anywhere under ``node``.
+
+    ``AuthState.can_edit`` -> ``{"can_edit"}``; a compound
+    ``AuthState.can_edit & Other.flag`` -> ``{"can_edit", "flag"}``.
+    """
+    return {n.attr for n in ast.walk(node) if isinstance(n, ast.Attribute)}
+
+
+def _is_rx_call(node: ast.AST, name: str) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == name
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "rx"
+    )
+
+
+def _dec_name(dec: ast.AST) -> str:
+    if isinstance(dec, ast.Call):
+        dec = dec.func
+    if isinstance(dec, ast.Attribute):
+        return dec.attr
+    if isinstance(dec, ast.Name):
+        return dec.id
+    return ""
+
+
+def _button_handler(call: ast.Call) -> str | None:
+    """For an ``rx.button(...)`` call, return its ``on_click`` handler method name.
+
+    ``on_click=State.delete_x(row.id)`` -> ``"delete_x"``;
+    ``on_click=State.save_x`` -> ``"save_x"``; ``None`` if not a button / no on_click.
+    """
+    if not _is_rx_call(call, "button"):
+        return None
+    for kw in call.keywords:
+        if kw.arg != "on_click":
+            continue
+        value = kw.value
+        if isinstance(value, ast.Call) and isinstance(value.func, ast.Attribute):
+            return value.func.attr
+        if isinstance(value, ast.Attribute):
+            return value.attr
+    return None
+
+
+def _required_gate(handler: str) -> str | None:
+    return next((g for p, g in GATE_FOR_PREFIX.items() if handler.startswith(p)), None)
+
+
+class _GateChecker(ast.NodeVisitor):
+    """Walk a page module tracking enclosing ``rx.cond`` visibility-gates and
+    record any create/destructive button rendered outside its required gate."""
+
+    def __init__(self) -> None:
+        self.gate_stack: list[set[str]] = []
+        self.violations: list[tuple[str, str]] = []  # (handler, required_gate)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        handler = _button_handler(node)
+        if handler:
+            required = _required_gate(handler)
+            if required:
+                active: set[str] = set().union(*self.gate_stack) if self.gate_stack else set()
+                if required not in active:
+                    self.violations.append((handler, required))
+
+        if _is_rx_call(node, "cond") and node.args:
+            gates = _attr_names(node.args[0]) & set(VIS_VARS)
+            self.gate_stack.append(gates)
+            self.generic_visit(node)
+            self.gate_stack.pop()
+        else:
+            self.generic_visit(node)
+
+
+def _computed_var_role(source: str, class_name: str, var_name: str) -> str | None:
+    """Return the role constant passed to ``check_role_hierarchy`` inside the
+    ``@rx.var`` computed var ``class_name.var_name``, or ``None`` if it is not a
+    computed var wired to ``check_role_hierarchy``."""
+    tree = ast.parse(source)
+    for cls in ast.walk(tree):
+        if not (isinstance(cls, ast.ClassDef) and cls.name == class_name):
+            continue
+        for fn in cls.body:
+            if not (isinstance(fn, ast.FunctionDef) and fn.name == var_name):
+                continue
+            if "var" not in {_dec_name(d) for d in fn.decorator_list}:
+                return None
+            for call in ast.walk(fn):
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "check_role_hierarchy"
+                ):
+                    for arg in call.args:
+                        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                            return arg.value
+    return None
+
+
+def _form_is_gated(source: str) -> bool:
+    """True if some ``rx.cond(<...can_edit...>, ... *_form() ...)`` exists — the
+    create/edit form is only rendered for roles that pass ``can_edit``."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not (_is_rx_call(node, "cond") and node.args):
+            continue
+        if "can_edit" not in _attr_names(node.args[0]):
+            continue
+        for branch in node.args[1:]:
+            for sub in ast.walk(branch):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Name)
+                    and sub.func.id.endswith("_form")
+                ):
+                    return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+class TestVisibilityVars:
+    """AuthState exposes the visibility gates with the same thresholds the
+    handlers enforce (editor for create/edit, admin for delete)."""
+
+    def test_authstate_defines_visibility_vars(self):
+        src = _module_source("datanika.ui.state.auth_state")
+        for var, role in VIS_VARS.items():
+            assert _computed_var_role(src, "AuthState", var) == role, (
+                f"AuthState.{var} must be an @rx.var calling "
+                f"check_role_hierarchy(self.current_role, '{role}')"
+            )
+
+
+class TestDestructiveControlsGated:
+    """Every create/destructive row control is wrapped in the matching gate."""
+
+    @pytest.mark.parametrize("page", RESOURCE_PAGES)
+    def test_destructive_controls_are_role_gated(self, page):
+        checker = _GateChecker()
+        checker.visit(ast.parse(_module_source(page)))
+        assert not checker.violations, (
+            f"{page}: create/destructive buttons rendered without their role gate: "
+            f"{checker.violations}"
+        )
+
+    @pytest.mark.parametrize("page", RESOURCE_PAGES)
+    def test_create_form_is_gated(self, page):
+        assert _form_is_gated(_module_source(page)), (
+            f"{page}: create/edit form must render only under rx.cond(AuthState.can_edit, ...)"
+        )
+
+
+class TestGateCheckerSelfCheck:
+    """Guard the AST checker itself so a broken checker can't hide regressions."""
+
+    def test_ungated_delete_is_flagged(self):
+        src = (
+            "import reflex as rx\n"
+            "def page():\n"
+            "    return rx.button('x', on_click=S.delete_thing(i))\n"
+        )
+        checker = _GateChecker()
+        checker.visit(ast.parse(src))
+        assert ("delete_thing", "can_delete") in checker.violations
+
+    def test_gated_delete_passes(self):
+        src = (
+            "import reflex as rx\n"
+            "def page():\n"
+            "    return rx.cond(AuthState.can_delete,\n"
+            "        rx.button('x', on_click=S.delete_thing(i)))\n"
+        )
+        checker = _GateChecker()
+        checker.visit(ast.parse(src))
+        assert checker.violations == []
+
+    def test_wrong_gate_is_flagged(self):
+        # a delete button under only can_edit is still a violation
+        src = (
+            "import reflex as rx\n"
+            "def page():\n"
+            "    return rx.cond(AuthState.can_edit,\n"
+            "        rx.button('x', on_click=S.delete_thing(i)))\n"
+        )
+        checker = _GateChecker()
+        checker.visit(ast.parse(src))
+        assert ("delete_thing", "can_delete") in checker.violations


### PR DESCRIPTION
## What & why

Viewers (and any sub-`editor` member) could **see** create / edit / copy / run / toggle / delete controls on the connections, uploads, pipelines, transformations and schedules pages, even though the underlying handlers correctly reject them. Not a security bypass — `_check_role` already blocks the actions server-side (e.g. `ConnectionState.delete_connection` → `_check_role("admin")`) — but a least-privilege / enterprise-RBAC-review UX gap (S2). Closes #313.

## Approach

Mirror each control's server-side `_check_role` gate at the UI-visibility layer:

- New `AuthState` computed vars: **`can_edit`** (editor+) and **`can_delete`** (admin+), each a thin wrapper over the existing `check_role_hierarchy(current_role, …)`.
- Each create/edit **form** and each row **Edit / Copy / Run / Toggle** control is wrapped in `rx.cond(AuthState.can_edit, …)`; **Delete** in `rx.cond(AuthState.can_delete, …)`.

### Gate mapping (matches `test_rbac_enforcement.py` EXPECTED_ROLES)

| Control | Handler gate | UI gate |
|---|---|---|
| form submit / Edit / Copy / Run / Toggle | `_check_role("editor")` | `can_edit` |
| Delete | `_check_role("admin")` | `can_delete` |
| Test (connections), Preview SQL/Result (transformations) | *ungated* | **left visible** |

**Decision — Test / Preview stay visible for viewers.** Those handlers are not `_check_role`-gated (read-only diagnostics), so hiding them would make the UI *stricter* than the server and create the opposite drift. If we later decide viewers shouldn't test/preview, that's a **handler** change (add `_check_role` + gate) — a separate follow-up, not this UI-visibility bug.

## Tests

- New `tests/test_ui/test_rbac_ui_visibility.py` — AST source-inspection (no Reflex state instantiation, matching the repo's RBAC-test convention). Locks: (a) `AuthState.can_edit/can_delete` call `check_role_hierarchy` with the right role; (b) every destructive/create row control across all 5 pages is nested in the correct gate; (c) each create/edit form is gated on `can_edit`. Includes checker self-tests so a broken checker can't hide a regression.
- Full suite: **2173 passed, 11 skipped**. Runtime-verified the gated controls compile to a client-side conditional bound to the state var (viewer → nothing rendered).

## For QA (#305)

`viewer-role-ui.spec.ts` is currently `test.fixme`. Against this branch it should assert a **viewer** sees **no** Create / Edit / Copy / Run / Toggle / Delete on `/connections` (and the same on uploads / pipelines / transformations / schedules), but **may** still see **Test** / **Preview**. An **editor** sees everything except Delete; **admin**/**owner** see all.

## Notes

- No new i18n keys — markup-only reuse of existing labels.
- Observed but **not** touched here: dev's `uv.lock` is stale vs `pyproject.toml` (`testcontainers[postgres]`, from the connector-smoke prep) — I reverted my incidental `uv run` re-sync to keep this PR scoped. Harmless to CI (`uv pip install -e .[dev]` reads pyproject, not the lock); flagging for the #311/#312 owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
