### PR TITLE
[Infra] Promote dev → master: Wave-1 connectors (Oracle + Pipedrive/Freshdesk/Asana)

### DIFF
--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "النطاق الفرعي",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "رمز Zendesk API",
+  "connections.freshdesk_domain": "نطاق Freshdesk",
+  "connections.ph_freshdesk_domain": "yourcompany (بدون .freshdesk.com)",
   "connections.base_id": "معرف القاعدة",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "Subdomain",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Zendesk-API-Token",
+  "connections.freshdesk_domain": "Freshdesk-Domain",
+  "connections.ph_freshdesk_domain": "yourcompany (ohne .freshdesk.com)",
   "connections.base_id": "Basis-ID",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "Υποτομέας",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Κλειδί API Zendesk",
+  "connections.freshdesk_domain": "Τομέας Freshdesk",
+  "connections.ph_freshdesk_domain": "yourcompany (χωρίς .freshdesk.com)",
   "connections.base_id": "ID βάσης",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -153,6 +153,8 @@
   "connections.zendesk_subdomain": "Subdomain",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Zendesk API token",
+  "connections.freshdesk_domain": "Freshdesk Domain",
+  "connections.ph_freshdesk_domain": "yourcompany (without .freshdesk.com)",
   "connections.base_id": "Base ID",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "Subdominio",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Token API de Zendesk",
+  "connections.freshdesk_domain": "Dominio de Freshdesk",
+  "connections.ph_freshdesk_domain": "yourcompany (sin .freshdesk.com)",
   "connections.base_id": "ID de la base",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "Sous-domaine",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Jeton API Zendesk",
+  "connections.freshdesk_domain": "Domaine Freshdesk",
+  "connections.ph_freshdesk_domain": "yourcompany (sans .freshdesk.com)",
   "connections.base_id": "ID de la base",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "Поддомен",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "API-токен Zendesk",
+  "connections.freshdesk_domain": "Домен Freshdesk",
+  "connections.ph_freshdesk_domain": "yourcompany (без .freshdesk.com)",
   "connections.base_id": "ID базы",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "Поддомен",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Zendesk API токен",
+  "connections.freshdesk_domain": "Freshdesk domen",
+  "connections.ph_freshdesk_domain": "yourcompany (bez .freshdesk.com)",
   "connections.base_id": "ID базе",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -366,6 +366,8 @@
   "connections.zendesk_subdomain": "子域名",
   "connections.ph_zendesk_subdomain": "yourcompany (without .zendesk.com)",
   "connections.ph_zendesk_token": "Zendesk API 令牌",
+  "connections.freshdesk_domain": "Freshdesk 域名",
+  "connections.ph_freshdesk_domain": "yourcompany（不含 .freshdesk.com）",
   "connections.base_id": "基础 ID",
   "connections.ph_base_id": "appXXXXXXXXXX",
   "connections.ph_airtable_key": "pat...",

--- a/datanika/models/connection.py
+++ b/datanika/models/connection.py
@@ -27,6 +27,7 @@ class ConnectionType(enum.StrEnum):
     DUCKDB = "duckdb"
     DATABRICKS = "databricks"
     SYNAPSE = "synapse"
+    ORACLE = "oracle"
     STRIPE = "stripe"
     GITHUB = "github"
     HUBSPOT = "hubspot"
@@ -40,6 +41,9 @@ class ConnectionType(enum.StrEnum):
     ZENDESK = "zendesk"
     AIRTABLE = "airtable"
     NOTION = "notion"
+    PIPEDRIVE = "pipedrive"
+    FRESHDESK = "freshdesk"
+    ASANA = "asana"
     KAFKA = "kafka"
 
 

--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -79,6 +79,16 @@ CONFIG_SCHEMAS: dict[str, dict] = {
         },
         required=["host", "database", "user", "password"],
     ),
