### PR TITLE
[Infra] Promote dev → master: Oracle connect fix (#341) + smoke asserts positively

### DIFF
--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -397,9 +397,11 @@ class ConnectionService:
         except ImportError:
             return False, f"Driver not installed for {connection_type.value}"
 
+        # Oracle rejects a bare ``SELECT 1`` (ORA-00923) — it needs FROM DUAL.
+        probe = "SELECT 1 FROM DUAL" if connection_type == ConnectionType.ORACLE else "SELECT 1"
         try:
             with engine.connect() as conn:
-                conn.execute(text("SELECT 1"))
+                conn.execute(text(probe))
             return True, "Connected successfully"
         except ImportError:
             return False, f"Driver not installed for {connection_type.value}"
@@ -532,7 +534,11 @@ class ConnectionService:
             qualified = preparer.quote(table)
             if schema:
                 qualified = f"{preparer.quote_schema(schema)}.{qualified}"
-            query = f"SELECT * FROM {qualified} LIMIT {limit}"
+            if connection_type == ConnectionType.ORACLE:
+                # Oracle has no LIMIT clause — use the 12c+ row-limiting form.
+                query = f"SELECT * FROM {qualified} FETCH FIRST {limit} ROWS ONLY"
+            else:
+                query = f"SELECT * FROM {qualified} LIMIT {limit}"
             with engine.connect() as conn:
                 result = conn.execute(text(query))
                 columns = list(result.keys())

--- a/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import contextlib
 
 import duckdb
+import pytest
 
 from datanika.services.dlt_runner import DltRunnerService
 
@@ -159,17 +160,26 @@ def test_asana_extract_load_assert(require_env, tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Oracle (SQL, source-only) — core#329 fixed (#334 service-name DSN + #341 dialect)
+# Oracle (SQL, source-only) — connect works (#329/#341); extract xfails on #347
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.xfail(
+    reason="core#347: Oracle *connect* is fixed (#329/#341), but the dlt single_table "
+    "extract still fails table reflection (NoSuchTableError: QA_E2E_WAVE1) — a separate "
+    "Oracle table-resolution/casing bug downstream of connect. Flips to XPASS when #347 "
+    "lands — delete this marker then.",
+    strict=False,
+    raises=Exception,
+)
 def test_oracle_extract_load_assert(require_env, tmp_path):
     """Seed a tiny table in Oracle XE (correct service-name form = positive control),
     then extract it through the Datanika connector → DuckDB → assert the rows land.
 
     The seed proves the driver/container/creds are healthy; the ``execute()`` call
-    exercises the connector's own DSN path (service-name → ``?service_name=`` +
-    Oracle dialect SQL), fixed by core#329 (#334 + #341). Asserts positively.
+    exercises the connector's extract path. Connect is fixed (#329/#341), but the dlt
+    ``single_table`` reflection currently raises ``NoSuchTableError`` (core#347) —
+    caught by the xfail above.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"

--- a/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import contextlib
 
 import duckdb
-import pytest
 
 from datanika.services.dlt_runner import DltRunnerService
 
@@ -160,25 +159,17 @@ def test_asana_extract_load_assert(require_env, tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Oracle (SQL, source-only) — xfails on core#329 until the DSN fix lands
+# Oracle (SQL, source-only) — core#329 fixed (#334 service-name DSN + #341 dialect)
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    reason="core#329: the Oracle connector emits the service name as a SID in the DSN "
-    "(connection_service._build_sa_url / dlt_runner._to_dlt_credentials), so extract via "
-    "execute() raises ORA-12505 against a service-name listener (the XE PDB). Flips to "
-    "XPASS when #329 lands — delete this marker then.",
-    strict=False,
-    raises=Exception,
-)
 def test_oracle_extract_load_assert(require_env, tmp_path):
     """Seed a tiny table in Oracle XE (correct service-name form = positive control),
     then extract it through the Datanika connector → DuckDB → assert the rows land.
 
     The seed proves the driver/container/creds are healthy; the ``execute()`` call
-    exercises the connector's own DSN path, which currently mishandles service names
-    (core#329) and raises ORA-12505 — caught by the xfail above.
+    exercises the connector's own DSN path (service-name → ``?service_name=`` +
+    Oracle dialect SQL), fixed by core#329 (#334 + #341). Asserts positively.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"

--- a/tests/test_connector_smoke/test_wave1_connectors_smoke.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_smoke.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import time
 
 import httpx
-import pytest
 
 
 def _log(msg: str) -> None:
@@ -54,13 +53,10 @@ def test_oracle_live_driver_and_connector(require_env):
        are healthy, addressed the *correct* way (service name / easy-connect).
        This is the real live-smoke value: catches driver break, XE image drift,
        network/creds issues. If it fails, the infra is broken — fail loud.
-    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``).
-       **Re-quarantined (xfail) under the REOPENED core#329.** #334 changed the URL
-       form but the connector still can't reach a service-name Oracle in practice —
-       the nightly caught it: the positive control (part 1) connects, but
-       ``test_connection`` still fails (ORA-12505). Engineering owns the real fix on
-       the reopened #329; until then this xfails so the nightly stays green. It flips
-       to a pass (XPASS) once #329 is truly fixed — delete the xfail block then.
+    2. **Our connector's path** (``_build_sa_url`` + ``ConnectionService.test_connection``)
+       reaching the same service-name Oracle. Fixed by core#329 — #334 (``?service_name=``
+       URL + dlt creds) plus #341 (Oracle ``DUAL`` probe / ``FETCH FIRST`` preview).
+       Asserts positively now; a regression here fails the nightly loud.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"
@@ -100,17 +96,10 @@ def test_oracle_live_driver_and_connector(require_env):
     assert table_count is not None and table_count >= 0
 
     # (2) Our connector's own connect path (URL builder + connect_args + engine).
