### PR TITLE
[QA] Fix nightly Kafka smoke: drop invalid api_version_auto_timeout_ms kwarg (closes #331)

### DIFF
--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -164,10 +164,6 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
-@pytest.mark.skip(
-    reason="core#331: installed kafka-python rejects api_version_auto_timeout_ms on "
-    "KafkaAdminClient. Quarantined so the re-enabled nightly stays green — remove when fixed."
-)
 def test_kafka_auth_and_list_topics(require_env):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 
@@ -199,7 +195,9 @@ def test_kafka_auth_and_list_topics(require_env):
         sasl_plain_username=env["KAFKA_SASL_USERNAME"],
         sasl_plain_password=env["KAFKA_SASL_PASSWORD"],
         request_timeout_ms=20000,
-        api_version_auto_timeout_ms=20000,
+        # No api_version_auto_timeout_ms: kafka-python's KafkaAdminClient rejects it
+        # (it is a consumer/producer kwarg, not an admin one) — passing it raised
+        # KafkaConfigurationError and broke the re-enabled nightly (core#331).
         client_id="qa-nightly-smoke",
     )
     try:


### PR DESCRIPTION
Clears the nightly connector-smoke regression tracked in #331.

## Root cause
`test_kafka_auth_and_list_topics` passed `api_version_auto_timeout_ms=20000` to `KafkaAdminClient(...)`. That kwarg is a **consumer/producer** option — it is not in `KafkaAdminClient.DEFAULT_CONFIG`, so newer (unpinned) kafka-python raises `KafkaConfigurationError: Unrecognized configs: {'api_version_auto_timeout_ms'}` at construction, before any network call. Pre-existing; surfaced when Infra re-enabled the nightly (auto-disabled during the ~2-month outage).

## Fix (issue Option 1 — the clean one)
- Drop `api_version_auto_timeout_ms` from the `KafkaAdminClient(...)` call (keep `request_timeout_ms=20000`), with a guard comment so it isn't re-added.
- Remove Infra's #312 quarantine `@pytest.mark.skip` so the live test runs again. The un-skipped nightly probe **is** the regression guard.

Chose Option 1 over pinning kafka-python to an old version to keep a broken kwarg.

## Verification
Reproduced the exact validation the nightly performs, against the latest kafka-python (ephemeral install, same as the workflow's unpinned `uv pip install kafka-python`):

```
rejects api_version_auto_timeout_ms: True   # not in KafkaAdminClient.DEFAULT_CONFIG → was the KafkaConfigurationError
accepts request_timeout_ms: True            # the kwarg kept is valid → constructor gets past config validation
```

`ruff check` + `ruff format --check` clean. The full SASL/SCRAM handshake + `list_topics` + topic assertion is unchanged and untouched by the bug; it runs live in the nightly (master copy, gated by `DATANIKA_CONNECTOR_SMOKE=1` against Redpanda Serverless) — not in PR CI.

Closes #331.
