### PR TITLE
[Engineering] Fix Oracle connector: DUAL probe + FETCH FIRST preview (closes #329)

### DIFF
--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -397,9 +397,11 @@ class ConnectionService:
         except ImportError:
             return False, f"Driver not installed for {connection_type.value}"
 
+        # Oracle rejects a bare ``SELECT 1`` (ORA-00923) — it needs FROM DUAL.
+        probe = "SELECT 1 FROM DUAL" if connection_type == ConnectionType.ORACLE else "SELECT 1"
         try:
             with engine.connect() as conn:
-                conn.execute(text("SELECT 1"))
+                conn.execute(text(probe))
             return True, "Connected successfully"
         except ImportError:
             return False, f"Driver not installed for {connection_type.value}"
@@ -532,7 +534,11 @@ class ConnectionService:
             qualified = preparer.quote(table)
             if schema:
                 qualified = f"{preparer.quote_schema(schema)}.{qualified}"
-            query = f"SELECT * FROM {qualified} LIMIT {limit}"
+            if connection_type == ConnectionType.ORACLE:
+                # Oracle has no LIMIT clause — use the 12c+ row-limiting form.
+                query = f"SELECT * FROM {qualified} FETCH FIRST {limit} ROWS ONLY"
+            else:
+                query = f"SELECT * FROM {qualified} LIMIT {limit}"
             with engine.connect() as conn:
                 result = conn.execute(text(query))
                 columns = list(result.keys())

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -175,6 +175,37 @@ class TestOracleConnector:
         assert connect_args == {"tcp_connect_timeout": 5}
         assert ok is True
 
+    @patch("datanika.services.connection_service.create_engine")
+    def test_probe_query_uses_dual_on_oracle(self, mock_ce):
+        # #329: Oracle rejects a bare `SELECT 1` (ORA-00923); the connectivity
+        # probe must use FROM DUAL. Mocks can't connect, but they lock the SQL
+        # text — the gap that let the SID/SELECT-1 bugs pass unit tests but fail
+        # the live Oracle smoke.
+        ConnectionService.test_connection(
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            ConnectionType.ORACLE,
+        )
+        conn = mock_ce.return_value.connect.return_value.__enter__.return_value
+        assert str(conn.execute.call_args[0][0]) == "SELECT 1 FROM DUAL"
+
+    @patch("datanika.services.connection_service.create_engine")
+    def test_preview_uses_fetch_first_on_oracle(self, mock_ce):
+        # #329: Oracle has no LIMIT clause (ORA-00933) — use FETCH FIRST.
+        engine = mock_ce.return_value
+        engine.dialect.identifier_preparer.quote = lambda x: f'"{x}"'
+        conn = engine.connect.return_value.__enter__.return_value
+        conn.execute.return_value.keys.return_value = ["id"]
+        conn.execute.return_value.fetchall.return_value = []
+        ConnectionService.preview_table(
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            ConnectionType.ORACLE,
+            "T329",
+            limit=5,
+        )
+        sql = str(conn.execute.call_args[0][0])
+        assert "FETCH FIRST 5 ROWS ONLY" in sql
+        assert "LIMIT" not in sql
+
 
 # --------------------------------------------------------------------------- #
 # SaaS REST connectors


### PR DESCRIPTION
## Why this reopened

#334 fixed the service-name **URL** (`?service_name=`), but the connector still couldn't connect to a service-name Oracle — the nightly `oracle-smoke` caught it (the job that, per the process gap, didn't run on #334's PR CI). Root cause was a layer deeper than the URL, and my #334 unit tests **mock `create_engine`**, so they never exercised a real Oracle. This time I validated against a real `gvenzl/oracle-xe:21-slim` container. Closes #329 (reopened).

## The two remaining bugs (both Oracle SQL-dialect quirks)

- **`test_connection`** probed with `SELECT 1` → Oracle rejects it (`ORA-00923`, needs `FROM DUAL`). The connection *established* (the #334 service-name URL was correct — the smoke's positive control proved that), but the probe query failed → generic "Connection failed". Now `SELECT 1 FROM DUAL` on Oracle.
- **`preview_table`** used `LIMIT n` → Oracle rejects it (`ORA-00933`). Now `FETCH FIRST n ROWS ONLY` on Oracle. (Same class, caught by the live repro while I had a real Oracle up — Growth's users would have hit this right after connecting.)

## Validation — real Oracle, not mocks (the actual lesson)

Against a live `oracle-xe:21-slim` (app user in PDB `XEPDB1`):

```
test_connection -> ok=True
list_tables     -> ['t329']
preview_table   -> cols=['id','name'] rows=[[1,'alpha'],[2,'beta']]
```

- The **exact nightly test** `test_oracle_live_driver_and_connector` **passes** locally against the container.
- **Re-validated in CI** via the `oracle-smoke` job (`workflow_dispatch` on this branch, ephemeral XE service container): run 29637201027.
- New **unit tests assert the probe + preview SQL text** (`SELECT 1 FROM DUAL`, `FETCH FIRST … ROWS ONLY`) — the guard the earlier mocked tests lacked (they asserted `connect_args` but not the query, so `SELECT 1`/`LIMIT` sailed through). 2236 core tests pass.

The `oracle-smoke` xfail was already removed in #334; this makes it pass for real.

## Out of scope (follow-up)

`preview_table`'s `LIMIT` is also wrong for **MSSQL / Synapse** (same `TOP`/`FETCH` dialect issue) — flagging for a general dialect-aware row-limit ticket, not fixing here to keep this focused on the reopened Oracle bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