-    #     Re-quarantined under the reopened core#329 — xfail on the connector, but keep
-    #     the positive control (part 1) as a hard assert so a genuine XE/driver/infra
-    #     break still fails loud rather than hiding behind this xfail.
     url = _build_sa_url(config, ConnectionType.ORACLE)
     assert url.startswith("oracle+oracledb://"), f"unexpected Oracle URL scheme: {url}"
     ok, msg = ConnectionService.test_connection(config, ConnectionType.ORACLE)
-    if not ok:
-        pytest.xfail(
-            f"core#329 (reopened): Oracle connector still can't reach a service-name Oracle — {msg}"
-        )
-    assert ok, msg  # xpasses once #329 is truly fixed — remove this xfail block then
+    assert ok, msg  # core#329 fixed (#334 + #341): connector reaches the service-name Oracle
 
 
 # ---------- Pipedrive (SaaS REST — api_token query auth) ----------

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -175,6 +175,37 @@ class TestOracleConnector:
         assert connect_args == {"tcp_connect_timeout": 5}
         assert ok is True
 
+    @patch("datanika.services.connection_service.create_engine")
+    def test_probe_query_uses_dual_on_oracle(self, mock_ce):
+        # #329: Oracle rejects a bare `SELECT 1` (ORA-00923); the connectivity
+        # probe must use FROM DUAL. Mocks can't connect, but they lock the SQL
+        # text — the gap that let the SID/SELECT-1 bugs pass unit tests but fail
+        # the live Oracle smoke.
+        ConnectionService.test_connection(
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            ConnectionType.ORACLE,
+        )
+        conn = mock_ce.return_value.connect.return_value.__enter__.return_value
+        assert str(conn.execute.call_args[0][0]) == "SELECT 1 FROM DUAL"
+
+    @patch("datanika.services.connection_service.create_engine")
+    def test_preview_uses_fetch_first_on_oracle(self, mock_ce):
+        # #329: Oracle has no LIMIT clause (ORA-00933) — use FETCH FIRST.
+        engine = mock_ce.return_value
+        engine.dialect.identifier_preparer.quote = lambda x: f'"{x}"'
+        conn = engine.connect.return_value.__enter__.return_value
+        conn.execute.return_value.keys.return_value = ["id"]
+        conn.execute.return_value.fetchall.return_value = []
+        ConnectionService.preview_table(
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            ConnectionType.ORACLE,
+            "T329",
+            limit=5,
+        )
+        sql = str(conn.execute.call_args[0][0])
+        assert "FETCH FIRST 5 ROWS ONLY" in sql
+        assert "LIMIT" not in sql
+
 
 # --------------------------------------------------------------------------- #
 # SaaS REST connectors


### PR DESCRIPTION
Promotes the **real Oracle fix** to prod and cleans up the connector-smoke. CI/test + connector-code change — deploy-pointer redeploys + smoke-prod.

## Included (3 commits)
- **[core#341] (Eng)** — Oracle connector: `SELECT 1 FROM DUAL` probe (was ORA-00923) + `FETCH FIRST … ROWS ONLY` preview (was ORA-00933). On top of #334's `?service_name=` URL, Oracle now **connects** to service-name / PDB / RAC / Autonomous. Unit tests now assert the probe/preview SQL text (the guard #334 lacked). **Closes #329.**
- **[core#346] (Infra)** — strip the now-satisfied Oracle **smoke** xfail → asserts positively.
- **[core#348] (Infra)** — the Oracle **E2E** extract is a *separate* bug ([core#347]: dlt `single_table` `NoSuchTableError`, downstream of connect), so its xfail stays (correct reason now).

## Validated GREEN before promoting
Dispatched the nightly on `dev` (real XE, [run 29638849232](https://github.com/datanika-io/datanika-core/actions/runs/29638849232)) — **both jobs SUCCESS**. The Oracle **smoke test now PASSES positively** (proves #341 fixes connect end-to-end); the Oracle E2E xfails on #347.

## ⚠️ Oracle is NOT yet end-to-end functional
#341 fixes **connect + preview**, but **extract still fails** ([core#347], open). So Oracle can't actually pull data yet — **keep Growth's Oracle announcement + SID hedge on hold until #347 lands**, not just #341.

Closes #329