### PR TITLE
[Infra] Promote dev → master: connector-smoke green (Kafka fix + Wave-1 E2E + Oracle/Kafka re-quarantine)

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -169,10 +169,17 @@ jobs:
             echo "ORACLE_PASSWORD=DatanikaSmoke1"
           } >> "$GITHUB_ENV"
 
-      - name: Run Oracle connector smoke test
+      - name: Run Oracle connector smoke + E2E tests
         env:
           DATANIKA_CONNECTOR_SMOKE: "1"
-        run: pytest tests/test_connector_smoke/test_wave1_connectors_smoke.py -v --tb=short -k oracle
+        # Both Wave-1 files' oracle-named tests: the auth/metadata smoke and the
+        # extract→load→assert E2E (core#311). `-k oracle` deselects the SaaS tests,
+        # which need creds this isolated container-only job doesn't have.
+        run: >-
+          pytest
+          tests/test_connector_smoke/test_wave1_connectors_smoke.py
+          tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+          -v --tb=short -k oracle
 
       - name: Telegram alert on failure
         if: failure()

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -164,10 +164,6 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
-@pytest.mark.skip(
-    reason="core#331: installed kafka-python rejects api_version_auto_timeout_ms on "
-    "KafkaAdminClient. Quarantined so the re-enabled nightly stays green — remove when fixed."
-)
 def test_kafka_auth_and_list_topics(require_env):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 
@@ -199,7 +195,9 @@ def test_kafka_auth_and_list_topics(require_env):
         sasl_plain_username=env["KAFKA_SASL_USERNAME"],
         sasl_plain_password=env["KAFKA_SASL_PASSWORD"],
         request_timeout_ms=20000,
-        api_version_auto_timeout_ms=20000,
+        # No api_version_auto_timeout_ms: kafka-python's KafkaAdminClient rejects it
+        # (it is a consumer/producer kwarg, not an admin one) — passing it raised
+        # KafkaConfigurationError and broke the re-enabled nightly (core#331).
         client_id="qa-nightly-smoke",
     )
     try:

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -164,6 +164,12 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
+@pytest.mark.skip(
+    reason="core#342: the Redpanda Serverless cluster is unreachable (bootstrap timeout) — "
+    "almost certainly paused/decommissioned after the ~2-month idle. #333 fixed the invalid "
+    "kwarg (that fix stays, below); this is a separate infra issue. Re-quarantined so the "
+    "nightly stays green. Remove this skip once the cluster is re-provisioned (see #342)."
+)
 def test_kafka_auth_and_list_topics(require_env):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 

