### PR TITLE
[Infra] Re-quarantine Kafka smoke — Redpanda cluster unreachable (#342)

### DIFF
--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -164,6 +164,12 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
+@pytest.mark.skip(
+    reason="core#342: the Redpanda Serverless cluster is unreachable (bootstrap timeout) — "
+    "almost certainly paused/decommissioned after the ~2-month idle. #333 fixed the invalid "
+    "kwarg (that fix stays, below); this is a separate infra issue. Re-quarantined so the "
+    "nightly stays green. Remove this skip once the cluster is re-provisioned (see #342)."
+)
 def test_kafka_auth_and_list_topics(require_env):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 


### PR DESCRIPTION
Validating #333 on `dev` (dispatch [run 29637132114](https://github.com/datanika-io/datanika-core/actions/runs/29637132114)) showed #333's kwarg fix is correct — but with the kwarg gone, the Kafka test now actually connects and the **Redpanda Serverless cluster is unreachable** (bootstrap timeout / repeated socket-disconnect). Almost certainly paused/decommissioned after the ~2-month idle (masked before because the #331 kwarg error aborted pre-connect).

Re-add a `skip` on `test_kafka_auth_and_list_topics` with a **new reason (cluster down, [core#342])** — **keeping #333's kwarg fix in the body** (the code fix is correct and stays). This keeps the re-enabled nightly green instead of firing Telegram every 03:00 on a down cluster. QA removes the skip once the cluster is re-provisioned.

Every other connector in that dev dispatch passed (BigQuery/Databricks/Stripe + Wave-1 SaaS auth + **#335's SaaS extract→load E2E**); `oracle-smoke` is green (Oracle re-quarantined via #340). This is the last red. refs #342