### PR TITLE
[Infra] Wire overage-E2E nightly: environment: production (core#267)

### DIFF
--- a/.github/workflows/overage-e2e-nightly.yml
+++ b/.github/workflows/overage-e2e-nightly.yml
@@ -36,6 +36,15 @@ on:
 jobs:
   overage-e2e:
     runs-on: ubuntu-latest
+    # Infra wiring: the sandbox + CF-Access secrets live on the `production`
+    # environment (not repo-level), so the job must select it or every
+    # `${{ secrets.* }}` resolves empty → the spec's skip-gates trip and the
+    # soak silently no-ops. `issues: write` lets the failure step file the
+    # dedup issue.
+    environment: production
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Completes the Infra wiring of Eng's drafted overage-E2E nightly soak (`overage-e2e-nightly.yml`, landed via #376). Adds `environment: production` to the job so the sandbox + CF-Access secrets (which live on the production environment, not repo-level) actually resolve — without it every `secrets.*` is empty and the spec's skip-gates silently no-op the soak. Also grants `issues: write` for the failure-issue step.

Secrets already set this session: `PADDLE_SANDBOX_API_KEY` + `PADDLE_SANDBOX_VENDOR_ID` (production env). Staging app env verified live: `PADDLE_OVERAGE_PRODUCT_ID`, `DATANIKA_E2E_ADMIN_ENABLE=1`, `PADDLE_SANDBOX_SUBSCRIPTION_ID`.

On promotion to master the scheduled run (default branch) executes #376's armed spec (`FAST_FORWARD_NOT_READY=false`). Then QA runs the 3-night soak. Part of #267.