### PR TITLE
[Engineering] De-globalize the MCP tool surface for remote transport (Closes #363)

### DIFF
--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -22,10 +22,17 @@ import sys
 from mcp.server.fastmcp import FastMCP
 
 from datanika_mcp.client import DatanikaClient
+from datanika_mcp.session import DatanikaSession, current_session
 
 # ---------------------------------------------------------------------------
-# Globals populated at startup
+# Session resolution — contextvar-first, module-global fallback
 # ---------------------------------------------------------------------------
+#
+# ``main()`` populates the module globals for the single-tenant stdio server.
+# A remote transport (SPEC_REMOTE_MCP.md P1) instead binds a per-request
+# ``DatanikaSession`` via ``session.use_session``; ``_session()`` prefers that
+# binding and falls back to the globals, so both transports share one tool
+# surface and the existing tests (which set the globals directly) stay green.
 
 _client: DatanikaClient | None = None
 _allow_write: bool = False
@@ -40,18 +47,34 @@ mcp = FastMCP(
 )
 
 
-def _get_client() -> DatanikaClient:
+def _session() -> DatanikaSession:
+    """Resolve the active session for the current tool call.
+
+    Prefers a per-request session bound by the transport (remote); falls back
+    to the process globals set by ``main()`` (stdio / tests). Raises if no
+    client is available on the fallback path — i.e. ``main()`` never ran.
+    """
+    session = current_session()
+    if session is not None:
+        return session
     if _client is None:
         raise RuntimeError("DatanikaClient not initialized — call main() first")
-    return _client
+    return DatanikaSession(client=_client, allow_write=_allow_write)
 
 
 def _require_write(action: str) -> None:
-    if not _allow_write:
-        raise RuntimeError(
-            f"Write access required for '{action}'. "
-            "Restart the server with --allow-write to enable mutations."
-        )
+    """Module-level write guard, kept for backward compatibility.
+
+    Tool bodies call ``_session().require_write`` directly; this shim exists
+    so code (and tests) referencing ``server._require_write`` keep working. It
+    resolves the write-grant from the bound session if present, else the
+    module globals — deliberately without a live client, so a write can be
+    rejected before the client is constructed.
+    """
+    session = current_session()
+    if session is None:
+        session = DatanikaSession(client=_client, allow_write=_allow_write)
+    session.require_write(action)
 
 
 # ===================================================================
@@ -65,25 +88,25 @@ def _require_write(action: str) -> None:
 @mcp.tool()
 def get_agent_tiers() -> str:
     """Get the 5-tier agent capability stack — describes what the API can do."""
-    return json.dumps(_get_client().get_agent_tiers(), indent=2)
+    return json.dumps(_session().client.get_agent_tiers(), indent=2)
 
 
 @mcp.tool()
 def get_connection_types() -> str:
     """List all supported connection types with their config schemas."""
-    return json.dumps(_get_client().get_connection_types(), indent=2)
+    return json.dumps(_session().client.get_connection_types(), indent=2)
 
 
 @mcp.tool()
 def list_connections() -> str:
     """List all connections in the organization."""
-    return json.dumps(_get_client().list_connections(), indent=2)
+    return json.dumps(_session().client.list_connections(), indent=2)
 
 
 @mcp.tool()
 def get_connection(connection_id: int) -> str:
     """Get details of a specific connection by ID."""
-    return json.dumps(_get_client().get_connection(connection_id), indent=2)
+    return json.dumps(_session().client.get_connection(connection_id), indent=2)
 
 
 @mcp.tool()
@@ -94,7 +117,7 @@ def introspect_connection(connection_id: int, schema: str | None = None) -> str:
         connection_id: The connection to introspect.
         schema: Optional schema name to filter tables.
     """
-    return json.dumps(_get_client().introspect_connection(connection_id, schema), indent=2)
+    return json.dumps(_session().client.introspect_connection(connection_id, schema), indent=2)
 
 
 @mcp.tool()
@@ -110,7 +133,7 @@ def preview_connection(
         limit: Max rows to return (default 100).
     """
     return json.dumps(
-        _get_client().preview_connection(connection_id, table, schema, limit),
+        _session().client.preview_connection(connection_id, table, schema, limit),
         indent=2,
     )
 
@@ -123,7 +146,7 @@ def query_connection(connection_id: int, query: str) -> str:
         connection_id: The connection to query.
         query: A single SELECT statement (no mutations allowed).
     """
-    return json.dumps(_get_client().query_connection(connection_id, query), indent=2)
+    return json.dumps(_session().client.query_connection(connection_id, query), indent=2)
 
 
 # --- Tier 3: Validate ---
@@ -136,7 +159,7 @@ def compile_transformation(transformation_id: int) -> str:
     Args:
         transformation_id: The transformation to compile.
     """
-    return json.dumps(_get_client().compile_transformation(transformation_id), indent=2)
+    return json.dumps(_session().client.compile_transformation(transformation_id), indent=2)
 
 
 @mcp.tool()
@@ -147,7 +170,7 @@ def preview_transformation(transformation_id: int, limit: int = 100) -> str:
         transformation_id: The transformation to preview.
         limit: Max rows to return (default 100, max 1000).
     """
-    return json.dumps(_get_client().preview_transformation(transformation_id, limit), indent=2)
+    return json.dumps(_session().client.preview_transformation(transformation_id, limit), indent=2)
 
 
 # --- Tier 4: Control (read half) ---
@@ -156,19 +179,19 @@ def preview_transformation(transformation_id: int, limit: int = 100) -> str:
 @mcp.tool()
 def list_uploads() -> str:
     """List all uploads (extract + load jobs) in the organization."""
-    return json.dumps(_get_client().list_uploads(), indent=2)
+    return json.dumps(_session().client.list_uploads(), indent=2)
 
 
 @mcp.tool()
 def list_pipelines() -> str:
     """List all pipelines (dbt transform orchestration) in the organization."""
-    return json.dumps(_get_client().list_pipelines(), indent=2)
+    return json.dumps(_session().client.list_pipelines(), indent=2)
 
 
 @mcp.tool()
 def list_transformations() -> str:
     """List all dbt transformations in the organization."""
-    return json.dumps(_get_client().list_transformations(), indent=2)
+    return json.dumps(_session().client.list_transformations(), indent=2)
 
 
 @mcp.tool()
@@ -180,7 +203,7 @@ def list_runs(target_type: str | None = None, status: str | None = None, limit: 
         status: Filter by status — 'pending', 'running', 'success', 'failed', 'cancelled'.
         limit: Max results (default 50, max 200).
     """
-    return json.dumps(_get_client().list_runs(target_type, status, limit), indent=2)
+    return json.dumps(_session().client.list_runs(target_type, status, limit), indent=2)
 
 
 @mcp.tool()
@@ -190,7 +213,7 @@ def get_run(run_id: int) -> str:
     Args:
         run_id: The run ID to look up.
     """
-    return json.dumps(_get_client().get_run(run_id), indent=2)
+    return json.dumps(_session().client.get_run(run_id), indent=2)
 
 
 @mcp.tool()
@@ -200,13 +223,13 @@ def get_run_logs(run_id: int) -> str:
     Args:
         run_id: The run ID whose logs to fetch.
     """
-    return json.dumps(_get_client().get_run_logs(run_id), indent=2)
+    return json.dumps(_session().client.get_run_logs(run_id), indent=2)
 
 
 @mcp.tool()
 def list_catalog() -> str:
     """List all catalog entries (source tables and dbt models)."""
-    return json.dumps(_get_client().list_catalog(), indent=2)
+    return json.dumps(_session().client.list_catalog(), indent=2)
 
 
 @mcp.tool()
@@ -216,7 +239,7 @@ def get_catalog_entry(entry_id: int) -> str:
     Args:
         entry_id: The catalog entry ID.
     """
-    return json.dumps(_get_client().get_catalog_entry(entry_id), indent=2)
+    return json.dumps(_session().client.get_catalog_entry(entry_id), indent=2)
 
 
 # ===================================================================
@@ -238,8 +261,8 @@ def create_connection(name: str, connection_type: str, config: dict) -> str:
         connection_type: One of the supported types (e.g. 'postgres', 'mysql', 'stripe').
         config: Connection-specific configuration (host, port, credentials, etc.).
     """
-    _require_write("create_connection")
-    return json.dumps(_get_client().create_connection(name, connection_type, config), indent=2)
+    _session().require_write("create_connection")
+    return json.dumps(_session().client.create_connection(name, connection_type, config), indent=2)
 
 
 @mcp.tool()
@@ -261,9 +284,9 @@ def create_upload(
         dlt_config: Optional dlt extraction config (load_mode, table_name, etc.).
         description: Optional description.
     """
-    _require_write("create_upload")
+    _session().require_write("create_upload")
     return json.dumps(
-        _get_client().create_upload(
+        _session().client.create_upload(
             name, source_connection_id, destination_connection_id, dlt_config, description
         ),
         indent=2,
@@ -287,9 +310,9 @@ def create_pipeline(
         command: dbt command — 'run', 'build', 'test', 'seed', 'snapshot', 'compile'.
         description: Optional description.
     """
-    _require_write("create_pipeline")
+    _session().require_write("create_pipeline")
     return json.dumps(
-        _get_client().create_pipeline(name, destination_connection_id, command, description),
+        _session().client.create_pipeline(name, destination_connection_id, command, description),
         indent=2,
     )
 
@@ -313,9 +336,9 @@ def create_transformation(
         description: Optional description.
         schema_name: Target schema (default 'staging').
     """
-    _require_write("create_transformation")
+    _session().require_write("create_transformation")
     return json.dumps(
-        _get_client().create_transformation(
+        _session().client.create_transformation(
             name, sql_body, materialization, description, schema_name
         ),
         indent=2,
@@ -333,8 +356,8 @@ def bulk_import(payload: dict) -> str:
         payload: JSON v2 import payload with version, connections, uploads,
                  pipelines, transformations sections. See AI_IMPORT_GUIDE.md.
     """
-    _require_write("bulk_import")
-    return json.dumps(_get_client().bulk_import(payload), indent=2)
+    _session().require_write("bulk_import")
+    return json.dumps(_session().client.bulk_import(payload), indent=2)
 
 
 # --- Tier 4: Execute ---
@@ -350,8 +373,8 @@ def trigger_upload(upload_id: int, wait: bool = False) -> str:
         upload_id: The upload to run.
         wait: If true, block until the run completes (up to 120s).
     """
-    _require_write("trigger_upload")
-    return json.dumps(_get_client().trigger_upload(upload_id, wait), indent=2)
+    _session().require_write("trigger_upload")
+    return json.dumps(_session().client.trigger_upload(upload_id, wait), indent=2)
 
 
 @mcp.tool()
@@ -364,8 +387,8 @@ def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
         pipeline_id: The pipeline to run.
         wait: If true, block until the run completes (up to 120s).
     """
-    _require_write("trigger_pipeline")
-    return json.dumps(_get_client().trigger_pipeline(pipeline_id, wait), indent=2)
+    _session().require_write("trigger_pipeline")
+    return json.dumps(_session().client.trigger_pipeline(pipeline_id, wait), indent=2)
 
 
 @mcp.tool()
@@ -378,8 +401,8 @@ def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
         transformation_id: The transformation to run.
         wait: If true, block until the run completes (up to 120s).
     """
-    _require_write("trigger_transformation")
-    return json.dumps(_get_client().trigger_transformation(transformation_id, wait), indent=2)
+    _session().require_write("trigger_transformation")
+    return json.dumps(_session().client.trigger_transformation(transformation_id, wait), indent=2)
 
 
 # ===================================================================

--- a/datanika-mcp/src/datanika_mcp/session.py
+++ b/datanika-mcp/src/datanika_mcp/session.py
@@ -1,0 +1,82 @@
+"""Per-request session resolution for the Datanika MCP tool surface.
+
+The stdio server runs one process per user, so a single process-global
+``(client, allow_write)`` pair was enough. A *remote* Streamable-HTTP server
+(``SPEC_REMOTE_MCP.md`` P1) serves many orgs from one process and must
+resolve those two values **per request** instead — otherwise one caller's
+credential and write-grant would leak into another's tool call.
+
+``DatanikaSession`` bundles the two values, and ``use_session`` binds one to
+a :class:`contextvars.ContextVar` for the duration of a request. Tool bodies
+read the active session via ``server._session()``, which prefers the
+contextvar and falls back to the module globals — so the stdio path (and the
+existing test-suite that sets those globals directly) keeps working unchanged.
+
+This module is deliberately transport-agnostic and imports nothing from the
+``mcp`` / FastMCP SDK: it is the version-insensitive foundation the remote
+transport is built on. Reading the FastMCP ``Context`` / bearer token and
+calling ``use_session`` is the transport layer's job, added in a later phase.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from datanika_mcp.client import DatanikaClient
+
+__all__ = ["DatanikaSession", "current_session", "use_session"]
+
+
+@dataclass(frozen=True)
+class DatanikaSession:
+    """The two values every tool needs, resolved per request.
+
+    ``client`` — an authenticated :class:`DatanikaClient` scoped to the
+    caller's org (a fixed CLI key on stdio; a per-request key on remote).
+    May be ``None`` only in the narrow "check write permission before a
+    client exists" path; any session handed to a tool has a live client.
+
+    ``allow_write`` — whether mutation tools are permitted for this session
+    (the stdio ``--allow-write`` flag; the OAuth write-consent grant on
+    remote).
+    """
+
+    client: DatanikaClient | None = None
+    allow_write: bool = False
+
+    def require_write(self, action: str) -> None:
+        """Raise ``RuntimeError`` if this session may not perform ``action``."""
+        if not self.allow_write:
+            raise RuntimeError(
+                f"Write access required for '{action}'. "
+                "Restart the server with --allow-write to enable mutations."
+            )
+
+
+# Per-request binding. Unset (``None``) on stdio and in unit tests, where the
+# module globals in ``server.py`` are the source of truth instead.
+_current_session: ContextVar[DatanikaSession | None] = ContextVar(
+    "datanika_mcp_session", default=None
+)
+
+
+def current_session() -> DatanikaSession | None:
+    """Return the :class:`DatanikaSession` bound to the current context, if any."""
+    return _current_session.get()
+
+
+@contextmanager
+def use_session(session: DatanikaSession) -> Iterator[DatanikaSession]:
+    """Bind ``session`` to the current context for the duration of the block.
+
+    The remote transport wraps each request in this; unit tests use it to
+    exercise the per-request path without mutating the module globals.
+    """
+    token = _current_session.set(session)
+    try:
+        yield session
+    finally:
+        _current_session.reset(token)

--- a/tests/test_mcp/test_mcp_session.py
+++ b/tests/test_mcp/test_mcp_session.py
@@ -1,0 +1,125 @@
+"""Tests for the de-globalized MCP tool surface (core#363, Remote-MCP P1).
+
+Proves the tool surface resolves a per-request ``DatanikaSession``: a
+contextvar binding wins over the module globals, and the globals remain the
+stdio / legacy fallback. Companion to ``test_mcp_server.py``, which pins the
+tool registry and the module-global path.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _add_mcp_to_path():
+    """Make ``datanika_mcp`` importable from the MCP sub-package."""
+    import pathlib
+
+    mcp_src = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+    if mcp_src not in sys.path:
+        sys.path.insert(0, mcp_src)
+
+
+@pytest.fixture
+def srv():
+    """The server module with its process globals snapshotted and restored.
+
+    De-globalization keeps ``_client`` / ``_allow_write`` as the stdio
+    fallback; these tests mutate them to prove per-request precedence, so we
+    restore the originals afterwards to stay hermetic across the file.
+    """
+    import datanika_mcp.server as server
+
+    saved_client, saved_allow = server._client, server._allow_write
+    try:
+        yield server
+    finally:
+        server._client, server._allow_write = saved_client, saved_allow
+
+
+class TestSessionResolution:
+    def test_bound_session_wins_over_globals(self, srv):
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        global_client = MagicMock(name="global")
+        bound_client = MagicMock(name="bound")
+        bound_client.list_connections.return_value = {"items": ["bound"]}
+        srv._client = global_client
+        srv._allow_write = False
+
+        with use_session(DatanikaSession(client=bound_client, allow_write=True)):
+            result = srv.list_connections()
+
+        bound_client.list_connections.assert_called_once()
+        global_client.list_connections.assert_not_called()
+        assert "bound" in result
+
+    def test_globals_used_when_no_session_bound(self, srv):
+        client = MagicMock()
+        client.list_uploads.return_value = {"items": []}
+        srv._client = client
+
+        result = srv.list_uploads()
+
+        client.list_uploads.assert_called_once()
+        assert '"items"' in result
+
+    def test_session_reset_after_context_exit(self, srv):
+        from datanika_mcp.session import DatanikaSession, current_session, use_session
+
+        assert current_session() is None
+        with use_session(DatanikaSession(client=MagicMock(), allow_write=True)):
+            assert current_session() is not None
+        assert current_session() is None
+
+    def test_uninitialized_fallback_raises(self, srv):
+        srv._client = None
+        srv._allow_write = False
+        with pytest.raises(RuntimeError, match="not initialized"):
+            srv.list_connections()
+
+
+class TestSessionWriteGuard:
+    def test_read_only_bound_session_blocks_writes(self, srv):
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        client = MagicMock()
+        # Globals grant write; the bound read-only session must still win.
+        srv._client = MagicMock()
+        srv._allow_write = True
+
+        with (
+            use_session(DatanikaSession(client=client, allow_write=False)),
+            pytest.raises(RuntimeError, match="Write access required"),
+        ):
+            srv.create_connection("t", "postgres", {"host": "h"})
+
+        client.create_connection.assert_not_called()
+
+    def test_read_write_bound_session_allows_writes(self, srv):
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        client = MagicMock()
+        client.create_connection.return_value = {"id": 7}
+        # Globals have no client and forbid writes; the bound session must win.
+        srv._client = None
+        srv._allow_write = False
+
+        with use_session(DatanikaSession(client=client, allow_write=True)):
+            result = srv.create_connection("t", "postgres", {"host": "h"})
+
+        client.create_connection.assert_called_once_with("t", "postgres", {"host": "h"})
+        assert '"id": 7' in result
+
+    def test_require_write_shim_reads_bound_session(self, srv):
+        """The back-compat ``_require_write`` shim honors the bound session."""
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        srv._allow_write = False  # global default forbids writes
+        with use_session(DatanikaSession(client=MagicMock(), allow_write=True)):
+            srv._require_write("create_connection")  # bound grant → no raise
+
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv._require_write("create_connection")  # unbound, global False → blocked


### PR DESCRIPTION
Remote-MCP P1 foundation — the version-insensitive first step of #363, off the signed-off `SPEC_REMOTE_MCP.md` (§5.1).

## What & why
`datanika-mcp` tools resolved their `(client, allow_write)` from **process globals** — fine for a one-user stdio process, impossible for a remote server that fronts many orgs from one process. This de-globalizes the tool surface so a per-request `DatanikaSession` drives every tool, while stdio keeps working unchanged.

## Design
- **`session.py` (new)** — `DatanikaSession(client, allow_write)` + `require_write()`, a `contextvars.ContextVar` binding, and `use_session()` / `current_session()`. Deliberately transport-agnostic (no `mcp`/FastMCP imports): the version-insensitive base a later Streamable-HTTP mount will populate from the FastMCP `Context` / bearer token.
- **`server._session()`** — resolves **contextvar-first, module-global fallback**. Remote binds a session per request; stdio (and the existing tests) rely on the `_client` / `_allow_write` globals `main()` sets.
- **Tool bodies** — mechanical: `_get_client()` → `_session().client`, `_require_write("x")` → `_session().require_write("x")`. The 25 tool signatures/docstrings are untouched (they are the product surface).
- **`_require_write` kept** as a back-compat shim (tests + external callers reference `server._require_write`); it resolves the write-grant from the bound session or globals, independent of client init, so a write can be rejected before a client exists.

## Invariants (re-check against the diff)
1. **stdio unchanged** — `main()` still sets the globals and runs `transport="stdio"`; nothing binds the contextvar on that path, so `_session()` falls through to the globals.
2. **25-tool registry intact** (17 read + 8 write); no tool added/removed/renamed.
3. **Per-request wins** — a bound *read-only* session blocks writes even when process globals say `allow_write=True`; a bound *read-write* session allows writes even when globals are unset/None.
4. **No new surface** — no transport, no OAuth AS, no write-tool enablement. Those are P2/P3 (P3 write tools gated on #338).

## Tests
- 7 new (`tests/test_mcp/test_mcp_session.py`): bound-session-wins-over-globals (reads + write-guard), globals fallback, contextvar reset, uninitialized-raise, shim-honours-binding.
- Existing 15 (`test_mcp_server.py`) unchanged and green.
- Full core precheck green locally: `ruff check/format` clean, **2282 passed, 19 skipped**.

Spec: `plans/engineering/SPEC_REMOTE_MCP.md`. Next P1 step: mount `/mcp` (Streamable-HTTP, stateless-JSON) with bearer = existing API key (still read-only).
