### PR TITLE
Promote: async MCP client — fix hosted tool-call deadlock (dev->master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ reflex.db*
 .secrets
 # Monorepo-wide secrets directory (defense in depth — actual secrets live at D:/Projects/Datanika/secrets/)
 secrets/
+
+# Per-agent scratch executor scripts (e.g. infra_exec.sh, qa_exec.sh, engineer_exec.sh) — never commit
+*_exec.sh

--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -117,10 +117,11 @@ You can also configure via environment variables:
 
 ## Self-hosted
 
-Point `--url` at your instance:
+Point `--url` at your instance. Use the **backend** port (`8000`) — `3000` is the
+Reflex frontend and serves no `/api/v1`:
 
 ```bash
-datanika-mcp --url http://localhost:3000 --api-key etf_your_key
+datanika-mcp --url http://localhost:8000 --api-key etf_your_key
 ```
 
 ## Releasing (maintainers)
@@ -131,8 +132,8 @@ datanika-mcp --url http://localhost:3000 --api-key etf_your_key
 2. Tag and push — the tag version must match `pyproject.toml`:
 
    ```bash
-   git tag mcp-v0.1.0
-   git push origin mcp-v0.1.0
+   git tag mcp-v0.2.0
+   git push origin mcp-v0.2.0
    ```
 
 3. The [`Release datanika-mcp to PyPI`](../.github/workflows/release-mcp.yml) workflow builds the sdist + wheel and publishes. Verify: `uvx datanika-mcp --help` resolves from PyPI.

--- a/datanika-mcp/pyproject.toml
+++ b/datanika-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datanika-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Datanika — browse connections, preview data, and manage pipelines from Claude Desktop"
 requires-python = ">=3.12"
 license = "AGPL-3.0-or-later"

--- a/datanika-mcp/server.json
+++ b/datanika-mcp/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "datanika-mcp"
   },
-  "version": "0.1.0",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "datanika-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/datanika-mcp/src/datanika_mcp/__init__.py
+++ b/datanika-mcp/src/datanika_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Datanika MCP server — browse connections, preview data, manage pipelines."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/datanika-mcp/src/datanika_mcp/client.py
+++ b/datanika-mcp/src/datanika_mcp/client.py
@@ -1,4 +1,14 @@
-"""Thin httpx wrapper for the Datanika REST API v1."""
+"""Thin httpx wrapper for the Datanika REST API v1.
+
+**Fully async by design** (core#388). The hosted remote transport mounts this
+tool surface into the Datanika backend itself, so a tool call is a *loopback*
+request to the very process serving it. A blocking ``httpx.Client`` call would
+hold the event loop that has to answer that request — the self-call could never
+complete, and every hosted tool call died at the timeout below. Every request
+method is therefore a coroutine, and every tool body awaits it, leaving the loop
+free to serve the call it just made. ``tests/test_mcp/test_mcp_async_io.py``
+pins this.
+"""
 
 from __future__ import annotations
 
@@ -8,32 +18,32 @@ import httpx
 class DatanikaClient:
     """Authenticated HTTP client for the Datanika REST API.
 
-    All methods return the parsed JSON body (dict/list) or raise
-    ``httpx.HTTPStatusError`` on 4xx/5xx.
+    All methods are coroutines returning the parsed JSON body (dict/list), or
+    raising ``httpx.HTTPStatusError`` on 4xx/5xx.
     """
 
     def __init__(self, base_url: str, api_key: str, timeout: float = 30.0) -> None:
         self._base = base_url.rstrip("/")