+    "oracle": _schema(
+        {
+            "host": _str("Oracle hostname"),
+            "port": _int("Port number", default=1521),
+            "database": _str("Service name (or SID)"),
+            "user": _str("Username"),
+            "password": _str("Password", sensitive=True),
+        },
+        required=["host", "database", "user", "password"],
+    ),
     "sqlite": _schema(
         {
             "path": _str("Path to SQLite file (or :memory:)"),
@@ -225,6 +235,21 @@ CONFIG_SCHEMAS: dict[str, dict] = {
     ),
     "notion": _schema(
         {"api_key": _str("Notion integration token", sensitive=True)},
+        required=["api_key"],
+    ),
+    "pipedrive": _schema(
+        {"api_key": _str("Pipedrive API token", sensitive=True)},
+        required=["api_key"],
+    ),
+    "freshdesk": _schema(
+        {
+            "domain": _str("Freshdesk domain (the <domain> in <domain>.freshdesk.com)"),
+            "api_key": _str("Freshdesk API key", sensitive=True),
+        },
+        required=["domain", "api_key"],
+    ),
+    "asana": _schema(
+        {"api_key": _str("Asana personal access token", sensitive=True)},
         required=["api_key"],
     ),
     "google_analytics": _schema(

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -19,6 +19,7 @@ SOURCE_TYPES = {
     "postgres",
     "mysql",
     "mssql",
+    "oracle",
     "sqlite",
     "rest_api",
     "s3",
@@ -42,6 +43,9 @@ SOURCE_TYPES = {
     "zendesk",
     "airtable",
     "notion",
+    "pipedrive",
+    "freshdesk",
+    "asana",
     "kafka",
 }
 
@@ -95,6 +99,9 @@ _NON_DB_TYPES = {
     ConnectionType.ZENDESK,
     ConnectionType.AIRTABLE,
     ConnectionType.NOTION,
+    ConnectionType.PIPEDRIVE,
+    ConnectionType.FRESHDESK,
+    ConnectionType.ASANA,
     ConnectionType.KAFKA,
 }
 
@@ -186,6 +193,16 @@ def _build_sa_url(config: dict, connection_type: ConnectionType) -> str:
             f"{quote_plus(config.get('password', ''))}@"
             f"{config.get('host', 'localhost')}:{port}/"
             f"{config.get('database', '')}{secure_qs}"
+        )
+
+    if connection_type == ConnectionType.ORACLE:
+        port = config.get("port", 1521)
+        # Oracle "easy connect": the URL path is the service name (thin mode).
+        return (
+            f"oracle+oracledb://{quote_plus(config.get('user', ''))}:"
+            f"{quote_plus(config.get('password', ''))}@"
+            f"{config.get('host', 'localhost')}:{port}/"
+            f"{config.get('database', '')}"
         )
 
     raise ValueError(f"Unsupported connection type for URL building: {connection_type}")
@@ -362,6 +379,9 @@ class ConnectionService:
         connect_args: dict = {}
         if connection_type == ConnectionType.MSSQL:
             connect_args = {"login_timeout": 5}
+        elif connection_type == ConnectionType.ORACLE:
+            # oracledb's DBAPI does not accept ``connect_timeout``.
+            connect_args = {"tcp_connect_timeout": 5}
         elif connection_type != ConnectionType.SQLITE:
             connect_args = {"connect_timeout": 5}
 

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -39,6 +39,9 @@ SUPPORTED_SAAS_TYPES = {
     "zendesk",
     "airtable",
     "notion",
+    "pipedrive",
+    "freshdesk",
+    "asana",
 }
 
 # Kafka is a streaming source with its own builder
@@ -126,6 +129,7 @@ SOURCE_DRIVERNAME_MAP = {
     "redshift": "redshift+redshift_connector",
     "clickhouse": "clickhousedb+connect",
     "duckdb": "duckdb",
+    "oracle": "oracle+oracledb",
 }
 
 # Types where user→username renaming is needed
@@ -137,6 +141,7 @@ _RENAME_USER_TYPES = {
     "redshift",
     "snowflake",
     "clickhouse",
+    "oracle",
 }
 
 # ClickHouse table engine types supported by dlt
@@ -153,8 +158,10 @@ class DltRunnerService:
         "sqlite",
         "clickhouse",
         "duckdb",
+        "oracle",
     }
-    SUPPORTED_DESTINATION_TYPES = SUPPORTED_SOURCE_TYPES | {
+    # Oracle is source-only — dlt ships no Oracle destination.
+    SUPPORTED_DESTINATION_TYPES = (SUPPORTED_SOURCE_TYPES - {"oracle"}) | {
         "bigquery",
         "snowflake",
         "redshift",
@@ -777,6 +784,65 @@ class DltRunnerService:
                     ],
                     headers={"Notion-Version": "2022-06-28"},
                 )
+
+        # Pipedrive / Freshdesk / Asana have no pinned verified-source module, so
+        # they go straight to the generic REST fallback (the same path every other
+        # SaaS connector lands on when its verified source isn't installed).
+        if connection_type == "pipedrive":
+            api_key = config.get("api_key") or config.get("api_token", "")
+            if not api_key:
+                raise DltRunnerError("Pipedrive source requires 'api_key'")
+            return self._rest_api_fallback(
+                "https://api.pipedrive.com/v1/",
+                {"type": "api_key", "api_key": api_key, "name": "api_token", "location": "query"},
+                dlt_config.get("resources")
+                or [
+                    {"name": "deals", "endpoint": {"path": "deals"}},
+                    {"name": "persons", "endpoint": {"path": "persons"}},
+                    {"name": "organizations", "endpoint": {"path": "organizations"}},
+                    {"name": "activities", "endpoint": {"path": "activities"}},
+                    {"name": "pipelines", "endpoint": {"path": "pipelines"}},
+                    {"name": "stages", "endpoint": {"path": "stages"}},
+                    {"name": "users", "endpoint": {"path": "users"}},
+                ],
+            )
+
+        if connection_type == "freshdesk":
+            api_key = config.get("api_key", "")
+            domain = config.get("domain", "")
+            if not api_key:
+                raise DltRunnerError("Freshdesk source requires 'api_key'")
+            if not domain:
+                raise DltRunnerError("Freshdesk source requires 'domain'")
+            return self._rest_api_fallback(
+                f"https://{domain}.freshdesk.com/api/v2/",
+                {"type": "http_basic", "username": api_key, "password": "X"},
+                dlt_config.get("resources")
+                or [
+                    {"name": "tickets", "endpoint": {"path": "tickets"}},
+                    {"name": "contacts", "endpoint": {"path": "contacts"}},
+                    {"name": "agents", "endpoint": {"path": "agents"}},
+                    {"name": "companies", "endpoint": {"path": "companies"}},
+                    {"name": "groups", "endpoint": {"path": "groups"}},
+                ],
+            )
+
+        if connection_type == "asana":
+            access_token = config.get("api_key") or config.get("access_token", "")
+            if not access_token:
+                raise DltRunnerError("Asana source requires 'api_key'")
+            return self._rest_api_fallback(
+                "https://app.asana.com/api/1.0/",
+                {"type": "bearer", "token": access_token},
+                dlt_config.get("resources")
+                or [
+                    {"name": "workspaces", "endpoint": {"path": "workspaces"}},
+                    {"name": "projects", "endpoint": {"path": "projects"}},
+                    {"name": "tasks", "endpoint": {"path": "tasks"}},
+                    {"name": "users", "endpoint": {"path": "users"}},
+                    {"name": "tags", "endpoint": {"path": "tags"}},
+                ],
+            )
 
         raise DltRunnerError(f"Unsupported SaaS source type: {connection_type}")
 

--- a/datanika/services/ir/builder.py
+++ b/datanika/services/ir/builder.py
@@ -30,6 +30,7 @@ SQL_TYPES = frozenset(
         "databricks",
         "synapse",
         "redshift",
+        "oracle",
     }
 )
 
@@ -53,6 +54,9 @@ SAAS_TYPES = frozenset(
         "kafka",
         "rest_api",
         "google_sheets",
+        "pipedrive",
+        "freshdesk",
+        "asana",
     }
 )
 

