### PR TITLE
[Infra] Promote core dev -> master (2026-07-20 wave 3): Gate-4 overage-E2E soak harness

### DIFF
--- a/.github/workflows/overage-e2e-nightly.yml
+++ b/.github/workflows/overage-e2e-nightly.yml
@@ -36,6 +36,15 @@ on:
 jobs:
   overage-e2e:
     runs-on: ubuntu-latest
+    # Infra wiring: the sandbox + CF-Access secrets live on the `production`
+    # environment (not repo-level), so the job must select it or every
+    # `${{ secrets.* }}` resolves empty → the spec's skip-gates trip and the
+    # soak silently no-ops. `issues: write` lets the failure step file the
+    # dedup issue.
+    environment: production
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/overage-e2e-nightly.yml
+++ b/.github/workflows/overage-e2e-nightly.yml
@@ -1,0 +1,116 @@
+name: Overage-charge E2E (staging soak)
+
+# V2 P5 overage-charge Gate 4 (core#267). Runs the self-seeding
+# e2e/tests/overage-charge-cycle.spec.ts against staging-app.datanika.io: the
+# spec seeds its own tenant via the /api/admin/e2e/* admin endpoints (cloud#72),
+# fast-forwards the billing clock, fires the notice + charge tasks, and asserts
+# the Paddle sandbox charge + the in-app "$5.00" notice. QA runs this ~3 nights
+# green as the last gate before the overage-charge cutover — do NOT flip
+# DATANIKA_OVERAGE_CHARGE_ENABLE on in prod until it is.
+#
+# ── Infra owns: secrets + the schedule ──────────────────────────────────────
+# Repo secrets to populate before this can actually run:
+#   PADDLE_SANDBOX_VENDOR_ID, PADDLE_SANDBOX_API_KEY  — client-side skip gates.
+#       The spec only checks they are PRESENT (the real Paddle call is
+#       server-side via the admin run-task endpoint); any non-empty sandbox
+#       values work.
+#   DATANIKA_STAGING_CF_ACCESS_CLIENT_ID / _SECRET    — already set (shared with
+#       the e2e-staging job); front-door auth for CF-Access-gated staging.
+# Staging APP env (set on the datanika-staging-app container via deploy, NOT CI):
+#   DATANIKA_E2E_ADMIN_ENABLE=1     — else /api/admin/e2e/* returns 404.
+#   PADDLE_SANDBOX_SUBSCRIPTION_ID  — a real sandbox sub (else the charge lands
+#       FAILED not ISSUED and Step 8 fails).
+#   PADDLE_OVERAGE_PRODUCT_ID       — else charge_subscription raises ValueError.
+# The kill-switch is force-enabled per-call by the run-task admin endpoint, so
+# DATANIKA_OVERAGE_CHARGE_ENABLE can stay OFF on staging.
+#
+# SAFE TO MERGE BEFORE WIRING: until the two PADDLE_SANDBOX_* secrets are set,
+# the spec's GATE skips every test (green no-op), so this never reports a false
+# red. A "green" run where all 3 tests SKIPPED is NOT a passing soak night.
+
+on:
+  schedule:
+    - cron: "30 3 * * *" # nightly 03:30 UTC — Infra: adjust or disable as needed
+  workflow_dispatch:
+
+jobs:
+  overage-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install e2e deps
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: e2e
+        run: npx playwright install chromium --with-deps
+
+      - name: Run overage-charge E2E against staging
+        working-directory: e2e
+        env:
+          CI: "true"
+          DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
+          DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
+          # Client-side skip gates — the spec runs only when both are present.
+          DATANIKA_E2E_OVERAGE_CHARGE: "1"
+          PADDLE_SANDBOX_VENDOR_ID: ${{ secrets.PADDLE_SANDBOX_VENDOR_ID }}
+          PADDLE_SANDBOX_API_KEY: ${{ secrets.PADDLE_SANDBOX_API_KEY }}
+          # The overage spec is tagged @slow — include it (config grepInverts @slow otherwise).
+          DATANIKA_E2E_SLOW: "1"
+          # The spec self-seeds via /api/admin/e2e/*, so skip the standard fixture
+          # seed (which would otherwise SSH into the staging container). The dummy
+          # email only satisfies global-setup's skip guard; the spec never reads it.
+          DATANIKA_E2E_SKIP_SEED: "1"
+          DATANIKA_E2E_USER_EMAIL: overage-e2e-skip@datanika.test
+        run: npx playwright test overage-charge-cycle.spec.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: overage-e2e-report
+          path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: Open QA issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create overage-e2e-failure \
+            --repo ${{ github.repository }} \
+            --color BFD4F2 --description "Overage-charge E2E soak failure" --force || true
+          # Dedup: comment on an open overage-e2e-failure issue if one exists,
+          # else open one — so a multi-night red streak doesn't spam.
+          existing=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label overage-e2e-failure \
+            --state open \
+            --limit 1 \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo ${{ github.repository }} \
+              --body "Another overage-charge E2E soak failure: $RUN_URL"
+          else
+            body=$(printf '%s\n' \
+              "The overage-charge Gate-4 E2E (overage-charge-cycle.spec.ts) failed on staging." \
+              "" \
+              "**Run:** $RUN_URL" \
+              "**Report:** the overage-e2e-report artifact on the run page." \
+              "" \
+              "If all 3 tests SKIPPED (not failed), the PADDLE_SANDBOX_* secrets or the staging admin-endpoint env are not wired yet — see the workflow header. If tests RAN and failed, check the Playwright report + staging app logs (charge_cycle_overages / the /api/admin/e2e/* handlers).")
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "[QA] Overage-charge E2E soak failed $(date -u +%Y-%m-%d)" \
+              --label overage-e2e-failure \
+              --body "$body"
+          fi

