### PR TITLE
[QA] Un-fixme viewer-role destructive-controls E2E test (closes #326)

### DIFF
--- a/e2e/tests/viewer-role-ui.spec.ts
+++ b/e2e/tests/viewer-role-ui.spec.ts
@@ -42,14 +42,14 @@ test.describe("RBAC: viewer role at the UI layer @slow", () => {
     });
   });
 
-  test.fixme(
+  test(
     "viewer does not see destructive/create controls on connections",
     async ({ page }) => {
-      // KNOWN GAP — core#313: /connections renders Create/Edit/Delete/Copy buttons
-      // regardless of role. The actions are blocked server-side (_check_role in
-      // connection_state.py), so there is no data-loss bypass, but a VIEWER should
-      // not SEE destructive controls (least privilege). Un-fixme when Engineering
-      // gates control visibility by role.
+      // core#313 (shipped in #318, live via promotion #322): /connections gates
+      // the create form + Edit/Copy/Delete controls behind AuthState.can_edit /
+      // can_delete, so a VIEWER (can_edit == can_delete == false) never renders
+      // them. Enforcement still lives server-side (_check_role in
+      // connection_state.py); this locks the least-privilege visibility gate.
       await loginAsViewer(page);
       await gotoReady(page, "/connections");
       await expect(


### PR DESCRIPTION
Flips the `test.fixme` → active `test` for the *"viewer does not see destructive/create controls on connections"* case in `e2e/tests/viewer-role-ui.spec.ts` (the second half of the viewer-role UI RBAC spec shipped in #314), and refreshes the stale "KNOWN GAP" comment.

## Why now
The gate this fixme waited on — **#313** — is shipped and live in prod:
- **PR #318** wraps the create form + Edit / Copy / Run / Delete controls in `rx.cond(AuthState.can_edit | AuthState.can_delete, ...)` across connections / uploads / pipelines / transformations / schedules.
- New `AuthState.can_edit` (editor+) / `can_delete` (admin+) computed vars back the gates; `ROLE_HIERARCHY` is `viewer=1 < editor=2 < admin=3`, so a VIEWER has `can_edit == can_delete == false`.
- Promoted to master via **#322** → live in prod.

So a viewer renders **zero** Create / Edit / Delete controls on `/connections` — exactly what the now-active assertions check.

## Verification
- `npx playwright test viewer-role-ui --list` → spec compiles clean, both tests collect (2 tests).
- Assertions traced against #318's diff + `check_role_hierarchy`: a viewer's `can_edit` / `can_delete` are both `false`, so the create form, Edit, and Delete buttons don't render → all three `toHaveCount(0)` assertions hold.
- The read-access half of this same spec already ran green vs seeded prod in #314.
- Test is `@slow` (gated to master-promotion PRs via `DATANIKA_E2E_SLOW=1`), so the live browser run executes on the **next promotion PR**, not on this dev PR's CI.

Companion source-level guard already in prod: `tests/test_ui/test_rbac_ui_visibility.py` (AST) from #318.

Closes #326.
