### PR TITLE
[Infra] docs(mcp): README From-PyPI note (datanika-mcp v0.1.0 live)

### DIFF
--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -7,7 +7,7 @@ MCP server for [Datanika](https://datanika.io) — browse connections, preview d
 ## Install
 
 ```bash
-# From PyPI (when published)
+# From PyPI (recommended)
 uvx datanika-mcp --help
 
 # From git


### PR DESCRIPTION
Docs-only follow-up to #354. `datanika-mcp` v0.1.0 is now published to PyPI (Trusted Publishing, OIDC) and verified installable via `uvx datanika-mcp==0.1.0`, so the README's `# From PyPI (when published)` caveat is stale.

Changes `(when published)` → `(recommended)`. No code, no behavior change. Rides the next core `dev→master` promotion.