### PR TITLE
[Infra] Strip now-dead Oracle smoke/E2E xfails (#341 landed)

### DIFF
--- a/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import contextlib
 
 import duckdb
-import pytest
 
 from datanika.services.dlt_runner import DltRunnerService
 
@@ -160,25 +159,17 @@ def test_asana_extract_load_assert(require_env, tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Oracle (SQL, source-only) — xfails on core#329 until the DSN fix lands
+# Oracle (SQL, source-only) — core#329 fixed (#334 service-name DSN + #341 dialect)
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    reason="core#329: the Oracle connector emits the service name as a SID in the DSN "
-    "(connection_service._build_sa_url / dlt_runner._to_dlt_credentials), so extract via "
-    "execute() raises ORA-12505 against a service-name listener (the XE PDB). Flips to "
-    "XPASS when #329 lands — delete this marker then.",
-    strict=False,
-    raises=Exception,
-)
 def test_oracle_extract_load_assert(require_env, tmp_path):
     """Seed a tiny table in Oracle XE (correct service-name form = positive control),
     then extract it through the Datanika connector → DuckDB → assert the rows land.
 
     The seed proves the driver/container/creds are healthy; the ``execute()`` call
-    exercises the connector's own DSN path, which currently mishandles service names
-    (core#329) and raises ORA-12505 — caught by the xfail above.
+    exercises the connector's own DSN path (service-name → ``?service_name=`` +
+    Oracle dialect SQL), fixed by core#329 (#334 + #341). Asserts positively.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"

--- a/tests/test_connector_smoke/test_wave1_connectors_smoke.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_smoke.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import time
 
 import httpx
-import pytest
 
 
 def _log(msg: str) -> None:
@@ -54,13 +53,10 @@ def test_oracle_live_driver_and_connector(require_env):
        are healthy, addressed the *correct* way (service name / easy-connect).
        This is the real live-smoke value: catches driver break, XE image drift,
        network/creds issues. If it fails, the infra is broken — fail loud.
-    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``).
-       **Re-quarantined (xfail) under the REOPENED core#329.** #334 changed the URL
-       form but the connector still can't reach a service-name Oracle in practice —
-       the nightly caught it: the positive control (part 1) connects, but
-       ``test_connection`` still fails (ORA-12505). Engineering owns the real fix on
-       the reopened #329; until then this xfails so the nightly stays green. It flips
-       to a pass (XPASS) once #329 is truly fixed — delete the xfail block then.
+    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``)
+       reaching the same service-name Oracle. Fixed by core#329 — #334 (``?service_name=``
+       URL + dlt creds) plus #341 (Oracle ``DUAL`` probe / ``FETCH FIRST`` preview).
+       Asserts positively now; a regression here fails the nightly loud.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"
@@ -100,17 +96,10 @@ def test_oracle_live_driver_and_connector(require_env):
     assert table_count is not None and table_count >= 0
 
     # (2) Our connector's own connect path (URL builder + connect_args + engine).
-    #     Re-quarantined under the reopened core#329 — xfail on the connector, but keep
-    #     the positive control (part 1) as a hard assert so a genuine XE/driver/infra
-    #     break still fails loud rather than hiding behind this xfail.
     url = _build_sa_url(config, ConnectionType.ORACLE)
     assert url.startswith("oracle+oracledb://"), f"unexpected Oracle URL scheme: {url}"
     ok, msg = ConnectionService.test_connection(config, ConnectionType.ORACLE)
-    if not ok:
-        pytest.xfail(
-            f"core#329 (reopened): Oracle connector still can't reach a service-name Oracle — {msg}"
-        )
-    assert ok, msg  # xpasses once #329 is truly fixed — remove this xfail block then
+    assert ok, msg  # core#329 fixed (#334 + #341): connector reaches the service-name Oracle
 
 
 # ---------- Pipedrive (SaaS REST — api_token query auth) ----------


### PR DESCRIPTION
Follow-on to promoting **[core#341]** (Oracle DUAL probe + FETCH FIRST preview). With #341 on top of #334 (`?service_name=` URL + dlt creds), the Oracle connector now connects to a service-name Oracle, so both Oracle quarantines are obsolete:

- `test_wave1_connectors_smoke.py` — remove the imperative `pytest.xfail` on the connector path (Infra #340) → `assert ok` positively (+ drop the now-unused `pytest` import).
- `test_wave1_connectors_extract_load.py` — remove the `@pytest.mark.xfail` decorator on the extract→load E2E (QA #335) → assert positively (+ drop `pytest` import).

**Validation:** I'll `workflow_dispatch` the nightly on `dev` (real XE service container) and confirm **both Oracle tests PASS positively** before promoting dev→master. If either still fails, I'll re-quarantine it and keep #329 open.

refs #329 (closed by #341's promotion).