### PR TITLE
[Infra] Promote core dev -> master (2026-07-20): SSRF egress guard + Remote-MCP P1 + E2E spec reconcile + MCP README

### DIFF
--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -7,7 +7,7 @@ MCP server for [Datanika](https://datanika.io) — browse connections, preview d
 ## Install
 
 ```bash
-# From PyPI (when published)
+# From PyPI (recommended)
 uvx datanika-mcp --help
 
 # From git

--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -22,10 +22,17 @@ import sys
 from mcp.server.fastmcp import FastMCP
 
 from datanika_mcp.client import DatanikaClient
+from datanika_mcp.session import DatanikaSession, current_session
 
 # ---------------------------------------------------------------------------
-# Globals populated at startup
+# Session resolution — contextvar-first, module-global fallback
 # ---------------------------------------------------------------------------
+#
+# ``main()`` populates the module globals for the single-tenant stdio server.
+# A remote transport (SPEC_REMOTE_MCP.md P1) instead binds a per-request
+# ``DatanikaSession`` via ``session.use_session``; ``_session()`` prefers that
+# binding and falls back to the globals, so both transports share one tool
+# surface and the existing tests (which set the globals directly) stay green.
 
 _client: DatanikaClient | None = None
 _allow_write: bool = False
@@ -40,18 +47,34 @@ mcp = FastMCP(
 )
 
 
-def _get_client() -> DatanikaClient:
+def _session() -> DatanikaSession:
+    """Resolve the active session for the current tool call.
+
+    Prefers a per-request session bound by the transport (remote); falls back
+    to the process globals set by ``main()`` (stdio / tests). Raises if no
+    client is available on the fallback path — i.e. ``main()`` never ran.
+    """
+    session = current_session()
+    if session is not None:
+        return session
     if _client is None:
         raise RuntimeError("DatanikaClient not initialized — call main() first")
-    return _client
+    return DatanikaSession(client=_client, allow_write=_allow_write)
 
 
 def _require_write(action: str) -> None:
-    if not _allow_write:
-        raise RuntimeError(
-            f"Write access required for '{action}'. "
-            "Restart the server with --allow-write to enable mutations."
-        )
+    """Module-level write guard, kept for backward compatibility.
+
+    Tool bodies call ``_session().require_write`` directly; this shim exists
+    so code (and tests) referencing ``server._require_write`` keep working. It
+    resolves the write-grant from the bound session if present, else the
+    module globals — deliberately without a live client, so a write can be
+    rejected before the client is constructed.
+    """
+    session = current_session()
+    if session is None:
+        session = DatanikaSession(client=_client, allow_write=_allow_write)
+    session.require_write(action)
 
 
 # ===================================================================
@@ -65,25 +88,25 @@ def _require_write(action: str) -> None:
 @mcp.tool()
 def get_agent_tiers() -> str:
     """Get the 5-tier agent capability stack — describes what the API can do."""
-    return json.dumps(_get_client().get_agent_tiers(), indent=2)
+    return json.dumps(_session().client.get_agent_tiers(), indent=2)
 
 
 @mcp.tool()
 def get_connection_types() -> str:
     """List all supported connection types with their config schemas."""
-    return json.dumps(_get_client().get_connection_types(), indent=2)
+    return json.dumps(_session().client.get_connection_types(), indent=2)
 
 
 @mcp.tool()
 def list_connections() -> str:
     """List all connections in the organization."""
-    return json.dumps(_get_client().list_connections(), indent=2)
+    return json.dumps(_session().client.list_connections(), indent=2)
 
 
 @mcp.tool()
 def get_connection(connection_id: int) -> str:
     """Get details of a specific connection by ID."""
-    return json.dumps(_get_client().get_connection(connection_id), indent=2)
+    return json.dumps(_session().client.get_connection(connection_id), indent=2)
 
 
 @mcp.tool()
@@ -94,7 +117,7 @@ def introspect_connection(connection_id: int, schema: str | None = None) -> str:
         connection_id: The connection to introspect.
         schema: Optional schema name to filter tables.
     """
-    return json.dumps(_get_client().introspect_connection(connection_id, schema), indent=2)
+    return json.dumps(_session().client.introspect_connection(connection_id, schema), indent=2)
 
 
 @mcp.tool()
@@ -110,7 +133,7 @@ def preview_connection(
         limit: Max rows to return (default 100).
     """
     return json.dumps(
-        _get_client().preview_connection(connection_id, table, schema, limit),
+        _session().client.preview_connection(connection_id, table, schema, limit),
         indent=2,
     )
 
@@ -123,7 +146,7 @@ def query_connection(connection_id: int, query: str) -> str:
         connection_id: The connection to query.
         query: A single SELECT statement (no mutations allowed).
     """
-    return json.dumps(_get_client().query_connection(connection_id, query), indent=2)
+    return json.dumps(_session().client.query_connection(connection_id, query), indent=2)
 
 
 # --- Tier 3: Validate ---
@@ -136,7 +159,7 @@ def compile_transformation(transformation_id: int) -> str:
     Args:
         transformation_id: The transformation to compile.
     """
-    return json.dumps(_get_client().compile_transformation(transformation_id), indent=2)
+    return json.dumps(_session().client.compile_transformation(transformation_id), indent=2)
 
 
 @mcp.tool()
@@ -147,7 +170,7 @@ def preview_transformation(transformation_id: int, limit: int = 100) -> str:
         transformation_id: The transformation to preview.
         limit: Max rows to return (default 100, max 1000).
     """
-    return json.dumps(_get_client().preview_transformation(transformation_id, limit), indent=2)
+    return json.dumps(_session().client.preview_transformation(transformation_id, limit), indent=2)
 
 
 # --- Tier 4: Control (read half) ---
@@ -156,19 +179,19 @@ def preview_transformation(transformation_id: int, limit: int = 100) -> str:
 @mcp.tool()
 def list_uploads() -> str:
     """List all uploads (extract + load jobs) in the organization."""
-    return json.dumps(_get_client().list_uploads(), indent=2)
+    return json.dumps(_session().client.list_uploads(), indent=2)
 
 
 @mcp.tool()
 def list_pipelines() -> str:
     """List all pipelines (dbt transform orchestration) in the organization."""
-    return json.dumps(_get_client().list_pipelines(), indent=2)
+    return json.dumps(_session().client.list_pipelines(), indent=2)
 
 
 @mcp.tool()
 def list_transformations() -> str:
     """List all dbt transformations in the organization."""
-    return json.dumps(_get_client().list_transformations(), indent=2)
+    return json.dumps(_session().client.list_transformations(), indent=2)
 
 
 @mcp.tool()
@@ -180,7 +203,7 @@ def list_runs(target_type: str | None = None, status: str | None = None, limit: 
         status: Filter by status — 'pending', 'running', 'success', 'failed', 'cancelled'.
         limit: Max results (default 50, max 200).
     """
-    return json.dumps(_get_client().list_runs(target_type, status, limit), indent=2)
+    return json.dumps(_session().client.list_runs(target_type, status, limit), indent=2)
 
 
 @mcp.tool()
@@ -190,7 +213,7 @@ def get_run(run_id: int) -> str:
     Args:
         run_id: The run ID to look up.
     """
-    return json.dumps(_get_client().get_run(run_id), indent=2)
+    return json.dumps(_session().client.get_run(run_id), indent=2)
 
 
 @mcp.tool()
@@ -200,13 +223,13 @@ def get_run_logs(run_id: int) -> str:
     Args:
         run_id: The run ID whose logs to fetch.
     """
-    return json.dumps(_get_client().get_run_logs(run_id), indent=2)
+    return json.dumps(_session().client.get_run_logs(run_id), indent=2)
 
 
 @mcp.tool()
 def list_catalog() -> str:
     """List all catalog entries (source tables and dbt models)."""
-    return json.dumps(_get_client().list_catalog(), indent=2)
+    return json.dumps(_session().client.list_catalog(), indent=2)
 
 
 @mcp.tool()
@@ -216,7 +239,7 @@ def get_catalog_entry(entry_id: int) -> str:
     Args:
         entry_id: The catalog entry ID.
     """
-    return json.dumps(_get_client().get_catalog_entry(entry_id), indent=2)
+    return json.dumps(_session().client.get_catalog_entry(entry_id), indent=2)
 
 
 # ===================================================================
@@ -238,8 +261,8 @@ def create_connection(name: str, connection_type: str, config: dict) -> str:
         connection_type: One of the supported types (e.g. 'postgres', 'mysql', 'stripe').
         config: Connection-specific configuration (host, port, credentials, etc.).
     """
-    _require_write("create_connection")
-    return json.dumps(_get_client().create_connection(name, connection_type, config), indent=2)
+    _session().require_write("create_connection")
+    return json.dumps(_session().client.create_connection(name, connection_type, config), indent=2)
 
 
 @mcp.tool()
@@ -261,9 +284,9 @@ def create_upload(
         dlt_config: Optional dlt extraction config (load_mode, table_name, etc.).
         description: Optional description.
     """
-    _require_write("create_upload")
+    _session().require_write("create_upload")
     return json.dumps(
-        _get_client().create_upload(
+        _session().client.create_upload(
             name, source_connection_id, destination_connection_id, dlt_config, description
         ),
         indent=2,
@@ -287,9 +310,9 @@ def create_pipeline(
         command: dbt command — 'run', 'build', 'test', 'seed', 'snapshot', 'compile'.
         description: Optional description.
     """
-    _require_write("create_pipeline")
+    _session().require_write("create_pipeline")
     return json.dumps(
-        _get_client().create_pipeline(name, destination_connection_id, command, description),
+        _session().client.create_pipeline(name, destination_connection_id, command, description),
         indent=2,
     )
 
@@ -313,9 +336,9 @@ def create_transformation(
         description: Optional description.
         schema_name: Target schema (default 'staging').
     """
-    _require_write("create_transformation")
+    _session().require_write("create_transformation")
     return json.dumps(
-        _get_client().create_transformation(
+        _session().client.create_transformation(
             name, sql_body, materialization, description, schema_name
         ),
         indent=2,
@@ -333,8 +356,8 @@ def bulk_import(payload: dict) -> str:
         payload: JSON v2 import payload with version, connections, uploads,
                  pipelines, transformations sections. See AI_IMPORT_GUIDE.md.
     """
-    _require_write("bulk_import")
-    return json.dumps(_get_client().bulk_import(payload), indent=2)
+    _session().require_write("bulk_import")
+    return json.dumps(_session().client.bulk_import(payload), indent=2)
 
 
 # --- Tier 4: Execute ---
@@ -350,8 +373,8 @@ def trigger_upload(upload_id: int, wait: bool = False) -> str:
         upload_id: The upload to run.
         wait: If true, block until the run completes (up to 120s).
     """
-    _require_write("trigger_upload")
-    return json.dumps(_get_client().trigger_upload(upload_id, wait), indent=2)
+    _session().require_write("trigger_upload")
+    return json.dumps(_session().client.trigger_upload(upload_id, wait), indent=2)
 
 
 @mcp.tool()
@@ -364,8 +387,8 @@ def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
         pipeline_id: The pipeline to run.
         wait: If true, block until the run completes (up to 120s).
     """
-    _require_write("trigger_pipeline")
-    return json.dumps(_get_client().trigger_pipeline(pipeline_id, wait), indent=2)
+    _session().require_write("trigger_pipeline")
+    return json.dumps(_session().client.trigger_pipeline(pipeline_id, wait), indent=2)
 
 
 @mcp.tool()
@@ -378,8 +401,8 @@ def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
         transformation_id: The transformation to run.
         wait: If true, block until the run completes (up to 120s).
     """
-    _require_write("trigger_transformation")
-    return json.dumps(_get_client().trigger_transformation(transformation_id, wait), indent=2)
+    _session().require_write("trigger_transformation")
+    return json.dumps(_session().client.trigger_transformation(transformation_id, wait), indent=2)
 
 
 # ===================================================================

--- a/datanika-mcp/src/datanika_mcp/session.py
+++ b/datanika-mcp/src/datanika_mcp/session.py
@@ -1,0 +1,82 @@
+"""Per-request session resolution for the Datanika MCP tool surface.
+
+The stdio server runs one process per user, so a single process-global
+``(client, allow_write)`` pair was enough. A *remote* Streamable-HTTP server
+(``SPEC_REMOTE_MCP.md`` P1) serves many orgs from one process and must
+resolve those two values **per request** instead — otherwise one caller's
+credential and write-grant would leak into another's tool call.
+
+``DatanikaSession`` bundles the two values, and ``use_session`` binds one to
+a :class:`contextvars.ContextVar` for the duration of a request. Tool bodies
+read the active session via ``server._session()``, which prefers the
+contextvar and falls back to the module globals — so the stdio path (and the
+existing test-suite that sets those globals directly) keeps working unchanged.
+
+This module is deliberately transport-agnostic and imports nothing from the
+``mcp`` / FastMCP SDK: it is the version-insensitive foundation the remote
+transport is built on. Reading the FastMCP ``Context`` / bearer token and
+calling ``use_session`` is the transport layer's job, added in a later phase.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from datanika_mcp.client import DatanikaClient
+
+__all__ = ["DatanikaSession", "current_session", "use_session"]
+
+
+@dataclass(frozen=True)
+class DatanikaSession:
+    """The two values every tool needs, resolved per request.
+
+    ``client`` — an authenticated :class:`DatanikaClient` scoped to the
+    caller's org (a fixed CLI key on stdio; a per-request key on remote).
+    May be ``None`` only in the narrow "check write permission before a
+    client exists" path; any session handed to a tool has a live client.
+
+    ``allow_write`` — whether mutation tools are permitted for this session
+    (the stdio ``--allow-write`` flag; the OAuth write-consent grant on
+    remote).
+    """
+
+    client: DatanikaClient | None = None
+    allow_write: bool = False
+
+    def require_write(self, action: str) -> None:
+        """Raise ``RuntimeError`` if this session may not perform ``action``."""
+        if not self.allow_write:
+            raise RuntimeError(
+                f"Write access required for '{action}'. "
+                "Restart the server with --allow-write to enable mutations."
+            )
+
+
+# Per-request binding. Unset (``None``) on stdio and in unit tests, where the
+# module globals in ``server.py`` are the source of truth instead.
+_current_session: ContextVar[DatanikaSession | None] = ContextVar(
+    "datanika_mcp_session", default=None
+)
+
+
+def current_session() -> DatanikaSession | None:
+    """Return the :class:`DatanikaSession` bound to the current context, if any."""
+    return _current_session.get()
+
+
+@contextmanager
+def use_session(session: DatanikaSession) -> Iterator[DatanikaSession]:
+    """Bind ``session`` to the current context for the duration of the block.
+
+    The remote transport wraps each request in this; unit tests use it to
+    exercise the per-request path without mutating the module globals.
+    """
+    token = _current_session.set(session)
+    try:
+        yield session
+    finally:
+        _current_session.reset(token)

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine, inspect, select, text
 from sqlalchemy.orm import Session
 
 from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
+from datanika.services.egress_guard import validate_egress_host
 from datanika.services.encryption import EncryptionService
 from datanika.services.naming import validate_name
 
@@ -232,6 +233,13 @@ class ConnectionService:
 
         emit("connection.before_create", session=session, org_id=org_id)
         validate_connection_name(name)
+        # SSRF pre-flight gate (core#338): reject connectors whose user-supplied
+        # base_url resolves to a non-public host at create time. Only fires when
+        # a base_url is present, so DB connectors and hardcoded-host SaaS
+        # (stripe/github/…) are unaffected.
+        base_url = (config or {}).get("base_url")
+        if base_url:
+            validate_egress_host(base_url)
         direction = infer_direction(connection_type)
         # Normalise "" → None so analytics queries can filter on a single
         # NULL check. ConnectionState.selected_template_slug defaults to ""

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -9,6 +9,8 @@ from dlt.sources.filesystem import filesystem
 from dlt.sources.rest_api import rest_api_source
 from dlt.sources.sql_database import sql_database, sql_table
 
+from datanika.services.egress_guard import validate_egress_host
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BATCH_SIZE = 10_000
@@ -377,6 +379,7 @@ class DltRunnerService:
         Shared by the generic ``rest_api`` connector and the ``openapi``
         connector (whose resources are derived from a spec).
         """
+        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
         client_config: dict = {"base_url": base_url}
         if headers:
             client_config["headers"] = headers
@@ -967,6 +970,7 @@ class DltRunnerService:
         headers: dict | None = None,
     ):
         """Generic REST API source used when a verified source module is not installed."""
+        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
         client: dict = {"base_url": base_url}
         if auth:
             client["auth"] = auth

--- a/datanika/services/egress_guard.py
+++ b/datanika/services/egress_guard.py
@@ -1,0 +1,81 @@
+"""Defense-in-depth PRE-FLIGHT SSRF guard for the ``rest_api`` connector family (core#338).
+
+User-supplied base URLs (generic ``rest_api``/``openapi`` connectors and the
+SaaS fallbacks whose host is user-controlled — e.g. Salesforce ``instance_url``,
+Shopify store) are handed to dlt's ``requests``-based REST client and fetched
+from inside the worker. Without a guard, a user could point a connector at
+``http://169.254.169.254/…`` (cloud metadata) or an internal ``10.0.0.0/8`` /
+``192.168.0.0/16`` service and exfiltrate it via the pipeline. ``validate_egress_host``
+resolves the hostname and rejects the request if ANY resolved IP is non-public.
+
+This is a pre-flight check only. It has TWO KNOWN RESIDUAL GAPS, deferred to P3
+(to be closed before any cloud-worker migration, and before enabling the
+OpenAPI-P2 URL-fetch feature):
+
+  (c) **Redirect hops are NOT re-validated.** dlt's REST client is ``requests``
+      based and follows redirects inside ``.session.send()``; a public host that
+      responds with a 30x redirect to a private IP would bypass this guard.
+      Closing it needs a custom ``requests.Session`` / ``HTTPAdapter`` that
+      re-validates every hop's resolved address.
+
+  (d) **A resource ``path`` that is itself an absolute ``http(s)://`` URL bypasses
+      ``base_url``** (dlt ``rest_client`` ``client.py:122-124`` joins/overrides the
+      base with an absolute path) and is not validated here — only ``base_url`` is
+      checked.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+class EgressValidationError(ValueError):
+    """Raised when a user-supplied URL points at a non-public / internal host."""
+
+
+def validate_egress_host(url: str) -> None:
+    """Reject *url* if its host resolves to any non-public IP address.
+
+    Raises :class:`EgressValidationError` for a non-``http(s)`` scheme, a
+    missing host, an unresolvable host (fail closed), or when ANY resolved IP
+    is private, loopback, link-local (incl. ``169.254.169.254`` cloud metadata),
+    multicast, reserved, or unspecified. Returns ``None`` when every resolved
+    IP is public.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise EgressValidationError(f"URL scheme must be http or https, got {parsed.scheme!r}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise EgressValidationError(f"URL has no host: {url!r}")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        # Fail closed: if we cannot resolve the host, we cannot prove it is
+        # public, so we refuse it.
+        raise EgressValidationError(f"could not resolve host {hostname!r}: {exc}") from exc
+
+    ip_strings = {info[4][0] for info in infos}
+    for ip_str in ip_strings:
+        ip = ipaddress.ip_address(ip_str)
+        # Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) so 127.0.0.1 et al. are
+        # classified against their real IPv4 range.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise EgressValidationError(
+                f"host {hostname!r} resolves to non-public address {ip_str} — refusing egress"
+            )
+
+    return None

--- a/e2e/tests/overage-charge-cycle.spec.ts
+++ b/e2e/tests/overage-charge-cycle.spec.ts
@@ -10,36 +10,47 @@ import { test, expect } from "@playwright/test";
  *   1. Seed tenant on V2 Pro plan (100 GB included, overage price set).
  *   2. Seed usage_ledger totalling 105 GB within the current billing period.
  *   3. Fast-forward clock to T-23h before cycle end.
- *   4. Trigger the `emit_charge_incoming_warnings` Celery task.
+ *   4. Trigger the `emit_charge_incoming_notices` Celery task.
  *   5. Assert: in-app Notification(type=CHARGE_INCOMING) visible in the
  *      notifications drawer; projected amount = 500 cents.
  *   6. Fast-forward to cycle end (T+1min).
- *   7. Trigger `settle_overage_charges`.
+ *   7. Trigger `charge_cycle_overages`.
  *   8. Assert: Paddle sandbox records a subscription-charge; Charge row
- *      status=succeeded; paddle_charge_id populated.
- *   9. Re-run the task — idempotent. Paddle is not called again; Charge
- *      row unchanged.
+ *      status=issued; paddle_transaction_id populated (txn_…).
+ *   9. Re-run the task — idempotent. Paddle is not called again; no second
+ *      Charge row is issued (unique idempotency_key barrier).
  *
- * Prerequisites (all three must be true or the suite skips):
+ * Client-side prerequisites (all three must be true or the suite skips):
  *   - DATANIKA_E2E_OVERAGE_CHARGE=1 — explicit opt-in; unsafe by default
  *   - PADDLE_SANDBOX_VENDOR_ID + PADDLE_SANDBOX_API_KEY — sandbox creds
  *   - Test-only admin endpoints live (see list below)
  *
- * Test-only admin endpoints required (Engineering V2 P5):
+ * Server-side prerequisites (staging app env — not skip gates, but the
+ * charge task no-ops / errors without them):
+ *   - DATANIKA_OVERAGE_CHARGE_ENABLE=1 — else `charge_cycle_overages` returns
+ *     {..., "disabled": true} and issues nothing (kill-switch, cloud#68)
+ *   - PADDLE_OVERAGE_PRODUCT_ID set — else PaddleClient.charge_subscription
+ *     raises ValueError (core#273)
+ *
+ * Test-only admin endpoints required (Engineering V2 P5 — see core#361):
  *   POST /api/admin/e2e/seed-overage-tenant
  *     body: { planSlug, includedGB, overagePriceCents, usageGB }
  *     returns: { orgId, subscriptionId, billingPeriodStart, billingPeriodEnd, authToken }
  *   POST /api/admin/e2e/advance-clock
  *     body: { toIso: string }  // fast-forward system time for scheduler-relative logic
  *   POST /api/admin/e2e/run-task
- *     body: { taskName: 'emit_charge_incoming_warnings' | 'settle_overage_charges' }
- *     returns: { status, logs }
+ *     body: { taskName: 'emit_charge_incoming_notices' | 'charge_cycle_overages' }
+ *     returns: { taskName, result }  // result = task's native return (int for
+ *              notices; { issued, skipped_idempotent, failed } for the charge loop)
+ *   GET  /api/admin/e2e/charges?subscriptionId=<id>
+ *     returns: Array<{ id, status, amountCents, paddleTransactionId }>
  *
- * All three are gated behind DATANIKA_ENV !== 'production' guards. See
- * core#249 for Engineering's admin-endpoint ship task.
+ * All are gated behind DATANIKA_ENV !== 'production' guards. Endpoints
+ * tracked in core#361; this spec reconciled to the shipped cloud interface
+ * in core#362.
  *
  * This spec is red-tests-first: the @slow tag + env gate keep it out of
- * PR CI; when Engineering ships the endpoints + charge loop, flip the
+ * PR CI; when Engineering ships the endpoints (core#361), flip the
  * FAST_FORWARD_NOT_READY constant to false and the assertions start
  * pulling real data.
  */
@@ -51,9 +62,19 @@ const GATE =
 
 const BASE_URL = process.env.DATANIKA_E2E_BASE_URL ?? "https://staging-app.datanika.io";
 
-// Flip to false when Engineering ships the test-only admin endpoints +
-// charge loop. At that point every test below should turn green.
+// Flip to false when Engineering ships the test-only admin endpoints
+// (core#361). At that point every test below should turn green.
 const FAST_FORWARD_NOT_READY = true;
+
+// Native return of the `charge_cycle_overages` Celery task (cloud dev:
+// datanika_cloud/billing/tasks.py). `disabled` appears only when the
+// DATANIKA_OVERAGE_CHARGE_ENABLE kill-switch is off.
+type ChargeSummary = {
+  issued: number;
+  skipped_idempotent: number;
+  failed: number;
+  disabled?: boolean;
+};
 
 test.describe("V2 P5 overage charge cycle @slow", () => {
   test.skip(
@@ -63,7 +84,7 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
 
   test.skip(
     () => FAST_FORWARD_NOT_READY,
-    "Engineering V2 P5 admin endpoints not shipped yet — see core#249",
+    "Engineering V2 P5 admin endpoints not shipped yet — see core#361",
   );
 
   test("cycle: seed → T-23h notify → T+0 charge → retry no-op", async ({
@@ -99,9 +120,9 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
     });
     expect(adv1.ok()).toBeTruthy();
 
-    // Step 4 — fire the warning task
+    // Step 4 — fire the notice task
     const warn = await request.post(`${BASE_URL}/api/admin/e2e/run-task`, {
-      data: { taskName: "emit_charge_incoming_warnings" },
+      data: { taskName: "emit_charge_incoming_notices" },
     });
     expect(warn.ok()).toBeTruthy();
 
@@ -128,14 +149,18 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
     });
     expect(adv2.ok()).toBeTruthy();
 
-    // Step 7 — settle the charge
+    // Step 7 — run the charge loop
     const settle1 = await request.post(`${BASE_URL}/api/admin/e2e/run-task`, {
-      data: { taskName: "settle_overage_charges" },
+      data: { taskName: "charge_cycle_overages" },
     });
     expect(settle1.ok()).toBeTruthy();
-    const settle1Body = (await settle1.json()) as { chargeId: number; paddleChargeId: string };
-
-    expect(settle1Body.paddleChargeId).toMatch(/^cha_/); // Paddle charge IDs prefixed with cha_
+    const settle1Body = (await settle1.json()) as {
+      taskName: string;
+      result: ChargeSummary;
+    };
+    // Exactly one charge issued this cycle; kill-switch must be on (no `disabled`).
+    expect(settle1Body.result.disabled).toBeFalsy();
+    expect(settle1Body.result.issued).toBe(1);
 
     // Step 8 — verify Charge row via admin list endpoint
     const listRes = await request.get(
@@ -147,25 +172,28 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
       id: number;
       status: string;
       amountCents: number;
-      paddleChargeId: string | null;
+      paddleTransactionId: string | null;
     }>;
     expect(charges).toHaveLength(1);
-    expect(charges[0].status).toBe("succeeded");
+    // Post-issue status is ISSUED (Paddle accepted). It flips to PAID only on
+    // the transaction.completed webhook, which is out of scope for this cycle.
+    expect(charges[0].status).toBe("issued");
     expect(charges[0].amountCents).toBe(500);
-    expect(charges[0].paddleChargeId).toBe(settle1Body.paddleChargeId);
+    expect(charges[0].paddleTransactionId).toMatch(/^txn_/); // Paddle transaction id
 
-    // Step 9 — idempotency: re-run the settle task
+    // Step 9 — idempotency: re-run the charge loop
     const settle2 = await request.post(`${BASE_URL}/api/admin/e2e/run-task`, {
-      data: { taskName: "settle_overage_charges" },
+      data: { taskName: "charge_cycle_overages" },
     });
     expect(settle2.ok()).toBeTruthy();
     const settle2Body = (await settle2.json()) as {
-      status: string;
-      skippedReason?: string;
+      taskName: string;
+      result: ChargeSummary;
     };
-    // Engineering may report "noop" via either (a) 200 + skippedReason
-    // or (b) an idempotency-specific status. Accept either.
-    expect(settle2Body.status === "noop" || settle2Body.skippedReason).toBeTruthy();
+    // The unique idempotency_key barrier means no second charge is issued.
+    // (Whether the row is de-selected or hits the guard is Eng's call — the
+    // invariant that matters is issued === 0, asserted robustly here.)
+    expect(settle2Body.result.issued).toBe(0);
 
     // Charge row count unchanged.
     const listRes2 = await request.get(
@@ -177,26 +205,29 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
   });
 
   test("Paddle 4xx response marks Charge failed with reason", async ({ request }) => {
-    // Scenario: seed a tenant whose Paddle sandbox subscription has been
-    // manually set to "card-declines-always". Settle the overage. Assert
-    // Charge.status=failed, Charge.failure_reason matches the Paddle body.
+    // Scenario: Paddle sandbox returns a 4xx on the POST /subscriptions/{id}/charge
+    // request (pre-acceptance rejection). After CHARGE_MAX_RETRIES the Charge goes
+    // to status=failed with `last_error` set to the Paddle body.
     //
-    // Gated on Engineering ship gate 3 (failed-payment policy) per
-    // SPEC_OVERAGE_BILLING_TESTS.md §4.4 + §10.5. When the policy lands,
-    // seed the decline-always subscription in the sandbox and uncomment
-    // this scenario.
-    test.skip(true, "Engineering ship gate 3 — failed-payment policy not yet specified");
+    // NB: this is the pre-acceptance path. A *post-acceptance* collection decline
+    // is different — the charge stays ISSUED while Paddle runs dunning (see
+    // docs/billing-failed-payment-policy.md §Grace period). Don't conflate them.
+    //
+    // The grace-period policy is now specified (cloud#48), but exercising this
+    // needs a sandbox subscription/product that forces a 4xx + a decline-simulation
+    // harness. Kept skipped until that harness lands.
+    test.skip(true, "Needs sandbox 4xx-forcing harness — see core#361 / SPEC §4.4");
   });
 
   test("no charge when usage under included", async ({ request }) => {
-    // Scenario: seed 80 GB usage on a 100 GB plan. Run settle at cycle
-    // close. Assert: no Paddle call, no Charge row.
+    // Scenario: seed 80 GB usage on a 100 GB plan. Run charge_cycle_overages at
+    // cycle close. Assert: no Paddle call, no Charge row (result.issued === 0).
     //
     // This is the "sanity" gate — catches a regression where the charge
     // loop fires on any usage, overage or not.
     test.skip(
       FAST_FORWARD_NOT_READY,
-      "Engineering V2 P5 not shipped — see core#249",
+      "Engineering V2 P5 not shipped — see core#361",
     );
   });
 });

--- a/tests/test_mcp/test_mcp_session.py
+++ b/tests/test_mcp/test_mcp_session.py
@@ -1,0 +1,125 @@
+"""Tests for the de-globalized MCP tool surface (core#363, Remote-MCP P1).
+
+Proves the tool surface resolves a per-request ``DatanikaSession``: a
+contextvar binding wins over the module globals, and the globals remain the
+stdio / legacy fallback. Companion to ``test_mcp_server.py``, which pins the
+tool registry and the module-global path.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _add_mcp_to_path():
+    """Make ``datanika_mcp`` importable from the MCP sub-package."""
+    import pathlib
+
+    mcp_src = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+    if mcp_src not in sys.path:
+        sys.path.insert(0, mcp_src)
+
+
+@pytest.fixture
+def srv():
+    """The server module with its process globals snapshotted and restored.
+
+    De-globalization keeps ``_client`` / ``_allow_write`` as the stdio
+    fallback; these tests mutate them to prove per-request precedence, so we
+    restore the originals afterwards to stay hermetic across the file.
+    """
+    import datanika_mcp.server as server
+
+    saved_client, saved_allow = server._client, server._allow_write
+    try:
+        yield server
+    finally:
+        server._client, server._allow_write = saved_client, saved_allow
+
+
+class TestSessionResolution:
+    def test_bound_session_wins_over_globals(self, srv):
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        global_client = MagicMock(name="global")
+        bound_client = MagicMock(name="bound")
+        bound_client.list_connections.return_value = {"items": ["bound"]}
+        srv._client = global_client
+        srv._allow_write = False
+
+        with use_session(DatanikaSession(client=bound_client, allow_write=True)):
+            result = srv.list_connections()
+
+        bound_client.list_connections.assert_called_once()
+        global_client.list_connections.assert_not_called()
+        assert "bound" in result
+
+    def test_globals_used_when_no_session_bound(self, srv):
+        client = MagicMock()
+        client.list_uploads.return_value = {"items": []}
+        srv._client = client
+
+        result = srv.list_uploads()
+
+        client.list_uploads.assert_called_once()
+        assert '"items"' in result
+
+    def test_session_reset_after_context_exit(self, srv):
+        from datanika_mcp.session import DatanikaSession, current_session, use_session
+
+        assert current_session() is None
+        with use_session(DatanikaSession(client=MagicMock(), allow_write=True)):
+            assert current_session() is not None
+        assert current_session() is None
+
+    def test_uninitialized_fallback_raises(self, srv):
+        srv._client = None
+        srv._allow_write = False
+        with pytest.raises(RuntimeError, match="not initialized"):
+            srv.list_connections()
+
+
+class TestSessionWriteGuard:
+    def test_read_only_bound_session_blocks_writes(self, srv):
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        client = MagicMock()
+        # Globals grant write; the bound read-only session must still win.
+        srv._client = MagicMock()
+        srv._allow_write = True
+
+        with (
+            use_session(DatanikaSession(client=client, allow_write=False)),
+            pytest.raises(RuntimeError, match="Write access required"),
+        ):
+            srv.create_connection("t", "postgres", {"host": "h"})
+
+        client.create_connection.assert_not_called()
+
+    def test_read_write_bound_session_allows_writes(self, srv):
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        client = MagicMock()
+        client.create_connection.return_value = {"id": 7}
+        # Globals have no client and forbid writes; the bound session must win.
+        srv._client = None
+        srv._allow_write = False
+
+        with use_session(DatanikaSession(client=client, allow_write=True)):
+            result = srv.create_connection("t", "postgres", {"host": "h"})
+
+        client.create_connection.assert_called_once_with("t", "postgres", {"host": "h"})
+        assert '"id": 7' in result
+
+    def test_require_write_shim_reads_bound_session(self, srv):
+        """The back-compat ``_require_write`` shim honors the bound session."""
+        from datanika_mcp.session import DatanikaSession, use_session
+
+        srv._allow_write = False  # global default forbids writes
+        with use_session(DatanikaSession(client=MagicMock(), allow_write=True)):
+            srv._require_write("create_connection")  # bound grant → no raise
+
+        with pytest.raises(RuntimeError, match="Write access required"):
+            srv._require_write("create_connection")  # unbound, global False → blocked

--- a/tests/test_security/test_egress_guard.py
+++ b/tests/test_security/test_egress_guard.py
@@ -1,0 +1,133 @@
+"""Security tests for the SSRF worker-egress guard (core#338).
+
+``validate_egress_host`` is a pre-flight guard for the ``rest_api`` connector
+family. It resolves a user-supplied URL's hostname and rejects it if ANY
+resolved IP is non-public (private, loopback, link-local incl. the
+169.254.169.254 cloud-metadata IP, multicast, reserved, or unspecified).
+
+All DNS is mocked via ``socket.getaddrinfo`` — these tests never touch the
+network and are fully deterministic.
+"""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from datanika.services.egress_guard import EgressValidationError, validate_egress_host
+
+
+def _gai(*ips: str):
+    """Build a ``socket.getaddrinfo``-style return value for the given IPs.
+
+    Each tuple is ``(family, type, proto, canonname, sockaddr)``; the guard
+    only reads ``sockaddr[0]`` (index ``[4][0]``), so a 2-tuple sockaddr is
+    sufficient for both IPv4 and IPv6.
+    """
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+
+# ---------------------------------------------------------------------------
+# REJECT — resolved IP is internal / non-public
+# ---------------------------------------------------------------------------
+class TestRejectsInternalIps:
+    @pytest.mark.parametrize(
+        ("label", "ip"),
+        [
+            ("loopback_v4", "127.0.0.1"),
+            ("cloud_metadata_link_local", "169.254.169.254"),
+            ("private_10_8", "10.0.0.1"),
+            ("private_192_168", "192.168.1.1"),
+            ("private_172_16", "172.16.0.1"),
+            ("loopback_v6", "::1"),
+            ("ula_v6", "fc00::1"),
+            ("unspecified", "0.0.0.0"),
+            ("ipv4_mapped_loopback", "::ffff:127.0.0.1"),
+        ],
+    )
+    def test_rejects_internal_ip(self, label, ip):
+        with (
+            patch("socket.getaddrinfo", return_value=_gai(ip)),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://user-supplied.example")
+
+    def test_rejects_hostname_resolving_to_private(self):
+        """A public-looking hostname that resolves to a private IP is rejected."""
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("10.1.2.3")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://internal.corp.example")
+
+    def test_rejects_if_any_resolved_ip_is_internal(self):
+        """DNS-rebind style: one public + one private A record → reject."""
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("93.184.216.34", "10.0.0.5")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://rebind.example")
+
+    def test_error_message_names_host_and_ip(self):
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("169.254.169.254")),
+            pytest.raises(EgressValidationError) as exc,
+        ):
+            validate_egress_host("https://metadata.example")
+        msg = str(exc.value)
+        assert "metadata.example" in msg
+        assert "169.254.169.254" in msg
+
+
+# ---------------------------------------------------------------------------
+# REJECT — malformed / unresolvable input
+# ---------------------------------------------------------------------------
+class TestRejectsBadInput:
+    def test_rejects_non_http_scheme(self):
+        # Scheme is checked before any DNS resolution; patch getaddrinfo to a
+        # public IP so a missing scheme-check would surface as a failing test.
+        with (
+            patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("ftp://example.com")
+
+    def test_rejects_file_scheme(self):
+        with pytest.raises(EgressValidationError):
+            validate_egress_host("file:///etc/passwd")
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(EgressValidationError):
+            validate_egress_host("https://")
+
+    def test_gaierror_fails_closed(self):
+        """Unresolvable host → fail closed (reject), never fail open."""
+        with (
+            patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")),
+            pytest.raises(EgressValidationError),
+        ):
+            validate_egress_host("https://does-not-resolve.invalid")
+
+
+# ---------------------------------------------------------------------------
+# ALLOW — resolved IP is public
+# ---------------------------------------------------------------------------
+class TestAllowsPublic:
+    def test_allows_public_ipv4(self):
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            assert validate_egress_host("https://example.com") is None
+
+    def test_allows_public_ipv6(self):
+        with patch(
+            "socket.getaddrinfo",
+            return_value=_gai("2606:2800:220:1:248:1893:25c8:1946"),
+        ):
+            assert validate_egress_host("https://ipv6.example.com") is None
+
+    def test_allows_http_scheme(self):
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            assert validate_egress_host("http://example.com") is None
+
+    def test_allows_all_public_multi_ip(self):
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34", "8.8.8.8")):
+            assert validate_egress_host("https://multi.example.com") is None

--- a/tests/test_services/test_connection_service.py
+++ b/tests/test_services/test_connection_service.py
@@ -1,11 +1,14 @@
 """TDD tests for connection management service."""
 
+from unittest.mock import patch
+
 import pytest
 from cryptography.fernet import Fernet
 
 from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
 from datanika.models.user import Organization
 from datanika.services.connection_service import ConnectionService, infer_direction
+from datanika.services.egress_guard import EgressValidationError
 from datanika.services.encryption import EncryptionService
 
 
@@ -85,6 +88,53 @@ class TestCreateConnection:
         assert conn.connection_type == ConnectionType.REST_API
         # REST_API is source-only, so direction should be SOURCE
         assert conn.direction == ConnectionDirection.SOURCE
+
+    # --- SSRF create-time egress gate (core#338) -------------------------------
+    def test_rejects_rest_api_base_url_resolving_to_private(self, svc, db_session, org):
+        """A rest_api base_url that resolves to a private IP is refused at create."""
+        with (
+            patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 0))]),
+            pytest.raises(EgressValidationError),
+        ):
+            svc.create_connection(
+                db_session,
+                org.id,
+                "Internal API",
+                ConnectionType.REST_API,
+                {"base_url": "http://internal.corp.example"},
+            )
+
+    def test_rejects_base_url_resolving_to_metadata_ip(self, svc, db_session, org):
+        with (
+            patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("169.254.169.254", 0))]),
+            pytest.raises(EgressValidationError),
+        ):
+            svc.create_connection(
+                db_session,
+                org.id,
+                "Metadata Grab",
+                ConnectionType.REST_API,
+                {"base_url": "http://169.254.169.254/latest/meta-data/"},
+            )
+
+    def test_allows_rest_api_public_base_url(self, svc, db_session, org):
+        with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]):
+            conn = svc.create_connection(
+                db_session,
+                org.id,
+                "Public API",
+                ConnectionType.REST_API,
+                {"base_url": "https://api.public.example"},
+            )
+        assert conn.connection_type == ConnectionType.REST_API
+
+    def test_guard_skipped_when_no_base_url(self, svc, db_session, org):
+        """DB connectors (no base_url) never hit the egress guard."""
+        with patch("datanika.services.connection_service.validate_egress_host") as mock_guard:
+            svc.create_connection(
+                db_session, org.id, "My DB", ConnectionType.POSTGRES, {"host": "localhost"}
+            )
+        mock_guard.assert_not_called()
 
 
 class TestGetConnection:

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -11,11 +11,30 @@ from datanika.services.dlt_runner import (
     DltRunnerService,
     _extract_rows_loaded,
 )
+from datanika.services.egress_guard import EgressValidationError
+from datanika.services.egress_guard import validate_egress_host as _real_validate_egress_host
 
 
 @pytest.fixture
 def svc():
     return DltRunnerService()
+
+
+@pytest.fixture(autouse=True)
+def _stub_egress_guard():
+    """Stub the SSRF egress guard (core#338) for source-construction tests.
+
+    Since #338, ``_rest_api_from_parts`` and ``_rest_api_fallback`` call
+    ``validate_egress_host`` as their first statement, which resolves the
+    base_url host via real DNS. The generic REST/OpenAPI/SaaS tests below hand
+    those functions fake or live hostnames, so we no-op the guard here to keep
+    them deterministic and offline. The guard's real behaviour is covered by
+    ``tests/test_security/test_egress_guard.py`` and by ``TestEgressGuardWiring``
+    (which restores the real function). Yields the mock so wiring tests can
+    assert it was invoked.
+    """
+    with patch("datanika.services.dlt_runner.validate_egress_host") as mock_guard:
+        yield mock_guard
 
 
 def _make_mock_pipeline(row_counts: dict | None = None):
@@ -1478,3 +1497,53 @@ class TestKafkaSource:
     def test_requires_topics(self, svc):
         with pytest.raises(DltRunnerError, match="topics"):
             svc._build_kafka_source({"bootstrap_servers": "localhost:9092"}, {})
+
+
+def _gai_private(ip: str = "10.0.0.5"):
+    """A ``socket.getaddrinfo`` return that resolves to a single private IP."""
+    return [(2, 1, 6, "", (ip, 0))]
+
+
+class TestEgressGuardWiring:
+    """core#338 — validate_egress_host is wired into the rest_api build paths.
+
+    ``_stub_egress_guard`` (autouse) no-ops the guard for every other test in
+    this module; these tests either assert against that stub mock or restore the
+    real guard (with mocked DNS) to prove a private base_url is rejected.
+    """
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_from_parts_invokes_guard(self, _mock_rest, svc, _stub_egress_guard):
+        svc._rest_api_from_parts("https://api.public.example", [{"name": "x"}])
+        _stub_egress_guard.assert_called_once_with("https://api.public.example")
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_fallback_invokes_guard(self, _mock_rest, svc, _stub_egress_guard):
+        svc._rest_api_fallback("https://api.public.example/", None, [{"name": "x"}])
+        _stub_egress_guard.assert_called_once_with("https://api.public.example/")
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_from_parts_rejects_private_base_url(self, _mock_rest, svc):
+        with (
+            patch(
+                "datanika.services.dlt_runner.validate_egress_host",
+                _real_validate_egress_host,
+            ),
+            patch("socket.getaddrinfo", return_value=_gai_private()),
+            pytest.raises(EgressValidationError),
+        ):
+            svc._rest_api_from_parts("http://internal.svc", [{"name": "x"}])
+
+    @patch("datanika.services.dlt_runner.rest_api_source", return_value="src")
+    def test_rest_api_fallback_rejects_metadata_base_url(self, _mock_rest, svc):
+        with (
+            patch(
+                "datanika.services.dlt_runner.validate_egress_host",
+                _real_validate_egress_host,
+            ),
+            patch("socket.getaddrinfo", return_value=_gai_private("169.254.169.254")),
+            pytest.raises(EgressValidationError),
+        ):
+            svc._rest_api_fallback(
+                "http://169.254.169.254/latest/meta-data/", None, [{"name": "x"}]
+            )

--- a/tests/test_services/test_openapi_connector.py
+++ b/tests/test_services/test_openapi_connector.py
@@ -53,6 +53,16 @@ def svc():
     return DltRunnerService()
 
 
+@pytest.fixture(autouse=True)
+def _stub_egress_guard():
+    """No-op the SSRF egress guard (core#338) so ``_build_openapi_source`` →
+    ``_rest_api_from_parts`` doesn't resolve the (fake) base_url host via real
+    DNS. The guard itself is covered by ``tests/test_security/test_egress_guard.py``.
+    """
+    with patch("datanika.services.dlt_runner.validate_egress_host"):
+        yield
+
+
 class TestWiring:
     def test_enum(self):
         assert ConnectionType.OPENAPI == "openapi"

--- a/tests/test_services/test_wave1_connectors.py
+++ b/tests/test_services/test_wave1_connectors.py
@@ -38,6 +38,16 @@ def svc():
     return DltRunnerService()
 
 
+@pytest.fixture(autouse=True)
+def _stub_egress_guard():
+    """No-op the SSRF egress guard (core#338) so the SaaS ``_rest_api_fallback``
+    paths (pipedrive / freshdesk / asana) don't resolve their base_url host via
+    real DNS. The guard itself is covered by ``tests/test_security/test_egress_guard.py``.
+    """
+    with patch("datanika.services.dlt_runner.validate_egress_host"):
+        yield
+
+
 # --------------------------------------------------------------------------- #
 # Enum
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Promotion of the 4 dev commits to `master` — triggers `deploy-pointer.yml` (build-from-source + SSH transfer + prod rebuild on pointer.gr; ~30s app/celery restart) then the post-deploy smoke gate. Merge-commit strategy per `RUNBOOK_DEV_TO_MASTER.md`.

**Bundled:**
- **[Infra] SSRF worker-egress guard** for the rest_api connector family (`validate_egress_host`) — #367. Hard ship-gate for OpenAPI-P2 URL-fetch (P3 residuals — redirect-hop recheck + absolute-resource-path — documented in the docstring; must close before P2 promotes).
- **[Engineering] De-globalize the MCP tool surface** for remote transport — #369 (Remote-MCP P1; read-only + bearer-is-API-key).
- **[QA] Reconcile the overage-charge E2E spec** to the shipped interface — #365.
- **[Infra] MCP README** From-PyPI note now that `datanika-mcp` v0.1.0 is live — #366.

Closes #338
Closes #362
Closes #363
