### PR TITLE
[Infra] Promote dev → master: Oracle service-name fix + viewer-role E2E un-fixme

### DIFF
--- a/datanika/i18n/ar.json
+++ b/datanika/i18n/ar.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "كلمة المرور",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "حقل قاعدة البيانات هو اسم خدمة Oracle (مثل XEPDB1 أو RAC أو Autonomous). فعّل «الاتصال عبر SID» فقط لـ Oracle القديم أحادي المثيل.",
+  "connections.oracle_use_sid": "الاتصال عبر SID (مثيل واحد قديم)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/de.json
+++ b/datanika/i18n/de.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Passwort",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "Das Feld Datenbank ist Ihr Oracle-Servicename (z. B. XEPDB1, RAC oder Autonomous). Aktivieren Sie 'Über SID verbinden' nur für klassische Einzelinstanz-Oracle.",
+  "connections.oracle_use_sid": "Über SID verbinden (Legacy-Einzelinstanz)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/el.json
+++ b/datanika/i18n/el.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Κωδικός",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "Το πεδίο Βάση δεδομένων είναι το όνομα υπηρεσίας Oracle (π.χ. XEPDB1, RAC ή Autonomous). Ενεργοποιήστε το «Σύνδεση με SID» μόνο για παλαιού τύπου μεμονωμένες βάσεις Oracle.",
+  "connections.oracle_use_sid": "Σύνδεση με SID (παλαιού τύπου μεμονωμένη)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/en.json
+++ b/datanika/i18n/en.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Password",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "The Database field is your Oracle service name (e.g. XEPDB1, RAC, or Autonomous). Enable 'Connect by SID' only for legacy single-instance Oracle.",
+  "connections.oracle_use_sid": "Connect by SID (legacy single-instance)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/es.json
+++ b/datanika/i18n/es.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Contraseña",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "El campo Base de datos es el nombre de servicio de Oracle (p. ej. XEPDB1, RAC o Autonomous). Active 'Conectar por SID' solo para Oracle heredado de instancia única.",
+  "connections.oracle_use_sid": "Conectar por SID (instancia única heredada)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/fr.json
+++ b/datanika/i18n/fr.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Mot de passe",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "Le champ Base de données est votre nom de service Oracle (par ex. XEPDB1, RAC ou Autonomous). Activez « Se connecter par SID » uniquement pour Oracle mono-instance hérité.",
+  "connections.oracle_use_sid": "Se connecter par SID (mono-instance hérité)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/ru.json
+++ b/datanika/i18n/ru.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Пароль",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "Поле «База данных» — это имя службы Oracle (например, XEPDB1, RAC или Autonomous). Включайте «Подключение по SID» только для устаревших одиночных экземпляров Oracle.",
+  "connections.oracle_use_sid": "Подключение по SID (устаревший одиночный экземпляр)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/sr.json
+++ b/datanika/i18n/sr.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "Лозинка",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "Polje Baza podataka je Oracle service name (npr. XEPDB1, RAC ili Autonomous). Uključite „Poveži preko SID-a“ samo za klasični Oracle sa jednom instancom.",
+  "connections.oracle_use_sid": "Poveži preko SID-a (klasična jedna instanca)",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/i18n/zh.json
+++ b/datanika/i18n/zh.json
@@ -93,6 +93,8 @@
   "connections.ph_user": "",
   "connections.ph_password": "密码",
   "connections.ph_database": "mydb",
+  "connections.oracle_service_hint": "「数据库」字段是您的 Oracle 服务名（例如 XEPDB1、RAC 或 Autonomous）。仅对传统单实例 Oracle 启用「通过 SID 连接」。",
+  "connections.oracle_use_sid": "通过 SID 连接（传统单实例）",
   "connections.ph_schema": "public",
   "connections.ph_db_path": "/data/my.db",
   "connections.ph_gcp_project": "my-gcp-project",

--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -83,9 +83,15 @@ CONFIG_SCHEMAS: dict[str, dict] = {
         {
             "host": _str("Oracle hostname"),
             "port": _int("Port number", default=1521),
-            "database": _str("Service name (or SID)"),
+            "database": _str(
+                "Service name (e.g. a PDB like XEPDB1, RAC, or Autonomous service); "
+                "or the SID when 'use_sid' is enabled"
+            ),
             "user": _str("Username"),
             "password": _str("Password", sensitive=True),
+            "use_sid": _bool(
+                "Connect by SID instead of service name (legacy single-instance Oracle)"
+            ),
         },
         required=["host", "database", "user", "password"],
     ),

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -197,13 +197,18 @@ def _build_sa_url(config: dict, connection_type: ConnectionType) -> str:
 
     if connection_type == ConnectionType.ORACLE:
         port = config.get("port", 1521)
