### PR TITLE
[QA] PR-time Oracle connector smoke gate (closes #339)

### DIFF
--- a/.github/workflows/oracle-connector-smoke.yml
+++ b/.github/workflows/oracle-connector-smoke.yml
@@ -1,0 +1,90 @@
+name: Oracle Connector Smoke (PR gate)
+
+# PR-time gate for the LIVE Oracle connector.
+#
+# connector-smoke is otherwise nightly-only (gated by DATANIKA_CONNECTOR_SMOKE),
+# so a change to the Oracle connect path — or a removal of the core#329 xfail —
+# can ship without ever running the live Oracle smoke on PR CI. That happened:
+# #334's DSN-string unit tests passed and it removed the xfail, but the live
+# connector still couldn't reach a service-name Oracle, and the false fix
+# promoted to prod (#336) because the smoke only ran nightly (core#329 reopened,
+# fix tracked in core#339). This runs the real gvenzl/oracle-xe smoke on any PR
+# touching the Oracle connect path, so a broken fix goes RED here, not in prod.
+# The XE container is an ephemeral throwaway with no secrets (like the postgres
+# test:test pattern in ci.yml), so it is safe to run on PR CI.
+
+on:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      # Oracle connect path (shared connector files — the Oracle logic lives here):
+      - "datanika/services/connection_service.py" # _build_sa_url (Oracle DSN)
+      - "datanika/services/dlt_runner.py" # _to_dlt_credentials (dlt extract path)
+      - "datanika/services/connection_schemas.py" # Oracle CONFIG_SCHEMAS
+      # Oracle test files (catch xfail removal / smoke edits):
+      - "tests/test_connector_smoke/test_wave1_connectors_smoke.py"
+      - "tests/test_connector_smoke/test_wave1_connectors_extract_load.py" # core#335
+      # Self-test when the gate itself changes:
+      - ".github/workflows/oracle-connector-smoke.yml"
+
+concurrency:
+  group: oracle-connector-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oracle-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      oracle:
+        image: gvenzl/oracle-xe:21-slim
+        ports:
+          - 1521:1521
+        env:
+          ORACLE_PASSWORD: DatanikaSmoke1
+          APP_USER: datanika_smoke
+          APP_USER_PASSWORD: DatanikaSmoke1
+        # gvenzl ships healthcheck.sh on PATH; GH Actions waits for the service
+        # to be healthy before any step runs. Generous retries for cold boot.
+        options: >-
+          --health-cmd "healthcheck.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 30
+          --health-start-period 30s
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        # oracledb + sqlalchemy are core deps; ".[dev]" pulls pytest. No
+        # BigQuery/Kafka/SaaS extras needed — this job only runs -k oracle.
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Oracle XE connection env
+        run: |
+          {
+            echo "ORACLE_HOST=localhost"
+            echo "ORACLE_PORT=1521"
+            echo "ORACLE_SERVICE=XEPDB1"
+            echo "ORACLE_USER=datanika_smoke"
+            echo "ORACLE_PASSWORD=DatanikaSmoke1"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Oracle connector smoke + E2E (live XE)
+        env:
+          DATANIKA_CONNECTOR_SMOKE: "1"
+        # Whole dir with -k oracle: runs both Wave-1 files' oracle tests (the
+        # live smoke here, the extract->load E2E once core#335 lands) and
+        # deselects the SaaS tests, which this no-secrets job can't run. While
+        # the connector is broken these xfail (green, tracked by #329); a PR
+        # that removes the xfail to declare it fixed runs the live assertion
+        # here, so a false fix fails RED at PR-time instead of in prod.
+        run: pytest tests/test_connector_smoke/ -v --tb=short -k oracle


### PR DESCRIPTION
Closes the CI gap that let a **false Oracle fix promote to prod**. Closes #339.

## The gap
`connector-smoke` is nightly-only (`DATANIKA_CONNECTOR_SMOKE`-gated), so it **never runs on PR CI**. #334 claimed to fix the Oracle service-name bug (core#329): its DSN-*string* unit tests passed and it removed the `pytest.xfail` guard — but the **live** connector still can't connect to a service-name Oracle. With no live smoke on the PR, the false fix merged and promoted to prod (#336). The nightly caught it after the fact and **#329 was reopened** ("Root cause is the live connection, not the DSN string").

## What this PR adds
A new **PR-time gate**: `.github/workflows/oracle-connector-smoke.yml`. On any PR touching the Oracle connect path — `connection_service.py` (`_build_sa_url`), `dlt_runner.py` (`_to_dlt_credentials`), `connection_schemas.py` — or the Oracle smoke/E2E test files, it stands up the same `gvenzl/oracle-xe` service container and runs `pytest tests/test_connector_smoke/ -k oracle`. The XE container is an **ephemeral throwaway with no secrets** (like `ci.yml`'s `postgres:test/test`), so it's safe on PR CI.

While the connector is broken the oracle tests `xfail` (green, tracked by #329). A future PR that **removes the xfail to declare #329 fixed** runs the live assertion here — a broken fix fails **RED at PR-time**, not in prod.

> **Scope note:** re-instating the xfail (so the nightly is green while #329 is broken) was already done by Infra's **#340**. This PR is only the complementary *PR-time gate* — the piece that actually prevents recurrence.

## Verified end-to-end (local gvenzl/oracle-xe:21-slim, service XEPDB1)
Ran the exact gate command against a live XE:
- **With the xfail** (current dev state, post-#340): `1 xfailed` — the positive control reaches `XEPDB1` (`all_tables=45`) but `ConnectionService.test_connection` returns `Connection failed`, independently reproducing the reopened #329. Gate = **green** (broken-but-tracked).
- **Reverted to the post-#334 positive-assert state** (the false-fix shape): the same command **FAILED red** (`AssertionError: Connection failed`). → The gate **would have caught #334**.

This PR only adds the workflow, which is in its own trigger paths, so the gate **self-tests on this PR** (expected: green / xfailed).

## For Infra (branch protection)
Consider adding `oracle-smoke` (this workflow) as a **required status check** for full enforcement. Caveat: it's path-filtered, so on PRs that don't touch Oracle files it won't run — a naively-required path-filtered check can block unrelated PRs (GitHub "required + skipped" gotcha). Either leave it non-required (a visible red check on Oracle PRs is already the signal that was missing on #334), or pair it with an always-green companion job. Your call.
