### PR TITLE
[Infra] Re-quarantine Oracle E2E extract (xfail) — separate bug #347

### DIFF
--- a/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import contextlib
 
 import duckdb
+import pytest
 
 from datanika.services.dlt_runner import DltRunnerService
 
@@ -159,17 +160,26 @@ def test_asana_extract_load_assert(require_env, tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Oracle (SQL, source-only) — core#329 fixed (#334 service-name DSN + #341 dialect)
+# Oracle (SQL, source-only) — connect works (#329/#341); extract xfails on #347
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.xfail(
+    reason="core#347: Oracle *connect* is fixed (#329/#341), but the dlt single_table "
+    "extract still fails table reflection (NoSuchTableError: QA_E2E_WAVE1) — a separate "
+    "Oracle table-resolution/casing bug downstream of connect. Flips to XPASS when #347 "
+    "lands — delete this marker then.",
+    strict=False,
+    raises=Exception,
+)
 def test_oracle_extract_load_assert(require_env, tmp_path):
     """Seed a tiny table in Oracle XE (correct service-name form = positive control),
     then extract it through the Datanika connector → DuckDB → assert the rows land.
 
     The seed proves the driver/container/creds are healthy; the ``execute()`` call
-    exercises the connector's own DSN path (service-name → ``?service_name=`` +
-    Oracle dialect SQL), fixed by core#329 (#334 + #341). Asserts positively.
+    exercises the connector's extract path. Connect is fixed (#329/#341), but the dlt
+    ``single_table`` reflection currently raises ``NoSuchTableError`` (core#347) —
+    caught by the xfail above.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"


### PR DESCRIPTION
Corrects an over-eager strip in #346. The dev dispatch ([run 29638026809](https://github.com/datanika-io/datanika-core/actions/runs/29638026809)) after promoting [#341] showed:

- ✅ **Oracle connect works** — the smoke `test_oracle_live_driver_and_connector` (`test_connection`) now **passes positively**. #341 (DUAL probe + FETCH FIRST) genuinely fixes #329.
- ❌ **Oracle extract still fails** — `test_oracle_extract_load_assert` throws `NoSuchTableError: QA_E2E_WAVE1`: the dlt `single_table` reflection can't resolve the table **after** connecting. Separate bug — filed **[core#347]**.

So I re-add the xfail on the **E2E only** (correct reason: #347, not #329), keeping the smoke connect probe un-quarantined. Nightly goes green again (smoke Oracle passes, E2E xfails). Remove when #347 lands. refs #347