### PR TITLE
[Engineering] Advertise datanika-mcp server in /llms.txt + agent-guide (closes #353)

### DIFF
--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -56,6 +56,16 @@ https://app.datanika.io/api/v1/agent-guide.md
 ## Agent Tiers (JSON)
 https://app.datanika.io/api/v1/meta/agent-tiers
 
+## MCP Server
+For MCP clients (Claude Desktop, Cursor), Datanika ships a first-class MCP \
+server — `datanika-mcp` — so you can browse connections, preview data, compile \
+and validate transformations, and run pipelines as native tools instead of raw \
+REST. Read-only by default; pass `--allow-write` to enable mutations.
+Install (no clone needed):
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" datanika-mcp
+Full tool list + Claude Desktop config:
+https://github.com/datanika-io/datanika-core/blob/master/datanika-mcp/README.md
+
 ## Base URL
 https://app.datanika.io/api/v1/
 
@@ -92,6 +102,23 @@ def _render_agent_guide() -> str:
 > [OpenAPI spec](https://app.datanika.io/api/v1/openapi.json) for
 > full request/response schemas. For machine-readable tier structure,
 > fetch [/api/v1/meta/agent-tiers](https://app.datanika.io/api/v1/meta/agent-tiers).
+
+## MCP Server (alternative to raw REST)
+
+If you're an MCP client (Claude Desktop, Cursor), use Datanika's first-class
+`datanika-mcp` server instead of calling REST directly — it exposes the same
+capabilities (browse connections, preview data, compile/validate
+transformations, run pipelines) as native tools. Read-only by default;
+`--allow-write` enables mutations.
+
+```
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" datanika-mcp
+```
+
+Full tool list + Claude Desktop / Cursor config:
+[datanika-mcp/README.md](https://github.com/datanika-io/datanika-core/blob/master/datanika-mcp/README.md)
+
+The REST golden path below still applies to plain HTTP clients.
 
 ## Quick-Start Loop
 

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -82,6 +82,13 @@ class TestLlmsTxt:
         resp = client.get("/llms.txt")
         assert "/api/v1/meta/agent-tiers" in resp.text
 
+    def test_advertises_mcp_server(self, client):
+        # #353: an agent reading the discovery doc must be able to find the MCP path.
+        resp = client.get("/llms.txt")
+        assert "MCP" in resp.text
+        assert "datanika-mcp" in resp.text
+        assert "uvx" in resp.text  # the install command
+
     def test_no_auth_required(self, client):
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
@@ -131,6 +138,12 @@ class TestAgentGuide:
     def test_contains_wait_true_pattern(self, client):
         resp = client.get("/api/v1/agent-guide.md")
         assert "?wait=true" in resp.text
+
+    def test_advertises_mcp_server(self, client):
+        # #353: MCP clients should be told to use datanika-mcp instead of raw REST.
+        resp = client.get("/api/v1/agent-guide.md")
+        assert "datanika-mcp" in resp.text
+        assert "MCP" in resp.text
 
     def test_no_auth_required(self, client):
         resp = client.get("/api/v1/agent-guide.md")


### PR DESCRIPTION
## What

Our agent-discovery docs (`/llms.txt`, `/api/v1/agent-guide.md`) pointed only at the REST API and never mentioned the first-class **MCP server** — so an MCP client (Claude Desktop, Cursor) reading them couldn't discover the `datanika-mcp` path. Part of the AI-first agent-surface wave. Closes #353.

## Changes

- **`/llms.txt`** — new `## MCP Server` section: one-liner + the `uvx --from "git+…#subdirectory=datanika-mcp" datanika-mcp` install + a link to `datanika-mcp/README.md` (tool list + Claude Desktop config).
- **agent-guide** — `## MCP Server (alternative to raw REST)` near the top: use `datanika-mcp` instead of raw REST for MCP clients, install line, README link. Notes the REST golden path still applies to plain HTTP clients.
- **SoT-derived**: links to the MCP README rather than duplicating its tool list (point 3 of the issue).

## Tests

New tests assert both surfaces advertise the MCP path (`datanika-mcp` + `uvx` install). The tier/capability parity tests stay green — no `"N tiers"` count reintroduced into `/llms.txt` (guarding the #80 regression). **2240 core tests pass.** Stops at dev-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)