### PR TITLE
[Infra] datanika-mcp PyPI release workflow (Trusted Publishing) (refs #354)

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,0 +1,72 @@
+name: Release datanika-mcp to PyPI
+
+# Tag-triggered release for the `datanika-mcp` package (a subdirectory of this repo).
+#
+# Cut a release (from master):
+#   1. Bump `version` in datanika-mcp/pyproject.toml
+#   2. git tag mcp-v0.1.0 && git push origin mcp-v0.1.0   (tag version MUST match pyproject)
+#
+# Publishing uses PyPI **Trusted Publishing** (OIDC) — NO API token stored anywhere.
+# One-time PyPI setup is required before the first release — see
+# plans/PLAN_HUMAN_LOCKERS.md "pypi-trusted-publisher-datanika-mcp":
+#   PyPI → add a (pending) trusted publisher for project `datanika-mcp`:
+#     Owner=datanika-io  Repository=datanika-core
+#     Workflow filename=release-mcp.yml  Environment=pypi
+# The workflow filename + environment below MUST match that config exactly.
+
+on:
+  push:
+    tags:
+      - "mcp-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify tag matches pyproject version
+        working-directory: datanika-mcp
+        run: |
+          tag_version="${GITHUB_REF_NAME#mcp-v}"
+          pkg_version="$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "(.*)"$/\1/')"
+          echo "tag=$tag_version pyproject=$pkg_version"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} ($tag_version) does not match datanika-mcp/pyproject.toml version ($pkg_version). Bump pyproject or fix the tag."
+            exit 1
+          fi
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "latest"
+
+      - name: Build sdist + wheel
+        working-directory: datanika-mcp
+        run: uv build --out-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: datanika-mcp/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Minimal-permission publish job (no build/test code runs here with the OIDC
+    # token) — the PyPA-recommended split. `environment: pypi` must match the
+    # environment named in the PyPI trusted-publisher config.
+    environment: pypi
+    permissions:
+      id-token: write # REQUIRED for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No password/token: OIDC trusted publishing. Defaults to publishing dist/.

--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -123,6 +123,22 @@ Point `--url` at your instance:
 datanika-mcp --url http://localhost:3000 --api-key etf_your_key
 ```
 
+## Releasing (maintainers)
+
+`datanika-mcp` publishes to PyPI via GitHub Actions **Trusted Publishing** (OIDC — no stored API token). To cut a release (from `master`):
+
+1. Bump `version` in [`pyproject.toml`](pyproject.toml).
+2. Tag and push — the tag version must match `pyproject.toml`:
+
+   ```bash
+   git tag mcp-v0.1.0
+   git push origin mcp-v0.1.0
+   ```
+
+3. The [`Release datanika-mcp to PyPI`](../.github/workflows/release-mcp.yml) workflow builds the sdist + wheel and publishes. Verify: `uvx datanika-mcp --help` resolves from PyPI.
+
+> First-release setup: a one-time PyPI trusted-publisher must be configured (project `datanika-mcp`, repo `datanika-io/datanika-core`, workflow `release-mcp.yml`, environment `pypi`) before the first tag will publish. See the infra human-locker.
+
 ## License
 
 AGPL-3.0 — same as the core Datanika platform.

--- a/datanika-mcp/pyproject.toml
+++ b/datanika-mcp/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
 [project.scripts]
 datanika-mcp = "datanika_mcp.server:main"
 
+[project.urls]
+Homepage = "https://datanika.io"
+Repository = "https://github.com/datanika-io/datanika-core"
+Documentation = "https://github.com/datanika-io/datanika-core/tree/master/datanika-mcp#readme"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Makes the `datanika-mcp` README's advertised `uvx datanika-mcp` one-liner real (it's currently git-install-only). Part of the AI-agent-surface wave.

## What
- **`.github/workflows/release-mcp.yml`** — tag `mcp-v*` → `uv build` the `datanika-mcp/` subdir → publish to PyPI via **Trusted Publishing (OIDC)**, **no stored token**. Split build/publish jobs (the publish job carries only `id-token: write` + `environment: pypi`) per the PyPA security pattern. The build step asserts the tag version matches `datanika-mcp/pyproject.toml`.
- **`datanika-mcp/pyproject.toml`** — add `[project.urls]` for the PyPI page. (It already had the `datanika-mcp = datanika_mcp.server:main` console entry point + hatchling build → `uvx datanika-mcp` resolves.)
- **README** — new "Releasing (maintainers)" section documenting the tag flow.

## Validated
- `uv build` (local) produces `datanika_mcp-0.1.0.tar.gz` + `...-py3-none-any.whl` cleanly.
- Workflow YAML parses; entry point `datanika_mcp.server:main` exists.

## Safe to merge now
The workflow **only** runs on an `mcp-v*` tag push — none exists, so merging changes nothing at runtime.

## ⚠️ One human step before the first publish (filed)
No PyPI account/token exists on disk (checked `SECRETS_INVENTORY.md` + `secrets/`). The founder does a **one-time ~3-min PyPI setup** — create the account + add a *pending* trusted publisher (project `datanika-mcp`, owner `datanika-io`, repo `datanika-core`, workflow `release-mcp.yml`, environment `pypi`). Then Infra promotes the workflow to master, pushes tag `mcp-v0.1.0`, verifies `uvx datanika-mcp --help`, and flips the README `(when published)` note. Full steps: `PLAN_HUMAN_LOCKERS.md#pypi-trusted-publisher-datanika-mcp`.

Closes #354 once the first publish lands (the workflow half is here).