### PR TITLE
[Infra] SSRF worker-egress guard for rest_api connector family (validate_egress_host)

### DIFF
--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine, inspect, select, text
 from sqlalchemy.orm import Session
 
 from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
+from datanika.services.egress_guard import validate_egress_host
 from datanika.services.encryption import EncryptionService
 from datanika.services.naming import validate_name
 
@@ -232,6 +233,13 @@ class ConnectionService:
 
         emit("connection.before_create", session=session, org_id=org_id)
         validate_connection_name(name)
+        # SSRF pre-flight gate (core#338): reject connectors whose user-supplied
+        # base_url resolves to a non-public host at create time. Only fires when
+        # a base_url is present, so DB connectors and hardcoded-host SaaS
+        # (stripe/github/…) are unaffected.
+        base_url = (config or {}).get("base_url")
+        if base_url:
+            validate_egress_host(base_url)
         direction = infer_direction(connection_type)
         # Normalise "" → None so analytics queries can filter on a single
         # NULL check. ConnectionState.selected_template_slug defaults to ""

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -9,6 +9,8 @@ from dlt.sources.filesystem import filesystem
 from dlt.sources.rest_api import rest_api_source
 from dlt.sources.sql_database import sql_database, sql_table
 
+from datanika.services.egress_guard import validate_egress_host
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BATCH_SIZE = 10_000
@@ -377,6 +379,7 @@ class DltRunnerService:
         Shared by the generic ``rest_api`` connector and the ``openapi``
         connector (whose resources are derived from a spec).
         """
+        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
         client_config: dict = {"base_url": base_url}
         if headers:
             client_config["headers"] = headers
@@ -967,6 +970,7 @@ class DltRunnerService:
         headers: dict | None = None,
     ):
         """Generic REST API source used when a verified source module is not installed."""
+        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
         client: dict = {"base_url": base_url}
         if auth:
             client["auth"] = auth

--- a/datanika/services/egress_guard.py
+++ b/datanika/services/egress_guard.py
@@ -1,0 +1,81 @@
+"""Defense-in-depth PRE-FLIGHT SSRF guard for the ``rest_api`` connector family (core#338).
+
+User-supplied base URLs (generic ``rest_api``/``openapi`` connectors and the
+SaaS fallbacks whose host is user-controlled — e.g. Salesforce ``instance_url``,
+Shopify store) are handed to dlt's ``requests``-based REST client and fetched
+from inside the worker. Without a guard, a user could point a connector at
+``http://169.254.169.254/…`` (cloud metadata) or an internal ``10.0.0.0/8`` /
+``192.168.0.0/16`` service and exfiltrate it via the pipeline. ``validate_egress_host``
+resolves the hostname and rejects the request if ANY resolved IP is non-public.
+
+This is a pre-flight check only. It has TWO KNOWN RESIDUAL GAPS, deferred to P3
+(to be closed before any cloud-worker migration, and before enabling the
+OpenAPI-P2 URL-fetch feature):
+
+  (c) **Redirect hops are NOT re-validated.** dlt's REST client is ``requests``
+      based and follows redirects inside ``.session.send()``; a public host that
+      responds with a 30x redirect to a private IP would bypass this guard.
+      Closing it needs a custom ``requests.Session`` / ``HTTPAdapter`` that
+      re-validates every hop's resolved address.
+
+  (d) **A resource ``path`` that is itself an absolute ``http(s)://`` URL bypasses
+      ``base_url``** (dlt ``rest_client`` ``client.py:122-124`` joins/overrides the
+      base with an absolute path) and is not validated here — only ``base_url`` is
+      checked.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+class EgressValidationError(ValueError):
+    """Raised when a user-supplied URL points at a non-public / internal host."""
+
+
+def validate_egress_host(url: str) -> None:
+    """Reject *url* if its host resolves to any non-public IP address.
+
+    Raises :class:`EgressValidationError` for a non-``http(s)`` scheme, a
+    missing host, an unresolvable host (fail closed), or when ANY resolved IP
+    is private, loopback, link-local (incl. ``169.254.169.254`` cloud metadata),
+    multicast, reserved, or unspecified. Returns ``None`` when every resolved
+    IP is public.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise EgressValidationError(f"URL scheme must be http or https, got {parsed.scheme!r}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise EgressValidationError(f"URL has no host: {url!r}")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        # Fail closed: if we cannot resolve the host, we cannot prove it is
+        # public, so we refuse it.
+        raise EgressValidationError(f"could not resolve host {hostname!r}: {exc}") from exc
+
+    ip_strings = {info[4][0] for info in infos}
+    for ip_str in ip_strings:
+        ip = ipaddress.ip_address(ip_str)
+        # Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) so 127.0.0.1 et al. are
+        # classified against their real IPv4 range.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise EgressValidationError(
+                f"host {hostname!r} resolves to non-public address {ip_str} — refusing egress"
+            )
+
+    return None

--- a/tests/test_security/test_egress_guard.py
+++ b/tests/test_security/test_egress_guard.py
@@ -1,0 +1,133 @@
+"""Security tests for the SSRF worker-egress guard (core#338).
+
+``validate_egress_host`` is a pre-flight guard for the ``rest_api`` connector
+family. It resolves a user-supplied URL's hostname and rejects it if ANY
+resolved IP is non-public (private, loopback, link-local incl. the
+169.254.169.254 cloud-metadata IP, multicast, reserved, or unspecified).
+
+All DNS is mocked via ``socket.getaddrinfo`` — these tests never touch the
+network and are fully deterministic.
+"""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from datanika.services.egress_guard import EgressValidationError, validate_egress_host
+
+
+def _gai(*ips: str):
+    """Build a ``socket.getaddrinfo``-style return value for the given IPs.
+
+    Each tuple is ``(family, type, proto, canonname, sockaddr)``; the guard
+    only reads ``sockaddr[0]`` (index ``[4][0]``), so a 2-tuple sockaddr is
+    sufficient for both IPv4 and IPv6.
+    """
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+
+# ---------------------------------------------------------------------------
+# REJECT — resolved IP is internal / non-public
+# ---------------------------------------------------------------------------
+class TestRejectsInternalIps:
+    @pytest.mark.parametrize(
+        ("label", "ip"),
+        [
+            ("loopback_v4", "127.0.0.1"),
+            ("cloud_metadata_link_local", "169.254.169.254"),
+            ("private_10_8", "10.0.0.1"),
+            ("private_192_168", "192.168.1.1"),
+            ("private_172_16", "172.16.0.1"),
+            ("loopback_v6", "::1"),
+            ("ula_v6", "fc00::1"),
+            ("unspecified", "0.0.0.0"),
+            ("ipv4_mapped_loopback", "::ffff:127.0.0.1"),
+        ],
+    )
+    def test_rejects_internal_ip(self, label, ip):
+        with (
+            patch("socket.getaddrinfo", return_value=_gai(ip)),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://user-supplied.example")
+
+    def test_rejects_hostname_resolving_to_private(self):
+        """A public-looking hostname that resolves to a private IP is rejected."""
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("10.1.2.3")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://internal.corp.example")
+
+    def test_rejects_if_any_resolved_ip_is_internal(self):
+        """DNS-rebind style: one public + one private A record → reject."""
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("93.184.216.34", "10.0.0.5")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://rebind.example")
+
+    def test_error_message_names_host_and_ip(self):
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("169.254.169.254")),
+            pytest.raises(EgressValidationError) as exc,
+        ):
+            validate_egress_host("https://metadata.example")
+        msg = str(exc.value)
+        assert "metadata.example" in msg
+        assert "169.254.169.254" in msg
+
+
+# ---------------------------------------------------------------------------
+# REJECT — malformed / unresolvable input
+# ---------------------------------------------------------------------------
+class TestRejectsBadInput:
+    def test_rejects_non_http_scheme(self):
+        # Scheme is checked before any DNS resolution; patch getaddrinfo to a
+        # public IP so a missing scheme-check would surface as a failing test.
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("ftp://example.com")
+
+    def test_rejects_file_scheme(self):
+        with pytest.raises(EgressValidationError):
+            validate_egress_host("file:///etc/passwd")
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(EgressValidationError):
+            validate_egress_host("https://")
+
+    def test_gaierror_fails_closed(self):
+        """Unresolvable host → fail closed (reject), never fail open."""
+        with (
+            patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://does-not-resolve.invalid")
+
+
+# ---------------------------------------------------------------------------
+# ALLOW — resolved IP is public
+# ---------------------------------------------------------------------------
+class TestAllowsPublic:
+    def test_allows_public_ipv4(self):
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            assert validate_egress_host("https://example.com") is None
+
+    def test_allows_public_ipv6(self):
+        with patch(
+            "socket.getaddrinfo",
+            return_value=_gai("2606:2800:220:1:248:1893:25c8:1946"),
+        ):
+            assert validate_egress_host("https://ipv6.example.com") is None
+
+    def test_allows_http_scheme(self):
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            assert validate_egress_host("http://example.com") is None
+
+    def test_allows_all_public_multi_ip(self):
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34", "8.8.8.8")):
+            assert validate_egress_host("https://multi.example.com") is None

--- a/tests/test_services/test_connection_service.py
+++ b/tests/test_services/test_connection_service.py
@@ -1,11 +1,14 @@
 """TDD tests for connection management service."""
 
+from unittest.mock import patch
+
 import pytest
 from cryptography.fernet import Fernet
 
 from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
 from datanika.models.user import Organization
 from datanika.services.connection_service import ConnectionService, infer_direction
+from datanika.services.egress_guard import EgressValidationError
 from datanika.services.encryption import EncryptionService
 
 
@@ -85,6 +88,53 @@ class TestCreateConnection:
         assert conn.connection_type == ConnectionType.REST_API
         # REST_API is source-only, so direction should be SOURCE
         assert conn.direction == ConnectionDirection.SOURCE
+
+    # --- SSRF create-time egress gate (core#338) -------------------------------
+    def test_rejects_rest_api_base_url_resolving_to_private(self, svc, db_session, org):
+        """A rest_api base_url that resolves to a private IP is refused at create."""
+        with (
+            patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 0))]),
+            pytest.raises(EgressValidationError),
+        ):
+            svc.create_connection(
+                db_session,
+                org.id,
+                "Internal API",
+                ConnectionType.REST_API,
+                {"base_url": "http://internal.corp.example"},
+            )
+
+    def test_rejects_base_url_resolving_to_metadata_ip(self, svc, db_session, org):
+        with (
+            patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("169.254.169.254", 0))]),
+            pytest.raises(EgressValidationError),
+        ):
+            svc.create_connection(
+                db_session,
+                org.id,
+                "Metadata Grab",
+                ConnectionType.REST_API,
+                {"base_url": "http://169.254.169.254/latest/meta-data/"},
+            )
+
+    def test_allows_rest_api_public_base_url(self, svc, db_session, org):
+        with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]):
+            conn = svc.create_connection(
+                db_session,
+                org.id,
+                "Public API",
+                ConnectionType.REST_API,
+                {"base_url": "https://api.public.example"},
+            )
+        assert conn.connection_type == ConnectionType.REST_API
+
+    def test_guard_skipped_when_no_base_url(self, svc, db_session, org):
+        """DB connectors (no base_url) never hit the egress guard."""
+        with patch("datanika.services.connection_service.validate_egress_host") as mock_guard:
+            svc.create_connection(
+                db_session, org.id, "My DB", ConnectionType.POSTGRES, {"host": "localhost"}
+            )
+        mock_guard.assert_not_called()
 
 
 class TestGetConnection:

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -11,11 +11,30 @@ from datanika.services.dlt_runner import (
     DltRunnerService,
     _extract_rows_loaded,
 )
+from datanika.services.egress_guard import EgressValidationError
+from datanika.services.egress_guard import validate_egress_host as _real_validate_egress_host
 
 
 @pytest.fixture
 def svc():
     return DltRunnerService()
+
+
+@pytest.fixture(autouse=True)
+def _stub_egress_guard():
+    """Stub the SSRF egress guard (core#338) for source-construction tests.
+
+    Since #338, ``_rest_api_from_parts`` and ``_rest_api_fallback`` call
+    ``validate_egress_host`` as their first statement, which resolves the
+    base_url host via real DNS. The generic REST/OpenAPI/SaaS tests below hand
+    those functions fake or live hostnames, so we no-op the guard here to keep
+    them deterministic and offline. The guard's real behaviour is covered by
+    ``tests/test_security/test_egress_guard.py`` and by ``TestEgressGuardWiring``
+    (which restores the real function). Yields the mock so wiring tests can
+    assert it was invoked.
+    """
+    with patch("datanika.services.dlt_runner.validate_egress_host") as mock_guard:
+        yield mock_guard
 
 
 def _make_mock_pipeline(row_counts: dict | None = None):
@@ -1478,3 +1497,53 @@ class TestKafkaSource:
     def test_requires_topics(self, svc):
         with pytest.raises(DltRunnerError, match="topics"):
             svc._build_kafka_source({"bootstrap_servers": "localhost:9092"}, {})
+
+
+def _gai_private(ip: str = "10.0.0.5"):
+    """A ``socket.getaddrinfo`` return that resolves to a single private IP."""
+    return [(2, 1, 6, "", (ip, 0))]
+
+
+class TestEgressGuardWiring:
+    """core#338 — validate_egress_host is wired into the rest_api build paths.
+
+    ``_stub_egress_guard`` (autouse) no-ops the guard for every other test in
+    this module; these tests either assert against that stub mock or restore the
+    real guard (with mocked DNS) to prove a private base_url is rejected.
+    """
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_from_parts_invokes_guard(self, _mock_rest, svc, _stub_egress_guard):
+        svc._rest_api_from_parts("https://api.public.example", [{"name": "x"}])
+        _stub_egress_guard.assert_called_once_with("https://api.public.example")
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_fallback_invokes_guard(self, _mock_rest, svc, _stub_egress_guard):
+        svc._rest_api_fallback("https://api.public.example/", None, [{"name": "x"}])
+        _stub_egress_guard.assert_called_once_with("https://api.public.example/")
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_from_parts_rejects_private_base_url(self, _mock_rest, svc):
+        with (
+            patch(
+                "datanika.services.dlt_runner.validate_egress_host",
+                _real_validate_egress_host,
+            ),
+            patch("socket.getaddrinfo", return_value=_gai_private()),
+            pytest.raises(EgressValidationError),
+        ):
+            svc._rest_api_from_parts("http://internal.svc", [{"name": "x"}])
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_fallback_rejects_metadata_base_url(self, _mock_rest, svc):
+        with (
+            patch(
+                "datanika.services.dlt_runner.validate_egress_host",
+                _real_validate_egress_host,
+            ),
+            patch("socket.getaddrinfo", return_value=_gai_private("169.254.169.254")),
+            pytest.raises(EgressValidationError),
+        ):
+            svc._rest_api_fallback(
+                "http://169.254.169.254/latest/meta-data/", None, [{"name": "x"}]
+            )

--- a/tests/test_services/test_openapi_connector.py
+++ b/tests/test_services/test_openapi_connector.py
@@ -53,6 +53,16 @@ def svc():
     return DltRunnerService()
 
 
+@pytest.fixture(autouse=True)
+def _stub_egress_guard():
+    """No-op the SSRF egress guard (core#338) so ``_build_openapi_source`` →
+    ``_rest_api_from_parts`` doesn't resolve the (fake) base_url host via real
+    DNS. The guard itself is covered by ``tests/test_security/test_egress_guard.py``.
+    """
+    with patch("datanika.services.dlt_runner.validate_egress_host"):
+        yield
+
+
 class TestWiring:
     def test_enum(self):
         assert ConnectionType.OPENAPI == "openapi"

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -38,6 +38,16 @@ def svc():
     return DltRunnerService()
 
 
+@pytest.fixture(autouse=True)
+def _stub_egress_guard():
+    """No-op the SSRF egress guard (core#338) so the SaaS ``_rest_api_fallback``
+    paths (pipedrive / freshdesk / asana) don't resolve their base_url host via
+    real DNS. The guard itself is covered by ``tests/test_security/test_egress_guard.py``.
+    """
+    with patch("datanika.services.dlt_runner.validate_egress_host"):
+        yield
+
+
 # --------------------------------------------------------------------------- #
 # Enum
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #338. Defense-in-depth SSRF guard so a user-supplied connector `base_url` can't point the Celery worker at an internal target (`169.254.169.254` cloud metadata, `127.0.0.1`, RFC1918, IPv6 ULA, …). Filed from the OpenAPI-P1 SSRF review.

## What it does
- **New `datanika/services/egress_guard.py`** — `validate_egress_host(url)`: rejects non-`http(s)` schemes, missing host, unresolvable host (**fail-closed**), and any host that resolves (all A/AAAA records) to a `is_private / is_loopback / is_link_local / is_multicast / is_reserved / is_unspecified` address. IPv4-mapped IPv6 is normalized so `::ffff:127.0.0.1` is caught. `EgressValidationError(ValueError)`.
- **Wired at the two `rest_api_source()` seams** in `dlt_runner.py` (`_rest_api_from_parts` → covers `rest_api` + `openapi`; `_rest_api_fallback` → covers all SaaS fallbacks incl. user-controlled Salesforce `instance_url` / Shopify store) — the only extract-time egress construction sites.
- **Create-time gate** in `connection_service.create_connection` — fires only when `config["base_url"]` is present, so DB connectors and hardcoded-host SaaS (stripe/github) are unaffected.

## Scope (P2/P3 — gates nothing active: single VPS, no metadata service, OpenAPI-P2 URL-fetch not started)
Ships the core defense (pre-flight base_url validation at extract + create time). **Two residual gaps are deliberately deferred to P3** and documented in the module docstring — matching the issue's own "before any cloud-worker migration / before P2 URL-fetch" framing:
- **(c)** redirect hops aren't re-validated (dlt is `requests`-based, follows redirects inside `.session.send()`; needs a custom `Session`/`HTTPAdapter`).
- **(d)** an absolute-URL resource `path` bypasses `base_url` (dlt `client.py:122-124`) and isn't checked.

## Tests (TDD)
- `tests/test_security/test_egress_guard.py` — 20 unit cases, `socket.getaddrinfo` mocked (deterministic/offline): rejects loopback/private/link-local/metadata/ULA/mapped-v4/bad-scheme/no-host/resolves-to-private/gaierror-fail-closed; allows public v4+v6.
- `tests/test_services/test_dlt_runner.py` — `TestEgressGuardWiring`: 2 tests assert the guard is invoked with `base_url`; 2 tests **restore the real guard + mock DNS to a private/metadata IP and assert `EgressValidationError` raises through the production path** (not false-greens). An autouse stub no-ops the guard for the pre-existing source-construction tests (they'd otherwise do real DNS on fake hosts → fail-closed).
- `tests/test_services/test_connection_service.py` — create-time gate accept/reject.

**Verified locally: full core suite 2275 passed / 19 skipped / 0 failed; ruff clean.** No i18n keys (dynamic validation errors are exempt).