-        # Oracle "easy connect": the URL path is the service name (thin mode).
-        return (
-            f"oracle+oracledb://{quote_plus(config.get('user', ''))}:"
+        userinfo = (
+            f"{quote_plus(config.get('user', ''))}:"
             f"{quote_plus(config.get('password', ''))}@"
             f"{config.get('host', 'localhost')}:{port}/"
-            f"{config.get('database', '')}"
         )
+        if config.get("use_sid"):
+            # Legacy SID connect (classic single-instance): the URL path is the SID.
+            return f"oracle+oracledb://{userinfo}{config.get('database', '')}"
+        # Default: service-name connect (PDB / RAC / Autonomous). SQLAlchemy's
+        # oracledb dialect reads the service name from the ?service_name= query;
+        # a value in the URL path is treated as a SID (#329).
+        return f"oracle+oracledb://{userinfo}?service_name={quote_plus(config.get('database', ''))}"
 
     raise ValueError(f"Unsupported connection type for URL building: {connection_type}")
 

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -194,6 +194,16 @@ class DltRunnerService:
             if connection_type == "duckdb" and "path" in creds:
                 creds["database"] = creds.pop("path")
 
+        # Oracle: connect by service name (PDB/RAC/Autonomous) unless use_sid.
+        # dlt builds the SQLAlchemy URL from these components, so — as with
+        # _build_sa_url — a "database" in the URL path resolves to a SID (#329).
+        if connection_type == "oracle":
+            use_sid = bool(creds.pop("use_sid", False))
+            if not use_sid and "database" in creds:
+                query = dict(creds.get("query") or {})
+                query["service_name"] = creds.pop("database")
+                creds["query"] = query
+
         return creds
 
     def build_destination(self, connection_type: str, config: dict):

--- a/datanika/ui/components/connection_config_fields.py
+++ b/datanika/ui/components/connection_config_fields.py
@@ -790,6 +790,30 @@ def mongodb_fields() -> rx.Component:
     )
 
 
+def oracle_fields() -> rx.Component:
+    """Fields for Oracle — db fields + service-name guidance + a legacy-SID toggle.
+
+    The shared ``database`` field holds the Oracle **service name** by default
+    (PDB/RAC/Autonomous); the hint says so. Check the toggle for classic
+    single-instance Oracle addressed by SID.
+    """
+    return rx.vstack(
+        db_fields(),
+        rx.callout(_t["connections.oracle_service_hint"], icon="info", size="1"),
+        rx.flex(
+            rx.checkbox(
+                _t["connections.oracle_use_sid"],
+                checked=ConnectionState.form_oracle_use_sid,
+                on_change=ConnectionState.set_form_oracle_use_sid,
+            ),
+            spacing="2",
+            align="center",
+        ),
+        spacing="2",
+        width="100%",
+    )
+
+
 def type_fields() -> rx.Component:
     """Render the appropriate config fields based on selected connection type."""
     return rx.fragment(
@@ -798,11 +822,11 @@ def type_fields() -> rx.Component:
             | (ConnectionState.form_type == "mysql")
             | (ConnectionState.form_type == "mssql")
             | (ConnectionState.form_type == "redshift")
-            | (ConnectionState.form_type == "synapse")
-            | (ConnectionState.form_type == "oracle"),
+            | (ConnectionState.form_type == "synapse"),
             db_fields(),
         ),
         rx.cond(ConnectionState.form_type == "clickhouse", clickhouse_fields()),
+        rx.cond(ConnectionState.form_type == "oracle", oracle_fields()),
         rx.cond(ConnectionState.form_type == "duckdb", duckdb_fields()),
         rx.cond(ConnectionState.form_type == "databricks", databricks_fields()),
         rx.cond(ConnectionState.form_type == "sqlite", sqlite_fields()),

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -240,6 +240,9 @@ class ConnectionState(BaseState):
     form_cluster_replication: bool = False
     form_secure: bool = False
 
+    # Oracle — connect by SID instead of service name (legacy single-instance)
+    form_oracle_use_sid: bool = False
+
     # Databricks
     form_http_path: str = ""
     form_token: str = ""
@@ -456,6 +459,8 @@ class ConnectionState(BaseState):
                 if self.form_cluster_replication:
                     config["table_engine_type"] = "replicated_merge_tree"
                 config["secure"] = self.form_secure
+            if t == "oracle" and self.form_oracle_use_sid:
+                config["use_sid"] = True
 
         elif t in ("duckdb", "sqlite"):
             if self.form_path:
@@ -671,6 +676,7 @@ class ConnectionState(BaseState):
         self.form_service_account_json = ""
         self.form_cluster_replication = False
         self.form_secure = False
