### PR TITLE
chore: gitignore *_exec.sh (agent scratch scripts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ reflex.db*
 .secrets
 # Monorepo-wide secrets directory (defense in depth — actual secrets live at D:/Projects/Datanika/secrets/)
 secrets/
+
+# Per-agent scratch executor scripts (e.g. infra_exec.sh, qa_exec.sh, engineer_exec.sh) — never commit
+*_exec.sh


### PR DESCRIPTION
Ignore per-agent scratch executor scripts (infra_exec.sh / qa_exec.sh / engineer_exec.sh) so they can't be accidentally committed. Pattern '*_exec.sh' does not match tests/.../test_execution_service.py. Merged to dev; reaches prod on the next real promotion (no CD needed for a gitignore).