### PR TITLE
[Infra] Promote dev → master (2026-07-19 batch)

### DIFF
--- a/.github/workflows/oracle-connector-smoke.yml
+++ b/.github/workflows/oracle-connector-smoke.yml
@@ -1,0 +1,90 @@
+name: Oracle Connector Smoke (PR gate)
+
+# PR-time gate for the LIVE Oracle connector.
+#
+# connector-smoke is otherwise nightly-only (gated by DATANIKA_CONNECTOR_SMOKE),
+# so a change to the Oracle connect path — or a removal of the core#329 xfail —
+# can ship without ever running the live Oracle smoke on PR CI. That happened:
+# #334's DSN-string unit tests passed and it removed the xfail, but the live
+# connector still couldn't reach a service-name Oracle, and the false fix
+# promoted to prod (#336) because the smoke only ran nightly (core#329 reopened,
+# fix tracked in core#339). This runs the real gvenzl/oracle-xe smoke on any PR
+# touching the Oracle connect path, so a broken fix goes RED here, not in prod.
+# The XE container is an ephemeral throwaway with no secrets (like the postgres
+# test:test pattern in ci.yml), so it is safe to run on PR CI.
+
+on:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      # Oracle connect path (shared connector files — the Oracle logic lives here):
+      - "datanika/services/connection_service.py" # _build_sa_url (Oracle DSN)
+      - "datanika/services/dlt_runner.py" # _to_dlt_credentials (dlt extract path)
+      - "datanika/services/connection_schemas.py" # Oracle CONFIG_SCHEMAS
+      # Oracle test files (catch xfail removal / smoke edits):
+      - "tests/test_connector_smoke/test_wave1_connectors_smoke.py"
+      - "tests/test_connector_smoke/test_wave1_connectors_extract_load.py" # core#335
+      # Self-test when the gate itself changes:
+      - ".github/workflows/oracle-connector-smoke.yml"
+
+concurrency:
+  group: oracle-connector-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oracle-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      oracle:
+        image: gvenzl/oracle-xe:21-slim
+        ports:
+          - 1521:1521
+        env:
+          ORACLE_PASSWORD: DatanikaSmoke1
+          APP_USER: datanika_smoke
+          APP_USER_PASSWORD: DatanikaSmoke1
+        # gvenzl ships healthcheck.sh on PATH; GH Actions waits for the service
+        # to be healthy before any step runs. Generous retries for cold boot.
+        options: >-
+          --health-cmd "healthcheck.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 30
+          --health-start-period 30s
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        # oracledb + sqlalchemy are core deps; ".[dev]" pulls pytest. No
+        # BigQuery/Kafka/SaaS extras needed — this job only runs -k oracle.
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Oracle XE connection env
+        run: |
+          {
+            echo "ORACLE_HOST=localhost"
+            echo "ORACLE_PORT=1521"
+            echo "ORACLE_SERVICE=XEPDB1"
+            echo "ORACLE_USER=datanika_smoke"
+            echo "ORACLE_PASSWORD=DatanikaSmoke1"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Oracle connector smoke + E2E (live XE)
+        env:
+          DATANIKA_CONNECTOR_SMOKE: "1"
+        # Whole dir with -k oracle: runs both Wave-1 files' oracle tests (the
+        # live smoke here, the extract->load E2E once core#335 lands) and
+        # deselects the SaaS tests, which this no-secrets job can't run. While
+        # the connector is broken these xfail (green, tracked by #329); a PR
+        # that removes the xfail to declare it fixed runs the live assertion
+        # here, so a false fix fails RED at PR-time instead of in prod.
+        run: pytest tests/test_connector_smoke/ -v --tb=short -k oracle

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,0 +1,72 @@
+name: Release datanika-mcp to PyPI
+
+# Tag-triggered release for the `datanika-mcp` package (a subdirectory of this repo).
+#
+# Cut a release (from master):
+#   1. Bump `version` in datanika-mcp/pyproject.toml
+#   2. git tag mcp-v0.1.0 && git push origin mcp-v0.1.0   (tag version MUST match pyproject)
+#
+# Publishing uses PyPI **Trusted Publishing** (OIDC) — NO API token stored anywhere.
+# One-time PyPI setup is required before the first release — see
+# plans/PLAN_HUMAN_LOCKERS.md "pypi-trusted-publisher-datanika-mcp":
+#   PyPI → add a (pending) trusted publisher for project `datanika-mcp`:
+#     Owner=datanika-io  Repository=datanika-core
+#     Workflow filename=release-mcp.yml  Environment=pypi
+# The workflow filename + environment below MUST match that config exactly.
+
+on:
+  push:
+    tags:
+      - "mcp-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify tag matches pyproject version
+        working-directory: datanika-mcp
+        run: |
+          tag_version="${GITHUB_REF_NAME#mcp-v}"
+          pkg_version="$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "(.*)"$/\1/')"
+          echo "tag=$tag_version pyproject=$pkg_version"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} ($tag_version) does not match datanika-mcp/pyproject.toml version ($pkg_version). Bump pyproject or fix the tag."
+            exit 1
+          fi
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "latest"
+
+      - name: Build sdist + wheel
+        working-directory: datanika-mcp
+        run: uv build --out-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: datanika-mcp/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Minimal-permission publish job (no build/test code runs here with the OIDC
+    # token) — the PyPA-recommended split. `environment: pypi` must match the
+    # environment named in the PyPI trusted-publisher config.
+    environment: pypi
+    permissions:
+      id-token: write # REQUIRED for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No password/token: OIDC trusted publishing. Defaults to publishing dist/.

--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -123,6 +123,22 @@ Point `--url` at your instance:
 datanika-mcp --url http://localhost:3000 --api-key etf_your_key
 ```
 
+## Releasing (maintainers)
+
+`datanika-mcp` publishes to PyPI via GitHub Actions **Trusted Publishing** (OIDC — no stored API token). To cut a release (from `master`):
+
+1. Bump `version` in [`pyproject.toml`](pyproject.toml).
+2. Tag and push — the tag version must match `pyproject.toml`:
+
+   ```bash
+   git tag mcp-v0.1.0
+   git push origin mcp-v0.1.0
+   ```
+
+3. The [`Release datanika-mcp to PyPI`](../.github/workflows/release-mcp.yml) workflow builds the sdist + wheel and publishes. Verify: `uvx datanika-mcp --help` resolves from PyPI.
+
+> First-release setup: a one-time PyPI trusted-publisher must be configured (project `datanika-mcp`, repo `datanika-io/datanika-core`, workflow `release-mcp.yml`, environment `pypi`) before the first tag will publish. See the infra human-locker.
+
 ## License
 
 AGPL-3.0 — same as the core Datanika platform.

--- a/datanika-mcp/pyproject.toml
+++ b/datanika-mcp/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
 [project.scripts]
 datanika-mcp = "datanika_mcp.server:main"
 
+[project.urls]
+Homepage = "https://datanika.io"
+Repository = "https://github.com/datanika-io/datanika-core"
+Documentation = "https://github.com/datanika-io/datanika-core/tree/master/datanika-mcp#readme"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/datanika-mcp/server.json
+++ b/datanika-mcp/server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "name": "io.github.datanika-io/datanika-mcp",
+  "description": "MCP server for Datanika: browse connections, preview data, run dbt transforms, and manage pipelines.",
+  "repository": {
+    "url": "https://github.com/datanika-io/datanika-core",
+    "source": "github",
+    "subfolder": "datanika-mcp"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "datanika-mcp",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DATANIKA_URL",
+          "description": "Datanika instance URL (defaults to https://app.datanika.io; set this for a self-hosted instance)",
+          "isRequired": false
+        },
+        {
+          "name": "DATANIKA_API_KEY",
+          "description": "Datanika API key",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "DATANIKA_ALLOW_WRITE",
+          "description": "Set to true to enable write/trigger tools (read-only by default)",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/datanika-mcp/smithery.yaml
+++ b/datanika-mcp/smithery.yaml
@@ -1,0 +1,32 @@
+# Smithery connects the datanika-io/datanika-core GitHub repo and reads this file.
+# https://smithery.ai/docs
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - apiKey
+    properties:
+      url:
+        type: string
+        default: "https://app.datanika.io"
+        description: "Datanika instance URL (leave as default for the hosted app; override for self-hosted)"
+      apiKey:
+        type: string
+        description: "Datanika API key"
+      allowWrite:
+        type: boolean
+        default: false
+        description: "Enable write/trigger tools (read-only by default)"
+  commandFunction: |
+    (config) => ({
+      command: "uvx",
+      args: [
+        "--from",
+        "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp",
+        "datanika-mcp",
+        "--url", config.url || "https://app.datanika.io",
+        "--api-key", config.apiKey,
+        ...(config.allowWrite ? ["--allow-write"] : [])
+      ]
+    })

--- a/datanika/services/agent_docs.py
+++ b/datanika/services/agent_docs.py
@@ -56,6 +56,16 @@ https://app.datanika.io/api/v1/agent-guide.md
 ## Agent Tiers (JSON)
 https://app.datanika.io/api/v1/meta/agent-tiers
 
+## MCP Server
+For MCP clients (Claude Desktop, Cursor), Datanika ships a first-class MCP \
+server — `datanika-mcp` — so you can browse connections, preview data, compile \
+and validate transformations, and run pipelines as native tools instead of raw \
+REST. Read-only by default; pass `--allow-write` to enable mutations.
+Install (no clone needed):
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" datanika-mcp
+Full tool list + Claude Desktop config:
+https://github.com/datanika-io/datanika-core/blob/master/datanika-mcp/README.md
+
 ## Base URL
 https://app.datanika.io/api/v1/
 
@@ -92,6 +102,23 @@ def _render_agent_guide() -> str:
 > [OpenAPI spec](https://app.datanika.io/api/v1/openapi.json) for
 > full request/response schemas. For machine-readable tier structure,
 > fetch [/api/v1/meta/agent-tiers](https://app.datanika.io/api/v1/meta/agent-tiers).
+
+## MCP Server (alternative to raw REST)
+
+If you're an MCP client (Claude Desktop, Cursor), use Datanika's first-class
+`datanika-mcp` server instead of calling REST directly — it exposes the same
+capabilities (browse connections, preview data, compile/validate
+transformations, run pipelines) as native tools. Read-only by default;
+`--allow-write` enables mutations.
+
+```
+uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" datanika-mcp
+```
+
+Full tool list + Claude Desktop / Cursor config:
+[datanika-mcp/README.md](https://github.com/datanika-io/datanika-core/blob/master/datanika-mcp/README.md)
+
+The REST golden path below still applies to plain HTTP clients.
 
 ## Quick-Start Loop
 

--- a/tests/test_mcp/test_registry_manifests.py
+++ b/tests/test_mcp/test_registry_manifests.py
@@ -1,0 +1,85 @@
+"""Parity tests for the datanika-mcp registry manifests (#359, refs #355).
+
+``server.json`` (official MCP registry) and ``smithery.yaml`` (Smithery) are
+package-metadata manifests that must not drift from the actual package
+(``datanika-mcp/pyproject.toml`` + ``server.py``). These tests fail CI on a
+version bump or an env-var rename that forgets to update the manifests.
+"""
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MCP_DIR = _REPO_ROOT / "datanika-mcp"
+_EXPECTED_ENV_VARS = {"DATANIKA_URL", "DATANIKA_API_KEY", "DATANIKA_ALLOW_WRITE"}
+
+
+def _pyproject() -> dict:
+    with (_MCP_DIR / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _server_json() -> dict:
+    return json.loads((_MCP_DIR / "server.json").read_text(encoding="utf-8"))
+
+
+def _package_env_var_names() -> set[str]:
+    """Env var names the server actually reads, scraped from server.py source."""
+    source = (_MCP_DIR / "src" / "datanika_mcp" / "server.py").read_text(encoding="utf-8")
+    return set(re.findall(r"DATANIKA_[A-Z_]+", source))
+
+
+class TestServerJson:
+    def test_is_valid_json_with_expected_shape(self):
+        data = _server_json()
+        assert data["name"] == "io.github.datanika-io/datanika-mcp"
+        assert data["repository"]["subfolder"] == "datanika-mcp"
+        assert len(data["packages"]) == 1
+
+    def test_version_matches_pyproject(self):
+        version = _pyproject()["project"]["version"]
+        data = _server_json()
+        assert data["version"] == version
+        assert data["packages"][0]["version"] == version
+
+    def test_package_points_at_pypi_identifier(self):
+        pkg = _server_json()["packages"][0]
+        assert pkg["registryType"] == "pypi"
+        assert pkg["identifier"] == _pyproject()["project"]["name"] == "datanika-mcp"
+        assert pkg["transport"]["type"] == "stdio"
+
+    def test_env_vars_match_server_source(self):
+        names = {e["name"] for e in _server_json()["packages"][0]["environmentVariables"]}
+        assert names == _EXPECTED_ENV_VARS
+        # No drift vs what server.py actually reads.
+        assert names == _package_env_var_names()
+
+    def test_api_key_marked_required_and_secret(self):
+        env = _server_json()["packages"][0]["environmentVariables"]
+        by_name = {e["name"]: e for e in env}
+        assert by_name["DATANIKA_API_KEY"]["isRequired"] is True
+        assert by_name["DATANIKA_API_KEY"]["isSecret"] is True
+        # URL has a working default in server.py; it must not be marked required.
+        assert by_name["DATANIKA_URL"].get("isRequired", False) is False
+
+
+class TestSmitheryYaml:
+    def test_stdio_startcommand_with_api_key_required(self):
+        yaml = pytest.importorskip("yaml")
+        data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
+        start = data["startCommand"]
+        assert start["type"] == "stdio"
+        schema = start["configSchema"]
+        assert "apiKey" in schema["required"]
+        assert set(schema["properties"]) == {"url", "apiKey", "allowWrite"}
+
+    def test_command_invokes_the_package(self):
+        yaml = pytest.importorskip("yaml")
+        data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
+        cmd = data["startCommand"]["commandFunction"]
+        assert "datanika-mcp" in cmd
+        assert "--api-key" in cmd

--- a/tests/test_services/test_agent_docs.py
+++ b/tests/test_services/test_agent_docs.py
@@ -82,6 +82,13 @@ class TestLlmsTxt:
         resp = client.get("/llms.txt")
         assert "/api/v1/meta/agent-tiers" in resp.text
 
+    def test_advertises_mcp_server(self, client):
+        # #353: an agent reading the discovery doc must be able to find the MCP path.
+        resp = client.get("/llms.txt")
+        assert "MCP" in resp.text
+        assert "datanika-mcp" in resp.text
+        assert "uvx" in resp.text  # the install command
+
     def test_no_auth_required(self, client):
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
@@ -131,6 +138,12 @@ class TestAgentGuide:
     def test_contains_wait_true_pattern(self, client):
         resp = client.get("/api/v1/agent-guide.md")
         assert "?wait=true" in resp.text
+
+    def test_advertises_mcp_server(self, client):
+        # #353: MCP clients should be told to use datanika-mcp instead of raw REST.
+        resp = client.get("/api/v1/agent-guide.md")
+        assert "datanika-mcp" in resp.text
+        assert "MCP" in resp.text
 
     def test_no_auth_required(self, client):
         resp = client.get("/api/v1/agent-guide.md")


### PR DESCRIPTION
Promotes 4 CI-green commits from `dev` to `master` (prod). **Core-only** — the cloud V2 P5 billing PRs stay held on cloud `dev` pending Gate 4 (green E2E, QA+Eng).

## Promoted
- **#345** [QA] PR-time Oracle connector smoke gate → closes #339
- **#357** [Engineering] Advertise `datanika-mcp` in `/llms.txt` + agent-guide → closes #353
- **#358** [Infra] `datanika-mcp` PyPI release workflow (Trusted Publishing, OIDC) — enables the `mcp-v*` tag release; #354 stays open until the first publish is verified
- **#360** [Engineering] `server.json` + `smithery.yaml` MCP registry manifests → closes #359

## Post-merge (Infra)
1. CD (`deploy-pointer.yml`) rebuilds + deploys prod — verify smoke-prod green.
2. Resync `dev`←`master` (lockstep).
3. Tag `mcp-v0.1.0` on master → `release-mcp.yml` OIDC-publishes `datanika-mcp` to PyPI. Verify `uvx datanika-mcp`, then close #354.

Closes #339
Closes #353
Closes #359