--- a/datanika/ui/components/connection_config_fields.py
+++ b/datanika/ui/components/connection_config_fields.py
@@ -663,6 +663,31 @@ def zendesk_fields() -> rx.Component:
     )
 
 
+def freshdesk_fields() -> rx.Component:
+    """Fields for freshdesk source (domain + API key)."""
+    return rx.vstack(
+        rx.text(_t["connections.freshdesk_domain"], " *", size="2", weight="bold"),
+        rx.input(
+            placeholder=_t["connections.ph_freshdesk_domain"],
+            value=ConnectionState.form_domain,
+            on_change=ConnectionState.set_form_domain,
+            required=True,
+            width="100%",
+        ),
+        rx.text(_t["connections.api_key"], " *", size="2", weight="bold"),
+        rx.input(
+            placeholder=_t["connections.ph_api_key"],
+            value=ConnectionState.form_api_key,
+            on_change=ConnectionState.set_form_api_key,
+            type="password",
+            required=True,
+            width="100%",
+        ),
+        spacing="2",
+        width="100%",
+    )
+
+
 def airtable_fields() -> rx.Component:
     """Fields for airtable source."""
     return rx.vstack(
@@ -773,7 +798,8 @@ def type_fields() -> rx.Component:
             | (ConnectionState.form_type == "mysql")
             | (ConnectionState.form_type == "mssql")
             | (ConnectionState.form_type == "redshift")
-            | (ConnectionState.form_type == "synapse"),
+            | (ConnectionState.form_type == "synapse")
+            | (ConnectionState.form_type == "oracle"),
             db_fields(),
         ),
         rx.cond(ConnectionState.form_type == "clickhouse", clickhouse_fields()),
@@ -795,7 +821,10 @@ def type_fields() -> rx.Component:
         rx.cond(ConnectionState.form_type == "stripe", stripe_fields()),
         rx.cond(ConnectionState.form_type == "github", github_fields()),
         rx.cond(
-            (ConnectionState.form_type == "hubspot") | (ConnectionState.form_type == "slack"),
+            (ConnectionState.form_type == "hubspot")
+            | (ConnectionState.form_type == "slack")
+            | (ConnectionState.form_type == "pipedrive")
+            | (ConnectionState.form_type == "asana"),
             saas_api_key_fields(),
         ),
         rx.cond(ConnectionState.form_type == "salesforce", salesforce_fields()),