--- a/e2e/tests/overage-charge-cycle.spec.ts
+++ b/e2e/tests/overage-charge-cycle.spec.ts
@@ -62,9 +62,10 @@ const GATE =
 
 const BASE_URL = process.env.DATANIKA_E2E_BASE_URL ?? "https://staging-app.datanika.io";
 
-// Flip to false when Engineering ships the test-only admin endpoints
-// (core#361). At that point every test below should turn green.
-const FAST_FORWARD_NOT_READY = true;
+// Armed: the test-only admin endpoints shipped (cloud#72). The tests still run
+// only where the GATE env is set (DATANIKA_E2E_OVERAGE_CHARGE=1 + Paddle sandbox
+// creds) — i.e. the staging overage run, never PR CI. See core#374 / core#267.
+const FAST_FORWARD_NOT_READY = false;
 
 // Native return of the `charge_cycle_overages` Celery task (cloud dev:
 // datanika_cloud/billing/tasks.py). `disabled` appears only when the
@@ -89,7 +90,6 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
 
   test("cycle: seed → T-23h notify → T+0 charge → retry no-op", async ({
     request,
-    page,
   }) => {
     // Step 1 — seed overage tenant
     const seedRes = await request.post(`${BASE_URL}/api/admin/e2e/seed-overage-tenant`, {
@@ -126,19 +126,27 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
     });
     expect(warn.ok()).toBeTruthy();
 
-    // Step 5 — assert in-app notification visible
-    await page.context().addCookies([
-      {
-        name: "session_token",
-        value: seed.authToken,
-        url: BASE_URL,
-      },
-    ]);
-    await page.goto(`${BASE_URL}/notifications`);
-    const card = page.getByRole("article", { name: /overage charge/i }).first();
-    await expect(card).toBeVisible();
-    await expect(card).toContainText(/\$5\.00/); // 5 GB * $1.00
-    await expect(card).toContainText(/Pro/);
+    // Step 5 — assert the CHARGE_INCOMING in-app notification landed.
+    // seed.authToken is a full-access API key (cloud#72 seeds it via
+    // ApiKeyService with scopes=None), NOT a session JWT — so read the notice
+    // through the REST API with a Bearer header rather than hydrating the
+    // /notifications UI with a session cookie. GET /api/v1/notifications is
+    // @api_endpoint(required_scope="notifications:read"); a null-scope key
+    // satisfies any scope, and the list is scoped to the key's org + user =
+    // the seeded overage tenant.
+    const notifRes = await request.get(`${BASE_URL}/api/v1/notifications`, {
+      headers: authHeaders,
+    });
+    expect(notifRes.ok()).toBeTruthy();
+    const notifBody = (await notifRes.json()) as {
+      items: Array<{ type: string; title: string; message: string }>;
+      unread_count: number;
+    };
+    const incoming = notifBody.items.find((n) => n.type === "charge_incoming");
+    expect(incoming, "expected a charge_incoming notification").toBeTruthy();
+    // Projected overage = 5 GB × $1.00 = $5.00
+    // (title: "Upcoming overage charge: $5.00").
+    expect(`${incoming!.title} ${incoming!.message}`).toContain("$5.00");
 
     // Step 6 — fast-forward to cycle end
     const cycleEnd = new Date(
@@ -220,14 +228,45 @@ test.describe("V2 P5 overage charge cycle @slow", () => {
   });
 
   test("no charge when usage under included", async ({ request }) => {
-    // Scenario: seed 80 GB usage on a 100 GB plan. Run charge_cycle_overages at
-    // cycle close. Assert: no Paddle call, no Charge row (result.issued === 0).
-    //
-    // This is the "sanity" gate — catches a regression where the charge
-    // loop fires on any usage, overage or not.
-    test.skip(
-      FAST_FORWARD_NOT_READY,
-      "Engineering V2 P5 not shipped — see core#361",
+    // Sanity gate: 80 GB on a 100 GB plan is UNDER the allotment, so cycle
+    // close must issue nothing — catches a regression where the charge loop
+    // fires on any usage, overage or not. (The describe-level GATE skip keeps
+    // this out of PR CI; it runs only in the staging overage run.)
+    const seedRes = await request.post(`${BASE_URL}/api/admin/e2e/seed-overage-tenant`, {
+      data: { planSlug: "pro", includedGB: 100, overagePriceCents: 100, usageGB: 80 },
+    });
+    expect(seedRes.ok()).toBeTruthy();
+    const seed = (await seedRes.json()) as {
+      subscriptionId: number;
+      billingPeriodEnd: string;
+      authToken: string;
+    };
+
+    // Fast-forward past cycle end and run the charge loop.
+    const cycleEnd = new Date(
+      new Date(seed.billingPeriodEnd).getTime() + 60 * 1000,
+    ).toISOString();
+    const adv = await request.post(`${BASE_URL}/api/admin/e2e/advance-clock`, {
+      data: { toIso: cycleEnd },
+    });
+    expect(adv.ok()).toBeTruthy();
+
+    const settle = await request.post(`${BASE_URL}/api/admin/e2e/run-task`, {
+      data: { taskName: "charge_cycle_overages" },
+    });
+    expect(settle.ok()).toBeTruthy();
+    const body = (await settle.json()) as { result: ChargeSummary };
+    // Under the allotment ⇒ nothing issued; kill-switch on (no `disabled`).
+    expect(body.result.disabled).toBeFalsy();
+    expect(body.result.issued).toBe(0);
+
+    // And no Charge row exists for this subscription.
+    const listRes = await request.get(
+      `${BASE_URL}/api/admin/e2e/charges?subscriptionId=${seed.subscriptionId}`,
+      { headers: { Authorization: `Bearer ${seed.authToken}` } },
     );
+    expect(listRes.ok()).toBeTruthy();
+    const charges = (await listRes.json()) as Array<unknown>;
+    expect(charges).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Promotes the Gate-4 overage-E2E soak wiring to `master` so the scheduled nightly runs on the default branch against the armed spec. Merge-commit per `RUNBOOK_DEV_TO_MASTER.md`.

**Bundled:**
- **[Engineering] Gate-4 E2E spec fixed + armed** — Bearer-REST notice check, fill under-limit body, `FAST_FORWARD_NOT_READY→false` (#376).
- **[Engineering] Drafted the overage-charge E2E nightly** workflow (`overage-e2e-nightly.yml`).
- **[Infra] Wired the nightly** — `environment: production` so the sandbox + CF-Access secrets resolve (else the soak silently skips); `issues: write` for the failure-issue step (#378).

After this lands, the nightly (`cron: 30 3 * * *` + `workflow_dispatch`) executes `overage-charge-cycle.spec.ts` against staging with the armed assertions. QA runs the 3-night soak — the last gate before the overage-charge cutover. **Do NOT flip `DATANIKA_OVERAGE_CHARGE_ENABLE` in prod until the soak is green.**

Closes #374
