### PR TITLE
[Infra] Re-quarantine Oracle connector smoke (xfail) — #329 reopened

### DIFF
--- a/tests/test_connector_smoke/test_wave1_connectors_smoke.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_smoke.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import time
 
 import httpx
+import pytest
 
 
 def _log(msg: str) -> None:
@@ -53,9 +54,13 @@ def test_oracle_live_driver_and_connector(require_env):
        are healthy, addressed the *correct* way (service name / easy-connect).
        This is the real live-smoke value: catches driver break, XE image drift,
        network/creds issues. If it fails, the infra is broken — fail loud.
-    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``)
-       reaching the same service-name Oracle. Fixed in core#329 — ``_build_sa_url``
-       now emits the ``?service_name=`` form (the URL path is SID-only).
+    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``).
+       **Re-quarantined (xfail) under the REOPENED core#329.** #334 changed the URL
+       form but the connector still can't reach a service-name Oracle in practice —
+       the nightly caught it: the positive control (part 1) connects, but
+       ``test_connection`` still fails (ORA-12505). Engineering owns the real fix on
+       the reopened #329; until then this xfails so the nightly stays green. It flips
+       to a pass (XPASS) once #329 is truly fixed — delete the xfail block then.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"
@@ -95,10 +100,17 @@ def test_oracle_live_driver_and_connector(require_env):
     assert table_count is not None and table_count >= 0
 
     # (2) Our connector's own connect path (URL builder + connect_args + engine).
+    #     Re-quarantined under the reopened core#329 — xfail on the connector, but keep
+    #     the positive control (part 1) as a hard assert so a genuine XE/driver/infra
+    #     break still fails loud rather than hiding behind this xfail.
     url = _build_sa_url(config, ConnectionType.ORACLE)
     assert url.startswith("oracle+oracledb://"), f"unexpected Oracle URL scheme: {url}"
     ok, msg = ConnectionService.test_connection(config, ConnectionType.ORACLE)
-    assert ok, msg  # core#329 fixed: connector reaches the service-name Oracle
+    if not ok:
+        pytest.xfail(
+            f"core#329 (reopened): Oracle connector still can't reach a service-name Oracle — {msg}"
+        )
+    assert ok, msg  # xpasses once #329 is truly fixed — remove this xfail block then
 
 
 # ---------- Pipedrive (SaaS REST — api_token query auth) ----------


### PR DESCRIPTION
The nightly `oracle-smoke` job is failing every 03:00 UTC (fired Telegram today) on a **known, reopened bug** — silence it while Engineering fixes it.

## Why
[core#334] changed `_build_sa_url` to the `?service_name=` form, and (over-optimistically) flipped this probe from an xfail to a hard `assert ok`. But the fix **doesn't actually connect** — the [today's nightly](https://github.com/datanika-io/datanika-core/actions/runs/29632430562) shows the **positive control connects** (service-name easy-connect works) while `ConnectionService.test_connection` **still returns False** (ORA-12505). So [core#329] is **reopened** and this probe is red.

## What
Restore the imperative `pytest.xfail()` on the **connector path only**, tracked under the reopened [core#329]. The **part-1 positive control stays a HARD assert** so a genuine XE/driver/infra break still fails loud (a whole-test `@xfail` decorator would hide that — which is why I use the imperative form, not a decorator). Flips to **XPASS** when #329 is truly fixed → delete the xfail block then.

Mirrors the Kafka quarantine ([core#331], being un-quarantined by #333) and #335's own Oracle-E2E xfail. **refs #329** (does NOT close it — Eng's real fix does).

Local validation deferred to a CI dispatch on `dev` (a fresh XE service container) — port 1521 is busy locally with `datanika-ora329` (Eng's #329 work), and the re-quarantine is deterministic anyway (the nightly proved `test_connection`→False, which `if not ok: pytest.xfail()` converts exactly).