### PR TITLE
[Engineering] Settle the MCP registry name + add the PyPI ownership marker (closes #391)

### DIFF
--- a/datanika-mcp/README.md
+++ b/datanika-mcp/README.md
@@ -1,5 +1,11 @@
 # Datanika MCP Server
 
+<!-- Official MCP registry ownership marker: mcp-publisher reads this line from the
+     PUBLISHED PyPI README to prove we own the package. It must match `name` in
+     server.json — tests/test_mcp/test_registry_manifests.py enforces both. -->
+
+mcp-name: io.datanika/datanika-mcp
+
 MCP server for [Datanika](https://datanika.io) — browse connections, preview data, compile and validate dbt transformations, monitor runs, and manage pipelines from Claude Desktop.
 
 **Read-only by default.** Pass `--allow-write` to enable creating resources and triggering pipeline runs.

--- a/datanika-mcp/server.json
+++ b/datanika-mcp/server.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
-  "name": "io.github.datanika-io/datanika-mcp",
-  "description": "MCP server for Datanika: browse connections, preview data, run dbt transforms, and manage pipelines.",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.datanika/datanika-mcp",
+  "description": "Read-only-by-default MCP for Datanika: browse data, run dbt transforms, manage ELT pipelines.",
   "repository": {
     "url": "https://github.com/datanika-io/datanika-core",
     "source": "github",
@@ -20,18 +20,21 @@
         {
           "name": "DATANIKA_URL",
           "description": "Datanika instance URL (defaults to https://app.datanika.io; set this for a self-hosted instance)",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         },
         {
           "name": "DATANIKA_API_KEY",
-          "description": "Datanika API key",
+          "description": "Datanika API key (from Settings -> API Keys)",
           "isRequired": true,
-          "isSecret": true
+          "isSecret": true,
+          "format": "string"
         },
         {
           "name": "DATANIKA_ALLOW_WRITE",
           "description": "Set to true to enable write/trigger tools (read-only by default)",
-          "isRequired": false
+          "isRequired": false,
+          "format": "string"
         }
       ]
     }

--- a/tests/test_mcp/test_registry_manifests.py
+++ b/tests/test_mcp/test_registry_manifests.py
@@ -17,6 +17,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MCP_DIR = _REPO_ROOT / "datanika-mcp"
 _EXPECTED_ENV_VARS = {"DATANIKA_URL", "DATANIKA_API_KEY", "DATANIKA_ALLOW_WRITE"}
 
+# The official registry's namespace for this server. `io.datanika/*` is
+# DNS-authenticated (apex TXT on datanika.io); the earlier
+# `io.github.datanika-io/*` route was abandoned because the registry needs a
+# `read:org` token the mcp-publisher OAuth app can't get for our org.
+_REGISTRY_NAME = "io.datanika/datanika-mcp"
+
 
 def _pyproject() -> dict:
     with (_MCP_DIR / "pyproject.toml").open("rb") as fh:
@@ -36,7 +42,7 @@ def _package_env_var_names() -> set[str]:
 class TestServerJson:
     def test_is_valid_json_with_expected_shape(self):
         data = _server_json()
-        assert data["name"] == "io.github.datanika-io/datanika-mcp"
+        assert data["name"] == _REGISTRY_NAME
         assert data["repository"]["subfolder"] == "datanika-mcp"
         assert len(data["packages"]) == 1
 
@@ -65,6 +71,35 @@ class TestServerJson:
         assert by_name["DATANIKA_API_KEY"]["isSecret"] is True
         # URL has a working default in server.py; it must not be marked required.
         assert by_name["DATANIKA_URL"].get("isRequired", False) is False
+
+
+class TestPypiOwnershipMarker:
+    """The official registry proves package ownership via the PyPI README.
+
+    ``mcp-publisher publish`` greps the **published** PyPI README for
+    ``mcp-name: <server name>``; without it the publish 400s (which is exactly
+    what blocked the 0.1.0 listing). Two things therefore have to hold, and
+    neither is obvious from reading either file alone.
+    """
+
+    def test_readme_carries_the_mcp_name_marker(self):
+        readme = (_MCP_DIR / "README.md").read_text(encoding="utf-8")
+        assert f"mcp-name: {_REGISTRY_NAME}" in readme, (
+            "datanika-mcp/README.md must carry the `mcp-name:` marker — the "
+            "registry reads it from the published PyPI README to prove we own "
+            "the package."
+        )
+
+    def test_marker_matches_server_json_name(self):
+        """A rename in one file without the other silently breaks publishing."""
+        readme = (_MCP_DIR / "README.md").read_text(encoding="utf-8")
+        declared = re.search(r"^mcp-name:\s*(\S+)", readme, re.MULTILINE)
+        assert declared, "no `mcp-name:` line found in datanika-mcp/README.md"
+        assert declared.group(1) == _server_json()["name"]
+
+    def test_that_readme_is_the_one_shipped_to_pypi(self):
+        """The marker is worthless if the file never reaches PyPI."""
+        assert _pyproject()["project"]["readme"] == "README.md"
 
 
 class TestSmitheryYaml:


### PR DESCRIPTION
Closes #391. Refs #355 (Growth's registry-listing issue).

## Why the official-registry publish was 400ing

Growth's DNS auth for the **`io.datanika`** namespace is already done — apex TXT on `datanika.io`, key in `secrets/mcp-registry-dns.env`, `mcp-publisher login dns` working. But `publish` still failed: the registry proves *package* ownership by grepping the **published PyPI README** for `mcp-name: <server name>`, and the live 0.1.0 predates the namespace choice.

Meanwhile the committed `datanika-mcp/server.json` still declared **`io.github.datanika-io/datanika-mcp`**, the namespace we abandoned — the registry requires a token that can read your **org role** via `read:org`, which the mcp-publisher OAuth app can't get for `datanika-io` (the founder is a confirmed owner; public membership was a red herring). DNS sidesteps GitHub entirely, so `io.datanika/*` is the route.

So the manifest and the plan disagreed, and the marker existed in neither.

## What this does

- **`server.json` → `io.datanika/datanika-mcp`**, aligned with the copy Growth had already schema-validated (2025-12-11 schema, their description, `format` on the env vars). The two copies were drifting; now there's one.
- **`README.md` → the `mcp-name:` marker**, directly under the H1 so it survives into the rendered PyPI README, with an HTML comment explaining what it is (comments are stripped in rendering).

**Validated for real, not just by my tests** — Growth's `mcp-publisher` v1.8.0 against the live registry:

```
$ mcp-publisher validate ./server.json
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

## Drift guards (3 new)

None of this is obvious from reading either file alone, and getting it wrong fails at publish time with a 400 rather than in CI:

1. the README must carry an `mcp-name:` marker;
2. it must equal `server.json`'s `name` — a rename in one file alone silently breaks publishing;
3. `pyproject`'s `readme` must still point at that README — a marker that never reaches PyPI is worthless.

The reason the GitHub namespace is not coming back is recorded next to the `_REGISTRY_NAME` constant, so the next person doesn't rediscover the `read:org` dead end.

Full precheck green: ruff + format clean, **2311 passed, 19 skipped**.

## What's left, and who owns it

Ships under **0.2.0** — #389 bumped the package, so the `0.1.1 re-release` plan in `MCP_REGISTRY_LISTINGS.md` is superseded (one release instead of two). Remaining steps are not Engineering's:

1. **Infra** — tag `mcp-v0.2.0` from `master` → `release-mcp.yml` publishes to PyPI *with the marker in the README*.
2. **Growth** — `mcp-publisher login dns --domain datanika.io --private-key <secrets/mcp-registry-dns.env>` then `publish` → `io.datanika/datanika-mcp` goes live.

Step 2 only works after step 1: the registry reads the marker from PyPI, not from this repo.
