### PR TITLE
[Engineering] Fix Oracle extract: normalize table identifier for dlt reflection (closes #347)

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -151,6 +151,24 @@ _RENAME_USER_TYPES = {
 CLICKHOUSE_ENGINE_TYPES = {"merge_tree", "replicated_merge_tree", "shared_merge_tree"}
 
 
+def _normalize_oracle_identifier(name: str | None) -> str | None:
+    """Normalize an Oracle table/schema identifier for dlt/SQLAlchemy reflection.
+
+    Oracle stores unquoted identifiers UPPERCASE, but SQLAlchemy reflection
+    expects the *normalized* (lowercase) form and denormalizes it back to
+    uppercase for the data-dictionary lookup. Passing an UPPERCASE name makes
+    SQLAlchemy treat it as a case-sensitive quoted identifier, so ``sql_table`` /
+    ``sql_database`` reflection misses the table (NoSuchTableError, #347).
+    ``normalize_name`` lower-cases a plain uppercase name and leaves genuinely
+    quoted / mixed-case names alone.
+    """
+    if not name:
+        return name
+    from sqlalchemy.dialects.oracle.base import OracleDialect
+
+    return OracleDialect().normalize_name(name) or name
+
+
 class DltRunnerService:
     """Builds dlt pipeline objects from connection configs and pipeline settings."""
 
@@ -272,6 +290,8 @@ class DltRunnerService:
 
         mode = dlt_config.get("mode", "full_database")
         schema = dlt_config.get("source_schema")
+        if connection_type == "oracle":
+            schema = _normalize_oracle_identifier(schema)
 
         creds = self._to_dlt_credentials(connection_type, config)
 
@@ -293,7 +313,10 @@ class DltRunnerService:
             query_adapter = make_query_adapter(filters_cfg)
 
         if mode == "single_table":
-            kwargs = {"credentials": creds, "table": dlt_config["table"], "chunk_size": batch_size}
+            table = dlt_config["table"]
+            if connection_type == "oracle":
+                table = _normalize_oracle_identifier(table)
+            kwargs = {"credentials": creds, "table": table, "chunk_size": batch_size}
             if schema is not None:
                 kwargs["schema"] = schema
             if backend is not None:
@@ -317,6 +340,8 @@ class DltRunnerService:
                 kwargs["backend"] = backend
             table_names = dlt_config.get("table_names")
             if table_names is not None:
+                if connection_type == "oracle":
+                    table_names = [_normalize_oracle_identifier(t) for t in table_names]
                 kwargs["table_names"] = table_names
             return sql_database(**kwargs)
 

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -206,6 +206,28 @@ class TestOracleConnector:
         assert "FETCH FIRST 5 ROWS ONLY" in sql
         assert "LIMIT" not in sql
 
+    @patch("datanika.services.dlt_runner.sql_table")
+    def test_build_source_normalizes_oracle_table(self, mock_sql_table):
+        # #347: the Oracle table name must be normalized (lower-cased) before dlt
+        # reflects it — else SQLAlchemy treats an UPPERCASE name as a
+        # case-sensitive quoted identifier and reflection misses the table
+        # (NoSuchTableError). Verified live against Oracle XE.
+        DltRunnerService().build_source(
+            "oracle",
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            {"mode": "single_table", "table": "QA_E2E_WAVE1"},
+        )
+        assert mock_sql_table.call_args.kwargs["table"] == "qa_e2e_wave1"
+
+    @patch("datanika.services.dlt_runner.sql_database")
+    def test_build_source_normalizes_oracle_table_names(self, mock_sql_db):
+        DltRunnerService().build_source(
+            "oracle",
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            {"mode": "full_database", "table_names": ["QA_E2E_WAVE1", "OTHER_TBL"]},
+        )
+        assert mock_sql_db.call_args.kwargs["table_names"] == ["qa_e2e_wave1", "other_tbl"]
+
 
 # --------------------------------------------------------------------------- #
 # SaaS REST connectors


### PR DESCRIPTION
## What

Fixes the Oracle **extract** path (downstream of #329's *connect* fix). QA's Wave-1 E2E got past connect and threw `NoSuchTableError: QA_E2E_WAVE1` on dlt `sql_table` reflection. Closes #347.

## Root cause — isolated against a real Oracle, not guessed

I reproduced against a live `gvenzl/oracle-xe:21-slim` and tried the config matrix. It's **table-name casing, not schema** (the issue's secondary hypothesis — schema is irrelevant):

```
FAIL | UPPER table, no schema (the E2E)   | NoSuchTableError
OK   | lower table, no schema             | 2 rows
FAIL | UPPER table, schema=APPUSER        | NoSuchTableError
OK   | lower table, schema=appuser        | 2 rows
```

Oracle stores unquoted identifiers UPPERCASE, but SQLAlchemy reflection expects the **normalized (lowercase)** form and denormalizes it back to uppercase for the data-dictionary lookup. An UPPERCASE name (what users type, and what the E2E seeds) is treated as a case-sensitive *quoted* identifier → reflection misses.

## The fix

`build_source` now runs the Oracle **table / schema / table_names** through the dialect's `normalize_name` before handing them to dlt's `sql_table` / `sql_database` (new `_normalize_oracle_identifier`). `QA_E2E_WAVE1 → qa_e2e_wave1` (which SQLAlchemy denormalizes back to `QA_E2E_WAVE1` for the lookup); already-lowercase and genuinely mixed-case/quoted names are left alone.

## Validation — real Oracle extract

- The **exact E2E config** (uppercase `QA_E2E_WAVE1`, no schema) now extracts **2 rows**, **deterministic across 3 fresh processes**. `full_database` with an uppercase `table_names` filter works too.
- `normalize_name` confirmed live: `QA_E2E_WAVE1→qa_e2e_wave1`, `MixedCase→MixedCase`.
- Unit tests assert the normalized name reaches `sql_table` / `sql_database`. 2238 core tests pass.

(Per the connector lesson from #329/#341: validated on the real code path against a real Oracle, not just mocks.)

## For QA (#311)

The extract path is fixed — **remove the `xfail` on `test_oracle_extract_load_assert` and re-run** once this promotes. That test isn't on `dev` yet (it's your #311 branch), so I couldn't run it here; my live `build_source` extraction is the equivalent validation of the same code path.

## Status

Oracle now works end-to-end: **connect** (#334 + #341) **and extract** (#347). So Oracle is genuinely usable once this promotes — the "hold Oracle messaging" caveat lifts after promotion + QA's E2E goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
