### PR TITLE
[Engineering] Remote-MCP P1 step 2: mount /mcp Streamable-HTTP + bearer=API-key (Closes #370)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ RUN uv run reflex init
 # Install cloud plugin AFTER reflex init (which recreates the venv)
 RUN uv pip install /cloud
 
+# Install the datanika-mcp tool-surface package so the app can mount the remote
+# MCP endpoint (/mcp). Copied in via `COPY datanika/ .` above → /app/datanika-mcp.
+# Optional at runtime (the mount is guarded), but present in prod. Remote-MCP P1.
+RUN uv pip install ./datanika-mcp
+
 EXPOSE 3000 8000
 
 CMD ["uv", "run", "reflex", "run", "--env", "prod"]

--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -15,11 +15,14 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import sys
+from collections.abc import AsyncIterator, Callable
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
 from datanika_mcp.client import DatanikaClient
 from datanika_mcp.session import DatanikaSession, current_session
@@ -403,6 +406,83 @@ def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
     """
     _session().require_write("trigger_transformation")
     return json.dumps(_session().client.trigger_transformation(transformation_id, wait), indent=2)
+
+
+# ===================================================================
+# Remote transport — Streamable HTTP (SPEC_REMOTE_MCP.md P1 step 2)
+# ===================================================================
+#
+# One tool surface, two transports. stdio runs ``mcp.run(transport="stdio")``
+# in ``main()`` below; the remote transport serves the same 25 ``@mcp.tool()``s
+# over Streamable HTTP. Per-request auth (bearer -> DatanikaSession) is layered
+# on by the hosting app (``datanika/services/mcp_routes.py``), which binds the
+# session into the contextvar the tools resolve via ``_session()`` — the tool
+# bodies are unchanged and unaware of the transport.
+#
+# Stateless-JSON (SPEC §11.1): no per-session affinity to coordinate across
+# workers for a read-only P1; the caller is authenticated per request.
+
+
+class _StreamableHTTPApp:
+    """ASGI adapter over a ``StreamableHTTPSessionManager``.
+
+    Starlette treats a *callable object* (not a plain function) as a raw ASGI
+    app, so a request reaches the MCP transport without the request/response
+    wrapper.
+    """
+
+    def __init__(self, manager: StreamableHTTPSessionManager) -> None:
+        self._manager = manager
+
+    async def __call__(self, scope, receive, send) -> None:
+        await self._manager.handle_request(scope, receive, send)
+
+
+def make_remote_transport() -> tuple[
+    _StreamableHTTPApp, Callable[[], contextlib.AbstractAsyncContextManager[None]]
+]:
+    """Build a Streamable-HTTP transport bound to the shared tool surface.
+
+    Returns ``(asgi_app, lifespan)``:
+
+    - ``asgi_app`` — the raw ASGI endpoint to mount at ``/mcp`` (wrap with auth
+      first). Stateless-JSON: a POST carries the JSON-RPC request + response.
+    - ``lifespan`` — an ``@asynccontextmanager`` factory that must be active for
+      the endpoint to serve (it owns the session manager's task group). Register
+      via ``rx.App.register_lifespan_task``.
+
+    A **fresh** manager per call (not a process global): ``run()`` may only be
+    entered once per ``StreamableHTTPSessionManager`` instance, so each hosting
+    app — and each test — gets its own.
+    """
+    manager = StreamableHTTPSessionManager(
+        app=mcp._mcp_server,  # the low-level Server the FastMCP instance wraps
+        stateless=True,
+        json_response=True,
+    )
+
+    @contextlib.asynccontextmanager
+    async def mcp_session_manager_lifespan() -> AsyncIterator[None]:
+        async with manager.run():
+            yield
+
+    return _StreamableHTTPApp(manager), mcp_session_manager_lifespan
+
+
+def create_streamable_http_app():
+    """A standalone Starlette app serving the tool surface at ``/mcp``.
+
+    No auth wrapper — for transport smoke tests and self-host experiments. The
+    authenticated production mount lives in ``datanika/services/mcp_routes.py``.
+    """
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+
+    asgi_app, lifespan = make_remote_transport()
+    return Starlette(
+        routes=[Route("/mcp", endpoint=asgi_app)],
+        lifespan=lambda _app: lifespan(),
+    )
 
 
 # ===================================================================

--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -1,3 +1,5 @@
+import logging
+
 import reflex as rx
 
 from datanika.config import settings as _settings
@@ -257,6 +259,23 @@ from datanika.services.metrics import PrometheusMiddleware, metrics_routes  # no
 for _route in metrics_routes:
     app._api.routes.append(_route)
 app._api.add_middleware(PrometheusMiddleware)
+
+# Mount remote MCP endpoint (/mcp) — Streamable HTTP, bearer=API-key, read-only
+# (Remote-MCP P1, #370). The datanika-mcp tool-surface package is installed in
+# the Docker image (``uv pip install ./datanika-mcp``) but is optional in
+# dev/CI, where it's exercised via its own tests — so skip cleanly if it isn't
+# importable rather than failing app startup.
+try:
+    from datanika.services.mcp_routes import mcp_lifespan, mcp_routes  # noqa: E402
+
+    for _route in mcp_routes:
+        app._api.routes.append(_route)
+    app.register_lifespan_task(mcp_lifespan)
+    logging.getLogger(__name__).info("Mounted remote MCP endpoint at /mcp (read-only)")
+except ImportError as _mcp_exc:
+    logging.getLogger(__name__).warning(
+        "datanika-mcp not installed; /mcp endpoint not mounted (%s)", _mcp_exc
+    )
 
 # Register every core-side hook subscriber (runs + quota + V2 P5 charge
 # events + external-channel dispatch). Delegated to

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -1,0 +1,106 @@
+"""Remote MCP endpoint (``/mcp``) — Streamable HTTP, bearer = API key (P1).
+
+Mounts the shared ``datanika-mcp`` tool surface over Streamable HTTP on the
+existing Starlette backend and wraps it with a thin bearer-token auth layer.
+The MCP server is a **thin authenticated client of this app's own REST API**
+at ``127.0.0.1:8000``: it forwards the caller's key on every tool call, so org
+isolation, scope enforcement, per-key rate limits, and V2 byte-metering are
+all inherited from ``api_middleware`` — none of it is re-implemented here
+(SPEC_REMOTE_MCP §5.4).
+
+P1 scope: **read-only** (``allow_write=False``); auth = an existing Datanika
+API key presented as ``Authorization: Bearer <key>`` (no OAuth AS — that is
+P2). The write tools are P3, gated on the #338 worker-egress guard.
+
+The per-request ``DatanikaSession`` is bound into the contextvar the tool
+surface resolves via ``server._session()`` — see ``datanika_mcp/session.py``.
+anyio copies the request task's context into the task the session manager
+spawns to execute the tool, so the binding reaches the tool body.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from datanika_mcp.client import DatanikaClient
+from datanika_mcp.server import make_remote_transport
+from datanika_mcp.session import DatanikaSession, use_session
+from starlette.datastructures import Headers
+from starlette.routing import Route
+
+# The MCP server calls this app's own REST API with the caller's key. The mount
+# runs in the backend process, so this is loopback in prod; overridable for
+# unusual topologies.
+_INTERNAL_API_URL = os.environ.get("DATANIKA_MCP_INTERNAL_URL", "http://127.0.0.1:8000")
+
+
+def _bearer_token(scope) -> str:
+    """Extract the bearer token from the ASGI scope, or "" if absent/malformed."""
+    auth = Headers(scope=scope).get("authorization", "")
+    if auth[:7].lower() == "bearer ":
+        return auth[7:].strip()
+    return ""
+
+
+async def _send_401(send) -> None:
+    body = json.dumps(
+        {
+            "error": "unauthorized",
+            "detail": "Provide a Datanika API key as an 'Authorization: Bearer <key>' header.",
+        }
+    ).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"www-authenticate", b'Bearer realm="datanika-mcp"'),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+class BearerSessionApp:
+    """ASGI middleware: authenticate the bearer API key and bind a per-request,
+    read-only :class:`DatanikaSession` for the wrapped MCP transport.
+
+    A missing or blank bearer token short-circuits to ``401`` with a
+    ``WWW-Authenticate: Bearer`` header. The key itself is validated lazily by
+    the REST API on the first tool call (the MCP server is a pure forwarder),
+    so ``initialize`` / ``tools/list`` succeed for any presented token — a
+    P2 pre-flight validation is a follow-up.
+    """
+
+    def __init__(self, app, *, base_url: str = _INTERNAL_API_URL) -> None:
+        self._app = app
+        self._base_url = base_url
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        token = _bearer_token(scope)
+        if not token:
+            await _send_401(send)
+            return
+
+        client = DatanikaClient(self._base_url, token)
+        session = DatanikaSession(client=client, allow_write=False)
+        try:
+            with use_session(session):
+                await self._app(scope, receive, send)
+        finally:
+            client.close()
+
+
+# Build the transport once (import time) and export the pieces datanika.py wires:
+#   - ``mcp_routes``   -> appended to ``app._api.routes``
+#   - ``mcp_lifespan`` -> registered via ``rx.App.register_lifespan_task`` so the
+#                         session manager's task group is active for app lifetime.
+_asgi_app, mcp_lifespan = make_remote_transport()
+
+mcp_routes = [Route("/mcp", endpoint=BearerSessionApp(_asgi_app))]

--- a/tests/test_mcp/test_mcp_remote.py
+++ b/tests/test_mcp/test_mcp_remote.py
@@ -1,0 +1,201 @@
+"""Tests for the remote MCP transport + bearer auth (core#370, Remote-MCP P1 step 2).
+
+Covers three layers:
+- the bearer-token ASGI auth wrapper (401s; binds a per-request read-only session);
+- the Streamable-HTTP transport (stateless-JSON: initialize + tools/list);
+- end-to-end tool routing (a bearer'd tools/call reaches the bound session's client;
+  a write tool is blocked read-only).
+
+The transport (`mcp` SDK) is exercised in-process via httpx ASGITransport with the
+session manager's lifespan entered manually (ASGITransport does not run lifespans).
+"""
+
+import json
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+import httpx
+
+# datanika-mcp is not installed in the test venv (the Docker image installs it);
+# make it importable before importing the route module that depends on it.
+_MCP_SRC = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+if _MCP_SRC not in sys.path:
+    sys.path.insert(0, _MCP_SRC)
+
+from datanika_mcp.server import create_streamable_http_app, make_remote_transport  # noqa: E402
+from datanika_mcp.session import current_session  # noqa: E402
+
+import datanika.services.mcp_routes as routes  # noqa: E402
+
+_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+_INIT = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "0"},
+    },
+}
+
+
+def _rpc(method: str, rpc_id: int, **params) -> dict:
+    return {"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params}
+
+
+# ---------------------------------------------------------------------------
+# Bearer auth wrapper
+# ---------------------------------------------------------------------------
+
+
+async def _ok_asgi(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+class TestBearerAuth:
+    async def test_missing_bearer_returns_401(self):
+        called = {"inner": False}
+
+        async def inner(scope, receive, send):
+            called["inner"] = True
+            await _ok_asgi(scope, receive, send)
+
+        app = routes.BearerSessionApp(inner)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp")
+
+        assert r.status_code == 401
+        assert r.headers.get("www-authenticate", "").lower().startswith("bearer")
+        assert called["inner"] is False  # short-circuits before the transport
+
+    async def test_non_bearer_scheme_returns_401(self):
+        app = routes.BearerSessionApp(_ok_asgi)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp", headers={"Authorization": "Basic Zm9vOmJhcg=="})
+        assert r.status_code == 401
+
+    async def test_valid_bearer_binds_readonly_session(self, monkeypatch):
+        captured = {}
+
+        class _FakeClient:
+            def __init__(self, base_url, token):
+                captured["base_url"] = base_url
+                captured["token"] = token
+
+            def close(self):
+                captured["closed"] = True
+
+        monkeypatch.setattr(routes, "DatanikaClient", _FakeClient)
+
+        seen = {}
+
+        async def inner(scope, receive, send):
+            session = current_session()
+            seen["allow_write"] = session.allow_write
+            seen["client_is_fake"] = isinstance(session.client, _FakeClient)
+            await _ok_asgi(scope, receive, send)
+
+        app = routes.BearerSessionApp(inner)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp", headers={"Authorization": "Bearer etf_abc123"})
+
+        assert r.status_code == 200
+        assert captured["token"] == "etf_abc123"  # key forwarded to the REST client
+        assert captured.get("closed") is True  # client closed after the request
+        assert seen["allow_write"] is False  # P1 = read-only
+        assert seen["client_is_fake"] is True  # tool would route through this client
+
+
+# ---------------------------------------------------------------------------
+# Streamable-HTTP transport (stateless-JSON)
+# ---------------------------------------------------------------------------
+
+
+class TestTransport:
+    def test_standalone_app_has_mcp_route(self):
+        app = create_streamable_http_app()
+        paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/mcp" in paths
+
+    async def test_initialize_and_tools_list(self):
+        asgi, lifespan = make_remote_transport()
+        async with (
+            lifespan(),
+            httpx.AsyncClient(transport=httpx.ASGITransport(app=asgi), base_url="http://t") as c,
+        ):
+            init = await c.post("/mcp", json=_INIT, headers=_HEADERS)
+            assert init.status_code == 200
+            assert init.json()["result"]["protocolVersion"]
+
+            listed = await c.post("/mcp", json=_rpc("tools/list", 2), headers=_HEADERS)
+            assert listed.status_code == 200
+            tools = listed.json()["result"]["tools"]
+            assert len(tools) == 25  # 17 read + 8 write, shared with stdio
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tool routing through the bound session
+# ---------------------------------------------------------------------------
+
+
+class TestToolRouting:
+    async def test_read_tool_call_routes_through_session(self, monkeypatch):
+        fake_client = MagicMock()
+        fake_client.list_connections.return_value = {"connections": [{"id": 1, "name": "pg"}]}
+        monkeypatch.setattr(routes, "DatanikaClient", lambda base_url, token: fake_client)
+
+        asgi, lifespan = make_remote_transport()
+        app = routes.BearerSessionApp(asgi)
+        auth = {**_HEADERS, "Authorization": "Bearer etf_read"}
+        async with (
+            lifespan(),
+            httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
+        ):
+            await c.post("/mcp", json=_INIT, headers=auth)
+            call = await c.post(
+                "/mcp",
+                json=_rpc("tools/call", 3, name="list_connections", arguments={}),
+                headers=auth,
+            )
+
+        assert call.status_code == 200
+        fake_client.list_connections.assert_called_once()
+        # The tool's JSON payload surfaces in the tool-call result content.
+        assert "pg" in json.dumps(call.json())
+
+    async def test_write_tool_blocked_read_only(self, monkeypatch):
+        fake_client = MagicMock()
+        monkeypatch.setattr(routes, "DatanikaClient", lambda base_url, token: fake_client)
+
+        asgi, lifespan = make_remote_transport()
+        app = routes.BearerSessionApp(asgi)
+        auth = {**_HEADERS, "Authorization": "Bearer etf_write"}
+        async with (
+            lifespan(),
+            httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
+        ):
+            await c.post("/mcp", json=_INIT, headers=auth)
+            call = await c.post(
+                "/mcp",
+                json=_rpc(
+                    "tools/call",
+                    4,
+                    name="create_connection",
+                    arguments={"name": "x", "connection_type": "postgres", "config": {}},
+                ),
+                headers=auth,
+            )
+
+        assert call.status_code == 200
+        # Read-only session -> the write guard fires; the tool never calls the client.
+        assert "Write access required" in json.dumps(call.json())
+        fake_client.create_connection.assert_not_called()


### PR DESCRIPTION
Remote-MCP **P1 step 2** — mounts the hosted Streamable-HTTP `/mcp` endpoint on the existing Starlette backend, authenticated by an existing Datanika API key. Closes #370.

Builds on **#369** (step 1, the de-globalized tool surface) — this branch is **stacked on #369**, so until #369 merges to `dev` the diff here also contains step 1's commit. Review the step-2 commit **`83e4f51`** in isolation.

## What & why
Step 1 made the 25 `@mcp.tool()`s resolve a per-request `DatanikaSession` from a contextvar. Step 2 adds the remote transport that populates it: a Streamable-HTTP endpoint serving the **same** tool surface as stdio, with a thin bearer-auth layer. No fork, no duplication (SPEC G2).

## Design
- **`datanika-mcp/server.py`** — `make_remote_transport()` builds a `StreamableHTTPSessionManager` (**stateless-JSON**, SPEC §11.1) over the low-level server and returns `(asgi_app, lifespan)`. A **fresh** manager per call (`run()` is once-per-instance → each host/test gets its own). `create_streamable_http_app()` wraps it as a standalone app for smoke tests.
- **`datanika/services/mcp_routes.py`** (new) — `BearerSessionApp` ASGI middleware: a missing/blank bearer → **401 + `WWW-Authenticate`**; otherwise it binds a **per-request, read-only** `DatanikaSession(DatanikaClient("127.0.0.1:8000", key))` into the step-1 contextvar for the request. anyio copies the request task's context into the task the session manager spawns to run the tool, so the binding reaches the tool body — **no FastMCP `Context` coupling** (validated by the e2e test). The MCP server stays a **thin forwarder** of the caller's key to its own REST API, so org isolation / scopes / rate-limits / V2 metering are inherited from `api_middleware` (SPEC §5.4), not re-implemented.
- **`datanika/datanika.py`** — mounts `/mcp` on `app._api.routes` + registers the session-manager lifespan via `rx.App.register_lifespan_task`. **Guarded import** so the app still boots where `datanika-mcp` isn't installed (dev/CI, where it's exercised via its own tests); prod installs it.
- **`Dockerfile`** — `uv pip install ./datanika-mcp`.

## Invariants (re-check against the diff)
1. **Read-only** — `allow_write=False`; the 8 write tools are listed but blocked at call (test: `create_connection` → "Write access required"). Write tools are P3, gated on #338.
2. **No OAuth AS** — bearer = an existing API key (P2 adds the AS).
3. **Auth required** — missing/blank bearer → 401 before the transport runs.
4. **stdio unchanged** — no change to `main()` / the stdio path; the transport is purely additive.
5. **App boots without `datanika-mcp`** — the mount import is guarded (warn + skip).

## Tests (`tests/test_mcp/test_mcp_remote.py`, 7)
- Bearer 401s (missing header, non-Bearer scheme).
- Read-only session binding: key forwarded to the REST client, `allow_write=False`, client closed after the request.
- Transport: `initialize` + `tools/list` → **25 tools** (stateless-JSON, driven in-process via httpx ASGITransport + a manually-entered lifespan).
- End-to-end: a bearer'd `tools/call list_connections` routes through the bound session's client (mock asserted called); `create_connection` is blocked read-only.
- Existing 22 MCP tests (step 1 + registry manifests) unchanged and green. Full core precheck: **2289 passed, 19 skipped**.

## Infra handshake (prod-only — non-blocking for dev-green)
Apache needs a `/mcp` proxy to `127.0.0.1:8000` with response buffering off (same class of handling as `/_event`). Ship gate (§7 P1): an MCP client lists + calls the 17 read tools against a real org; isolation holds.

Next: **P2** (OAuth 2.1 one-click AS), then **P3** (write tools behind consent + directory listing).