-        self._http = httpx.Client(
+        self._http = httpx.AsyncClient(
             base_url=self._base,
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=timeout,
         )
 
-    def close(self) -> None:
-        self._http.close()
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
-    def _get(self, path: str, **params) -> dict:
-        resp = self._http.get(path, params=params or None)
+    async def _get(self, path: str, **params) -> dict:
+        resp = await self._http.get(path, params=params or None)
         resp.raise_for_status()
         return resp.json()
 
-    def _post(self, path: str, json: dict | None = None) -> dict:
-        resp = self._http.post(path, json=json)
+    async def _post(self, path: str, json: dict | None = None) -> dict:
+        resp = await self._http.post(path, json=json)
         resp.raise_for_status()
         return resp.json()
 
@@ -41,44 +51,44 @@ class DatanikaClient:
     # Read-only — Tier 1: Discover & Introspect
     # ------------------------------------------------------------------
 
-    def get_agent_tiers(self) -> dict:
-        return self._get("/api/v1/meta/agent-tiers")
+    async def get_agent_tiers(self) -> dict:
+        return await self._get("/api/v1/meta/agent-tiers")
 
-    def get_connection_types(self) -> dict:
-        return self._get("/api/v1/meta/connection-types")
+    async def get_connection_types(self) -> dict:
+        return await self._get("/api/v1/meta/connection-types")
 
-    def list_connections(self) -> dict:
-        return self._get("/api/v1/connections")
+    async def list_connections(self) -> dict:
+        return await self._get("/api/v1/connections")
 
-    def get_connection(self, connection_id: int) -> dict:
-        return self._get(f"/api/v1/connections/{connection_id}")
+    async def get_connection(self, connection_id: int) -> dict:
+        return await self._get(f"/api/v1/connections/{connection_id}")
 
-    def introspect_connection(self, connection_id: int, schema: str | None = None) -> dict:
+    async def introspect_connection(self, connection_id: int, schema: str | None = None) -> dict:
         body = {}
         if schema:
             body["schema"] = schema
-        return self._post(f"/api/v1/connections/{connection_id}/introspect", json=body)
+        return await self._post(f"/api/v1/connections/{connection_id}/introspect", json=body)
 
-    def preview_connection(
+    async def preview_connection(
         self, connection_id: int, table: str, schema: str | None = None, limit: int = 100
     ) -> dict:
         body: dict = {"table": table, "limit": limit}
         if schema:
             body["schema"] = schema
-        return self._post(f"/api/v1/connections/{connection_id}/preview", json=body)
+        return await self._post(f"/api/v1/connections/{connection_id}/preview", json=body)
 
-    def query_connection(self, connection_id: int, query: str) -> dict:
-        return self._post(f"/api/v1/connections/{connection_id}/query", json={"query": query})
+    async def query_connection(self, connection_id: int, query: str) -> dict:
+        return await self._post(f"/api/v1/connections/{connection_id}/query", json={"query": query})
 
     # ------------------------------------------------------------------
     # Read-only — Tier 3: Validate
     # ------------------------------------------------------------------
 
-    def compile_transformation(self, transformation_id: int) -> dict:
-        return self._post(f"/api/v1/transformations/{transformation_id}/compile")
+    async def compile_transformation(self, transformation_id: int) -> dict:
+        return await self._post(f"/api/v1/transformations/{transformation_id}/compile")
 
-    def preview_transformation(self, transformation_id: int, limit: int = 100) -> dict:
-        return self._post(
+    async def preview_transformation(self, transformation_id: int, limit: int = 100) -> dict:
+        return await self._post(
             f"/api/v1/transformations/{transformation_id}/preview",
             json={"limit": limit},
         )
@@ -87,16 +97,16 @@ class DatanikaClient:
     # Read-only — Tier 4: Control (read half)
     # ------------------------------------------------------------------
 
-    def list_uploads(self) -> dict:
-        return self._get("/api/v1/uploads")
+    async def list_uploads(self) -> dict:
+        return await self._get("/api/v1/uploads")
 
-    def list_pipelines(self) -> dict:
-        return self._get("/api/v1/pipelines")
+    async def list_pipelines(self) -> dict:
+        return await self._get("/api/v1/pipelines")
 
-    def list_transformations(self) -> dict:
-        return self._get("/api/v1/transformations")
+    async def list_transformations(self) -> dict:
+        return await self._get("/api/v1/transformations")
 
-    def list_runs(
+    async def list_runs(
         self,
         target_type: str | None = None,
         status: str | None = None,
@@ -107,31 +117,31 @@ class DatanikaClient:
             params["target_type"] = target_type
         if status:
             params["status"] = status
-        return self._get("/api/v1/runs", **params)
+        return await self._get("/api/v1/runs", **params)
 
-    def get_run(self, run_id: int) -> dict:
-        return self._get(f"/api/v1/runs/{run_id}")
+    async def get_run(self, run_id: int) -> dict:
+        return await self._get(f"/api/v1/runs/{run_id}")
 
-    def get_run_logs(self, run_id: int) -> dict:
-        return self._get(f"/api/v1/runs/{run_id}/logs")
+    async def get_run_logs(self, run_id: int) -> dict:
+        return await self._get(f"/api/v1/runs/{run_id}/logs")
 
-    def list_catalog(self) -> dict:
-        return self._get("/api/v1/catalog")
+    async def list_catalog(self) -> dict:
+        return await self._get("/api/v1/catalog")
 
-    def get_catalog_entry(self, entry_id: int) -> dict:
-        return self._get(f"/api/v1/catalog/{entry_id}")
+    async def get_catalog_entry(self, entry_id: int) -> dict:
+        return await self._get(f"/api/v1/catalog/{entry_id}")
 
     # ------------------------------------------------------------------
     # Write — Tier 2: Build (requires --allow-write)
     # ------------------------------------------------------------------
 
-    def create_connection(self, name: str, connection_type: str, config: dict) -> dict:
-        return self._post(
+    async def create_connection(self, name: str, connection_type: str, config: dict) -> dict:
+        return await self._post(
             "/api/v1/connections",
             json={"name": name, "connection_type": connection_type, "config": config},
         )
 
-    def create_upload(
+    async def create_upload(
         self,
         name: str,
         source_connection_id: int,
@@ -148,9 +158,9 @@ class DatanikaClient:
             body["dlt_config"] = dlt_config
         if description:
             body["description"] = description
-        return self._post("/api/v1/uploads", json=body)
+        return await self._post("/api/v1/uploads", json=body)
 
-    def create_pipeline(
+    async def create_pipeline(
         self,
         name: str,
         destination_connection_id: int,
@@ -164,9 +174,9 @@ class DatanikaClient:
         }
         if description:
             body["description"] = description
-        return self._post("/api/v1/pipelines", json=body)
+        return await self._post("/api/v1/pipelines", json=body)
 
-    def create_transformation(
+    async def create_transformation(
         self,
         name: str,
         sql_body: str,
@@ -182,29 +192,29 @@ class DatanikaClient:
         }
         if description:
             body["description"] = description
-        return self._post("/api/v1/transformations", json=body)
+        return await self._post("/api/v1/transformations", json=body)
 
-    def bulk_import(self, payload: dict) -> dict:
-        return self._post("/api/v1/import", json=payload)
+    async def bulk_import(self, payload: dict) -> dict:
+        return await self._post("/api/v1/import", json=payload)
 
     # ------------------------------------------------------------------
     # Write — Tier 4: Execute (requires --allow-write)
     # ------------------------------------------------------------------
 
-    def trigger_upload(self, upload_id: int, wait: bool = False) -> dict:
+    async def trigger_upload(self, upload_id: int, wait: bool = False) -> dict:
         path = f"/api/v1/uploads/{upload_id}/run"
         if wait:
             path += "?wait=true"
-        return self._post(path)
+        return await self._post(path)
 
-    def trigger_pipeline(self, pipeline_id: int, wait: bool = False) -> dict:
+    async def trigger_pipeline(self, pipeline_id: int, wait: bool = False) -> dict:
         path = f"/api/v1/pipelines/{pipeline_id}/run"
         if wait:
             path += "?wait=true"
-        return self._post(path)
+        return await self._post(path)
 
-    def trigger_transformation(self, transformation_id: int, wait: bool = False) -> dict:
+    async def trigger_transformation(self, transformation_id: int, wait: bool = False) -> dict:
         path = f"/api/v1/transformations/{transformation_id}/run"
         if wait:
             path += "?wait=true"
-        return self._post(path)
+        return await self._post(path)

--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -83,48 +83,56 @@ def _require_write(action: str) -> None:
 # ===================================================================
 # Read-only tools — always available
 # ===================================================================
+#
+# **Every tool is `async def`** and awaits the client (core#388). FastMCP runs a
+# sync tool inline on the event loop; the hosted transport is mounted inside the
+# very backend the client calls, so a blocking request would hold the loop that
+# has to answer it — the self-call deadlocks and the tool dies at the client
+# timeout. `tests/test_mcp/test_mcp_async_io.py` fails if a sync tool reappears.
 
 
 # --- Tier 1: Discover & Introspect ---
 
 
 @mcp.tool()
-def get_agent_tiers() -> str:
+async def get_agent_tiers() -> str:
     """Get the 5-tier agent capability stack — describes what the API can do."""
-    return json.dumps(_session().client.get_agent_tiers(), indent=2)
+    return json.dumps(await _session().client.get_agent_tiers(), indent=2)
 
 
 @mcp.tool()
-def get_connection_types() -> str:
+async def get_connection_types() -> str:
     """List all supported connection types with their config schemas."""
-    return json.dumps(_session().client.get_connection_types(), indent=2)
+    return json.dumps(await _session().client.get_connection_types(), indent=2)
 
 
 @mcp.tool()
-def list_connections() -> str:
+async def list_connections() -> str:
     """List all connections in the organization."""
-    return json.dumps(_session().client.list_connections(), indent=2)
+    return json.dumps(await _session().client.list_connections(), indent=2)
 
 
 @mcp.tool()
-def get_connection(connection_id: int) -> str:
+async def get_connection(connection_id: int) -> str:
     """Get details of a specific connection by ID."""
-    return json.dumps(_session().client.get_connection(connection_id), indent=2)
+    return json.dumps(await _session().client.get_connection(connection_id), indent=2)
 
 
 @mcp.tool()
-def introspect_connection(connection_id: int, schema: str | None = None) -> str:
+async def introspect_connection(connection_id: int, schema: str | None = None) -> str:
     """List schemas and tables of a source connection.
 
     Args:
         connection_id: The connection to introspect.
         schema: Optional schema name to filter tables.
     """
-    return json.dumps(_session().client.introspect_connection(connection_id, schema), indent=2)
+    return json.dumps(
+        await _session().client.introspect_connection(connection_id, schema), indent=2
+    )
 
 
 @mcp.tool()
-def preview_connection(
+async def preview_connection(
     connection_id: int, table: str, schema: str | None = None, limit: int = 100
 ) -> str:
     """Preview the first N rows of a table from a source connection.
@@ -136,69 +144,73 @@ def preview_connection(
         limit: Max rows to return (default 100).
     """
     return json.dumps(
-        _session().client.preview_connection(connection_id, table, schema, limit),
+        await _session().client.preview_connection(connection_id, table, schema, limit),
         indent=2,
     )
 
 
 @mcp.tool()
-def query_connection(connection_id: int, query: str) -> str:
+async def query_connection(connection_id: int, query: str) -> str:
     """Execute a read-only SQL query against a source connection.
 
     Args:
         connection_id: The connection to query.
         query: A single SELECT statement (no mutations allowed).
     """
-    return json.dumps(_session().client.query_connection(connection_id, query), indent=2)
+    return json.dumps(await _session().client.query_connection(connection_id, query), indent=2)
 
 
 # --- Tier 3: Validate ---
 
 
 @mcp.tool()
-def compile_transformation(transformation_id: int) -> str:
+async def compile_transformation(transformation_id: int) -> str:
     """Compile a dbt transformation — resolves Jinja, ref(), source(). No execution.
 
     Args:
         transformation_id: The transformation to compile.
     """
-    return json.dumps(_session().client.compile_transformation(transformation_id), indent=2)
+    return json.dumps(await _session().client.compile_transformation(transformation_id), indent=2)
 
 
 @mcp.tool()
-def preview_transformation(transformation_id: int, limit: int = 100) -> str:
+async def preview_transformation(transformation_id: int, limit: int = 100) -> str:
     """Compile and execute a transformation, returning preview rows.
 
     Args:
         transformation_id: The transformation to preview.
         limit: Max rows to return (default 100, max 1000).
     """
-    return json.dumps(_session().client.preview_transformation(transformation_id, limit), indent=2)
+    return json.dumps(
+        await _session().client.preview_transformation(transformation_id, limit), indent=2
+    )
 
 
 # --- Tier 4: Control (read half) ---
 
 
 @mcp.tool()
-def list_uploads() -> str:
+async def list_uploads() -> str:
     """List all uploads (extract + load jobs) in the organization."""
-    return json.dumps(_session().client.list_uploads(), indent=2)
+    return json.dumps(await _session().client.list_uploads(), indent=2)
 
 
 @mcp.tool()
-def list_pipelines() -> str:
+async def list_pipelines() -> str:
     """List all pipelines (dbt transform orchestration) in the organization."""
-    return json.dumps(_session().client.list_pipelines(), indent=2)
+    return json.dumps(await _session().client.list_pipelines(), indent=2)
 
 
 @mcp.tool()
-def list_transformations() -> str:
+async def list_transformations() -> str:
     """List all dbt transformations in the organization."""
-    return json.dumps(_session().client.list_transformations(), indent=2)
+    return json.dumps(await _session().client.list_transformations(), indent=2)
 
 
 @mcp.tool()
-def list_runs(target_type: str | None = None, status: str | None = None, limit: int = 50) -> str:
+async def list_runs(
+    target_type: str | None = None, status: str | None = None, limit: int = 50
+) -> str:
     """List pipeline/upload/transformation runs with optional filters.
 
     Args:
@@ -206,43 +218,43 @@ def list_runs(target_type: str | None = None, status: str | None = None, limit: 
         status: Filter by status — 'pending', 'running', 'success', 'failed', 'cancelled'.
         limit: Max results (default 50, max 200).
     """
-    return json.dumps(_session().client.list_runs(target_type, status, limit), indent=2)
+    return json.dumps(await _session().client.list_runs(target_type, status, limit), indent=2)
 
 
 @mcp.tool()
-def get_run(run_id: int) -> str:
+async def get_run(run_id: int) -> str:
     """Get details of a specific run by ID.
 
     Args:
         run_id: The run ID to look up.
     """
-    return json.dumps(_session().client.get_run(run_id), indent=2)
+    return json.dumps(await _session().client.get_run(run_id), indent=2)
 
 
 @mcp.tool()
-def get_run_logs(run_id: int) -> str:
+async def get_run_logs(run_id: int) -> str:
     """Get the logs of a specific run.
 
     Args:
         run_id: The run ID whose logs to fetch.
     """
-    return json.dumps(_session().client.get_run_logs(run_id), indent=2)
+    return json.dumps(await _session().client.get_run_logs(run_id), indent=2)
 
 
 @mcp.tool()
-def list_catalog() -> str:
+async def list_catalog() -> str:
     """List all catalog entries (source tables and dbt models)."""
-    return json.dumps(_session().client.list_catalog(), indent=2)
+    return json.dumps(await _session().client.list_catalog(), indent=2)
 
 
 @mcp.tool()
-def get_catalog_entry(entry_id: int) -> str:
+async def get_catalog_entry(entry_id: int) -> str:
     """Get details of a specific catalog entry.
 
     Args:
         entry_id: The catalog entry ID.
     """
-    return json.dumps(_session().client.get_catalog_entry(entry_id), indent=2)
+    return json.dumps(await _session().client.get_catalog_entry(entry_id), indent=2)
 
 
 # ===================================================================
@@ -254,7 +266,7 @@ def get_catalog_entry(entry_id: int) -> str:
 
 
 @mcp.tool()
-def create_connection(name: str, connection_type: str, config: dict) -> str:
+async def create_connection(name: str, connection_type: str, config: dict) -> str:
     """Create a new data connection.
 
     Requires --allow-write.
@@ -265,11 +277,13 @@ def create_connection(name: str, connection_type: str, config: dict) -> str:
         config: Connection-specific configuration (host, port, credentials, etc.).
     """
     _session().require_write("create_connection")
-    return json.dumps(_session().client.create_connection(name, connection_type, config), indent=2)
+    return json.dumps(
+        await _session().client.create_connection(name, connection_type, config), indent=2
+    )
 
 
 @mcp.tool()
-def create_upload(
+async def create_upload(
     name: str,
     source_connection_id: int,
     destination_connection_id: int,
@@ -289,7 +303,7 @@ def create_upload(
     """
     _session().require_write("create_upload")
     return json.dumps(
-        _session().client.create_upload(
+        await _session().client.create_upload(
             name, source_connection_id, destination_connection_id, dlt_config, description
         ),
         indent=2,
@@ -297,7 +311,7 @@ def create_upload(
 
 
 @mcp.tool()
-def create_pipeline(
+async def create_pipeline(
     name: str,
     destination_connection_id: int,
     command: str = "run",
@@ -315,13 +329,15 @@ def create_pipeline(
     """
     _session().require_write("create_pipeline")
     return json.dumps(
-        _session().client.create_pipeline(name, destination_connection_id, command, description),
+        await _session().client.create_pipeline(
+            name, destination_connection_id, command, description
+        ),
         indent=2,
     )
 
 
 @mcp.tool()
-def create_transformation(
+async def create_transformation(
     name: str,
     sql_body: str,
     materialization: str = "view",
@@ -341,7 +357,7 @@ def create_transformation(
     """
     _session().require_write("create_transformation")
     return json.dumps(
-        _session().client.create_transformation(
+        await _session().client.create_transformation(
             name, sql_body, materialization, description, schema_name
         ),
         indent=2,
@@ -349,7 +365,7 @@ def create_transformation(
 
 
 @mcp.tool()
-def bulk_import(payload: dict) -> str:
+async def bulk_import(payload: dict) -> str:
     """Bulk-import connections, uploads, pipelines, and transformations in one call.
 
     Requires --allow-write. Uses the JSON v2 import format.
@@ -360,14 +376,14 @@ def bulk_import(payload: dict) -> str:
                  pipelines, transformations sections. See AI_IMPORT_GUIDE.md.
     """
     _session().require_write("bulk_import")
-    return json.dumps(_session().client.bulk_import(payload), indent=2)
+    return json.dumps(await _session().client.bulk_import(payload), indent=2)
 
 
 # --- Tier 4: Execute ---
 
 
 @mcp.tool()
-def trigger_upload(upload_id: int, wait: bool = False) -> str:
+async def trigger_upload(upload_id: int, wait: bool = False) -> str:
     """Trigger an upload run.
 
     Requires --allow-write.
@@ -377,11 +393,11 @@ def trigger_upload(upload_id: int, wait: bool = False) -> str:
         wait: If true, block until the run completes (up to 120s).
     """
     _session().require_write("trigger_upload")
-    return json.dumps(_session().client.trigger_upload(upload_id, wait), indent=2)
+    return json.dumps(await _session().client.trigger_upload(upload_id, wait), indent=2)
 
 
 @mcp.tool()
-def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
+async def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
     """Trigger a pipeline run (dbt build/run/test).
 
     Requires --allow-write.
@@ -391,11 +407,11 @@ def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
         wait: If true, block until the run completes (up to 120s).
     """
     _session().require_write("trigger_pipeline")
-    return json.dumps(_session().client.trigger_pipeline(pipeline_id, wait), indent=2)
+    return json.dumps(await _session().client.trigger_pipeline(pipeline_id, wait), indent=2)
 
 
 @mcp.tool()
-def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
+async def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
     """Trigger a transformation run.
 
     Requires --allow-write.
@@ -405,7 +421,9 @@ def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
         wait: If true, block until the run completes (up to 120s).
     """
     _session().require_write("trigger_transformation")
-    return json.dumps(_session().client.trigger_transformation(transformation_id, wait), indent=2)
+    return json.dumps(
+        await _session().client.trigger_transformation(transformation_id, wait), indent=2
+    )
 
 
 # ===================================================================
@@ -514,7 +532,7 @@ def main() -> None:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.0",
+        version="%(prog)s 0.2.0",
     )
 
     args = parser.parse_args()

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -16,6 +16,12 @@ The per-request ``DatanikaSession`` is bound into the contextvar the tool
 surface resolves via ``server._session()`` — see ``datanika_mcp/session.py``.
 anyio copies the request task's context into the task the session manager
 spawns to execute the tool, so the binding reaches the tool body.
+
+Because that REST call is a **loopback into this same process**, the whole tool
+path must be non-blocking: the loop serving the tool call is also the loop that
+has to answer it. ``DatanikaClient`` is therefore an ``httpx.AsyncClient`` and
+every tool is ``async def`` — a single sync hop deadlocks the endpoint until the
+client's timeout fires (core#388).
 """
 
 from __future__ import annotations
@@ -94,7 +100,7 @@ class BearerSessionApp:
             with use_session(session):
                 await self._app(scope, receive, send)
         finally:
-            client.close()
+            await client.aclose()
 
 
 # Build the transport once (import time) and export the pieces datanika.py wires:

--- a/tests/test_mcp/test_mcp_async_io.py
+++ b/tests/test_mcp/test_mcp_async_io.py
@@ -1,0 +1,174 @@
+"""Regression probe for core#388 — a hosted MCP tool must never block the loop.
+
+The hosted ``/mcp`` endpoint is mounted into this app's *own* backend, and every
+tool is a forwarder to this app's *own* REST API on ``127.0.0.1:8000``. The
+FastMCP SDK runs a **sync** tool function inline on the event loop
+(``func_metadata.call_fn_with_arg_validation``: ``await fn(...)`` when the tool
+is a coroutine function, plain ``fn(...)`` otherwise). So a blocking
+``httpx.Client`` call inside a tool holds the only loop that could serve the
+loopback request — the self-call can never be answered, and every hosted tool
+call died at the client's 30s timeout (``Error executing tool list_connections:
+timed out``). That is what shipped to prod on 2026-07-21: the protocol layer
+(``initialize`` / ``tools/list``) was fine, every ``tools/call`` timed out.
+
+The pre-existing remote tests could not catch it: they drive the transport
+through ``httpx.ASGITransport`` with a mocked client, so nothing ever performed
+real I/O from inside the loop. Two layers guard the class here:
+
+- **structural** — every registered tool and every ``DatanikaClient`` request
+  method is a coroutine function (a future ``def`` tool re-introduces the bug);
+- **behavioural** — a real ``tools/call`` whose REST API is served *by the same
+  event loop* over a real socket. Under the sync client this hangs the loop and
+  fails on the timeout; with the async client it answers in milliseconds.
+"""
+
+import asyncio
+import inspect
+import json
+import pathlib
+import sys
+
+import anyio
+import httpx
+import pytest
+
+# datanika-mcp is not installed in the test venv (the Docker image installs it);
+# make it importable before importing the route module that depends on it.
+_MCP_SRC = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+if _MCP_SRC not in sys.path:
+    sys.path.insert(0, _MCP_SRC)
+
+from datanika_mcp.client import DatanikaClient  # noqa: E402
+from datanika_mcp.server import make_remote_transport  # noqa: E402
+from datanika_mcp.server import mcp as server  # noqa: E402
+
+import datanika.services.mcp_routes as routes  # noqa: E402
+
+_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+_INIT = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "0"},
+    },
+}
+
+
+def _rpc(method: str, rpc_id: int, **params) -> dict:
+    return {"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params}
+
+
+# ---------------------------------------------------------------------------
+# Structural — nothing on the tool path may be synchronous
+# ---------------------------------------------------------------------------
+
+
+class TestNoSyncOnTheToolPath:
+    def test_every_registered_tool_is_a_coroutine_function(self):
+        """A sync tool is executed inline on the loop -> loopback deadlock."""
+        sync_tools = [t.name for t in server._tool_manager.list_tools() if not t.is_async]
+        assert sync_tools == [], (
+            f"Tools must be `async def` (core#388): {sync_tools}. The FastMCP SDK "
+            "calls a sync tool inline on the event loop, which deadlocks the "
+            "self-call to this app's own REST API."
+        )
+
+    def test_every_client_method_is_a_coroutine_function(self):
+        """``DatanikaClient`` is awaited from tool bodies — no blocking I/O."""
+        blocking = [
+            name
+            for name, attr in vars(DatanikaClient).items()
+            if not name.startswith("__") and inspect.isfunction(attr)
+            if not inspect.iscoroutinefunction(attr)
+        ]
+        assert blocking == [], f"DatanikaClient methods must be `async def` (core#388): {blocking}"
+
+    def test_client_built_outside_a_loop_still_works_inside_one(self):
+        """The stdio path builds the client *before* ``mcp.run()`` starts a loop.
+
+        A deliberately sync test (no ambient loop) so the ``AsyncClient`` is
+        constructed exactly as ``main()`` constructs it; a transport bound to
+        the wrong loop would surface here, not on the remote path.
+        """
+        client = DatanikaClient("http://127.0.0.1:9", "etf_stdio")
+
+        async def _use() -> None:
+            with pytest.raises(httpx.ConnectError):  # nothing listens on :9
+                await client.list_connections()
+            await client.aclose()
+
+        asyncio.run(_use())
+
+
+# ---------------------------------------------------------------------------
+# Behavioural — the loopback self-call the sync client deadlocked on
+# ---------------------------------------------------------------------------
+
+
+async def _serve_fake_api(payload: dict, seen: dict) -> tuple[asyncio.AbstractServer, int]:
+    """A one-shot HTTP/1.1 server on the *test's own* event loop.
+
+    Stands in for the backend the MCP tools call back into. Because it shares
+    the loop with the tool being exercised, it can only answer if that tool
+    yields — which is exactly the invariant under test.
+    """
+    body = json.dumps(payload).encode()
+    head = (
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+        b"Content-Length: " + str(len(body)).encode() + b"\r\nConnection: close\r\n\r\n"
+    )
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            request = await reader.readuntil(b"\r\n\r\n")
+            seen["request"] = request.decode("latin-1")
+            writer.write(head + body)
+            await writer.drain()
+        except (asyncio.IncompleteReadError, ConnectionError):
+            pass  # client vanished during teardown
+        finally:
+            writer.close()
+
+    srv = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return srv, srv.sockets[0].getsockname()[1]
+
+
+class TestLoopbackToolCall:
+    async def test_tool_call_against_a_same_loop_api_does_not_deadlock(self):
+        seen: dict = {}
+        api, port = await _serve_fake_api({"connections": [{"id": 1, "name": "loopback-pg"}]}, seen)
+        asgi, lifespan = make_remote_transport()
+        app = routes.BearerSessionApp(asgi, base_url=f"http://127.0.0.1:{port}")
+        auth = {**_HEADERS, "Authorization": "Bearer etf_loopback"}
+
+        try:
+            async with (
+                lifespan(),
+                httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=app), base_url="http://t"
+                ) as client,
+            ):
+                await client.post("/mcp", json=_INIT, headers=auth)
+                # Generous vs. a healthy call (ms), far under the client's 30s
+                # timeout: a blocked loop cannot answer, so this is the failure
+                # signal rather than a 30s hang.
+                with anyio.fail_after(10):
+                    call = await client.post(
+                        "/mcp",
+                        json=_rpc("tools/call", 3, name="list_connections", arguments={}),
+                        headers=auth,
+                    )
+        finally:
+            api.close()
+            await api.wait_closed()
+
+        assert call.status_code == 200
+        result = call.json()["result"]
+        assert result.get("isError") is not True, result
+        assert "loopback-pg" in json.dumps(result)
+        # The caller's bearer key reached the REST API over the real hop.
+        assert "Bearer etf_loopback" in seen["request"]
+        assert "/api/v1/connections" in seen["request"]

--- a/tests/test_mcp/test_mcp_remote.py
+++ b/tests/test_mcp/test_mcp_remote.py
@@ -13,7 +13,7 @@ session manager's lifespan entered manually (ASGITransport does not run lifespan
 import json
 import pathlib
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import httpx
 
@@ -89,7 +89,7 @@ class TestBearerAuth:
                 captured["base_url"] = base_url
                 captured["token"] = token
 
-            def close(self):
+            async def aclose(self):
                 captured["closed"] = True
 
         monkeypatch.setattr(routes, "DatanikaClient", _FakeClient)
@@ -149,7 +149,8 @@ class TestTransport:
 
 class TestToolRouting:
     async def test_read_tool_call_routes_through_session(self, monkeypatch):
-        fake_client = MagicMock()
+        # AsyncMock: the client is awaited from the tool body (core#388).
+        fake_client = AsyncMock()
         fake_client.list_connections.return_value = {"connections": [{"id": 1, "name": "pg"}]}
         monkeypatch.setattr(routes, "DatanikaClient", lambda base_url, token: fake_client)
 
@@ -173,7 +174,7 @@ class TestToolRouting:
         assert "pg" in json.dumps(call.json())
 
     async def test_write_tool_blocked_read_only(self, monkeypatch):
-        fake_client = MagicMock()
+        fake_client = AsyncMock()
         monkeypatch.setattr(routes, "DatanikaClient", lambda base_url, token: fake_client)
 
         asgi, lifespan = make_remote_transport()

--- a/tests/test_mcp/test_mcp_server.py
+++ b/tests/test_mcp/test_mcp_server.py
@@ -2,10 +2,13 @@
 
 These tests verify tool registration, the write-guard, and the CLI
 argument parser without requiring a live Datanika instance.
+
+Tools are ``async def`` and await the client (core#388), so the tool-body tests
+are coroutines and the mock clients are ``AsyncMock``s.
 """
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -95,21 +98,21 @@ class TestWriteGuard:
         srv._allow_write = True
         srv._require_write("create_connection")  # should not raise
 
-    def test_create_connection_calls_require_write(self):
+    async def test_create_connection_calls_require_write(self):
         import datanika_mcp.server as srv
 
         srv._allow_write = False
-        srv._client = MagicMock()
+        srv._client = AsyncMock()
         with pytest.raises(RuntimeError, match="Write access required"):
-            srv.create_connection("test", "postgres", {"host": "localhost"})
+            await srv.create_connection("test", "postgres", {"host": "localhost"})
 
-    def test_trigger_pipeline_calls_require_write(self):
+    async def test_trigger_pipeline_calls_require_write(self):
         import datanika_mcp.server as srv
 
         srv._allow_write = False
-        srv._client = MagicMock()
+        srv._client = AsyncMock()
         with pytest.raises(RuntimeError, match="Write access required"):
-            srv.trigger_pipeline(1, wait=False)
+            await srv.trigger_pipeline(1, wait=False)
 
 
 # ---------------------------------------------------------------------------
@@ -118,40 +121,40 @@ class TestWriteGuard:
 
 
 class TestReadToolsCallClient:
-    def test_list_connections_calls_client(self):
+    async def test_list_connections_calls_client(self):
         import datanika_mcp.server as srv
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.list_connections.return_value = {"items": []}
         srv._client = mock_client
 
-        result = srv.list_connections()
-        mock_client.list_connections.assert_called_once()
+        result = await srv.list_connections()
+        mock_client.list_connections.assert_awaited_once()
         assert '"items"' in result
 
-    def test_get_run_logs_calls_client(self):
+    async def test_get_run_logs_calls_client(self):
         import datanika_mcp.server as srv
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.get_run_logs.return_value = {"run_id": 42, "logs": "ok"}
         srv._client = mock_client
 
-        result = srv.get_run_logs(42)
-        mock_client.get_run_logs.assert_called_once_with(42)
+        result = await srv.get_run_logs(42)
+        mock_client.get_run_logs.assert_awaited_once_with(42)
         assert "42" in result
 
-    def test_compile_transformation_calls_client(self):
+    async def test_compile_transformation_calls_client(self):
         import datanika_mcp.server as srv
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.compile_transformation.return_value = {
             "compiled_sql": "SELECT 1",
             "node": "model.t.stg_orders",
         }
         srv._client = mock_client
 
-        result = srv.compile_transformation(5)
-        mock_client.compile_transformation.assert_called_once_with(5)
+        result = await srv.compile_transformation(5)
+        mock_client.compile_transformation.assert_awaited_once_with(5)
         assert "SELECT 1" in result
 
 
@@ -161,43 +164,43 @@ class TestReadToolsCallClient:
 
 
 class TestWriteToolsCallClient:
-    def test_create_connection_calls_client(self):
+    async def test_create_connection_calls_client(self):
         import datanika_mcp.server as srv
 
         srv._allow_write = True
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.create_connection.return_value = {"id": 1, "name": "test"}
         srv._client = mock_client
 
-        result = srv.create_connection("test", "postgres", {"host": "localhost"})
-        mock_client.create_connection.assert_called_once_with(
+        result = await srv.create_connection("test", "postgres", {"host": "localhost"})
+        mock_client.create_connection.assert_awaited_once_with(
             "test", "postgres", {"host": "localhost"}
         )
         assert '"id": 1' in result
 
-    def test_bulk_import_calls_client(self):
+    async def test_bulk_import_calls_client(self):
         import datanika_mcp.server as srv
 
         srv._allow_write = True
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.bulk_import.return_value = {"created": {"connections": [1]}}
         srv._client = mock_client
 
         payload = {"version": 2, "connections": [{"name": "a"}]}
-        result = srv.bulk_import(payload)
-        mock_client.bulk_import.assert_called_once_with(payload)
+        result = await srv.bulk_import(payload)
+        mock_client.bulk_import.assert_awaited_once_with(payload)
         assert "connections" in result
 
-    def test_trigger_upload_with_wait(self):
+    async def test_trigger_upload_with_wait(self):
         import datanika_mcp.server as srv
 
         srv._allow_write = True
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.trigger_upload.return_value = {"run_id": 10, "status": "success"}
         srv._client = mock_client
 
-        result = srv.trigger_upload(3, wait=True)
-        mock_client.trigger_upload.assert_called_once_with(3, True)
+        result = await srv.trigger_upload(3, wait=True)
+        mock_client.trigger_upload.assert_awaited_once_with(3, True)
         assert "success" in result
 
 

--- a/tests/test_mcp/test_mcp_session.py
+++ b/tests/test_mcp/test_mcp_session.py
@@ -7,7 +7,7 @@ tool registry and the module-global path.
 """
 
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -40,30 +40,30 @@ def srv():
 
 
 class TestSessionResolution:
-    def test_bound_session_wins_over_globals(self, srv):
+    async def test_bound_session_wins_over_globals(self, srv):
         from datanika_mcp.session import DatanikaSession, use_session
 
-        global_client = MagicMock(name="global")
-        bound_client = MagicMock(name="bound")
+        global_client = AsyncMock(name="global")
+        bound_client = AsyncMock(name="bound")
         bound_client.list_connections.return_value = {"items": ["bound"]}
         srv._client = global_client
         srv._allow_write = False
 
         with use_session(DatanikaSession(client=bound_client, allow_write=True)):
-            result = srv.list_connections()
+            result = await srv.list_connections()
 
-        bound_client.list_connections.assert_called_once()
-        global_client.list_connections.assert_not_called()
+        bound_client.list_connections.assert_awaited_once()
+        global_client.list_connections.assert_not_awaited()
         assert "bound" in result
 
-    def test_globals_used_when_no_session_bound(self, srv):
-        client = MagicMock()
+    async def test_globals_used_when_no_session_bound(self, srv):
+        client = AsyncMock()
         client.list_uploads.return_value = {"items": []}
         srv._client = client
 
-        result = srv.list_uploads()
+        result = await srv.list_uploads()
 
-        client.list_uploads.assert_called_once()
+        client.list_uploads.assert_awaited_once()
         assert '"items"' in result
 
     def test_session_reset_after_context_exit(self, srv):
@@ -74,43 +74,43 @@ class TestSessionResolution:
             assert current_session() is not None
         assert current_session() is None
 
-    def test_uninitialized_fallback_raises(self, srv):
+    async def test_uninitialized_fallback_raises(self, srv):
         srv._client = None
         srv._allow_write = False
         with pytest.raises(RuntimeError, match="not initialized"):
-            srv.list_connections()
+            await srv.list_connections()
 
 
 class TestSessionWriteGuard:
-    def test_read_only_bound_session_blocks_writes(self, srv):
+    async def test_read_only_bound_session_blocks_writes(self, srv):
         from datanika_mcp.session import DatanikaSession, use_session
 
-        client = MagicMock()
+        client = AsyncMock()
         # Globals grant write; the bound read-only session must still win.
-        srv._client = MagicMock()
+        srv._client = AsyncMock()
         srv._allow_write = True
 
         with (
             use_session(DatanikaSession(client=client, allow_write=False)),
             pytest.raises(RuntimeError, match="Write access required"),
         ):
-            srv.create_connection("t", "postgres", {"host": "h"})
+            await srv.create_connection("t", "postgres", {"host": "h"})
 
-        client.create_connection.assert_not_called()
+        client.create_connection.assert_not_awaited()
 
-    def test_read_write_bound_session_allows_writes(self, srv):
+    async def test_read_write_bound_session_allows_writes(self, srv):
         from datanika_mcp.session import DatanikaSession, use_session
 
-        client = MagicMock()
+        client = AsyncMock()
         client.create_connection.return_value = {"id": 7}
         # Globals have no client and forbid writes; the bound session must win.
         srv._client = None
         srv._allow_write = False
 
         with use_session(DatanikaSession(client=client, allow_write=True)):
-            result = srv.create_connection("t", "postgres", {"host": "h"})
+            result = await srv.create_connection("t", "postgres", {"host": "h"})
 
-        client.create_connection.assert_called_once_with("t", "postgres", {"host": "h"})
+        client.create_connection.assert_awaited_once_with("t", "postgres", {"host": "h"})
         assert '"id": 7' in result
 
     def test_require_write_shim_reads_bound_session(self, srv):

--- a/tests/test_services/test_sso_saml_forgery.py
+++ b/tests/test_services/test_sso_saml_forgery.py
@@ -1,0 +1,162 @@
+"""CI regression probe for the SAML authentication-bypass (fixed 2026-07-20; now public).
+
+The old ``sso_routes._saml_parse`` base64-decoded the SAMLResponse and trusted the
+``<NameID>`` with **no** signature validation → any org's SSO could be forged for
+account takeover. The fix validates every Response via python3-saml/xmlsec (XML-DSig
+against the org's IdP cert, ``wantAssertionsSigned``, audience, destination,
+conditions, InResponseTo). ``sso_callback`` returns 401 on any validation failure.
+
+This probe pins the security invariant at PR time so the bug class can't silently
+return: **a forged SAMLResponse never authenticates — the callback returns 401 and
+issues no token.** The Redis request-id gate is patched OPEN so the forgery is
+rejected by the SAML *validator* (the fix), not the replay defence — a future
+regression that weakened signature validation would flip this red.
+
+python3-saml/xmlsec is a main dependency, so CI + Docker always run this; the
+``importorskip`` only guards a stale local venv.
+"""
+
+import base64
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("onelogin.saml2")  # xmlsec/python3-saml needed to drive the real validator
+
+from starlette.applications import Starlette  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from datanika.services.sso_routes import _sign_state, sso_routes  # noqa: E402
+
+
+def _self_signed_idp_cert() -> str:
+    """A real throwaway self-signed cert (bare base64 body, as ``saml_idp_cert`` is
+    stored) so OneLogin settings load cleanly — the point of the probe is that the
+    forged Response is NOT signed by the matching private key."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import Encoding
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "idp.example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=3650))
+        .sign(key, hashes.SHA256())
+    )
+    pem = cert.public_bytes(Encoding.PEM).decode()
+    return "".join(line for line in pem.splitlines() if "CERTIFICATE" not in line)
+
+
+_IDP_CERT = _self_signed_idp_cert()
+_ACS = "http://localhost:8000/api/auth/sso/callback"  # settings.oauth_redirect_base_url default
+
+
+def _forged_unsigned_response(email: str, in_response_to: str) -> str:
+    """A structurally-valid but UNSIGNED SAML Response asserting ``email`` — everything
+    plausible (matching Destination / Audience / InResponseTo / current conditions)
+    except the XML-DSig signature the attacker cannot produce. base64-encoded."""
+    now = datetime.now(UTC)
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    xml = (
+        '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+        ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+        f' ID="_resp{uuid.uuid4().hex}" Version="2.0" IssueInstant="{now.strftime(fmt)}"'
+        f' Destination="{_ACS}" InResponseTo="{in_response_to}">'
+        "<saml:Issuer>https://idp.example.com</saml:Issuer>"
+        "<samlp:Status><samlp:StatusCode"
+        ' Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>'
+        f'<saml:Assertion ID="_ass{uuid.uuid4().hex}" Version="2.0"'
+        f' IssueInstant="{now.strftime(fmt)}">'
+        "<saml:Issuer>https://idp.example.com</saml:Issuer>"
+        "<saml:Subject>"
+        '<saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">'
+        f"{email}</saml:NameID>"
+        '<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">'
+        f'<saml:SubjectConfirmationData InResponseTo="{in_response_to}" Recipient="{_ACS}"'
+        f' NotOnOrAfter="{(now + timedelta(minutes=5)).strftime(fmt)}"/>'
+        "</saml:SubjectConfirmation></saml:Subject>"
+        f'<saml:Conditions NotBefore="{(now - timedelta(minutes=5)).strftime(fmt)}"'
+        f' NotOnOrAfter="{(now + timedelta(minutes=5)).strftime(fmt)}">'
+        "<saml:AudienceRestriction><saml:Audience>datanika</saml:Audience>"
+        "</saml:AudienceRestriction></saml:Conditions>"
+        f'<saml:AuthnStatement AuthnInstant="{now.strftime(fmt)}"'
+        f' SessionIndex="_sess{uuid.uuid4().hex}">'
+        "<saml:AuthnContext><saml:AuthnContextClassRef>"
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
+        "</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement>"
+        "</saml:Assertion></samlp:Response>"
+    )
+    return base64.b64encode(xml.encode()).decode()
+
+
+class TestSAMLForgeryRejection:
+    """``sso_callback`` must 401 a forged assertion — the auth-bypass regression guard.
+
+    On the old (vulnerable) ``_saml_parse`` these forgeries would have returned the
+    attacker's NameID and the callback would issue a session token (302). Asserting
+    401 pins the fix.
+    """
+
+    _STATE = "forgery-probe-state"
+    _ORG = "victim-org"
+    _REQ_ID = "_authnreq_forgery"
+
+    def _mock_saml_sso(self) -> MagicMock:
+        sso = MagicMock()
+        sso.is_active = True
+        sso.protocol.value = "saml"
+        sso.saml_idp_cert = _IDP_CERT
+        sso.saml_idp_entity_id = "https://idp.example.com"
+        sso.saml_idp_sso_url = "https://idp.example.com/saml/sso"
+        sso.saml_sp_entity_id = "datanika"
+        return sso
+
+    def _signed_state_cookie(self) -> str:
+        return f"{self._ORG}:{self._STATE}:{_sign_state(self._STATE)}"
+
+    def _post_callback(self, form: dict):
+        app = Starlette(routes=sso_routes)
+        with (
+            patch("datanika.services.sso_routes._get_session") as mock_sess,
+            patch("datanika.services.sso_routes._sso_service") as mock_svc,
+            # Replay gate OPEN → the forgery must be stopped by the SAML validator itself.
+            patch(
+                "datanika.services.sso_routes._consume_saml_request_id",
+                return_value=self._REQ_ID,
+            ),
+        ):
+            mock_sess.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            mock_svc.return_value.get_sso_config_by_org_slug.return_value = self._mock_saml_sso()
+            client = TestClient(app, raise_server_exceptions=False)
+            client.cookies.set("sso_state", self._signed_state_cookie())
+            return client.post("/api/auth/sso/callback", data=form, follow_redirects=False)
+
+    def test_unsigned_forged_assertion_is_rejected_401(self):
+        resp = self._post_callback(
+            {"SAMLResponse": _forged_unsigned_response("attacker@victim.example.com", self._REQ_ID)}
+        )
+        assert resp.status_code == 401
+        # Not the success path: no auth token is issued (that path is a 302 to /auth/complete).
+        assert resp.status_code != 302
+        assert "token=" not in resp.headers.get("location", "")
+
+    def test_garbage_samlresponse_is_rejected_401(self):
+        resp = self._post_callback(
+            {"SAMLResponse": base64.b64encode(b"<not-a-saml-response/>").decode()}
+        )
+        assert resp.status_code == 401
+
+    def test_missing_samlresponse_is_rejected_401(self):
+        resp = self._post_callback({})
+        assert resp.status_code == 401


### PR DESCRIPTION
Promotes #389 (closes #388): async MCP client fixes the 30s hosted `tools/call` deadlock; carries datanika-mcp 0.2.0 + the README port fix. Uses --merge per RUNBOOK so master stays a descendant of dev (clean FF resync).