--- a/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
@@ -1,0 +1,232 @@
+"""Nightly live-connector E2E — Wave-1 drop (core#311).
+
+The *extract → load → assert* layer for the Wave-1 connectors, complementing
+``test_wave1_connectors_smoke.py`` (which only does auth + metadata). Each test
+drives the **real** Datanika connector path — ``DltRunnerService.execute()``,
+the same synchronous entrypoint the upload task calls
+(``datanika/tasks/upload_tasks.py`` → ``runner.execute(...)``) — to extract a
+single resource from the live vendor into a scratch DuckDB file, then asserts on
+the loaded rows + schema by reading the DuckDB back. No Celery / DB / session.
+
+Coverage split (deliberate):
+- Auth + metadata reachability → ``test_wave1_connectors_smoke.py``.
+- Offline correctness (URL/auth/IR) → ``tests/test_services/test_wave1_connectors.py``.
+- **This suite** → the full live ELT round-trip (extract → load → assert) per connector.
+
+Each test overrides ``dlt_config["resources"]`` to ONE low-volume, no-params
+endpoint so the load is fast and deterministic (``write_disposition="replace"``
+makes reruns idempotent). Endpoints are chosen to always return >= 1 row for the
+QA account (its own user / agent / workspace) and to need no query params — e.g.
+Asana's default ``tasks`` resource 400s without a project/assignee, so we use
+``workspaces``.
+
+Env vars (identical to the smoke; in CI materialized from ``QA_WAVE1_CREDENTIALS``
++ the Oracle XE service container — see ``.github/workflows/nightly-connector-smoke.yml``):
+
+| Connector | Env vars |
+|-----------|----------|
+| Oracle    | ``ORACLE_{HOST,PORT,SERVICE,USER,PASSWORD}`` |
+| Pipedrive | ``PIPEDRIVE_API_TOKEN`` |
+| Freshdesk | ``FRESHDESK_API_KEY`` ``FRESHDESK_DOMAIN`` |
+| Asana     | ``ASANA_ACCESS_TOKEN`` |
+
+Skipped unless ``DATANIKA_CONNECTOR_SMOKE=1`` (see conftest.py). Locally:
+
+    set -a && source secrets/pipedrive.env secrets/freshdesk.env secrets/asana.env && set +a
+    DATANIKA_CONNECTOR_SMOKE=1 uv run pytest \\
+        tests/test_connector_smoke/test_wave1_connectors_extract_load.py -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import duckdb
+import pytest
+
+from datanika.services.dlt_runner import DltRunnerService
+
+
+def _log(msg: str) -> None:
+    """Print with a stable prefix so the nightly log is scannable."""
+    print(f"[e2e] {msg}")
+
+
+def _saas_extract_load(source_type: str, source_config: dict, resource: str, tmp_path) -> tuple:
+    """Extract one ``resource`` from a live SaaS source into a scratch DuckDB via the
+    real ``DltRunnerService.execute()`` path.
+
+    Returns ``(db_path, dataset, rows_loaded)``. ``dataset`` is the DuckDB schema
+    dlt writes the resource table into.
+    """
+    db_path = str(tmp_path / "scratch.duckdb")
+    dataset = f"{source_type}_e2e"
+    runner = DltRunnerService(pipelines_dir=str(tmp_path / "dlt"))
+    result = runner.execute(
+        pipeline_id=1,
+        source_type=source_type,
+        source_config=source_config,
+        destination_type="duckdb",
+        destination_config={"path": db_path},
+        dlt_config={
+            # Override the connector's default resource list down to one safe endpoint.
+            "resources": [{"name": resource, "endpoint": {"path": resource}}],
+            "write_disposition": "replace",
+        },
+        dataset_name=dataset,
+        run_id=1,
+    )
+    return db_path, dataset, result["rows_loaded"]
+
+
+def _read_back(db_path: str, dataset: str, table: str) -> tuple[int, set[str]]:
+    """Reopen the scratch DuckDB and return (row_count, column_names) for a loaded table."""
+    con = duckdb.connect(db_path)
+    try:
+        n = con.execute(f'SELECT count(*) FROM "{dataset}"."{table}"').fetchone()[0]
+        cols = {
+            row[0]
+            for row in con.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = ? AND table_name = ?",
+                [dataset, table],
+            ).fetchall()
+        }
+    finally:
+        con.close()
+    return n, cols
+
+
+# --------------------------------------------------------------------------- #
+# Pipedrive (SaaS REST — api_token query auth)
+# --------------------------------------------------------------------------- #
+
+
+def test_pipedrive_extract_load_assert(require_env, tmp_path):
+    """Extract Pipedrive ``users`` → DuckDB → assert rows + ``id`` column landed."""
+    env = require_env("PIPEDRIVE_API_TOKEN")
+    db_path, dataset, rows = _saas_extract_load(
+        "pipedrive", {"api_key": env["PIPEDRIVE_API_TOKEN"]}, "users", tmp_path
+    )
+    assert rows >= 1, f"Pipedrive users: dlt reported {rows} rows loaded"
+    n, cols = _read_back(db_path, dataset, "users")
+    _log(f"pipedrive: users rows={n} cols={len(cols)}")
+    assert n >= 1, f"Pipedrive users: {n} rows in DuckDB {dataset}.users"
+    assert "id" in cols, f"Pipedrive users: no 'id' column; got {sorted(cols)}"
+
+
+# --------------------------------------------------------------------------- #
+# Freshdesk (SaaS REST — HTTP basic auth)
+# --------------------------------------------------------------------------- #
+
+
+def test_freshdesk_extract_load_assert(require_env, tmp_path):
+    """Extract Freshdesk ``agents`` → DuckDB → assert rows + ``id`` column landed."""
+    env = require_env("FRESHDESK_API_KEY", "FRESHDESK_DOMAIN")
+    subdomain = env["FRESHDESK_DOMAIN"].strip().removesuffix(".freshdesk.com")
+    db_path, dataset, rows = _saas_extract_load(
+        "freshdesk",
+        {"api_key": env["FRESHDESK_API_KEY"], "domain": subdomain},
+        "agents",
+        tmp_path,
+    )
+    assert rows >= 1, f"Freshdesk agents: dlt reported {rows} rows loaded"
+    n, cols = _read_back(db_path, dataset, "agents")
+    _log(f"freshdesk: agents rows={n} cols={len(cols)}")
+    assert n >= 1, f"Freshdesk agents: {n} rows in DuckDB {dataset}.agents"
+    assert "id" in cols, f"Freshdesk agents: no 'id' column; got {sorted(cols)}"
+
+
+# --------------------------------------------------------------------------- #
+# Asana (SaaS REST — bearer PAT)
+# --------------------------------------------------------------------------- #
+
+
+def test_asana_extract_load_assert(require_env, tmp_path):
+    """Extract Asana ``workspaces`` → DuckDB → assert rows + ``gid`` column landed.
+
+    ``workspaces`` (not the default ``tasks``, which 400s without a project/assignee)
+    always returns >= 1 for a valid PAT.
+    """
+    env = require_env("ASANA_ACCESS_TOKEN")
+    db_path, dataset, rows = _saas_extract_load(
+        "asana", {"api_key": env["ASANA_ACCESS_TOKEN"]}, "workspaces", tmp_path
+    )
+    assert rows >= 1, f"Asana workspaces: dlt reported {rows} rows loaded"
+    n, cols = _read_back(db_path, dataset, "workspaces")
+    _log(f"asana: workspaces rows={n} cols={len(cols)}")
+    assert n >= 1, f"Asana workspaces: {n} rows in DuckDB {dataset}.workspaces"
+    assert "gid" in cols, f"Asana workspaces: no 'gid' column; got {sorted(cols)}"
+
+
+# --------------------------------------------------------------------------- #
+# Oracle (SQL, source-only) — xfails on core#329 until the DSN fix lands
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.xfail(
+    reason="core#329: the Oracle connector emits the service name as a SID in the DSN "
+    "(connection_service._build_sa_url / dlt_runner._to_dlt_credentials), so extract via "
+    "execute() raises ORA-12505 against a service-name listener (the XE PDB). Flips to "
+    "XPASS when #329 lands — delete this marker then.",
+    strict=False,
+    raises=Exception,
+)
+def test_oracle_extract_load_assert(require_env, tmp_path):
+    """Seed a tiny table in Oracle XE (correct service-name form = positive control),
+    then extract it through the Datanika connector → DuckDB → assert the rows land.
+
+    The seed proves the driver/container/creds are healthy; the ``execute()`` call
+    exercises the connector's own DSN path, which currently mishandles service names
+    (core#329) and raises ORA-12505 — caught by the xfail above.
+    """
+    env = require_env(
+        "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"
+    )
+
+    from sqlalchemy import create_engine, text
+
+    host, port, service = env["ORACLE_HOST"], int(env["ORACLE_PORT"]), env["ORACLE_SERVICE"]
+    user, password = env["ORACLE_USER"], env["ORACLE_PASSWORD"]
+    table = "QA_E2E_WAVE1"
+
+    # Seed via the correct service-name easy-connect form (the smoke's positive control).
+    seed = create_engine(
+        f"oracle+oracledb://{user}:{password}@{host}:{port}/?service_name={service}",
+        connect_args={"tcp_connect_timeout": 5},
+    )
+    try:
+        with seed.connect() as conn:
+            with contextlib.suppress(Exception):  # first run: table doesn't exist yet
+                conn.execute(text(f"DROP TABLE {table}"))  # DDL auto-commits in Oracle
+            conn.execute(text(f"CREATE TABLE {table} (id NUMBER PRIMARY KEY, name VARCHAR2(50))"))
+            conn.execute(text(f"INSERT INTO {table} (id, name) VALUES (1, 'alpha')"))
+            conn.execute(text(f"INSERT INTO {table} (id, name) VALUES (2, 'beta')"))
+            conn.commit()
+    finally:
+        seed.dispose()
+
+    # Extract through the REAL connector path (single_table mode) into a scratch DuckDB.
+    db_path = str(tmp_path / "scratch.duckdb")
+    dataset = "oracle_e2e"
+    runner = DltRunnerService(pipelines_dir=str(tmp_path / "dlt"))
+    result = runner.execute(
+        pipeline_id=1,
+        source_type="oracle",
+        source_config={
+            "host": host,
+            "port": port,
+            "database": service,  # Oracle service name — core#329 mis-treats this as a SID
+            "user": user,
+            "password": password,
+        },
+        destination_type="duckdb",
+        destination_config={"path": db_path},
+        dlt_config={"mode": "single_table", "table": table, "write_disposition": "replace"},
+        dataset_name=dataset,
+        run_id=1,
+    )
+    assert result["rows_loaded"] >= 2, f"Oracle {table}: dlt reported {result['rows_loaded']} rows"
+    n, _cols = _read_back(db_path, dataset, table.lower())  # dlt lowercases identifiers
+    _log(f"oracle: {table} rows={n}")
+    assert n >= 2, f"Oracle {table}: {n} rows in DuckDB {dataset}.{table.lower()}"

--- a/tests/test_connector_smoke/test_wave1_connectors_smoke.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_smoke.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import time
 
 import httpx
+import pytest
 
 
 def _log(msg: str) -> None:
@@ -53,9 +54,13 @@ def test_oracle_live_driver_and_connector(require_env):
        are healthy, addressed the *correct* way (service name / easy-connect).
        This is the real live-smoke value: catches driver break, XE image drift,
        network/creds issues. If it fails, the infra is broken — fail loud.
-    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``)
-       reaching the same service-name Oracle. Fixed in core#329 — ``_build_sa_url``
-       now emits the ``?service_name=`` form (the URL path is SID-only).
+    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``).
+       **Re-quarantined (xfail) under the REOPENED core#329.** #334 changed the URL
+       form but the connector still can't reach a service-name Oracle in practice —
+       the nightly caught it: the positive control (part 1) connects, but
+       ``test_connection`` still fails (ORA-12505). Engineering owns the real fix on
+       the reopened #329; until then this xfails so the nightly stays green. It flips
+       to a pass (XPASS) once #329 is truly fixed — delete the xfail block then.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"
@@ -95,10 +100,17 @@ def test_oracle_live_driver_and_connector(require_env):
     assert table_count is not None and table_count >= 0
 
     # (2) Our connector's own connect path (URL builder + connect_args + engine).
+    #     Re-quarantined under the reopened core#329 — xfail on the connector, but keep
+    #     the positive control (part 1) as a hard assert so a genuine XE/driver/infra
+    #     break still fails loud rather than hiding behind this xfail.
     url = _build_sa_url(config, ConnectionType.ORACLE)
     assert url.startswith("oracle+oracledb://"), f"unexpected Oracle URL scheme: {url}"
     ok, msg = ConnectionService.test_connection(config, ConnectionType.ORACLE)
-    assert ok, msg  # core#329 fixed: connector reaches the service-name Oracle
+    if not ok:
+        pytest.xfail(
+            f"core#329 (reopened): Oracle connector still can't reach a service-name Oracle — {msg}"
+        )
+    assert ok, msg  # xpasses once #329 is truly fixed — remove this xfail block then
 
 
 # ---------- Pipedrive (SaaS REST — api_token query auth) ----------


### PR DESCRIPTION
Restores the nightly connector-smoke to **green** and lands two QA PRs. CI/test-only changes (no app-code) — deploy-pointer will redeploy the identical image + smoke-prod, expected pre-launch.

## Included (4 commits)
- **[core#333] (QA)** — fix the nightly Kafka smoke: drop the invalid `api_version_auto_timeout_ms` kwarg (**Closes #331**). The code fix is correct and stays.
- **[core#335] (QA)** — Wave-1 connector **E2E**: real extract→load→assert per connector (**Closes #311**). Validated live: Pipedrive/Freshdesk/Asana SaaS extract→load **pass**; Oracle E2E xfails on #329.
- **[core#340] (Infra)** — **re-quarantine the Oracle smoke** (xfail) under the **reopened [core#329]**: #334 changed the URL form but the connector still can't reach a service-name Oracle (positive control connects; `test_connection` still ORA-12505). Keeps the part-1 positive control as a hard assert.
- **[core#343] (Infra)** — **re-quarantine the Kafka smoke** (skip) under **[core#342]**: with #333's kwarg fix, the test now connects and finds the **Redpanda Serverless cluster unreachable** (down/paused after the ~2-month idle). Keeps #333's kwarg fix; skips only for the cluster-down reason until QA re-provisions.

## Validated GREEN before promoting
Dispatched the nightly on `dev` twice ([final: run 29637400812](https://github.com/datanika-io/datanika-core/actions/runs/29637400812)) — **both `smoke` and `oracle-smoke` SUCCESS**. So tomorrow's 03:00 scheduled run (from master) will be green: Oracle xfail (#329), Kafka skip (#342), everything else passes.

## Open (tracked)
- **[core#329] REOPENED** (Eng) — real Oracle service-name fix (#334 was incomplete). Oracle **cannot** connect via service name yet.
- **[core#342]** (QA/human) — re-provision the Redpanda cluster, then remove the Kafka skip.

Closes #331
Closes #311