+        self.form_oracle_use_sid = False
         self.form_http_path = ""
         self.form_token = ""
         self.form_catalog = ""
@@ -727,6 +733,7 @@ class ConnectionState(BaseState):
         self.form_service_account_json = ""
         self.form_cluster_replication = False
         self.form_secure = False
+        self.form_oracle_use_sid = False
         self.form_http_path = ""
         self.form_token = ""
         self.form_catalog = ""
@@ -756,6 +763,8 @@ class ConnectionState(BaseState):
                     config.get("table_engine_type") == "replicated_merge_tree"
                 )
                 self.form_secure = config.get("secure", False)
+            if conn_type == "oracle":
+                self.form_oracle_use_sid = config.get("use_sid", False)
         elif conn_type in ("duckdb", "sqlite"):
             self.form_path = config.get("path", "")
         elif conn_type == "bigquery":

--- a/e2e/tests/viewer-role-ui.spec.ts
+++ b/e2e/tests/viewer-role-ui.spec.ts
@@ -42,14 +42,14 @@ test.describe("RBAC: viewer role at the UI layer @slow", () => {
     });
   });
 
-  test.fixme(
+  test(
     "viewer does not see destructive/create controls on connections",
     async ({ page }) => {
-      // KNOWN GAP — core#313: /connections renders Create/Edit/Delete/Copy buttons
-      // regardless of role. The actions are blocked server-side (_check_role in
-      // connection_state.py), so there is no data-loss bypass, but a VIEWER should
-      // not SEE destructive controls (least privilege). Un-fixme when Engineering
-      // gates control visibility by role.
+      // core#313 (shipped in #318, live via promotion #322): /connections gates
+      // the create form + Edit/Copy/Delete controls behind AuthState.can_edit /
+      // can_delete, so a VIEWER (can_edit == can_delete == false) never renders
+      // them. Enforcement still lives server-side (_check_role in
+      // connection_state.py); this locks the least-privilege visibility gate.
       await loginAsViewer(page);
       await gotoReady(page, "/connections");
       await expect(

--- a/tests/test_connector_smoke/test_wave1_connectors_smoke.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_smoke.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import time
 
 import httpx
-import pytest
 
 
 def _log(msg: str) -> None:
@@ -54,11 +53,9 @@ def test_oracle_live_driver_and_connector(require_env):
        are healthy, addressed the *correct* way (service name / easy-connect).
        This is the real live-smoke value: catches driver break, XE image drift,
        network/creds issues. If it fails, the infra is broken — fail loud.
-    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``).
-       Currently **xfails** on core#329: ``_build_sa_url`` puts the service name
-       in the DSN path, which SQLAlchemy's oracledb dialect treats as a SID
-       (ORA-12505), so it can't reach a service-name Oracle (PDB/RAC/Autonomous).
-       When #329 lands, this xfail flips to a pass — delete the xfail block then.
+    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``)
+       reaching the same service-name Oracle. Fixed in core#329 — ``_build_sa_url``
+       now emits the ``?service_name=`` form (the URL path is SID-only).
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"
@@ -101,11 +98,7 @@ def test_oracle_live_driver_and_connector(require_env):
     url = _build_sa_url(config, ConnectionType.ORACLE)
     assert url.startswith("oracle+oracledb://"), f"unexpected Oracle URL scheme: {url}"
     ok, msg = ConnectionService.test_connection(config, ConnectionType.ORACLE)
-    if not ok:
-        pytest.xfail(f"core#329: Oracle connector uses SID semantics for a service name — {msg}")
-    # Reaching here means core#329 is FIXED: remove this xfail guard (and the
-    # positive-control note) so the smoke asserts the connector positively.
-    assert ok, msg
+    assert ok, msg  # core#329 fixed: connector reaches the service-name Oracle
 
 
 # ---------- Pipedrive (SaaS REST — api_token query auth) ----------

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -68,14 +68,14 @@ class TestOracleConnector:
             },
             ConnectionType.ORACLE,
         )
-        assert url == "oracle+oracledb://scott:tiger@db.example.com:1521/XEPDB1"
+        assert url == "oracle+oracledb://scott:tiger@db.example.com:1521/?service_name=XEPDB1"
 
     def test_build_sa_url_default_port(self):
         url = _build_sa_url(
             {"host": "h", "user": "u", "password": "p", "database": "SVC"},
             ConnectionType.ORACLE,
         )
-        assert "@h:1521/SVC" in url
+        assert "@h:1521/?service_name=SVC" in url
 
     def test_build_sa_url_quotes_special_chars(self):
         url = _build_sa_url(
@@ -83,6 +83,38 @@ class TestOracleConnector:
             ConnectionType.ORACLE,
         )
         assert "p%40ss%2Fword" in url