@@ -805,6 +834,7 @@ def type_fields() -> rx.Component:
         rx.cond(ConnectionState.form_type == "google_ads", google_ads_fields()),
         rx.cond(ConnectionState.form_type == "facebook_ads", facebook_ads_fields()),
         rx.cond(ConnectionState.form_type == "zendesk", zendesk_fields()),
+        rx.cond(ConnectionState.form_type == "freshdesk", freshdesk_fields()),
         rx.cond(ConnectionState.form_type == "airtable", airtable_fields()),
         rx.cond(
             ConnectionState.form_type == "notion",

--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -23,6 +23,7 @@ PICKER_TYPES: list[str] = [
     "postgres",
     "mysql",
     "mssql",
+    "oracle",
     "sqlite",
     "redshift",
     "synapse",
@@ -49,6 +50,9 @@ PICKER_TYPES: list[str] = [
     "zendesk",
     "airtable",
     "notion",
+    "pipedrive",
+    "freshdesk",
+    "asana",
     # Dev tools
     "github",
     "jira",

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -71,10 +71,11 @@ _DEFAULT_PORTS: dict[str, str] = {
     "mongodb": "27017",
     "clickhouse": "8123",
     "synapse": "1433",
+    "oracle": "1521",
 }
 
 # Connection types that use the SQL database form group (host/port/user/pass/db/schema)
-_DB_TYPES = {"postgres", "mysql", "mssql", "redshift", "clickhouse", "synapse"}
+_DB_TYPES = {"postgres", "mysql", "mssql", "redshift", "clickhouse", "synapse", "oracle"}
 
 # Mapping of pipeline-template ``source_config_defaults`` keys to the
 # matching ConnectionState ``form_*`` attribute. Module-level (not a class
@@ -624,6 +625,16 @@ class ConnectionState(BaseState):
             if self.form_group_id:
                 config["group_id"] = self.form_group_id
 
+        elif t in ("pipedrive", "asana"):
+            if self.form_api_key:
+                config["api_key"] = self.form_api_key
+
+        elif t == "freshdesk":
+            if self.form_api_key:
+                config["api_key"] = self.form_api_key
+            if self.form_domain:
+                config["domain"] = self.form_domain
+
         return config
 
     def _reset_form_fields(self):
@@ -832,6 +843,11 @@ class ConnectionState(BaseState):
             topics = config.get("topics", [])
             self.form_topics = ", ".join(topics) if isinstance(topics, list) else topics
             self.form_group_id = config.get("group_id", "")
+        elif conn_type in ("pipedrive", "asana"):
+            self.form_api_key = config.get("api_key", "")
+        elif conn_type == "freshdesk":
+            self.form_api_key = config.get("api_key", "")
+            self.form_domain = config.get("domain", "")
 
     async def load_connections(self):
         org_id = await self._get_org_id()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "duckdb>=1.0",
     "snowflake-sqlalchemy>=1.7",
     "sqlalchemy-bigquery>=1.11",
+    "oracledb>=2.0",
 
     # Web framework
     "reflex>=0.7",

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -252,7 +252,7 @@ class TestBuildSource:
 
     def test_unsupported_type_raises(self, svc):
         with pytest.raises(DltRunnerError, match="Unsupported source type"):
-            svc.build_source("oracle", {}, {})
+            svc.build_source("teradata", {}, {})
 
     def test_bigquery_not_valid_as_source(self, svc):
         with pytest.raises(DltRunnerError, match="Unsupported source type"):

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -1,0 +1,232 @@
+"""Wave-1 connectors — Oracle (SQL) + Pipedrive / Freshdesk / Asana (SaaS REST).
+
+Mirrors the existing connector conventions:
+- SQL URL / connect_args → ``test_connection_service.py`` (TestBuildSaUrl, connect_args)
+- SaaS ``_build_saas_source`` → ``test_dlt_runner.py`` (TestStripeSaasSource, …)
+
+All mocked — no live creds, no real driver import (create_engine / rest_api_source
+are patched). Live connectivity is covered by QA/Infra smoke against real containers.
+
+Regression + feature tests for datanika-core#309.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_schemas import CONFIG_SCHEMAS, list_connection_types
+from datanika.services.connection_service import (
+    _NON_DB_TYPES,
+    DESTINATION_TYPES,
+    SOURCE_TYPES,
+    ConnectionService,
+    _build_sa_url,
+)
+from datanika.services.dlt_runner import (
+    _RENAME_USER_TYPES,
+    SOURCE_DRIVERNAME_MAP,
+    SUPPORTED_SAAS_TYPES,
+    DltRunnerError,
+    DltRunnerService,
+)
+from datanika.services.ir.builder import SAAS_TYPES, SQL_TYPES
+
+
+@pytest.fixture
+def svc():
+    return DltRunnerService()
+
+
+# --------------------------------------------------------------------------- #
+# Enum
+# --------------------------------------------------------------------------- #
+
+
+class TestWave1Enum:
+    def test_new_connection_types_exist(self):
+        assert ConnectionType.ORACLE == "oracle"
+        assert ConnectionType.PIPEDRIVE == "pipedrive"
+        assert ConnectionType.FRESHDESK == "freshdesk"
+        assert ConnectionType.ASANA == "asana"
+
+
+# --------------------------------------------------------------------------- #
+# Oracle (SQL, source-only)
+# --------------------------------------------------------------------------- #
+
+
+class TestOracleConnector:
+    def test_build_sa_url(self):
+        url = _build_sa_url(
+            {
+                "host": "db.example.com",
+                "port": 1521,
+                "user": "scott",
+                "password": "tiger",
+                "database": "XEPDB1",
+            },
+            ConnectionType.ORACLE,
+        )
+        assert url == "oracle+oracledb://scott:tiger@db.example.com:1521/XEPDB1"
+
+    def test_build_sa_url_default_port(self):
+        url = _build_sa_url(
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            ConnectionType.ORACLE,
+        )
+        assert "@h:1521/SVC" in url
+
+    def test_build_sa_url_quotes_special_chars(self):
+        url = _build_sa_url(
+            {"host": "h", "user": "u", "password": "p@ss/word", "database": "SVC"},
+            ConnectionType.ORACLE,
+        )
+        assert "p%40ss%2Fword" in url
+
+    def test_is_source_not_destination(self):
+        assert "oracle" in SOURCE_TYPES
+        assert "oracle" not in DESTINATION_TYPES
+        assert ConnectionType.ORACLE not in _NON_DB_TYPES  # SQL type → SELECT 1 works
+
+    def test_supported_as_dlt_source_only(self):
+        assert "oracle" in DltRunnerService.SUPPORTED_SOURCE_TYPES
+        assert "oracle" not in DltRunnerService.SUPPORTED_DESTINATION_TYPES
+
+    def test_driver_maps(self):
+        assert SOURCE_DRIVERNAME_MAP["oracle"] == "oracle+oracledb"
+        assert "oracle" in _RENAME_USER_TYPES
+
+    def test_to_dlt_credentials_renames_user_and_sets_driver(self):
+        creds = DltRunnerService._to_dlt_credentials(
+            "oracle", {"host": "h", "user": "u", "password": "p", "database": "SVC"}
+        )
+        assert creds["drivername"] == "oracle+oracledb"
+        assert creds["username"] == "u"
+        assert "user" not in creds
+
+    def test_in_ir_sql_types(self):
+        assert "oracle" in SQL_TYPES
+        assert "oracle" not in SAAS_TYPES
+
+    def test_config_schema(self):
+        schema = CONFIG_SCHEMAS["oracle"]
+        props = schema["properties"]
+        assert {"host", "port", "database", "user", "password"} <= set(props)
+        assert schema["required"] == ["host", "database", "user", "password"]
+        assert props["password"].get("format") == "password"
+
+    @patch("datanika.services.connection_service.create_engine")
+    def test_connect_args_avoids_connect_timeout(self, mock_ce):
+        # oracledb's DBAPI rejects ``connect_timeout``; it must not be passed.
+        ok, _msg = ConnectionService.test_connection(
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            ConnectionType.ORACLE,
+        )
+        connect_args = mock_ce.call_args.kwargs["connect_args"]
+        assert "connect_timeout" not in connect_args
+        assert connect_args == {"tcp_connect_timeout": 5}
+        assert ok is True
+
+
+# --------------------------------------------------------------------------- #
+# SaaS REST connectors
+# --------------------------------------------------------------------------- #
+
+
+class TestPipedriveConnector:
+    def test_registered_as_saas_source(self):
+        assert "pipedrive" in SUPPORTED_SAAS_TYPES
+        assert "pipedrive" in SOURCE_TYPES
+        assert ConnectionType.PIPEDRIVE in _NON_DB_TYPES
+        assert "pipedrive" in SAAS_TYPES
+
+    @patch("datanika.services.dlt_runner.rest_api_source")
+    def test_builds_rest_api_source(self, mock_rest, svc):
+        mock_rest.return_value = "pd_src"
+        result = svc._build_saas_source("pipedrive", {"api_key": "tok123"}, {})
+        assert result == "pd_src"
+        cfg = mock_rest.call_args[0][0]
+        assert cfg["client"]["base_url"] == "https://api.pipedrive.com/v1/"
+        assert len(cfg["resources"]) >= 3
+        # Pipedrive authenticates with an api_token query param
+        assert cfg["client"]["auth"]["location"] == "query"
+        assert cfg["client"]["auth"]["name"] == "api_token"
+
+    def test_requires_api_key(self, svc):
+        with pytest.raises(DltRunnerError, match="api"):
+            svc._build_saas_source("pipedrive", {}, {})
+
+    def test_config_schema(self):
+        assert CONFIG_SCHEMAS["pipedrive"]["required"] == ["api_key"]
+        assert CONFIG_SCHEMAS["pipedrive"]["properties"]["api_key"]["format"] == "password"
+
+
+class TestFreshdeskConnector:
+    def test_registered_as_saas_source(self):
+        assert "freshdesk" in SUPPORTED_SAAS_TYPES
+        assert "freshdesk" in SOURCE_TYPES
+        assert ConnectionType.FRESHDESK in _NON_DB_TYPES
+        assert "freshdesk" in SAAS_TYPES
+
+    @patch("datanika.services.dlt_runner.rest_api_source")
+    def test_builds_rest_api_source(self, mock_rest, svc):
+        mock_rest.return_value = "fd_src"
+        result = svc._build_saas_source("freshdesk", {"api_key": "k", "domain": "acme"}, {})
+        assert result == "fd_src"
+        cfg = mock_rest.call_args[0][0]
+        assert cfg["client"]["base_url"] == "https://acme.freshdesk.com/api/v2/"
+        assert len(cfg["resources"]) >= 3
+        # Freshdesk uses HTTP basic (api_key as username)
+        assert cfg["client"]["auth"]["type"] == "http_basic"
+        assert cfg["client"]["auth"]["username"] == "k"
+
+    def test_requires_api_key_and_domain(self, svc):
+        with pytest.raises(DltRunnerError, match="api_key|domain"):
+            svc._build_saas_source("freshdesk", {}, {})
+        with pytest.raises(DltRunnerError, match="domain"):
+            svc._build_saas_source("freshdesk", {"api_key": "k"}, {})
+
+    def test_config_schema(self):
+        assert set(CONFIG_SCHEMAS["freshdesk"]["required"]) == {"domain", "api_key"}
+
+
+class TestAsanaConnector:
+    def test_registered_as_saas_source(self):
+        assert "asana" in SUPPORTED_SAAS_TYPES
+        assert "asana" in SOURCE_TYPES
+        assert ConnectionType.ASANA in _NON_DB_TYPES
+        assert "asana" in SAAS_TYPES
+
+    @patch("datanika.services.dlt_runner.rest_api_source")
+    def test_builds_rest_api_source(self, mock_rest, svc):
+        mock_rest.return_value = "as_src"
+        result = svc._build_saas_source("asana", {"api_key": "pat123"}, {})
+        assert result == "as_src"
+        cfg = mock_rest.call_args[0][0]
+        assert cfg["client"]["base_url"] == "https://app.asana.com/api/1.0/"
+        assert len(cfg["resources"]) >= 3
+        assert cfg["client"]["auth"] == {"type": "bearer", "token": "pat123"}
+
+    def test_requires_api_key(self, svc):
+        with pytest.raises(DltRunnerError, match="api|token"):
+            svc._build_saas_source("asana", {}, {})
+
+    def test_config_schema(self):
+        assert CONFIG_SCHEMAS["asana"]["required"] == ["api_key"]
+
+
+# --------------------------------------------------------------------------- #
+# Discovery — all 4 flow through list_connection_types()
+# --------------------------------------------------------------------------- #
+
+
+class TestWave1Discovery:
+    @pytest.mark.parametrize("slug", ["oracle", "pipedrive", "freshdesk", "asana"])
+    def test_in_config_schemas(self, slug):
+        assert slug in CONFIG_SCHEMAS
+
+    @pytest.mark.parametrize("slug", ["oracle", "pipedrive", "freshdesk", "asana"])
+    def test_listed_by_discovery_endpoint(self, slug):
+        listed = {item["type"] for item in list_connection_types()}
+        assert slug in listed

--- a/uv.lock
+++ b/uv.lock
@@ -944,6 +944,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "google-auth" },
     { name = "gspread" },
+    { name = "oracledb" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "prometheus-client" },
     { name = "pydantic" },
@@ -967,6 +968,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -992,6 +994,7 @@ requires-dist = [
     { name = "gspread", specifier = ">=6.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "oracledb", specifier = ">=2.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1009,6 +1012,7 @@ requires-dist = [
     { name = "snowflake-sqlalchemy", specifier = ">=1.7" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "sqlalchemy-bigquery", specifier = ">=1.11" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1325,6 +1329,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
 ]
 
 [[package]]
@@ -2728,6 +2746,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "oracledb"
+version = "4.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/ae/4576e5df7b8eadec51bb7d981a2bcc0d8387d7d6998a51d146c0886a523e/oracledb-4.0.2.tar.gz", hash = "sha256:0a380ab72853487ea2764c5df772f35026b4219868fc3eba68e193c9aea230ac", size = 881658, upload-time = "2026-07-14T17:21:28.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/89/2568c2d32afb3c0a66cef2e74dac7769f69e117a14402301b106970475dd/oracledb-4.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cbe3a75b463a334da9b3d76026062bcfb24ec563b7df291f700c9f7eefcbeefe", size = 4366002, upload-time = "2026-07-14T17:21:58.951Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c8/1825d240aa68b255eb78867c62964d2a69c6ae6197ab3543fe220539bf69/oracledb-4.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d11723018b6aeae035f4e1feae4150b7cca1161023c2d68d957d7310fe0dd56", size = 2286174, upload-time = "2026-07-14T17:22:00.649Z" },
+    { url = "https://files.pythonhosted.org/packages/10/31/5b9d6fa28942ff38e2d76dcef3184e7569d4b0006d0425f92a3d4a764dc4/oracledb-4.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:579f2c568433523a990cde5bea73c980d144754dc54d3ab2cd37efd670dc31d6", size = 2490198, upload-time = "2026-07-14T17:22:02.322Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4e/77b21ec50c786270a7471abd6f48ec3c2e629ce304ec792eeeb6f03ba4d0/oracledb-4.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82d3d83bdc6246e53f8ad8b598d2508e9f5d983e352ce2e8a71a020200ba2d6", size = 2330058, upload-time = "2026-07-14T17:23:04.213Z" },
+    { url = "https://files.pythonhosted.org/packages/24/83/834e07805b8b3aaab7e87b818ef44ab3cb5394a73149a580ecf73cd92d4d/oracledb-4.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b4f2b51837248d4acfb323a64c48d89b62467b0f73d1211c99db9b80df0cdfbc", size = 2510815, upload-time = "2026-07-14T17:23:05.838Z" },
+    { url = "https://files.pythonhosted.org/packages/49/10/f05a3348a50ecab07b86317424751a4f63891e31c228a6d95f92b9538afd/oracledb-4.0.2-cp312-cp312-win32.whl", hash = "sha256:b5d203426f0d191842b4cfd87c223163ccc57f7e7875ec7ed073f163de2229af", size = 1488879, upload-time = "2026-07-14T17:23:07.53Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/99fe3fa29466533df10fdfed90faee133aa1e7147b9edfc13b839e06f738/oracledb-4.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:5fe6e07ed29f84a6656e0580b4e662109d3bb90fc13d8f98ae3a56a67c75b80e", size = 1865771, upload-time = "2026-07-14T17:23:09.374Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cb/009980df826442900419a7bc317e35dc85a031bc2d3806256d469de7d670/oracledb-4.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:a1f46b01a089e0e0dd44c4ac4c5c79903760976346c74a698955c1fb76d68bf5", size = 1519969, upload-time = "2026-07-14T17:23:11.531Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cb/e9ad24c2fa20ff977ca52b5a68a2010a054f724d420681be75e7e3d92b57/oracledb-4.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af4121112f0b68e8d61ce46a086c6aec8256fa2ca32d2e6467195a6c575c207b", size = 4352202, upload-time = "2026-07-14T17:23:13.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ad/583d85906b5c4b344600be2bf30077f3a6c2bf04ee01b4fee9856d1da269/oracledb-4.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a814307ca8a6bf0649d8bf0a650a72f23030d9af052a2d4a481b94b6ab50d5a4", size = 2274847, upload-time = "2026-07-14T17:23:14.967Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/53/badcc7e29ba9e9f2158f2e18214197d63c53d99c4720d436d8fc0b6b175f/oracledb-4.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b89c02670bafc9b1fcc0d15175f097bdc1968bc36ee4d66aa63aee09bfbbe30", size = 2474482, upload-time = "2026-07-14T17:23:16.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/76/0bc64bdfc7ca794f4576c757da89617922be402f9fcf434bf5de7e44235a/oracledb-4.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:db0d76199b6dffd721bda48dad4eeea6603942ce2e246f3b9301d85af6bda0ee", size = 2327237, upload-time = "2026-07-14T17:23:18.602Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f5/2fc4e30b24a60e40fa6419dbadd8f869878a3ac49d28b7d16bca59dd2519/oracledb-4.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f5ed684ab419603d53981e0f32b51da673e21a42d7dce1bf3f215a9301c7c108", size = 2504800, upload-time = "2026-07-14T17:23:20.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/03/0a15a43a88addfb7b4f8d8343f0c47df68173510a27e2196b6b7347efb06/oracledb-4.0.2-cp313-cp313-win32.whl", hash = "sha256:a45a13e33509db5bd3622a05cb2e4a6cb41d56d1bfd2a32caeacd26f4ce8b988", size = 1493052, upload-time = "2026-07-14T17:23:21.603Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4a/9895cb5a1fffa68f2d9fb1cfb43de88628c049d313734de7ecef17099460/oracledb-4.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:6444be4991f33754cd98f624cecef3eb98db3e87f8ac14e9b65bd3591c9dd252", size = 1864126, upload-time = "2026-07-14T17:23:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/14/5c7c44a8f441783d461b9657994e03f8798e28bebe67395951c53c86c270/oracledb-4.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:087fdf5bc36b03dc3c55f7abc944a163ba8edc9c802bc8baf91698a52041ee13", size = 1519906, upload-time = "2026-07-14T17:23:24.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/96/30cdbc8399f8edd5cd8bc28bae89fba0eaa40c529168360e9aa84fa21e97/oracledb-4.0.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:58e71a3c1e294a99e39b086adf42074d48287548bf8edfa720c9507106186bbb", size = 4389290, upload-time = "2026-07-14T17:23:25.769Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/35/eec834f01d84f6974ff9b397b83cc80b67064410476049aaf9f88269590d/oracledb-4.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78d4a1cc1482b5927a9962c7766aeeae616a85eedbe49af8b797148ac1c1ac32", size = 2315809, upload-time = "2026-07-14T17:23:27.265Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/09/5185ea1270987fa3514ff6bf99540e23befefdb511759137f57848e1ab72/oracledb-4.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14124b5e8e4ba087f105ee389ee43e407840220a0ba2504de68eed903f51a711", size = 2490090, upload-time = "2026-07-14T17:23:28.995Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/63/2547b13274f95d2eb073af2c936a37d7da3025f910937dc2e411b7160784/oracledb-4.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:36e72ffaaf589041dac72ddf589d694c0a9ac4576662a04628966d4ea089d6ea", size = 2365819, upload-time = "2026-07-14T17:23:30.691Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bd/f52b69a5d86d62cf9cb3992a7cafd1d46c418ae64eaa8a256a3d1eee9e51/oracledb-4.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0101b88c15ae628af556506840ae876e12bdb75506ef342e4990ac1758bad1eb", size = 2518689, upload-time = "2026-07-14T17:23:32.566Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6d15fedcbd67fabd6c9c345554e184ba6617e389bfea348358f8aacc0e5f/oracledb-4.0.2-cp314-cp314-win32.whl", hash = "sha256:b14d52c09b3c7a8273b3640ba06675acec5000dab0356ef288587c46c30bbbb4", size = 1514946, upload-time = "2026-07-14T17:23:33.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b9/d6e2c3ee3d9fb3585f04910ecf6ff91dbfd84e8dafc06084717f6a134bca/oracledb-4.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:5c1f13ba535d9f0fc61e1987720988612cf9424667d491fc344ba681f3336a17", size = 1915171, upload-time = "2026-07-14T17:23:35.574Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6b/47f5c76223798ebfb5b6d41e9c3a451d296d6d90123584d85159e4236ff5/oracledb-4.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:93b4d2cd17a93224711fadd28f77e956e5c6575cd923f24bfe0b1a2a581beb79", size = 1574652, upload-time = "2026-07-14T17:23:36.982Z" },
 ]
 
 [[package]]
@@ -4332,6 +4386,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bundled release — promotes the Wave-1 connector drop to prod. CD (`deploy-pointer.yml`) builds-from-source + deploys to pointer.gr on merge, then runs smoke + smoke-prod.

## What's included
- **Wave-1 connectors** (core#323, rebased clean onto dev): 4 new dlt **source** connectors — Oracle (`sql_database` via `oracle+oracledb`, source-only), Pipedrive / Freshdesk / Asana (SaaS REST via the existing `rest_api` fallback). +31 tests, 2204 core tests green. New `oracledb` dep (pure-Python thin mode, no system libs).

Promotion is a single clean commit — `dev` was reconciled up to `master` first (it was 5 empty promotion-merge commits behind, identical trees), then #323 rebased on top, so this promotes exactly the connector work and nothing else.

## Post-deploy verification (Infra)
- deploy-pointer build + deploy green, `smoke` + `smoke-prod` green
- app + celery healthy on pointer.gr; new connectors visible in the connection-type picker

## Follow-ups (not in this PR)
- Live connector smoke (Oracle XE container + Pipedrive/Freshdesk/Asana creds) — Infra #312
- Setup docs — Product landing#227/#228; announcement + SEO — Growth landing#226/#229 (promote with the landing wave)

Closes #309