### PR TITLE
SECURITY: SAML assertion auth-bypass fix (P0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.12-slim
 
-# System deps for psycopg2, bcrypt, cryptography
+# System deps for psycopg2, bcrypt, cryptography, and xmlsec/lxml (SAML).
+# libxml2-dev/libxslt1-dev/libxmlsec1-dev/pkg-config + zlib1g-dev/libssl-dev let
+# us build lxml + xmlsec FROM SOURCE (below) against the SAME system libxml2 —
+# the prebuilt wheels each bundle a different libxml2 and mismatch at import on
+# debian-slim ("lxml & xmlsec libxml2 library version mismatch").
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl unzip gcc libpq-dev && \
+    curl unzip gcc libpq-dev \
+    libxml2-dev libxslt1-dev libxmlsec1-dev libxmlsec1-openssl pkg-config \
+    zlib1g-dev libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv
@@ -16,8 +22,11 @@ COPY datanika/pyproject.toml datanika/uv.lock datanika/README.md ./
 # Stub the package so uv sync can resolve it without full source
 RUN mkdir -p datanika && touch datanika/__init__.py
 
-# Install dependencies (no dev deps in production image)
-RUN uv sync --frozen --no-dev
+# Install dependencies (no dev deps in production image). Build lxml + xmlsec
+# from source (against the system libxml2 above) so they share ONE libxml2 — the
+# prebuilt wheels mismatch at import on debian-slim. A satisfied, source-built
+# package survives reflex-init's idempotent re-sync below.
+RUN uv sync --frozen --no-dev --no-binary-package lxml --no-binary-package xmlsec
 
 # Copy full application code
 COPY datanika/ .

--- a/datanika/services/sso_routes.py
+++ b/datanika/services/sso_routes.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import logging
 import secrets
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
@@ -19,6 +19,48 @@ from datanika.services.user_service import UserService
 logger = logging.getLogger(__name__)
 
 _SSO_STATE_COOKIE = "sso_state"
+
+# SAML AuthnRequest ids are stored single-use (InResponseTo binding + replay
+# defence): written at login keyed by the state token, consumed
+# (get-and-delete) at the callback. A replayed or forged Response finds no id
+# and is rejected.
+_SAML_REQUEST_TTL = 600  # seconds
+
+
+class SamlValidationError(Exception):
+    """A SAML Response failed validation. The callback maps this to a 401."""
+
+
+def _redis():
+    import redis
+
+    return redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def _saml_request_key(state: str) -> str:
+    return f"sso:saml:req:{state}"
+
+
+def _store_saml_request_id(state: str, request_id: str) -> None:
+    try:
+        _redis().setex(_saml_request_key(state), _SAML_REQUEST_TTL, request_id)
+    except Exception:
+        logger.exception("Failed to store SAML request id (SAML login will fail closed)")
+
+
+def _consume_saml_request_id(state: str) -> str | None:
+    """Return the stored AuthnRequest id for ``state`` and delete it (single use)."""
+    try:
+        r = _redis()
+        key = _saml_request_key(state)
+        pipe = r.pipeline()
+        pipe.get(key)
+        pipe.delete(key)
+        value, _ = pipe.execute()
+        return value
+    except Exception:
+        logger.exception("Failed to consume SAML request id")
+        return None
 
 
 def _get_session():
@@ -141,6 +183,9 @@ async def _saml_login(request: Request, sso, org_slug: str) -> RedirectResponse:
         saml_request = base64.b64encode(deflated).decode()
 
         state = secrets.token_urlsafe(32)
+        # Bind this AuthnRequest id to the state so the callback can enforce
+        # InResponseTo + single-use (replay defence).
+        _store_saml_request_id(state, request_id)
         params = urlencode(
             {
                 "SAMLRequest": saml_request,
@@ -185,7 +230,7 @@ async def sso_callback(request: Request) -> RedirectResponse:
             if sso.protocol.value == "oidc":
                 email, full_name = await _oidc_exchange(request, sso, svc)
             elif sso.protocol.value == "saml":
-                email, full_name = await _saml_parse(request, sso)
+                email, full_name = await _saml_parse(request, sso, stored_state)
             else:
                 return RedirectResponse(
                     url=_frontend("/login?error=Unsupported+protocol"), status_code=302
@@ -219,6 +264,11 @@ async def sso_callback(request: Request) -> RedirectResponse:
                 )
             ).scalar_one_or_none()
             # Gross imports above — let me fix inline
+        except SamlValidationError:
+            # A forged / unsigned / tampered / expired / replayed assertion is
+            # an attack, not a user error — reject with 401, issue no session.
+            logger.warning("SAML validation rejected the callback for org %s", org_slug)
+            return Response("Unauthorized: SAML assertion failed validation.", status_code=401)
         except Exception:
             logger.exception("SSO callback failed for %s", org_slug)
             return RedirectResponse(
@@ -341,38 +391,100 @@ async def _oidc_exchange(request: Request, sso, svc: SSOService) -> tuple[str, s
     return "", ""
 
 
-async def _saml_parse(request: Request, sso) -> tuple[str, str]:
-    """Parse SAML Response and extract user email."""
-    import base64
-    from xml.etree.ElementTree import fromstring
+async def _saml_parse(request: Request, sso, state: str) -> tuple[str, str]:
+    """Validate a SAML Response and extract the user's email.
+
+    SECURITY (auth boundary): the assertion is trusted ONLY after full SAML
+    validation against the org's configured IdP certificate — XML-DSig
+    signature (WantAssertionsSigned), Audience, Destination, Conditions
+    (NotBefore / NotOnOrAfter), and InResponseTo. Any failure raises
+    ``SamlValidationError``, which the callback turns into a 401. Parsing and
+    signature verification are done by python3-saml (xmlsec): there is no
+    hand-rolled XML, so no XXE and no signature-wrapping. Replay is prevented
+    by consuming the single-use AuthnRequest id bound at login.
+    """
+    from onelogin.saml2.auth import OneLogin_Saml2_Auth
+    from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
     form = await request.form()
     saml_response = form.get("SAMLResponse", "")
     if not saml_response:
-        raise ValueError("Missing SAMLResponse")
+        raise SamlValidationError("Missing SAMLResponse")
 
-    xml_bytes = base64.b64decode(saml_response)
-    root = fromstring(xml_bytes)
+    if not (sso.saml_idp_cert or "").strip():
+        # No trust anchor configured -> nothing to verify against -> refuse.
+        raise SamlValidationError("SAML IdP certificate not configured")
 
-    # Extract NameID (email)
-    ns = {
-        "saml": "urn:oasis:names:tc:SAML:2.0:assertion",
-        "samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+    # Consume the single-use AuthnRequest id (InResponseTo + replay defence).
+    # A replayed or unsolicited Response finds no id here and is rejected.
+    request_id = _consume_saml_request_id(state)
+    if not request_id:
+        raise SamlValidationError("Unknown or already-used SAML request (possible replay)")
+
+    acs_url = f"{settings.oauth_redirect_base_url}/api/auth/sso/callback"
+    parsed = urlparse(acs_url)
+    req_data = {
+        "https": "on" if parsed.scheme == "https" else "off",
+        "http_host": parsed.netloc,  # includes the port when the ACS URL has one
+        "script_name": parsed.path,
+        "get_data": {},
+        "post_data": {"SAMLResponse": saml_response},
     }
-    name_id = root.find(".//saml:NameID", ns)
-    email = name_id.text if name_id is not None else ""
+    saml_settings = {
+        "strict": True,
+        "sp": {
+            "entityId": sso.saml_sp_entity_id or settings.sso_sp_entity_id,
+            "assertionConsumerService": {
+                "url": acs_url,
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            },
+            "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+        },
+        "idp": {
+            "entityId": sso.saml_idp_entity_id or "",
+            "singleSignOnService": {
+                "url": sso.saml_idp_sso_url or acs_url,
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            "x509cert": OneLogin_Saml2_Utils.format_cert(sso.saml_idp_cert),
+        },
+        "security": {
+            "wantAssertionsSigned": True,
+            "wantMessagesSigned": False,
+            "wantNameId": True,
+            "wantAttributeStatement": False,
+            "requestedAuthnContext": False,
+            "rejectUnsolicitedResponsesWithInResponseTo": True,
+        },
+    }
 
-    # Extract attributes for name
+    try:
+        auth = OneLogin_Saml2_Auth(req_data, old_settings=saml_settings)
+        auth.process_response(request_id=request_id)
+    except Exception as exc:
+        logger.warning("SAML response could not be processed: %s", type(exc).__name__)
+        raise SamlValidationError("SAML response could not be processed") from exc
+
+    if not auth.is_authenticated():
+        reason = auth.get_last_error_reason() or "; ".join(auth.get_errors())
+        logger.warning("SAML validation failed: %s", reason)
+        raise SamlValidationError(f"SAML validation failed: {reason}")
+
+    email = (auth.get_nameid() or "").strip()
+    if not email:
+        raise SamlValidationError("SAML assertion did not contain a NameID")
+
     full_name = ""
-    for attr in root.findall(".//saml:Attribute", ns):
-        attr_name = attr.get("Name", "")
-        val_elem = attr.find("saml:AttributeValue", ns)
-        if (
-            val_elem is not None
-            and val_elem.text
-            and ("displayName" in attr_name or "name" in attr_name.lower())
-        ):
-            full_name = val_elem.text
+    attributes = auth.get_attributes()
+    for key in (
+        "displayName",
+        "http://schemas.microsoft.com/identity/claims/displayname",
+        "name",
+        "cn",
+    ):
+        values = attributes.get(key)
+        if values:
+            full_name = values[0]
             break
 
     return email, full_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     # dbt-databricks requires sqlalchemy<2.0, incompatible with our stack
     # dbt-synapse requires sqlalchemy<2.0, incompatible with our stack
     # Both platforms work as dlt destinations — dbt transforms deferred until adapter compat
-
     # SaaS source dependencies (optional — needed only for dlt verified sources,
     # REST API fallback works without these)
     # "stripe>=5.0",
@@ -30,11 +29,9 @@ dependencies = [
     # "google-analytics-data>=0.18",
     # "google-ads>=24.0",
     # "confluent-kafka>=2.3",
-
     # Google Sheets
     "gspread>=6.0",
     "google-auth>=2.0",
-
     # SQL drivers
     "pymysql>=1.1",
     "pymssql>=2.2",
@@ -44,31 +41,26 @@ dependencies = [
     "snowflake-sqlalchemy>=1.7",
     "sqlalchemy-bigquery>=1.11",
     "oracledb>=2.0",
-
     # Web framework
     "reflex>=0.7",
-
     # Database
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.30",
     "alembic>=1.14",
-
     # Auth
     "passlib[bcrypt]>=1.7",
     "python-jose[cryptography]>=3.3",
-
     # Task queue & scheduling
     "celery[redis]>=5.4",
     "redis>=5.0",
     "apscheduler>=3.10",
-
     # Config & utilities
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "cryptography>=44.0",
-
     # Monitoring
     "prometheus-client>=0.21",
+    "python3-saml>=1.16,<2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_security/test_saml_assertion_verification.py
+++ b/tests/test_security/test_saml_assertion_verification.py
@@ -1,0 +1,238 @@
+"""Security regression: SAML assertions get full validation before trust.
+
+Guards the P0 auth bypass in ``sso_routes._saml_parse`` (the SAML Response was
+base64-decoded and its ``NameID`` trusted with **no** signature verification, so
+an attacker who started a login flow could forge an assertion for any victim and
+receive a session). The fix validates every SAML Response against the org's IdP
+certificate via python3-saml (xmlsec): signature + WantAssertionsSigned +
+Audience + Destination + Conditions (expiry) + InResponseTo, with single-use
+request-id consumption for replay.
+
+Headline red-test (what the user asked for): a forged/unsigned SAMLResponse
+POSTed to ``/api/auth/sso/callback`` -> **401**.
+"""
+
+import base64
+import datetime as dt
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from datanika.config import settings
+from datanika.services.sso_routes import (
+    _SSO_STATE_COOKIE,
+    SamlValidationError,
+    _saml_parse,
+    _sign_state,
+    sso_routes,
+)
+
+_IDP_ENTITY = "https://idp.example.com"
+_SP_ENTITY = "datanika-test"
+_REQUEST_ID = "_datanika_req_abc"
+_ACS = f"{settings.oauth_redirect_base_url}/api/auth/sso/callback"
+
+
+def _make_idp() -> tuple[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode()
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "idp.example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(dt.datetime(2020, 1, 1))
+        .not_valid_after(dt.datetime(2035, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    return key_pem, cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+_KEY_PEM, _CERT_PEM = _make_idp()
+
+
+def _iso(t: dt.datetime) -> str:
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _assertion_xml(
+    *,
+    email: str = "real@corp.com",
+    audience: str = _SP_ENTITY,
+    request_id: str = _REQUEST_ID,
+    recipient: str = _ACS,
+    minutes_valid: int = 5,
+) -> str:
+    now = dt.datetime.now(dt.UTC)
+    nb = _iso(now - dt.timedelta(minutes=5))
+    noa = _iso(now + dt.timedelta(minutes=minutes_valid))
+    ii = _iso(now)
+    return (
+        f'<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a1"'
+        f' Version="2.0" IssueInstant="{ii}"><saml:Issuer>{_IDP_ENTITY}</saml:Issuer>'
+        "<saml:Subject><saml:NameID "
+        'Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">'
+        f"{email}</saml:NameID>"
+        f'<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">'
+        f'<saml:SubjectConfirmationData NotOnOrAfter="{noa}" Recipient="{recipient}"'
+        f' InResponseTo="{request_id}"/></saml:SubjectConfirmation></saml:Subject>'
+        f'<saml:Conditions NotBefore="{nb}" NotOnOrAfter="{noa}"><saml:AudienceRestriction>'
+        f"<saml:Audience>{audience}</saml:Audience></saml:AudienceRestriction></saml:Conditions>"
+        f'<saml:AuthnStatement AuthnInstant="{ii}" SessionIndex="_s1"><saml:AuthnContext>'
+        f"<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
+        f"</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>"
+    )
+
+
+def _response_b64(
+    assertion_xml: str,
+    *,
+    sign: bool = True,
+    key_pem: str = _KEY_PEM,
+    cert_pem: str = _CERT_PEM,
+    destination: str = _ACS,
+    request_id: str = _REQUEST_ID,
+) -> str:
+    a = OneLogin_Saml2_Utils.add_sign(assertion_xml, key_pem, cert_pem) if sign else assertion_xml
+    if isinstance(a, bytes):
+        a = a.decode()
+    if a.startswith("<?xml"):
+        a = a[a.index("?>") + 2 :]
+    now = _iso(dt.datetime.now(dt.UTC))
+    resp = (
+        f'<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+        f' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_r1" Version="2.0"'
+        f' IssueInstant="{now}" Destination="{destination}" InResponseTo="{request_id}">'
+        f"<saml:Issuer>{_IDP_ENTITY}</saml:Issuer><samlp:Status>"
+        f'<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>'
+        f"{a}</samlp:Response>"
+    )
+    return base64.b64encode(resp.encode()).decode()
+
+
+def _sso(cert: str = _CERT_PEM):
+    sso = MagicMock()
+    sso.saml_idp_cert = cert
+    sso.saml_idp_entity_id = _IDP_ENTITY
+    sso.saml_idp_sso_url = "https://idp.example.com/sso"
+    sso.saml_sp_entity_id = _SP_ENTITY
+    return sso
+
+
+class _FakeRequest:
+    def __init__(self, saml_response_b64: str):
+        self._data = {"SAMLResponse": saml_response_b64}
+
+    async def form(self):
+        return self._data
+
+
+async def _parse(response_b64: str, *, sso=None, request_id: str | None = _REQUEST_ID):
+    """Call _saml_parse with the single-use request-id consume stubbed."""
+    with patch("datanika.services.sso_routes._consume_saml_request_id", return_value=request_id):
+        return await _saml_parse(_FakeRequest(response_b64), sso or _sso(), "state123")
+
+
+class TestSamlParseFullValidation:
+    async def test_valid_signed_assertion_accepted(self):
+        email, _ = await _parse(_response_b64(_assertion_xml(email="real@corp.com")))
+        assert email == "real@corp.com"
+
+    async def test_unsigned_rejected(self):
+        with pytest.raises(SamlValidationError):
+            await _parse(_response_b64(_assertion_xml(email="victim@corp.com"), sign=False))
+
+    async def test_signed_by_attacker_key_rejected(self):
+        akey, acert = _make_idp()
+        forged = _response_b64(
+            _assertion_xml(email="victim@corp.com"), key_pem=akey, cert_pem=acert
+        )
+        with pytest.raises(SamlValidationError):
+            await _parse(forged)  # verified against the configured IdP cert
+
+    async def test_tampered_after_signing_rejected(self):
+        b64 = _response_b64(_assertion_xml(email="real@corp.com"))
+        tampered = base64.b64encode(
+            base64.b64decode(b64).replace(b"real@corp.com", b"attacker@corp.com")
+        ).decode()
+        with pytest.raises(SamlValidationError):
+            await _parse(tampered)
+
+    async def test_wrong_audience_rejected(self):
+        with pytest.raises(SamlValidationError):
+            await _parse(_response_b64(_assertion_xml(audience="some-other-sp")))
+
+    async def test_wrong_destination_rejected(self):
+        forged = _response_b64(
+            _assertion_xml(recipient="https://evil.example/acs"),
+            destination="https://evil.example/acs",
+        )
+        with pytest.raises(SamlValidationError):
+            await _parse(forged)
+
+    async def test_bad_in_response_to_rejected(self):
+        # Assertion built for a different request id than the one we consumed.
+        forged = _response_b64(_assertion_xml(request_id="_forged"), request_id="_forged")
+        with pytest.raises(SamlValidationError):
+            await _parse(forged, request_id=_REQUEST_ID)
+
+    async def test_expired_conditions_rejected(self):
+        with pytest.raises(SamlValidationError):
+            await _parse(_response_b64(_assertion_xml(minutes_valid=-10)))
+
+    async def test_replayed_or_unknown_request_id_rejected(self):
+        # Redis consume returns None -> already used / unknown -> replay.
+        with pytest.raises(SamlValidationError):
+            await _parse(_response_b64(_assertion_xml()), request_id=None)
+
+    async def test_missing_idp_cert_rejected(self):
+        with pytest.raises(SamlValidationError):
+            await _parse(_response_b64(_assertion_xml()), sso=_sso(cert=""))
+
+
+class TestSamlCallbackForgedReturns401:
+    """The headline red-test: a forged/unsigned SAMLResponse to the ACS -> 401."""
+
+    def _client(self, mock_svc, mock_session):
+        mock_sso = _sso()
+        mock_sso.is_active = True
+        mock_sso.protocol.value = "saml"
+        mock_svc.return_value.get_sso_config_by_org_slug.return_value = mock_sso
+        mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_session.return_value.__exit__ = MagicMock(return_value=False)
+        return TestClient(Starlette(routes=sso_routes), raise_server_exceptions=False)
+
+    @patch("datanika.services.sso_routes._get_session")
+    @patch("datanika.services.sso_routes._sso_service")
+    def test_forged_unsigned_response_returns_401(self, mock_svc, mock_session):
+        org_slug = f"acme-{uuid.uuid4().hex[:6]}"
+        state = "state123"
+        cookie = f"{org_slug}:{state}:{_sign_state(state)}"
+        forged = _response_b64(_assertion_xml(email="victim@corp.com"), sign=False)
+
+        client = self._client(mock_svc, mock_session)
+        with patch(
+            "datanika.services.sso_routes._consume_saml_request_id", return_value=_REQUEST_ID
+        ):
+            resp = client.post(
+                "/api/auth/sso/callback",
+                data={"SAMLResponse": forged},
+                cookies={_SSO_STATE_COOKIE: cookie},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -953,6 +953,7 @@ dependencies = [
     { name = "pymssql" },
     { name = "pymysql" },
     { name = "python-jose", extra = ["cryptography"] },
+    { name = "python3-saml" },
     { name = "redis" },
     { name = "reflex" },
     { name = "snowflake-sqlalchemy" },
@@ -1006,6 +1007,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
+    { name = "python3-saml", specifier = ">=1.16,<2" },
     { name = "redis", specifier = ">=5.0" },
     { name = "reflex", specifier = ">=0.7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
@@ -3693,6 +3695,20 @@ wheels = [
 ]
 
 [[package]]
+name = "python3-saml"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "lxml" },
+    { name = "xmlsec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/98/6e0268c3a9893af3d4c5cf670183e0314cd6b5cb034a612d6a7cc5060df8/python3-saml-1.16.0.tar.gz", hash = "sha256:97c9669aecabc283c6e5fb4eb264f446b6e006f5267d01c9734f9d8bffdac133", size = 83468, upload-time = "2023-10-09T10:37:43.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/14/49d9828443b58bd5cc80a454c91b0f867fbf36a24975d501945e6cb9e32f/python3_saml-1.16.0-py3-none-any.whl", hash = "sha256:20b97d11b04f01ee22e98f4a38242e2fea2e28fbc7fbc9bdd57cab5ac7fc2d0d", size = 76155, upload-time = "2023-10-09T10:40:34.001Z" },
+]
+
+[[package]]
 name = "pytimeparse"
 version = "1.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -4652,6 +4668,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "xmlsec"
+version = "1.3.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/14/538b75379e6ab8f688f14d8663e2ab138d9c778bac4999d155b5f33c71c1/xmlsec-1.3.17.tar.gz", hash = "sha256:f3fac9ae679f66585925cc00c5f6839ae36c1d03157619571dee18acc05b9c01", size = 115637, upload-time = "2025-11-11T16:20:46.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/a5/d91216f7dbb85cb65cb7249fcc894f5389a8a4843857aff678646cab77fa/xmlsec-1.3.17-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df4a8d7fef3ffe90e572400d47392ea480120e339c292f802830ed09d449e622", size = 3450960, upload-time = "2025-11-11T16:19:47.794Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/38/c37bd4e164259e0b271fe4d17d054f31c7287a1e4c47d24ef77d723b3493/xmlsec-1.3.17-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed63cbd87dd69ebcf3a9f82d87b67818c9a7d656325dd4fb34d6c4dfbaa84017", size = 3846774, upload-time = "2025-11-11T16:19:49.636Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ff/83430c5df33c6ad402728a681998c5b2872c090b556a558d02f8cf1d2f24/xmlsec-1.3.17-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5c3008b32a15d24b6c9da39bf6ede8dc3122570a640a73795d763aea55a2193e", size = 4425910, upload-time = "2025-11-11T16:19:50.95Z" },
+    { url = "https://files.pythonhosted.org/packages/02/41/bb94c7a97ea613b3860f6152bb7efcf5be524d135592e094ecc64ff79228/xmlsec-1.3.17-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a0b9a1dcda547e0340eefa6f4a04b87dbd9e40cd514487f347934f94fd559ab", size = 4169038, upload-time = "2025-11-11T16:19:52.217Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/852ba0805df27b7bd1e88e9524d9573b076c3a126e936b1f18c6f22fb968/xmlsec-1.3.17-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3a53c14d4bc40b0f0fcc6d7908b88f3cbbcf36e25c392f796d88aee7dee5beea", size = 3876430, upload-time = "2025-11-11T16:19:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f0/08fec6adc65f6911b49b4fa71e920c8f6434f44fdc427c71360e6dd9e9ce/xmlsec-1.3.17-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5346616e1fe1015f7800698c15225c7902f45db199e217af2039a21989aff7e9", size = 4464419, upload-time = "2025-11-11T16:19:54.777Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ce/84789ba3929715806deae88f10bc31e1ff904aa735059ee3855c104a142d/xmlsec-1.3.17-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:64c1184d51c8a67e3d1eb3ac477e307a07e2b40fd03cd0c8084b147ea0f342db", size = 4215080, upload-time = "2025-11-11T16:19:56.293Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/57b5054187cd2b42e5310dc1f6d209fced456f93dae25345a422b3a290ef/xmlsec-1.3.17-cp312-cp312-win_amd64.whl", hash = "sha256:d360d4adfb53d3adeca398c225cb7e2a73a2246414455937082a1fa19bd8572b", size = 2445872, upload-time = "2025-11-11T16:19:57.713Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7b/f64c95df054dd793ae1925f04248abd359b1c26cc2320d67407e7fd26e4d/xmlsec-1.3.17-cp312-cp312-win_arm64.whl", hash = "sha256:eee89c268a35f8a08a8e9abef6f466b97577e94f5cac8bf32c25e97cd5020097", size = 2261464, upload-time = "2025-11-11T16:19:58.937Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/25/d0c03351bbf776f2272d602272ca9d759d48f0f4e90707987098abb48e14/xmlsec-1.3.17-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:672e41dc7962da4ce84b67aa1c3a008338e3b88332f5484b9911b91cee0997ed", size = 3450899, upload-time = "2025-11-11T16:20:00.29Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/00db758c40d42ae2d43603552262b1027c02bbac934be26425e820c63c0f/xmlsec-1.3.17-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:72fc6d336dd68d62822c6536ff4b2453fda94ea652eddb4a958ac97b16ac7001", size = 3846790, upload-time = "2025-11-11T16:20:01.515Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/91/00cd12243f5f8cccec23e0d9946379861b954bf98c52d3f68b9eb565ba76/xmlsec-1.3.17-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae88c3aaab5704adfdbce913b3a18db1eb96c49c970657cc01c0d1c420ffdec3", size = 4427662, upload-time = "2025-11-11T16:20:02.931Z" },
+    { url = "https://files.pythonhosted.org/packages/77/64/d198a8109c11124b01abbd34167dd951896b12392ccfc3f12c40eb3f0c35/xmlsec-1.3.17-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79b471fdd1d3a92b80907828eaa809f6e34023583488b1b8dc3f951529e7a2f8", size = 4170229, upload-time = "2025-11-11T16:20:04.244Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a9/3e061f10d0d921102a55b4c0442c8c5af4e01e175ea1584774eeef2e50aa/xmlsec-1.3.17-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:040f28a7aacfdb467df46d423e4af05569e9376bc8c7f6416b0761e16a0e3d0b", size = 3877622, upload-time = "2025-11-11T16:20:05.593Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1a/b8a71915bf1d59944d815c92e77a06e9c2dc4dc855a44a3127c86b0dd7f2/xmlsec-1.3.17-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67717fe5151df68987a1387cba11ba28ce19b3bb9a2d10d650277cd910e510e7", size = 4464934, upload-time = "2025-11-11T16:20:07.358Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/0f/4b9057c6049137256bb972d114d2858fc8b24e72c97e05e26a00d2db8ed2/xmlsec-1.3.17-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9bb6faa4ae0268204cfa6b0c0de1c9121eb606eea8c66c7d7ce62e89a17f9efa", size = 4215150, upload-time = "2025-11-11T16:20:10.008Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6b/a2e8bc2f94b90c2904007663c8162423fadd3cd98b7ca1632b66dcdc31cb/xmlsec-1.3.17-cp313-cp313-win_amd64.whl", hash = "sha256:66fe5aaccf68fb85fe0b64277e3f594d6b01ddefb98ef1ceb0a666652d6ec580", size = 2445890, upload-time = "2025-11-11T16:20:11.575Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/df/27210baa675eb9e5d80ed43e80d865be8fbf6148ea464d2b4d4ad1ba9f01/xmlsec-1.3.17-cp313-cp313-win_arm64.whl", hash = "sha256:5319d0bdaf9e597a0ba8dfb3840c4ae57e51f462e7620953f32b07df6267f2ba", size = 2261424, upload-time = "2025-11-11T16:20:12.88Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2c/0169a383769d563f6582d5b3a2ccf7f612f4bf98cbd417a27287443b63c5/xmlsec-1.3.17-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:5d0e69291f90b28e9442d8e0e69d3e06cede8a3c44e856413fd284de81ce2888", size = 3450932, upload-time = "2025-11-11T16:20:14.334Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/be65923c5aa3097f422af3d917ffda15590ab0f4c9a5a5d78d520ae7fc9a/xmlsec-1.3.17-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5616ad5016794b0dd41d03eef5b721e31bb306353226b25fc88fedb7d4f7c37e", size = 3847248, upload-time = "2025-11-11T16:20:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/58/24e047e6a5f0c266e949c7c03c2770163038e7abd322c95bfbae021f9477/xmlsec-1.3.17-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4be73fbde421d6188300e02ad92d2d5435c708a35ede8124ebdf6b00330d7cb", size = 4428590, upload-time = "2025-11-11T16:20:18.012Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/23/e5212147d227da638311287045c90a47bb560b0552cc7daca0919a870220/xmlsec-1.3.17-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3961102a6ba8250670814bd1086139fb918e03bf146ef85dc8b6084a9b027d1", size = 4169645, upload-time = "2025-11-11T16:20:19.646Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/ed1f6d18f7c10dc61f791aade218b2271b4fc3092dd499036bc391a32945/xmlsec-1.3.17-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:728058a1623a620811a3cdf2dd4894b5d9413ede20c8ddddf98fdea5eafe9529", size = 3878531, upload-time = "2025-11-11T16:20:20.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/eb/09050fd1dc109ebe5bfefd0eab0829cab4fae51b3a244949e31dccf144e1/xmlsec-1.3.17-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:593264c192d1836162d75478c8b1cb5874f3b69dcc5bdfac642a0933abefa93a", size = 4464490, upload-time = "2025-11-11T16:20:22.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2e/52e9ef2b5c8ef2470e1e3ae3ef89f7ac45eecd267c7b3bab8a7ad7d68af1/xmlsec-1.3.17-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d1fc1fbe2e8585a3f468cf4154d0ec36cd95a15e68429ad8cc8ccd7c04e84ae", size = 4214358, upload-time = "2025-11-11T16:20:24.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cd/5e9061027a203fd083b6058c2948ee1a16bd909d3a0e331e054362ca550e/xmlsec-1.3.17-cp314-cp314-win_amd64.whl", hash = "sha256:e2bf1d07c4f97afeb957f626b8c3ebb8cef300efa0cb95599e936c69a66a1b17", size = 2513252, upload-time = "2025-11-11T16:20:25.738Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e9/b2f4b9092434b854bcae0d901c10a7e96d2a12d03cc35dbf7a7b2c91502b/xmlsec-1.3.17-cp314-cp314-win_arm64.whl", hash = "sha256:3a6ced8c7744e896cb5a9fd0156d204df3143a62bae11be91cab8e9743d40eec", size = 2328451, upload-time = "2025-11-11T16:20:27.247Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## SECURITY — P0 SAML assertion auth-bypass

**Severity: P0 — complete authentication bypass / account takeover.**

`services/sso_routes.py::_saml_parse` base64-decoded the `SAMLResponse`, parsed it with stdlib `xml.etree`, and trusted the `<NameID>` (user email) with **no signature validation of any kind** — despite the SP metadata advertising `WantAssertionsSigned="true"`. An attacker could start a real SSO flow to obtain a valid `sso_state` cookie, POST a **forged unsigned** `<saml:Response>` naming any victim, and the callback would mint real JWTs + a membership. The `xml.etree` parse was additionally XXE- and signature-wrapping-exposed.

### Fix (commit 1 — validation)
- Replace the hand-rolled parse with **`python3-saml`** (OneLogin, backed by `xmlsec`), validating every Response in **strict** mode against the org's configured IdP cert: XML-DSig signature + `wantAssertionsSigned`, audience == our SP entityId, destination == our ACS URL, conditions (`NotBefore`/`NotOnOrAfter`), and `InResponseTo`. Because validation is done by `xmlsec` (not hand-rolled XML), no XXE / no signature-wrapping.
- **Replay:** AuthnRequest id generated at login, stored single-use in Redis (`sso:saml:req:{state}`, 10-min TTL), get-and-delete-consumed at the callback.
- Callback returns **401** (not the friendly `302 -> /login?error=`) on any validation failure — a forged assertion is an attack, not a user error. Dedicated `SamlValidationError`.
- Adds `python3-saml>=1.16,<2` (pulls `xmlsec` + `isodate`).

### Build fix (commit 2)
The prebuilt `xmlsec` and `lxml` wheels each bundle a different libxml2 and mismatch at import on debian-slim (`lxml & xmlsec libxml2 library version mismatch`). Build both from source against ONE shared system libxml2: `uv sync --no-binary-package lxml --no-binary-package xmlsec` + `libxml2-dev libxslt1-dev libxmlsec1-dev libxmlsec1-openssl pkg-config zlib1g-dev libssl-dev`.

### Verification
- Full core suite green (**2304 passed, 16 skipped**), incl. a route-level red-test (forged/unsigned `SAMLResponse` POST -> 401) plus unit tests: unsigned / attacker-key / tampered / wrong-audience / wrong-destination / bad-InResponseTo / expired / replay / missing-cert.
- Production was patched out-of-band **before** this landed public (coordinated disclosure); the running container imports `xmlsec 1.3.17` + `onelogin.saml2` + `sso_routes.SamlValidationError`, app healthy, endpoints 200.

**Self-hosters: upgrade to include this fix.** A follow-up GitHub Security Advisory will document the CVE-class details.
