### PR TITLE
[Engineering] Add server.json + smithery.yaml MCP registry manifests (closes #359)

### DIFF
--- a/datanika-mcp/server.json
+++ b/datanika-mcp/server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "name": "io.github.datanika-io/datanika-mcp",
+  "description": "MCP server for Datanika: browse connections, preview data, run dbt transforms, and manage pipelines.",
+  "repository": {
+    "url": "https://github.com/datanika-io/datanika-core",
+    "source": "github",
+    "subfolder": "datanika-mcp"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "datanika-mcp",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DATANIKA_URL",
+          "description": "Datanika instance URL (defaults to https://app.datanika.io; set this for a self-hosted instance)",
+          "isRequired": false
+        },
+        {
+          "name": "DATANIKA_API_KEY",
+          "description": "Datanika API key",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "DATANIKA_ALLOW_WRITE",
+          "description": "Set to true to enable write/trigger tools (read-only by default)",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/datanika-mcp/smithery.yaml
+++ b/datanika-mcp/smithery.yaml
@@ -1,0 +1,32 @@
+# Smithery connects the datanika-io/datanika-core GitHub repo and reads this file.
+# https://smithery.ai/docs
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - apiKey
+    properties:
+      url:
+        type: string
+        default: "https://app.datanika.io"
+        description: "Datanika instance URL (leave as default for the hosted app; override for self-hosted)"
+      apiKey:
+        type: string
+        description: "Datanika API key"
+      allowWrite:
+        type: boolean
+        default: false
+        description: "Enable write/trigger tools (read-only by default)"
+  commandFunction: |
+    (config) => ({
+      command: "uvx",
+      args: [
+        "--from",
+        "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp",
+        "--url", config.url || "https://app.datanika.io",
+        "--api-key", config.apiKey,
+        ...(config.allowWrite ? ["--allow-write"] : [])
+      ]
+    })

--- a/tests/test_mcp/test_registry_manifests.py
+++ b/tests/test_mcp/test_registry_manifests.py
@@ -1,0 +1,85 @@
+"""Parity tests for the datanika-mcp registry manifests (#359, refs #355).
+
+``server.json`` (official MCP registry) and ``smithery.yaml`` (Smithery) are
+package-metadata manifests that must not drift from the actual package
+(``datanika-mcp/pyproject.toml`` + ``server.py``). These tests fail CI on a
+version bump or an env-var rename that forgets to update the manifests.
+"""
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MCP_DIR = _REPO_ROOT / "datanika-mcp"
+_EXPECTED_ENV_VARS = {"DATANIKA_URL", "DATANIKA_API_KEY", "DATANIKA_ALLOW_WRITE"}
+
+
+def _pyproject() -> dict:
+    with (_MCP_DIR / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _server_json() -> dict:
+    return json.loads((_MCP_DIR / "server.json").read_text(encoding="utf-8"))
+
+
+def _package_env_var_names() -> set[str]:
+    """Env var names the server actually reads, scraped from server.py source."""
+    source = (_MCP_DIR / "src" / "datanika_mcp" / "server.py").read_text(encoding="utf-8")
+    return set(re.findall(r"DATANIKA_[A-Z_]+", source))
+
+
+class TestServerJson:
+    def test_is_valid_json_with_expected_shape(self):
+        data = _server_json()
+        assert data["name"] == "io.github.datanika-io/datanika-mcp"
+        assert data["repository"]["subfolder"] == "datanika-mcp"
+        assert len(data["packages"]) == 1
+
+    def test_version_matches_pyproject(self):
+        version = _pyproject()["project"]["version"]
+        data = _server_json()
+        assert data["version"] == version
+        assert data["packages"][0]["version"] == version
+
+    def test_package_points_at_pypi_identifier(self):
+        pkg = _server_json()["packages"][0]
+        assert pkg["registryType"] == "pypi"
+        assert pkg["identifier"] == _pyproject()["project"]["name"] == "datanika-mcp"
+        assert pkg["transport"]["type"] == "stdio"
+
+    def test_env_vars_match_server_source(self):
+        names = {e["name"] for e in _server_json()["packages"][0]["environmentVariables"]}
+        assert names == _EXPECTED_ENV_VARS
+        # No drift vs what server.py actually reads.
+        assert names == _package_env_var_names()
+
+    def test_api_key_marked_required_and_secret(self):
+        env = _server_json()["packages"][0]["environmentVariables"]
+        by_name = {e["name"]: e for e in env}
+        assert by_name["DATANIKA_API_KEY"]["isRequired"] is True
+        assert by_name["DATANIKA_API_KEY"]["isSecret"] is True
+        # URL has a working default in server.py; it must not be marked required.
+        assert by_name["DATANIKA_URL"].get("isRequired", False) is False
+
+
+class TestSmitheryYaml:
+    def test_stdio_startcommand_with_api_key_required(self):
+        yaml = pytest.importorskip("yaml")
+        data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
+        start = data["startCommand"]
+        assert start["type"] == "stdio"
+        schema = start["configSchema"]
+        assert "apiKey" in schema["required"]
+        assert set(schema["properties"]) == {"url", "apiKey", "allowWrite"}
+
+    def test_command_invokes_the_package(self):
+        yaml = pytest.importorskip("yaml")
+        data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
+        cmd = data["startCommand"]["commandFunction"]
+        assert "datanika-mcp" in cmd
+        assert "--api-key" in cmd


### PR DESCRIPTION
Lands the two package-metadata manifests the MCP-registry discoverability wave needs in `datanika-mcp/`, so the official registry and Smithery can list us. Growth has no core worktree and these reference the package + install command, so Engineering commits them (drafts from `plans/growth/MCP_REGISTRY_LISTINGS.md`).

## What
- **`datanika-mcp/server.json`** — official MCP registry manifest (`registry.modelcontextprotocol.io`, read by `mcp-publisher`). Reverse-DNS name `io.github.datanika-io/datanika-mcp`, pypi package `datanika-mcp` v0.1.0, stdio transport, the three env vars.
- **`datanika-mcp/smithery.yaml`** — Smithery `startCommand` (stdio) + config schema; `commandFunction` runs the git-install `uvx` form.
- **`tests/test_mcp/test_registry_manifests.py`** — parity guard (7 tests).

## Validated against the real package
Cross-checked both manifests against `datanika-mcp/pyproject.toml` + `server.py`:
- Version/identifier pinned to `pyproject` (`0.1.0` / `datanika-mcp`).
- Env-var names match what `server.py` actually reads (`DATANIKA_URL`/`DATANIKA_API_KEY`/`DATANIKA_ALLOW_WRITE`).
- **Correctness fix vs the draft:** only `--api-key` is hard-required in `main()` (`--url` defaults to `https://app.datanika.io`), so `DATANIKA_URL` / `smithery` `url` are marked **optional**, not required.

## Parity test guards drift
The new test fails CI if a future version bump or env-var rename desyncs the manifests from the package — the exact class of drift that would silently break a published registry listing. Scoped to package-derived invariants only (not the evolving external registry schema, which `mcp-publisher validate` checks at publish time).

## Not in scope (gated / other owners)
The registry **submissions** themselves (`mcp-publisher publish`, Smithery/mcp.so/Glama claims) stay gated on the PyPI package (Infra #354) + a one-time human GitHub device-login. Tracked under #355.

Precheck green locally: **2247 passed, 19 skipped**, ruff + format clean.

Closes #359. Refs #355.