+
+    def test_build_sa_url_sid_mode(self):
+        # use_sid=True → legacy SID connect (the URL path is the SID).
+        url = _build_sa_url(
+            {"host": "h", "user": "u", "password": "p", "database": "ORCL", "use_sid": True},
+            ConnectionType.ORACLE,
+        )
+        assert url == "oracle+oracledb://u:p@h:1521/ORCL"
+
+    def test_dsn_uses_service_name_not_sid(self):
+        # #329: guard the *resolved* DSN semantics, not just the URL string — the
+        # bug was a correct-looking path URL that SQLAlchemy resolves to a SID.
+        from sqlalchemy import create_engine
+        from sqlalchemy.engine import make_url
+
+        cases = [
+            (
+                {"host": "h", "user": "u", "password": "p", "database": "XEPDB1"},
+                "SERVICE_NAME=XEPDB1",
+                "(SID=",
+            ),
+            (
+                {"host": "h", "user": "u", "password": "p", "database": "ORCL", "use_sid": True},
+                "SID=ORCL",
+                "SERVICE_NAME=",
+            ),
+        ]
+        for cfg, expect, forbid in cases:
+            url = make_url(_build_sa_url(cfg, ConnectionType.ORACLE))
+            dsn = create_engine(url).dialect.create_connect_args(url)[1]["dsn"]
+            assert expect in dsn, dsn
+            assert forbid not in dsn, dsn
 
     def test_is_source_not_destination(self):
         assert "oracle" in SOURCE_TYPES
@@ -97,13 +129,25 @@ class TestOracleConnector:
         assert SOURCE_DRIVERNAME_MAP["oracle"] == "oracle+oracledb"
         assert "oracle" in _RENAME_USER_TYPES
 
-    def test_to_dlt_credentials_renames_user_and_sets_driver(self):
+    def test_to_dlt_credentials_service_name(self):
+        # Default: the dlt extract path must also use service_name, not SID (#329).
         creds = DltRunnerService._to_dlt_credentials(
             "oracle", {"host": "h", "user": "u", "password": "p", "database": "SVC"}
         )
         assert creds["drivername"] == "oracle+oracledb"
         assert creds["username"] == "u"
         assert "user" not in creds
+        assert creds.get("query") == {"service_name": "SVC"}
+        assert "database" not in creds  # moved into the service_name query
+
+    def test_to_dlt_credentials_sid_mode(self):
+        creds = DltRunnerService._to_dlt_credentials(
+            "oracle",
+            {"host": "h", "user": "u", "password": "p", "database": "ORCL", "use_sid": True},
+        )
+        assert creds["database"] == "ORCL"  # SID stays in the URL path
+        assert "service_name" not in (creds.get("query") or {})
+        assert "use_sid" not in creds  # our flag never leaks into dlt credentials
 
     def test_in_ir_sql_types(self):
         assert "oracle" in SQL_TYPES
@@ -115,6 +159,9 @@ class TestOracleConnector:
         assert {"host", "port", "database", "user", "password"} <= set(props)
         assert schema["required"] == ["host", "database", "user", "password"]
         assert props["password"].get("format") == "password"
+        # #329: optional legacy-SID toggle (default = service name)
+        assert props["use_sid"]["type"] == "boolean"
+        assert "use_sid" not in schema["required"]
 
     @patch("datanika.services.connection_service.create_engine")
     def test_connect_args_avoids_connect_timeout(self, mock_ce):


### PR DESCRIPTION
Two clean, CI-green fixes. CD (`deploy-pointer.yml`) builds + deploys + smoke on merge.

## Included
- **[core#334] — Oracle connector service-name fix** (closes the [core#329] defect Infra found via the connector smoke). `_build_sa_url` now emits the `?service_name=` easy-connect form instead of the SID-only DSN path, so Oracle connects to **service-name / PDB / RAC / Autonomous** databases (the modern default). Also fixes the dlt credentials path + updates the unit test + **removes the `pytest.xfail` in the connector smoke** (it now positively asserts the connector connects).
- **[core#327] — viewer-role destructive-controls E2E un-fixme** (QA). Removes a test `fixme` now that the underlying viewer-RBAC behaviour is correct.

## Note
- The OpenAPI-connector P1 ([core#328]) is promoted **separately** (next) — it's a new user-facing connector type touching `openapi_inline` (the smoke-prod surface), so isolating it keeps the CD/smoke signal unambiguous. SSRF review passed (see #328).
- Post-deploy: the connector smoke's Oracle probe should now go green end-to-end (was xfail).

Closes #329
Closes #326