### PR TITLE
[Infra] Promote dev → master: Oracle extract fix (#350) — Oracle now works end-to-end

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -151,6 +151,24 @@ _RENAME_USER_TYPES = {
 CLICKHOUSE_ENGINE_TYPES = {"merge_tree", "replicated_merge_tree", "shared_merge_tree"}
 
 
+def _normalize_oracle_identifier(name: str | None) -> str | None:
+    """Normalize an Oracle table/schema identifier for dlt/SQLAlchemy reflection.
+
+    Oracle stores unquoted identifiers UPPERCASE, but SQLAlchemy reflection
+    expects the *normalized* (lowercase) form and denormalizes it back to
+    uppercase for the data-dictionary lookup. Passing an UPPERCASE name makes
+    SQLAlchemy treat it as a case-sensitive quoted identifier, so ``sql_table`` /
+    ``sql_database`` reflection misses the table (NoSuchTableError, #347).
+    ``normalize_name`` lower-cases a plain uppercase name and leaves genuinely
+    quoted / mixed-case names alone.
+    """
+    if not name:
+        return name
+    from sqlalchemy.dialects.oracle.base import OracleDialect
+
+    return OracleDialect().normalize_name(name) or name
+
+
 class DltRunnerService:
     """Builds dlt pipeline objects from connection configs and pipeline settings."""
 
@@ -272,6 +290,8 @@ class DltRunnerService:
 
         mode = dlt_config.get("mode", "full_database")
         schema = dlt_config.get("source_schema")
+        if connection_type == "oracle":
+            schema = _normalize_oracle_identifier(schema)
 
         creds = self._to_dlt_credentials(connection_type, config)
 
@@ -293,7 +313,10 @@ class DltRunnerService:
             query_adapter = make_query_adapter(filters_cfg)
 
         if mode == "single_table":
-            kwargs = {"credentials": creds, "table": dlt_config["table"], "chunk_size": batch_size}
+            table = dlt_config["table"]
+            if connection_type == "oracle":
+                table = _normalize_oracle_identifier(table)
+            kwargs = {"credentials": creds, "table": table, "chunk_size": batch_size}
             if schema is not None:
                 kwargs["schema"] = schema
             if backend is not None:
@@ -317,6 +340,8 @@ class DltRunnerService:
                 kwargs["backend"] = backend
             table_names = dlt_config.get("table_names")
             if table_names is not None:
+                if connection_type == "oracle":
+                    table_names = [_normalize_oracle_identifier(t) for t in table_names]
                 kwargs["table_names"] = table_names
             return sql_database(**kwargs)
 

--- a/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
+++ b/tests/test_connector_smoke/test_wave1_connectors_extract_load.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import contextlib
 
 import duckdb
-import pytest
 
 from datanika.services.dlt_runner import DltRunnerService
 
@@ -160,26 +159,18 @@ def test_asana_extract_load_assert(require_env, tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Oracle (SQL, source-only) — connect works (#329/#341); extract xfails on #347
+# Oracle (SQL, source-only) — connect (#329/#341) + extract (#347/#350) fixed
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    reason="core#347: Oracle *connect* is fixed (#329/#341), but the dlt single_table "
-    "extract still fails table reflection (NoSuchTableError: QA_E2E_WAVE1) — a separate "
-    "Oracle table-resolution/casing bug downstream of connect. Flips to XPASS when #347 "
-    "lands — delete this marker then.",
-    strict=False,
-    raises=Exception,
-)
 def test_oracle_extract_load_assert(require_env, tmp_path):
     """Seed a tiny table in Oracle XE (correct service-name form = positive control),
     then extract it through the Datanika connector → DuckDB → assert the rows land.
 
     The seed proves the driver/container/creds are healthy; the ``execute()`` call
-    exercises the connector's extract path. Connect is fixed (#329/#341), but the dlt
-    ``single_table`` reflection currently raises ``NoSuchTableError`` (core#347) —
-    caught by the xfail above.
+    exercises the connector's extract path — connect fixed by #329 (#334 + #341),
+    Oracle table-identifier normalization for dlt reflection fixed by #347 (#350).
+    Asserts positively.
     """
     env = require_env(
         "ORACLE_HOST", "ORACLE_PORT", "ORACLE_SERVICE", "ORACLE_USER", "ORACLE_PASSWORD"

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -206,6 +206,28 @@ class TestOracleConnector:
         assert "FETCH FIRST 5 ROWS ONLY" in sql
         assert "LIMIT" not in sql
 
+    @patch("datanika.services.dlt_runner.sql_table")
+    def test_build_source_normalizes_oracle_table(self, mock_sql_table):
+        # #347: the Oracle table name must be normalized (lower-cased) before dlt
+        # reflects it — else SQLAlchemy treats an UPPERCASE name as a
+        # case-sensitive quoted identifier and reflection misses the table
+        # (NoSuchTableError). Verified live against Oracle XE.
+        DltRunnerService().build_source(
+            "oracle",
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            {"mode": "single_table", "table": "QA_E2E_WAVE1"},
+        )
+        assert mock_sql_table.call_args.kwargs["table"] == "qa_e2e_wave1"
+
+    @patch("datanika.services.dlt_runner.sql_database")
+    def test_build_source_normalizes_oracle_table_names(self, mock_sql_db):
+        DltRunnerService().build_source(
+            "oracle",
+            {"host": "h", "user": "u", "password": "p", "database": "SVC"},
+            {"mode": "full_database", "table_names": ["QA_E2E_WAVE1", "OTHER_TBL"]},
+        )
+        assert mock_sql_db.call_args.kwargs["table_names"] == ["qa_e2e_wave1", "other_tbl"]
+
 
 # --------------------------------------------------------------------------- #
 # SaaS REST connectors


### PR DESCRIPTION
Promotes the **Oracle extract fix** to prod. With this, Oracle is **end-to-end functional**: connect (#341, already live from #349) + extract (#350).

## Included (2 commits)
- **[core#350] (Eng)** — `dlt_runner._normalize_oracle_identifier` (SQLAlchemy `OracleDialect().normalize_name()`) normalizes Oracle table/schema identifiers so `sql_table`/`sql_database` reflection resolves them (was `NoSuchTableError`). **Closes #347.**
- **[core#351] (Infra)** — strip the now-satisfied Oracle E2E xfail → asserts positively.

## Validated GREEN before promoting
Dispatched the nightly on `dev` (real XE, [run 29640108514](https://github.com/datanika-io/datanika-core/actions/runs/29640108514)) — **oracle-smoke: 2 passed** (both `test_oracle_live_driver_and_connector` **and** `test_oracle_extract_load_assert` PASS positively, extract→load→row-assert against a real XE). Not assumed — observed.

## State note (for the record)
The connect fix (#341) was **already live in prod** from last turn's #349 — verified today via SSH on `datanika-app` (`FROM DUAL` / `FETCH FIRST` / `service_name` all present in the running container). This PR adds the missing **extract** half.

## After this lands
Oracle connects AND extracts (validated end-to-end) → **Growth can drop the SID hedge and announce Oracle**, and promote landing#229.

Closes #347