### PR TITLE
[Engineering] Remote-MCP P2: OAuth 2.1 authorization server (closes #393)

### DIFF
--- a/datanika/datanika.py
+++ b/datanika/datanika.py
@@ -277,6 +277,15 @@ except ImportError as _mcp_exc:
         "datanika-mcp not installed; /mcp endpoint not mounted (%s)", _mcp_exc
     )
 
+# Mount the MCP OAuth 2.1 authorization server (Remote-MCP P2, #393) —
+# discovery, dynamic client registration, authorize/consent, token. Unlike
+# /mcp this has no dependency on the datanika-mcp package, so it mounts
+# unconditionally: the AS is pure protocol over our own models.
+from datanika.services.mcp_oauth_routes import mcp_oauth_routes  # noqa: E402
+
+for _route in mcp_oauth_routes:
+    app._api.routes.append(_route)
+
 # Register every core-side hook subscriber (runs + quota + V2 P5 charge
 # events + external-channel dispatch). Delegated to
 # ``services._register_hooks`` so the Celery worker can call the same

--- a/datanika/migrations/helpers.py
+++ b/datanika/migrations/helpers.py
@@ -30,6 +30,9 @@ PUBLIC_TABLES: set[str] = {
     "subscriptions",
     "usage_ledger",
     "charges",
+    "oauth_clients",
+    "oauth_grants",
+    "oauth_tokens",
 }
 
 # Tables managed by Alembic but not belonging to either category

--- a/datanika/migrations/versions/b3f9d17c245e_add_mcp_oauth_tables.py
+++ b/datanika/migrations/versions/b3f9d17c245e_add_mcp_oauth_tables.py
@@ -1,0 +1,125 @@
+"""Remote-MCP P2 — OAuth 2.1 authorization-server tables
+
+Adds ``oauth_clients`` (RFC 7591 dynamic client registrations),
+``oauth_grants`` (a user's consent for one client + one org, holding the
+minted org-scoped API key encrypted, plus the one-time authorization code)
+and ``oauth_tokens`` (issued access/refresh tokens, hashed at rest).
+
+See ``datanika/models/mcp_oauth.py`` and SPEC_REMOTE_MCP §5.3 for why consent
+mints a real API key rather than a parallel credential: revocation stays the
+existing API-keys UI and the MCP server stays a pure forwarder.
+
+Revision ID: b3f9d17c245e
+Revises: d0e5f6g7h8i9
+Create Date: 2026-07-21 13:30:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b3f9d17c245e"
+down_revision: str | None = "d0e5f6g7h8i9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Timestamp columns are spelled out per table rather than factored into a
+    # helper: tests/test_migrations/test_migration_coverage.py reads these files
+    # as text to prove every model column has a migration, and a helper hides
+    # them from it.
+    op.create_table(
+        "oauth_clients",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("client_id", sa.String(length=64), nullable=False),
+        sa.Column("client_name", sa.String(length=255), nullable=False),
+        sa.Column("redirect_uris", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_oauth_clients_client_id", "oauth_clients", ["client_id"], unique=True)
+
+    op.create_table(
+        "oauth_grants",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.BigInteger(), sa.ForeignKey("organizations.id"), nullable=False),
+        sa.Column("client_id", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("api_key_id", sa.BigInteger(), sa.ForeignKey("api_keys.id"), nullable=False),
+        sa.Column("encrypted_api_key", sa.Text(), nullable=False),
+        sa.Column("code_hash", sa.String(length=64), nullable=True),
+        sa.Column("code_challenge", sa.String(length=128), nullable=False),
+        sa.Column("redirect_uri", sa.String(length=2000), nullable=False),
+        sa.Column("scope", sa.String(length=500), nullable=False),
+        sa.Column("resource", sa.String(length=500), nullable=False),
+        sa.Column("code_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Unique so a code can never resolve to two grants; nullable because the
+    # hash is cleared on redemption (Postgres allows many NULLs under UNIQUE).
+    op.create_index("ix_oauth_grants_code_hash", "oauth_grants", ["code_hash"], unique=True)
+    op.create_index("ix_oauth_grants_org_id", "oauth_grants", ["org_id"])
+    op.create_index("ix_oauth_grants_client_id", "oauth_grants", ["client_id"])
+
+    op.create_table(
+        "oauth_tokens",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.BigInteger(), sa.ForeignKey("organizations.id"), nullable=False),
+        sa.Column("grant_id", sa.BigInteger(), sa.ForeignKey("oauth_grants.id"), nullable=False),
+        sa.Column("access_token_hash", sa.String(length=64), nullable=False),
+        sa.Column("refresh_token_hash", sa.String(length=64), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("refresh_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_oauth_tokens_access_token_hash", "oauth_tokens", ["access_token_hash"], unique=True
+    )
+    op.create_index(
+        "ix_oauth_tokens_refresh_token_hash", "oauth_tokens", ["refresh_token_hash"], unique=True
+    )
+    op.create_index("ix_oauth_tokens_grant_id", "oauth_tokens", ["grant_id"])
+    op.create_index("ix_oauth_tokens_org_id", "oauth_tokens", ["org_id"])
+
+    connection = op.get_bind()
+    connection.commit()
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oauth_tokens_org_id", table_name="oauth_tokens")
+    op.drop_index("ix_oauth_tokens_grant_id", table_name="oauth_tokens")
+    op.drop_index("ix_oauth_tokens_refresh_token_hash", table_name="oauth_tokens")
+    op.drop_index("ix_oauth_tokens_access_token_hash", table_name="oauth_tokens")
+    op.drop_table("oauth_tokens")
+
+    op.drop_index("ix_oauth_grants_client_id", table_name="oauth_grants")
+    op.drop_index("ix_oauth_grants_org_id", table_name="oauth_grants")
+    op.drop_index("ix_oauth_grants_code_hash", table_name="oauth_grants")
+    op.drop_table("oauth_grants")
+
+    op.drop_index("ix_oauth_clients_client_id", table_name="oauth_clients")
+    op.drop_table("oauth_clients")
+
+    connection = op.get_bind()
+    connection.commit()

--- a/datanika/models/__init__.py
+++ b/datanika/models/__init__.py
@@ -4,6 +4,7 @@ from datanika.models.base import Base, TenantMixin, TimestampMixin
 from datanika.models.catalog_entry import CatalogEntry, CatalogEntryType
 from datanika.models.connection import Connection, ConnectionDirection, ConnectionType
 from datanika.models.dependency import Dependency, NodeType
+from datanika.models.mcp_oauth import OAuthClient, OAuthGrant, OAuthToken
 from datanika.models.pipeline import DbtCommand, Pipeline, PipelineStatus
 from datanika.models.run import Run, RunStatus
 from datanika.models.schedule import Schedule
@@ -41,4 +42,7 @@ __all__ = [
     "CatalogEntry",
     "CatalogEntryType",
     "UploadedFile",
+    "OAuthClient",
+    "OAuthGrant",
+    "OAuthToken",
 ]

--- a/datanika/models/mcp_oauth.py
+++ b/datanika/models/mcp_oauth.py
@@ -1,0 +1,86 @@
+"""OAuth 2.1 authorization-server models for the hosted MCP endpoint (core#393).
+
+Datanika is the **Authorization Server** for its own ``/mcp`` Resource Server
+(SPEC_REMOTE_MCP §5.3). Three tables, deliberately small — this AS serves one
+resource and public clients only, it is not a general-purpose IdP (§3).
+
+The load-bearing choice is in :class:`OAuthGrant`: consent mints **one
+org-scoped API key per grant**, so revocation is the existing API-keys UI and
+the MCP server stays a pure credential forwarder. The raw key is stored
+**Fernet-encrypted** (the same treatment connection credentials get) because
+the tool path has to replay it on every call — unlike ``api_keys.key_hash``,
+which only ever needs to verify. Access/refresh tokens are separate opaque
+strings kept as SHA-256 hashes, so a database read yields nothing replayable
+except the encrypted key, which needs ``CREDENTIAL_ENCRYPTION_KEY`` to open.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import JSON, BigInteger, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from datanika.models.base import Base, TenantMixin, TimestampMixin
+
+
+class OAuthClient(Base, TimestampMixin):
+    """An MCP client registered via RFC 7591 Dynamic Client Registration.
+
+    Not org-scoped: "Claude.ai" is one client registration that any number of
+    orgs may then grant access to. Public clients only — there is no secret
+    column because there is no secret; PKCE is the proof of possession.
+    """
+
+    __tablename__ = "oauth_clients"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    client_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    client_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    redirect_uris: Mapped[list] = mapped_column(JSON, nullable=False)
+
+
+class OAuthGrant(Base, TimestampMixin, TenantMixin):
+    """One user's consent for one client to reach one org's data.
+
+    Holds the minted API key (encrypted) for the life of the grant, plus the
+    one-time authorization code. ``code_hash`` is cleared on redemption so a
+    replayed code cannot resolve to a grant at all.
+    """
+
+    __tablename__ = "oauth_grants"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    client_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"), nullable=False)
+    api_key_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("api_keys.id"), nullable=False)
+    encrypted_api_key: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # One-time authorization code (SHA-256 hex), NULLed once redeemed.
+    code_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True)
+    code_challenge: Mapped[str] = mapped_column(String(128), nullable=False)
+    redirect_uri: Mapped[str] = mapped_column(String(2000), nullable=False)
+    scope: Mapped[str] = mapped_column(String(500), nullable=False)
+    # RFC 8707 — the resource this grant is for. Bound into every token so the
+    # RS can refuse anything not minted for /mcp (confused-deputy, SPEC §10).
+    resource: Mapped[str] = mapped_column(String(500), nullable=False)
+    code_expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class OAuthToken(Base, TimestampMixin, TenantMixin):
+    """An issued access token (+ its refresh token), both hashed at rest."""
+
+    __tablename__ = "oauth_tokens"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    grant_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("oauth_grants.id"), nullable=False, index=True
+    )
+    access_token_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True
+    )
+    refresh_token_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    refresh_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/datanika/services/mcp_oauth.py
+++ b/datanika/services/mcp_oauth.py
@@ -1,0 +1,497 @@
+"""OAuth 2.1 Authorization Server for the hosted MCP endpoint (core#393, P2).
+
+Implements the MCP remote-auth flow (SPEC_REMOTE_MCP §5.3/§8/§10) so an MCP
+client can add Datanika with one click instead of a pasted API key:
+
+    POST /mcp (no token)            -> 401 + WWW-Authenticate: resource_metadata=...
+    GET  /.well-known/oauth-protected-resource
+    GET  /.well-known/oauth-authorization-server
+    POST /oauth/register            -> RFC 7591 dynamic client registration
+    GET  /oauth/authorize           -> validate, then hand off to the consent screen
+    POST /api/oauth/consent         -> (app JWT) mint the key + authorization code
+    POST /oauth/token               -> code+PKCE -> access/refresh; rotating refresh
+
+**Why consent redirects to the frontend.** Datanika's browser session is a JWT
+the Reflex frontend holds (social login lands on ``/auth/complete?token=…``),
+so a backend route cannot read it from a cookie. ``/oauth/authorize`` therefore
+validates the OAuth request and redirects to the frontend consent page, which
+carries the user's JWT to ``POST /api/oauth/consent`` in an Authorization
+header. No token is ever put in a query string.
+
+**Scope of the grant.** P2 issues **read-only** grants — the eight ``*:read``
+scopes, which is exactly what the 17 read tools need. Write tools are P3 and
+gated on the #338 egress guard, so a write grant could not unlock anything
+today; offering one would be consent theatre.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlencode, urlparse
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from datanika.config import settings
+from datanika.models.api_key import ApiKey
+from datanika.models.mcp_oauth import OAuthClient, OAuthGrant, OAuthToken
+from datanika.services.api_key_service import ApiKeyService
+from datanika.services.encryption import EncryptionService
+
+MCP_RESOURCE_PATH = "/mcp"
+
+#: Where the frontend renders the consent screen (Product owns the page itself).
+CONSENT_PATH = "/oauth/consent"
+
+_CODE_TTL = timedelta(minutes=5)
+_ACCESS_TTL = timedelta(hours=1)
+_REFRESH_TTL = timedelta(days=30)
+
+_CODE_PREFIX = "dtk_ac_"
+_ACCESS_PREFIX = "dtk_at_"
+_REFRESH_PREFIX = "dtk_rt_"
+
+#: Every resource family the REST API exposes, read half only. A grant carries
+#: exactly these, so `api_middleware` rejects writes without the MCP layer
+#: implementing any authz of its own (SPEC §5.4).
+_READ_SCOPES = (
+    "catalog:read",
+    "connections:read",
+    "notifications:read",
+    "pipelines:read",
+    "runs:read",
+    "schedules:read",
+    "transformations:read",
+    "uploads:read",
+)
+
+
+def read_only_scopes() -> list[str]:
+    """The scope set a P2 consent grants."""
+    return list(_READ_SCOPES)
+
+
+class McpOAuthError(Exception):
+    """An OAuth error, carrying the RFC 6749 error code as its message.
+
+    The code is what goes on the wire (``invalid_grant``, ``invalid_request``,
+    …); ``description`` is the human half, safe to show a developer.
+    """
+
+    def __init__(self, code: str, description: str = "") -> None:
+        super().__init__(code)
+        self.code = code
+        self.description = description
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _aware(value: datetime | None) -> datetime | None:
+    """SQLite hands back naive datetimes; compare in UTC regardless."""
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _is_loopback(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in {"127.0.0.1", "::1", "localhost"}
+
+
+class McpOAuthService:
+    """Authorization-server logic. Transport-free so it is testable directly."""
+
+    def __init__(
+        self,
+        public_base_url: str | None = None,
+        encryption_key_provider=None,
+        api_key_service: ApiKeyService | None = None,
+    ) -> None:
+        self._base = (public_base_url or settings.oauth_redirect_base_url).rstrip("/")
+        self._encryption_key = encryption_key_provider or (
+            lambda: settings.credential_encryption_key
+        )
+        self._keys = api_key_service or ApiKeyService()
+
+    # ------------------------------------------------------------------
+    # Identity of this AS / RS
+    # ------------------------------------------------------------------
+
+    @property
+    def issuer(self) -> str:
+        return self._base
+
+    @property
+    def resource(self) -> str:
+        """The RFC 8707 resource identifier tokens are bound to."""
+        return f"{self._base}{MCP_RESOURCE_PATH}"
+
+    def protected_resource_metadata(self) -> dict:
+        return {
+            "resource": self.resource,
+            "authorization_servers": [self.issuer],
+            "scopes_supported": read_only_scopes(),
+            "bearer_methods_supported": ["header"],
+        }
+
+    def authorization_server_metadata(self) -> dict:
+        return {
+            "issuer": self.issuer,
+            "authorization_endpoint": f"{self._base}/oauth/authorize",
+            "token_endpoint": f"{self._base}/oauth/token",
+            "registration_endpoint": f"{self._base}/oauth/register",
+            "scopes_supported": read_only_scopes(),
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            # OAuth 2.1: PKCE is mandatory and `plain` is gone.
+            "code_challenge_methods_supported": ["S256"],
+            # Public clients only — there are no secrets to authenticate with.
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+
+    # ------------------------------------------------------------------
+    # RFC 7591 — dynamic client registration
+    # ------------------------------------------------------------------
+
+    def register_client(self, session: Session, client_name: str, redirect_uris: list[str]) -> dict:
+        if not redirect_uris:
+            raise McpOAuthError("invalid_redirect_uri", "At least one redirect_uri is required.")
+        for uri in redirect_uris:
+            parsed = urlparse(uri)
+            # https everywhere, except the loopback interface native clients
+            # must use (RFC 8252 §7.3).
+            if parsed.scheme == "https":
+                continue
+            if parsed.scheme == "http" and _is_loopback(uri):
+                continue
+            raise McpOAuthError(
+                "invalid_redirect_uri",
+                f"redirect_uri must be https (or http on loopback): {uri}",
+            )
+
+        client = OAuthClient(
+            client_id="mcp_" + secrets.token_urlsafe(24),
+            client_name=(client_name or "MCP client")[:255],
+            redirect_uris=list(redirect_uris),
+        )
+        session.add(client)
+        session.flush()
+
+        return {
+            "client_id": client.client_id,
+            "client_name": client.client_name,
+            "redirect_uris": client.redirect_uris,
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "client_id_issued_at": int(_now().timestamp()),
+        }
+
+    def get_client(self, session: Session, client_id: str) -> OAuthClient | None:
+        return session.execute(
+            select(OAuthClient).where(
+                OAuthClient.client_id == client_id, OAuthClient.deleted_at.is_(None)
+            )
+        ).scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # Authorization request validation (pre-consent)
+    # ------------------------------------------------------------------
+
+    def validate_authorization_request(
+        self,
+        session: Session,
+        *,
+        client_id: str,
+        redirect_uri: str,
+        response_type: str,
+        code_challenge: str,
+        code_challenge_method: str,
+        resource: str | None,
+    ) -> OAuthClient:
+        """Check everything that must hold before a human is shown a consent screen.
+
+        Errors here cannot be redirected back to the client (an unvalidated
+        ``redirect_uri`` is exactly what an attacker would supply), so callers
+        render them directly.
+        """
+        client = self.get_client(session, client_id)
+        if client is None:
+            raise McpOAuthError("invalid_client", "Unknown client_id.")
+        if redirect_uri not in (client.redirect_uris or []):
+            raise McpOAuthError(
+                "invalid_request", "redirect_uri is not registered for this client."
+            )
+        if response_type != "code":
+            raise McpOAuthError(
+                "unsupported_response_type", "Only response_type=code is supported."
+            )
+        self._check_pkce(code_challenge, code_challenge_method)
+        self._check_resource(resource)
+        return client
+
+    def _check_pkce(self, code_challenge: str, code_challenge_method: str) -> None:
+        if code_challenge_method != "S256":
+            raise McpOAuthError(
+                "invalid_request", "code_challenge_method must be S256 (OAuth 2.1)."
+            )
+        if not code_challenge:
+            raise McpOAuthError("invalid_request", "code_challenge is required.")
+
+    def _check_resource(self, resource: str | None) -> None:
+        """RFC 8707 — refuse to mint a token for anyone else's resource.
+
+        This is the confused-deputy guard (SPEC §10): a token we issue is only
+        ever valid for our own ``/mcp``, so it cannot be replayed elsewhere,
+        and we never accept one minted elsewhere.
+        """
+        if resource is None:
+            return  # optional; the token is bound to our resource regardless
+        if resource.rstrip("/") != self.resource:
+            raise McpOAuthError("invalid_target", f"Unknown resource: {resource}")
+
+    # ------------------------------------------------------------------
+    # Consent — mint the org-scoped key and the one-time code
+    # ------------------------------------------------------------------
+
+    def grant_consent(
+        self,
+        session: Session,
+        *,
+        client_id: str,
+        org_id: int,
+        user_id: int,
+        redirect_uri: str,
+        code_challenge: str,
+        code_challenge_method: str,
+        scope: str,
+        resource: str | None,
+    ) -> tuple[OAuthGrant, str]:
+        """Record consent. Returns ``(grant, authorization_code)``.
+
+        The raw code is returned once and never stored — only its hash is, so a
+        database leak cannot be replayed into a token.
+        """
+        client = self.get_client(session, client_id)
+        if client is None:
+            raise McpOAuthError("invalid_client", "Unknown client_id.")
+        if redirect_uri not in (client.redirect_uris or []):
+            raise McpOAuthError(
+                "invalid_request", "redirect_uri is not registered for this client."
+            )
+        self._check_pkce(code_challenge, code_challenge_method)
+        self._check_resource(resource)
+
+        granted = self._narrow_scope(scope)
+
+        api_key, raw_key = self._keys.create_api_key(
+            session,
+            org_id=org_id,
+            user_id=user_id,
+            name=f"MCP: {client.client_name}"[:255],
+            scopes=granted,
+        )
+
+        code = _CODE_PREFIX + secrets.token_urlsafe(32)
+        grant = OAuthGrant(
+            client_id=client.client_id,
+            org_id=org_id,
+            user_id=user_id,
+            api_key_id=api_key.id,
+            encrypted_api_key=self._encrypt(raw_key),
+            code_hash=_sha256(code),
+            code_challenge=code_challenge,
+            redirect_uri=redirect_uri,
+            scope=" ".join(granted),
+            resource=self.resource,
+            code_expires_at=_now() + _CODE_TTL,
+        )
+        session.add(grant)
+        session.flush()
+        return grant, code
+
+    def _narrow_scope(self, requested: str) -> list[str]:
+        """Grant at most read-only, never more than was asked for.
+
+        An unknown or empty request collapses to the full read-only set rather
+        than erroring: MCP clients routinely omit `scope`, and the ceiling is
+        read-only anyway.
+        """
+        asked = [s for s in (requested or "").split() if s]
+        if not asked:
+            return read_only_scopes()
+        narrowed = [s for s in asked if s in _READ_SCOPES]
+        return narrowed or read_only_scopes()
+
+    # ------------------------------------------------------------------
+    # Token endpoint
+    # ------------------------------------------------------------------
+
+    def exchange_code(
+        self, session: Session, *, code: str, code_verifier: str, redirect_uri: str
+    ) -> dict:
+        grant = session.execute(
+            select(OAuthGrant).where(
+                OAuthGrant.code_hash == _sha256(code),
+                OAuthGrant.revoked_at.is_(None),
+                OAuthGrant.deleted_at.is_(None),
+            )
+        ).scalar_one_or_none()
+        # A redeemed code has had its hash cleared, so a replay lands here too.
+        if grant is None:
+            raise McpOAuthError("invalid_grant", "Authorization code is invalid or already used.")
+
+        expires = _aware(grant.code_expires_at)
+        if expires is not None and expires < _now():
+            raise McpOAuthError("invalid_grant", "Authorization code has expired.")
+        if redirect_uri != grant.redirect_uri:
+            raise McpOAuthError("invalid_grant", "redirect_uri does not match the grant.")
+        if not self._verify_pkce(code_verifier, grant.code_challenge):
+            raise McpOAuthError("invalid_grant", "PKCE verification failed.")
+
+        # Burn the code before issuing anything — a concurrent replay finds
+        # nothing to redeem.
+        grant.code_hash = None
+        session.flush()
+
+        return self._issue(session, grant)
+
+    def _verify_pkce(self, verifier: str, challenge: str) -> bool:
+        if not verifier:
+            return False
+        digest = hashlib.sha256(verifier.encode()).digest()
+        computed = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+        return secrets.compare_digest(computed, challenge)
+
+    def refresh(self, session: Session, *, refresh_token: str) -> dict:
+        token = session.execute(
+            select(OAuthToken).where(
+                OAuthToken.refresh_token_hash == _sha256(refresh_token),
+                OAuthToken.revoked_at.is_(None),
+                OAuthToken.deleted_at.is_(None),
+            )
+        ).scalar_one_or_none()
+        if token is None:
+            raise McpOAuthError("invalid_grant", "Refresh token is invalid or already rotated.")
+
+        refresh_expires = _aware(token.refresh_expires_at)
+        if refresh_expires is not None and refresh_expires < _now():
+            raise McpOAuthError("invalid_grant", "Refresh token has expired.")
+
+        grant = session.get(OAuthGrant, token.grant_id)
+        if grant is None or grant.revoked_at is not None:
+            raise McpOAuthError("invalid_grant", "The underlying grant was revoked.")
+
+        # Rotation: the presented pair dies as the new one is born, so a stolen
+        # refresh token is single-use and its reuse is detectable.
+        token.revoked_at = _now()
+        session.flush()
+        return self._issue(session, grant)
+
+    def _issue(self, session: Session, grant: OAuthGrant) -> dict:
+        access = _ACCESS_PREFIX + secrets.token_urlsafe(32)
+        refresh = _REFRESH_PREFIX + secrets.token_urlsafe(32)
+        now = _now()
+
+        session.add(
+            OAuthToken(
+                grant_id=grant.id,
+                org_id=grant.org_id,
+                access_token_hash=_sha256(access),
+                refresh_token_hash=_sha256(refresh),
+                expires_at=now + _ACCESS_TTL,
+                refresh_expires_at=now + _REFRESH_TTL,
+            )
+        )
+        session.flush()
+
+        return {
+            "access_token": access,
+            "refresh_token": refresh,
+            "token_type": "Bearer",
+            "expires_in": int(_ACCESS_TTL.total_seconds()),
+            "scope": grant.scope,
+        }
+
+    # ------------------------------------------------------------------
+    # Resource-server side — bearer -> the credential the tools replay
+    # ------------------------------------------------------------------
+
+    def resolve_access_token(self, session: Session, access_token: str) -> str | None:
+        """Return the org-scoped API key behind a bearer token, or ``None``.
+
+        ``None`` covers every rejection — unknown, expired, revoked grant, and
+        (deliberately) a revoked *API key*: revocation in the existing keys UI
+        has to kill the MCP session too, which is the whole point of minting a
+        real key rather than inventing a parallel credential (SPEC §5.3).
+        """
+        if not access_token or not access_token.startswith(_ACCESS_PREFIX):
+            return None
+
+        token = session.execute(
+            select(OAuthToken).where(
+                OAuthToken.access_token_hash == _sha256(access_token),
+                OAuthToken.revoked_at.is_(None),
+                OAuthToken.deleted_at.is_(None),
+            )
+        ).scalar_one_or_none()
+        if token is None:
+            return None
+
+        expires = _aware(token.expires_at)
+        if expires is not None and expires < _now():
+            return None
+
+        grant = session.get(OAuthGrant, token.grant_id)
+        if grant is None or grant.revoked_at is not None or grant.deleted_at is not None:
+            return None
+
+        api_key = session.get(ApiKey, grant.api_key_id)
+        if api_key is None or api_key.deleted_at is not None:
+            return None
+        key_expiry = _aware(api_key.expires_at)
+        if key_expiry is not None and key_expiry < _now():
+            return None
+
+        return self.decrypt_api_key(grant)
+
+    # ------------------------------------------------------------------
+    # Credential storage
+    # ------------------------------------------------------------------
+
+    def _encrypt(self, raw_key: str) -> str:
+        return EncryptionService(self._encryption_key()).encrypt({"key": raw_key})
+
+    def decrypt_api_key(self, grant: OAuthGrant) -> str:
+        return EncryptionService(self._encryption_key()).decrypt(grant.encrypted_api_key)["key"]
+
+    # ------------------------------------------------------------------
+    # Consent hand-off URL
+    # ------------------------------------------------------------------
+
+    def consent_redirect_url(self, params: dict, frontend_url: str | None = None) -> str:
+        """Where ``/oauth/authorize`` sends the browser to collect consent."""
+        base = (frontend_url or settings.frontend_url).rstrip("/")
+        return f"{base}{CONSENT_PATH}?{urlencode(params)}"
+
+    @staticmethod
+    def client_redirect_url(redirect_uri: str, code: str, state: str | None) -> str:
+        params = {"code": code}
+        if state:
+            params["state"] = state
+        joiner = "&" if "?" in redirect_uri else "?"
+        return f"{redirect_uri}{joiner}{urlencode(params)}"
+
+    @staticmethod
+    def error_json(exc: McpOAuthError) -> bytes:
+        return json.dumps({"error": exc.code, "error_description": exc.description}).encode()

--- a/datanika/services/mcp_oauth_routes.py
+++ b/datanika/services/mcp_oauth_routes.py
@@ -1,0 +1,287 @@
+"""Starlette routes for the MCP OAuth 2.1 authorization server (core#393, P2).
+
+The HTTP half of :mod:`datanika.services.mcp_oauth` — see that module for the
+flow and the design rationale. Routes are appended to ``app._api.routes`` the
+same way the social-login, SSO and webhook routes are (SPEC §4.3).
+
+Discovery, registration and token endpoints answer **cross-origin**: browser
+based MCP clients (Claude.ai) fetch them from their own origin, so without CORS
+the one-click flow dies at the first preflight. They are unauthenticated by
+design — metadata is public, and registration is open, which is what "dynamic"
+means in RFC 7591. The credential-bearing endpoint (``/api/oauth/consent``) is
+same-origin and JWT-authenticated, and is deliberately *not* CORS-open.
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+from datanika.config import settings
+from datanika.services.auth import AuthService
+from datanika.services.mcp_oauth import McpOAuthError, McpOAuthService
+
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, MCP-Protocol-Version",
+    "Access-Control-Max-Age": "3600",
+}
+
+
+def _service() -> McpOAuthService:
+    return McpOAuthService()
+
+
+def _get_session():
+    from datanika.db import get_sync_session
+
+    return get_sync_session()
+
+
+def _public(payload: dict) -> JSONResponse:
+    return JSONResponse(payload, headers=_CORS_HEADERS)
+
+
+def _oauth_error(exc: McpOAuthError, status: int = 400) -> JSONResponse:
+    return JSONResponse(
+        {"error": exc.code, "error_description": exc.description},
+        status_code=status,
+        headers=_CORS_HEADERS,
+    )
+
+
+async def _body_params(request: Request) -> dict:
+    """OAuth posts form-encoded; some clients send JSON. Accept both."""
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        try:
+            return json.loads(await request.body() or b"{}")
+        except json.JSONDecodeError:
+            return {}
+    form = await request.form()
+    return dict(form)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+async def protected_resource_metadata(request: Request) -> Response:
+    if request.method == "OPTIONS":
+        return Response(status_code=204, headers=_CORS_HEADERS)
+    return _public(_service().protected_resource_metadata())
+
+
+async def authorization_server_metadata(request: Request) -> Response:
+    if request.method == "OPTIONS":
+        return Response(status_code=204, headers=_CORS_HEADERS)
+    return _public(_service().authorization_server_metadata())
+
+
+# ---------------------------------------------------------------------------
+# RFC 7591 — dynamic client registration
+# ---------------------------------------------------------------------------
+
+
+async def register_client(request: Request) -> Response:
+    if request.method == "OPTIONS":
+        return Response(status_code=204, headers=_CORS_HEADERS)
+
+    payload = await _body_params(request)
+    redirect_uris = payload.get("redirect_uris") or []
+    if isinstance(redirect_uris, str):
+        redirect_uris = [redirect_uris]
+
+    svc = _service()
+    with _get_session() as session:
+        try:
+            registered = svc.register_client(
+                session,
+                client_name=str(payload.get("client_name") or "MCP client"),
+                redirect_uris=[str(u) for u in redirect_uris],
+            )
+        except McpOAuthError as exc:
+            return _oauth_error(exc)
+        session.commit()
+
+    return JSONResponse(registered, status_code=201, headers=_CORS_HEADERS)
+
+
+# ---------------------------------------------------------------------------
+# Authorization — validate, then hand off to the consent screen
+# ---------------------------------------------------------------------------
+
+
+async def authorize(request: Request) -> Response:
+    q = request.query_params
+    svc = _service()
+
+    with _get_session() as session:
+        try:
+            svc.validate_authorization_request(
+                session,
+                client_id=q.get("client_id", ""),
+                redirect_uri=q.get("redirect_uri", ""),
+                response_type=q.get("response_type", ""),
+                code_challenge=q.get("code_challenge", ""),
+                code_challenge_method=q.get("code_challenge_method", ""),
+                resource=q.get("resource"),
+            )
+        except McpOAuthError as exc:
+            # Never redirect on a validation failure: an unvalidated
+            # redirect_uri is precisely what an attacker would supply, so
+            # bouncing the error there would be an open redirect.
+            return _oauth_error(exc)
+
+    # Consent needs the user's app session, which lives in the frontend as a
+    # JWT — so the browser goes there, and the frontend calls back into
+    # /api/oauth/consent with an Authorization header (never a query string).
+    consent_params = {
+        k: v
+        for k, v in (
+            ("client_id", q.get("client_id")),
+            ("redirect_uri", q.get("redirect_uri")),
+            ("code_challenge", q.get("code_challenge")),
+            ("code_challenge_method", q.get("code_challenge_method")),
+            ("scope", q.get("scope")),
+            ("state", q.get("state")),
+            ("resource", q.get("resource")),
+        )
+        if v
+    }
+    return RedirectResponse(url=svc.consent_redirect_url(consent_params), status_code=302)
+
+
+async def client_info(request: Request) -> Response:
+    """What the consent screen must show about the app asking for access.
+
+    The screen looks the name up here rather than trusting one passed through
+    the URL: a crafted consent link could otherwise label a real ``client_id``
+    with any name it liked, and the user would be consenting to something other
+    than what they read. Registrations are not secret — the name and redirect
+    URIs are exactly what a user needs to see to decide.
+    """
+    client_id = request.query_params.get("client_id", "")
+    with _get_session() as session:
+        client = _service().get_client(session, client_id)
+
+    if client is None:
+        return JSONResponse({"error": "invalid_client"}, status_code=404)
+    return JSONResponse(
+        {
+            "client_id": client.client_id,
+            "client_name": client.client_name,
+            "redirect_uris": client.redirect_uris,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consent grant — called by the frontend consent screen with the user's JWT
+# ---------------------------------------------------------------------------
+
+
+async def consent(request: Request) -> Response:
+    auth = request.headers.get("authorization", "")
+    if auth[:7].lower() != "bearer ":
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    claims = AuthService(settings.secret_key).decode_token(auth[7:].strip(), expected_type="access")
+    if not claims:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    payload = await _body_params(request)
+    svc = _service()
+
+    with _get_session() as session:
+        try:
+            _grant, code = svc.grant_consent(
+                session,
+                client_id=str(payload.get("client_id", "")),
+                # The org comes from the signed session, never from the request
+                # body — otherwise a consent screen could be talked into
+                # granting access to an org the user isn't a member of.
+                org_id=int(claims["org_id"]),
+                user_id=int(claims["user_id"]),
+                redirect_uri=str(payload.get("redirect_uri", "")),
+                code_challenge=str(payload.get("code_challenge", "")),
+                code_challenge_method=str(payload.get("code_challenge_method", "")),
+                scope=str(payload.get("scope") or ""),
+                resource=payload.get("resource"),
+            )
+        except McpOAuthError as exc:
+            return _oauth_error(exc)
+        session.commit()
+
+    return JSONResponse(
+        {
+            "redirect_to": svc.client_redirect_url(
+                str(payload.get("redirect_uri", "")), code, payload.get("state")
+            )
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint
+# ---------------------------------------------------------------------------
+
+
+async def token(request: Request) -> Response:
+    if request.method == "OPTIONS":
+        return Response(status_code=204, headers=_CORS_HEADERS)
+
+    payload = await _body_params(request)
+    grant_type = str(payload.get("grant_type", ""))
+    svc = _service()
+
+    with _get_session() as session:
+        try:
+            if grant_type == "authorization_code":
+                issued = svc.exchange_code(
+                    session,
+                    code=str(payload.get("code", "")),
+                    code_verifier=str(payload.get("code_verifier", "")),
+                    redirect_uri=str(payload.get("redirect_uri", "")),
+                )
+            elif grant_type == "refresh_token":
+                issued = svc.refresh(session, refresh_token=str(payload.get("refresh_token", "")))
+            else:
+                return _oauth_error(
+                    McpOAuthError(
+                        "unsupported_grant_type",
+                        "Supported: authorization_code, refresh_token.",
+                    )
+                )
+        except McpOAuthError as exc:
+            return _oauth_error(exc)
+        session.commit()
+
+    return JSONResponse(
+        issued,
+        headers={**_CORS_HEADERS, "Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+mcp_oauth_routes = [
+    Route(
+        "/.well-known/oauth-protected-resource",
+        protected_resource_metadata,
+        methods=["GET", "OPTIONS"],
+    ),
+    Route(
+        "/.well-known/oauth-authorization-server",
+        authorization_server_metadata,
+        methods=["GET", "OPTIONS"],
+    ),
+    Route("/oauth/register", register_client, methods=["POST", "OPTIONS"]),
+    Route("/oauth/authorize", authorize, methods=["GET"]),
+    Route("/api/oauth/client-info", client_info, methods=["GET"]),
+    Route("/api/oauth/consent", consent, methods=["POST"]),
+    Route("/oauth/token", token, methods=["POST", "OPTIONS"]),
+]

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -29,16 +29,23 @@ from __future__ import annotations
 import json
 import os
 
+import anyio
 from datanika_mcp.client import DatanikaClient
 from datanika_mcp.server import make_remote_transport
 from datanika_mcp.session import DatanikaSession, use_session
 from starlette.datastructures import Headers
 from starlette.routing import Route
 
+from datanika.services.mcp_oauth import McpOAuthService
+
 # The MCP server calls this app's own REST API with the caller's key. The mount
 # runs in the backend process, so this is loopback in prod; overridable for
 # unusual topologies.
 _INTERNAL_API_URL = os.environ.get("DATANIKA_MCP_INTERNAL_URL", "http://127.0.0.1:8000")
+
+# Access tokens the AS issues are prefixed so the resource server can tell them
+# apart from a pasted API key (``etf_``) without a database round-trip.
+_OAUTH_TOKEN_PREFIX = "dtk_at_"
 
 
 def _bearer_token(scope) -> str:
@@ -50,11 +57,28 @@ def _bearer_token(scope) -> str:
 
 
 async def _send_401(send) -> None:
+    """401 + the pointer an MCP client follows to start the OAuth flow.
+
+    ``WWW-Authenticate: ... resource_metadata=...`` is the entry point of the
+    MCP remote-auth spec: an unauthenticated client reads it, fetches the
+    protected-resource metadata, discovers the AS, registers, and runs the
+    one-click flow (core#393). Without the parameter a client has no way to
+    find the AS and can only fall back to a hand-pasted API key.
+    """
+    svc = McpOAuthService()
     body = json.dumps(
         {
             "error": "unauthorized",
-            "detail": "Provide a Datanika API key as an 'Authorization: Bearer <key>' header.",
+            "detail": (
+                "Authenticate with OAuth (see the resource metadata in the "
+                "WWW-Authenticate header) or present a Datanika API key as "
+                "'Authorization: Bearer <key>'."
+            ),
         }
+    ).encode()
+    challenge = (
+        f'Bearer realm="datanika-mcp", '
+        f'resource_metadata="{svc.issuer}/.well-known/oauth-protected-resource"'
     ).encode()
     await send(
         {
@@ -62,11 +86,36 @@ async def _send_401(send) -> None:
             "status": 401,
             "headers": [
                 (b"content-type", b"application/json"),
-                (b"www-authenticate", b'Bearer realm="datanika-mcp"'),
+                (b"www-authenticate", challenge),
             ],
         }
     )
     await send({"type": "http.response.body", "body": body})
+
+
+def _resolve_oauth_token_sync(token: str) -> str | None:
+    """Exchange an issued access token for the API key it was minted with."""
+    from datanika.db import get_sync_session
+
+    with get_sync_session() as session:
+        return McpOAuthService().resolve_access_token(session, token)
+
+
+async def _resolve_credential(token: str) -> str | None:
+    """Map a presented bearer to the API key the tool path forwards.
+
+    Two credentials are accepted: an OAuth access token issued by our own AS
+    (P2), and a raw Datanika API key pasted by the user (P1, unchanged — it
+    still works, and self-hosters rely on it).
+
+    The token lookup is a **blocking** DB call, so it runs in a worker thread:
+    this handler is on the same event loop that has to serve the tool's own
+    loopback request, and holding it is what made every hosted tool call time
+    out in core#388.
+    """
+    if token.startswith(_OAUTH_TOKEN_PREFIX):
+        return await anyio.to_thread.run_sync(_resolve_oauth_token_sync, token)
+    return token
 
 
 class BearerSessionApp:
@@ -74,10 +123,15 @@ class BearerSessionApp:
     read-only :class:`DatanikaSession` for the wrapped MCP transport.
 
     A missing or blank bearer token short-circuits to ``401`` with a
-    ``WWW-Authenticate: Bearer`` header. The key itself is validated lazily by
-    the REST API on the first tool call (the MCP server is a pure forwarder),
-    so ``initialize`` / ``tools/list`` succeed for any presented token — a
-    P2 pre-flight validation is a follow-up.
+    ``WWW-Authenticate: Bearer`` header carrying the resource-metadata pointer
+    that starts the OAuth flow.
+
+    Validation differs by credential type. An **OAuth access token** (P2) is
+    resolved up front — unknown, expired, revoked, or bound to a revoked API
+    key all 401 before the transport is touched. A **raw API key** (P1) is
+    still validated lazily by the REST API on the first tool call, since the
+    MCP server is a pure forwarder; ``initialize`` / ``tools/list`` therefore
+    succeed for any pasted string, which is unchanged behaviour.
     """
 
     def __init__(self, app, *, base_url: str = _INTERNAL_API_URL) -> None:
@@ -94,7 +148,15 @@ class BearerSessionApp:
             await _send_401(send)
             return
 
-        client = DatanikaClient(self._base_url, token)
+        credential = await _resolve_credential(token)
+        if not credential:
+            # An OAuth token that is expired, revoked, or simply not ours. The
+            # same 401 sends the client back through discovery, which is how it
+            # learns to refresh rather than guess.
+            await _send_401(send)
+            return
+
+        client = DatanikaClient(self._base_url, credential)
         session = DatanikaSession(client=client, allow_write=False)
         try:
             with use_session(session):

--- a/tests/test_migrations/test_migration_coverage.py
+++ b/tests/test_migrations/test_migration_coverage.py
@@ -137,3 +137,53 @@ class TestMigrationCoverage:
             f"Model columns not found in any migration: {missing}. "
             f"Add a migration with op.add_column() for each missing column."
         )
+
+
+class TestRevisionGraph:
+    """Guard the Alembic revision graph itself.
+
+    ``migration-roundtrip`` already catches a broken graph, but only in CI and
+    only with a live Postgres — a hand-picked revision id that collides with an
+    existing one (core#393) got all the way to a red CI job. These checks are
+    pure text over the versions directory, so they fail in the unit suite in
+    milliseconds instead.
+    """
+
+    def test_revision_ids_are_unique(self):
+        seen: dict[str, list[str]] = {}
+        for path, source in _read_migration_sources():
+            match = re.search(r'^revision: str = "([^"]+)"', source, re.MULTILINE)
+            if match:
+                seen.setdefault(match.group(1), []).append(path.name)
+
+        duplicates = {rev: files for rev, files in seen.items() if len(files) > 1}
+        assert not duplicates, (
+            f"Duplicate Alembic revision ids: {duplicates}. Alembic refuses to "
+            f"resolve 'head' when an id appears twice — pick a fresh id."
+        )
+
+    def test_exactly_one_head(self):
+        revisions: set[str] = set()
+        parents: set[str] = set()
+        for _path, source in _read_migration_sources():
+            rev = re.search(r'^revision: str = "([^"]+)"', source, re.MULTILINE)
+            down = re.search(r'^down_revision: str \| None = "([^"]+)"', source, re.MULTILINE)
+            if rev:
+                revisions.add(rev.group(1))
+            if down:
+                parents.add(down.group(1))
+
+        heads = revisions - parents
+        assert len(heads) == 1, (
+            f"Expected exactly one migration head, found {sorted(heads)}. "
+            f"A new migration must set down_revision to the current head."
+        )
+
+
+def _read_migration_sources() -> list[tuple[Path, str]]:
+    versions_dir = Path(__file__).parent.parent.parent / "datanika" / "migrations" / "versions"
+    return [
+        (path, path.read_text(encoding="utf-8"))
+        for path in sorted(versions_dir.glob("*.py"))
+        if path.name != "__init__.py"
+    ]

--- a/tests/test_services/test_mcp_oauth.py
+++ b/tests/test_services/test_mcp_oauth.py
@@ -1,0 +1,298 @@
+"""Tests for the MCP OAuth 2.1 authorization server (core#393, Remote-MCP P2).
+
+The security-critical half of P2 lives in ``McpOAuthService``: PKCE
+verification, single-use authorization codes, redirect-URI matching, resource
+binding, and resolving an access token back to the org-scoped API key the tool
+path replays. Everything here is exercised against a real (SQLite) session with
+real rows — the failure modes this guards against are all about *state*
+(a code redeemed twice, a revoked key still working), which a mocked session
+cannot express.
+"""
+
+import base64
+import hashlib
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from datanika.models.api_key import ApiKey
+from datanika.models.mcp_oauth import OAuthClient, OAuthToken
+from datanika.models.user import Organization, User
+from datanika.services.mcp_oauth import (
+    MCP_RESOURCE_PATH,
+    McpOAuthError,
+    McpOAuthService,
+    read_only_scopes,
+)
+
+_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+
+
+def _pkce(verifier: str = "a" * 64) -> tuple[str, str]:
+    """Return (verifier, S256 challenge) exactly as an MCP client computes it."""
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+# A throwaway Fernet key so the tests never depend on the deployment's real one.
+_TEST_FERNET_KEY = base64.urlsafe_b64encode(b"0" * 32).decode()
+_PUBLIC_BASE = "https://app.datanika.io"
+
+
+@pytest.fixture
+def svc() -> McpOAuthService:
+    return McpOAuthService(
+        public_base_url=_PUBLIC_BASE, encryption_key_provider=lambda: _TEST_FERNET_KEY
+    )
+
+
+@pytest.fixture
+def org(db_session) -> Organization:
+    row = Organization(name="Acme", slug="acme-mcp-oauth")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def user(db_session) -> User:
+    row = User(email="oauth@example.com", password_hash="hashed", full_name="OAuth User")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def client_row(db_session) -> OAuthClient:
+    client = OAuthClient(
+        client_id="mcp_testclient", client_name="Claude.ai", redirect_uris=[_REDIRECT]
+    )
+    db_session.add(client)
+    db_session.flush()
+    return client
+
+
+@pytest.fixture
+def consented(db_session, svc, client_row, org, user):
+    """A completed consent → (grant, code, verifier)."""
+    verifier, challenge = _pkce()
+    grant, code = svc.grant_consent(
+        db_session,
+        client_id=client_row.client_id,
+        org_id=org.id,
+        user_id=user.id,
+        redirect_uri=_REDIRECT,
+        code_challenge=challenge,
+        code_challenge_method="S256",
+        scope=" ".join(read_only_scopes()),
+        resource=f"https://app.datanika.io{MCP_RESOURCE_PATH}",
+    )
+    db_session.flush()
+    return grant, code, verifier
+
+
+class TestConsentMintsAReadOnlyKey:
+    def test_mints_one_org_scoped_api_key(self, db_session, consented, org):
+        grant, _code, _verifier = consented
+        key = db_session.get(ApiKey, grant.api_key_id)
+
+        assert key is not None
+        assert key.org_id == org.id
+        # Read-only: every granted scope ends in :read, so the write endpoints
+        # reject this key at api_middleware without MCP re-implementing authz.
+        assert key.scopes and all(s.endswith(":read") for s in key.scopes)
+        assert not any(s.endswith(":write") for s in key.scopes)
+
+    def test_key_is_recoverable_only_via_encryption(self, db_session, svc, consented):
+        """The tool path replays the key, so it must decrypt — and only decrypt."""
+        grant, _code, _verifier = consented
+        assert "etf_" not in grant.encrypted_api_key  # not stored in the clear
+        assert svc.decrypt_api_key(grant).startswith("etf_")
+
+
+class TestAuthorizationCodeExchange:
+    def test_happy_path_returns_access_and_refresh_tokens(self, db_session, svc, consented):
+        grant, code, verifier = consented
+
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT
+        )
+
+        assert issued["token_type"] == "Bearer"
+        assert issued["access_token"] and issued["refresh_token"]
+        assert issued["expires_in"] > 0
+        assert issued["scope"] == grant.scope
+
+    def test_code_is_single_use(self, db_session, svc, consented):
+        _grant, code, verifier = consented
+        svc.exchange_code(db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT)
+
+        with pytest.raises(McpOAuthError, match="invalid_grant"):
+            svc.exchange_code(db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT)
+
+    def test_wrong_verifier_is_rejected(self, db_session, svc, consented):
+        _grant, code, _verifier = consented
+        with pytest.raises(McpOAuthError, match="invalid_grant"):
+            svc.exchange_code(db_session, code=code, code_verifier="b" * 64, redirect_uri=_REDIRECT)
+
+    def test_mismatched_redirect_uri_is_rejected(self, db_session, svc, consented):
+        _grant, code, verifier = consented
+        with pytest.raises(McpOAuthError, match="invalid_grant"):
+            svc.exchange_code(
+                db_session, code=code, code_verifier=verifier, redirect_uri="https://evil.test/cb"
+            )
+
+    def test_expired_code_is_rejected(self, db_session, svc, consented):
+        grant, code, verifier = consented
+        grant.code_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        db_session.flush()
+
+        with pytest.raises(McpOAuthError, match="invalid_grant"):
+            svc.exchange_code(db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT)
+
+
+class TestPkceIsMandatory:
+    def test_plain_challenge_method_is_refused(self, db_session, svc, client_row, org, user):
+        """OAuth 2.1 drops `plain`; accepting it would make PKCE decorative."""
+        with pytest.raises(McpOAuthError, match="invalid_request"):
+            svc.grant_consent(
+                db_session,
+                client_id=client_row.client_id,
+                org_id=org.id,
+                user_id=user.id,
+                redirect_uri=_REDIRECT,
+                code_challenge="whatever",
+                code_challenge_method="plain",
+                scope=" ".join(read_only_scopes()),
+                resource=f"https://app.datanika.io{MCP_RESOURCE_PATH}",
+            )
+
+    def test_unregistered_redirect_uri_is_refused_at_consent(
+        self, db_session, svc, client_row, org, user
+    ):
+        _verifier, challenge = _pkce()
+        with pytest.raises(McpOAuthError, match="invalid_request"):
+            svc.grant_consent(
+                db_session,
+                client_id=client_row.client_id,
+                org_id=org.id,
+                user_id=user.id,
+                redirect_uri="https://evil.test/cb",
+                code_challenge=challenge,
+                code_challenge_method="S256",
+                scope=" ".join(read_only_scopes()),
+                resource=f"https://app.datanika.io{MCP_RESOURCE_PATH}",
+            )
+
+
+class TestAccessTokenResolution:
+    """Resolving a bearer token to the credential the MCP tool path replays."""
+
+    def test_resolves_to_the_granted_api_key(self, db_session, svc, consented):
+        grant, code, verifier = consented
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT
+        )
+
+        resolved = svc.resolve_access_token(db_session, issued["access_token"])
+        assert resolved == svc.decrypt_api_key(grant)
+
+    def test_unknown_token_resolves_to_none(self, db_session, svc):
+        assert svc.resolve_access_token(db_session, "dtk_at_nonsense") is None
+
+    def test_expired_token_resolves_to_none(self, db_session, svc, consented):
+        _grant, code, verifier = consented
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT
+        )
+        token = db_session.query(OAuthToken).one()
+        token.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        db_session.flush()
+
+        assert svc.resolve_access_token(db_session, issued["access_token"]) is None
+
+    def test_revoking_the_api_key_kills_the_token(self, db_session, svc, consented):
+        """Revocation is the existing API-keys UI (SPEC §5.3) — it must bite here."""
+        grant, code, verifier = consented
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        key.deleted_at = datetime.now(UTC)
+        db_session.flush()
+
+        assert svc.resolve_access_token(db_session, issued["access_token"]) is None
+
+
+class TestRefresh:
+    def test_refresh_rotates_both_tokens(self, db_session, svc, consented):
+        _grant, code, verifier = consented
+        first = svc.exchange_code(
+            db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT
+        )
+
+        second = svc.refresh(db_session, refresh_token=first["refresh_token"])
+
+        assert second["access_token"] != first["access_token"]
+        assert second["refresh_token"] != first["refresh_token"]
+        # The old access token dies with its row — no lingering parallel session.
+        assert svc.resolve_access_token(db_session, first["access_token"]) is None
+        assert svc.resolve_access_token(db_session, second["access_token"]) is not None
+
+    def test_reusing_a_rotated_refresh_token_is_rejected(self, db_session, svc, consented):
+        _grant, code, verifier = consented
+        first = svc.exchange_code(
+            db_session, code=code, code_verifier=verifier, redirect_uri=_REDIRECT
+        )
+        svc.refresh(db_session, refresh_token=first["refresh_token"])
+
+        with pytest.raises(McpOAuthError, match="invalid_grant"):
+            svc.refresh(db_session, refresh_token=first["refresh_token"])
+
+
+class TestDynamicClientRegistration:
+    def test_registers_a_public_client(self, db_session, svc):
+        registered = svc.register_client(
+            db_session, client_name="Cursor", redirect_uris=["https://cursor.sh/cb"]
+        )
+
+        assert registered["client_id"].startswith("mcp_")
+        # Public client: no secret is issued, so none can leak.
+        assert "client_secret" not in registered
+        assert registered["token_endpoint_auth_method"] == "none"
+
+    def test_rejects_non_https_redirect(self, db_session, svc):
+        with pytest.raises(McpOAuthError, match="invalid_redirect_uri"):
+            svc.register_client(
+                db_session, client_name="Sketchy", redirect_uris=["http://evil.test/cb"]
+            )
+
+    def test_allows_http_loopback_redirect(self, db_session, svc):
+        """Native clients legitimately use 127.0.0.1 loopback (RFC 8252)."""
+        registered = svc.register_client(
+            db_session, client_name="Local", redirect_uris=["http://127.0.0.1:33418/cb"]
+        )
+        assert registered["client_id"]
+
+    def test_requires_at_least_one_redirect(self, db_session, svc):
+        with pytest.raises(McpOAuthError, match="invalid_redirect_uri"):
+            svc.register_client(db_session, client_name="Nowhere", redirect_uris=[])
+
+
+class TestResourceBinding:
+    def test_grant_for_another_resource_is_refused(self, db_session, svc, client_row, org, user):
+        """Confused-deputy (SPEC §10): we only mint tokens for our own /mcp."""
+        _verifier, challenge = _pkce()
+        with pytest.raises(McpOAuthError, match="invalid_target"):
+            svc.grant_consent(
+                db_session,
+                client_id=client_row.client_id,
+                org_id=org.id,
+                user_id=user.id,
+                redirect_uri=_REDIRECT,
+                code_challenge=challenge,
+                code_challenge_method="S256",
+                scope=" ".join(read_only_scopes()),
+                resource="https://someone-else.example/mcp",
+            )

--- a/tests/test_services/test_mcp_oauth_routes.py
+++ b/tests/test_services/test_mcp_oauth_routes.py
@@ -1,0 +1,412 @@
+"""HTTP-level tests for the MCP OAuth AS (core#393, Remote-MCP P2).
+
+Drives the endpoints an MCP client actually calls, in the order it calls them:
+discovery → registration → authorize → consent → token. The service-level
+guarantees (PKCE, single-use codes, resource binding) are proven in
+``test_mcp_oauth.py``; this file is about the wire — status codes, CORS,
+form-vs-JSON bodies, the consent hand-off, and the ``WWW-Authenticate`` pointer
+that makes the flow discoverable in the first place.
+"""
+
+import base64
+import hashlib
+import pathlib
+import sys
+from unittest.mock import patch
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+
+from datanika.models.user import Organization, User
+from datanika.services.auth import AuthService
+from datanika.services.mcp_oauth import MCP_RESOURCE_PATH, McpOAuthService
+from datanika.services.mcp_oauth_routes import mcp_oauth_routes
+
+# datanika-mcp is not installed in the test venv; the resource-server test
+# below needs its transport, so make the package importable first.
+_MCP_SRC = str(pathlib.Path(__file__).resolve().parents[2] / "datanika-mcp" / "src")
+if _MCP_SRC not in sys.path:
+    sys.path.insert(0, _MCP_SRC)
+
+_PUBLIC_BASE = "https://app.datanika.io"
+_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+_SECRET = "test-secret-key"
+
+
+def _pkce(verifier: str = "v" * 64) -> tuple[str, str]:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return verifier, base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+@pytest.fixture
+def app() -> Starlette:
+    return Starlette(routes=mcp_oauth_routes)
+
+
+@pytest.fixture
+def wired(db_session, monkeypatch):
+    """Point the routes at the test session + a fixed public base URL."""
+    from contextlib import contextmanager
+
+    import datanika.services.mcp_oauth_routes as routes
+
+    @contextmanager
+    def _session():
+        # The routes commit; the fixture's outer transaction still rolls back.
+        yield db_session
+
+    monkeypatch.setattr(routes, "_get_session", _session)
+    monkeypatch.setattr(
+        routes,
+        "_service",
+        # A throwaway Fernet key: the deployment's real CREDENTIAL_ENCRYPTION_KEY
+        # is the insecure placeholder in tests, which Fernet rejects outright.
+        lambda: McpOAuthService(
+            public_base_url=_PUBLIC_BASE,
+            encryption_key_provider=lambda: base64.urlsafe_b64encode(b"0" * 32).decode(),
+        ),
+    )
+    monkeypatch.setattr(db_session, "commit", db_session.flush)
+    return db_session
+
+
+@pytest.fixture
+def org(db_session) -> Organization:
+    row = Organization(name="Acme", slug="acme-oauth-routes")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def user(db_session) -> User:
+    row = User(email="routes@example.com", password_hash="h", full_name="Routes User")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def jwt(org, user) -> str:
+    return AuthService(_SECRET).create_access_token(user_id=user.id, org_id=org.id)
+
+
+async def _client(app) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t")
+
+
+class TestDiscovery:
+    async def test_protected_resource_metadata_points_at_the_as(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.get("/.well-known/oauth-protected-resource")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["resource"] == f"{_PUBLIC_BASE}{MCP_RESOURCE_PATH}"
+        assert body["authorization_servers"] == [_PUBLIC_BASE]
+
+    async def test_as_metadata_requires_s256_and_public_clients(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.get("/.well-known/oauth-authorization-server")
+
+        body = r.json()
+        # OAuth 2.1: `plain` must not be advertised, or clients will offer it.
+        assert body["code_challenge_methods_supported"] == ["S256"]
+        assert body["token_endpoint_auth_methods_supported"] == ["none"]
+        assert body["registration_endpoint"] == f"{_PUBLIC_BASE}/oauth/register"
+
+    async def test_discovery_is_cors_readable(self, app, wired):
+        """Browser-based clients fetch discovery cross-origin; no CORS, no flow."""
+        async with await _client(app) as c:
+            r = await c.get("/.well-known/oauth-protected-resource")
+            preflight = await c.options("/.well-known/oauth-authorization-server")
+
+        assert r.headers["access-control-allow-origin"] == "*"
+        assert preflight.status_code == 204
+
+
+class TestRegistration:
+    async def test_registers_and_returns_201(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.post(
+                "/oauth/register",
+                json={"client_name": "Claude.ai", "redirect_uris": [_REDIRECT]},
+            )
+
+        assert r.status_code == 201
+        assert r.json()["client_id"].startswith("mcp_")
+
+    async def test_rejects_plaintext_redirect(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.post(
+                "/oauth/register",
+                json={"client_name": "Sketchy", "redirect_uris": ["http://evil.test/cb"]},
+            )
+
+        assert r.status_code == 400
+        assert r.json()["error"] == "invalid_redirect_uri"
+
+
+class TestAuthorize:
+    async def _register(self, c) -> str:
+        r = await c.post(
+            "/oauth/register", json={"client_name": "Claude.ai", "redirect_uris": [_REDIRECT]}
+        )
+        return r.json()["client_id"]
+
+    async def test_valid_request_redirects_to_the_consent_screen(self, app, wired):
+        _verifier, challenge = _pkce()
+        async with await _client(app) as c:
+            client_id = await self._register(c)
+            r = await c.get(
+                "/oauth/authorize",
+                params={
+                    "client_id": client_id,
+                    "redirect_uri": _REDIRECT,
+                    "response_type": "code",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "state": "xyz",
+                },
+            )
+
+        assert r.status_code == 302
+        assert "/oauth/consent?" in r.headers["location"]
+        assert "state=xyz" in r.headers["location"]
+
+    async def test_unregistered_redirect_does_not_redirect(self, app, wired):
+        """An open redirect here would hand codes to whoever asked for one."""
+        _verifier, challenge = _pkce()
+        async with await _client(app) as c:
+            client_id = await self._register(c)
+            r = await c.get(
+                "/oauth/authorize",
+                params={
+                    "client_id": client_id,
+                    "redirect_uri": "https://evil.test/cb",
+                    "response_type": "code",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+            )
+
+        assert r.status_code == 400
+        assert r.json()["error"] == "invalid_request"
+
+    async def test_plain_pkce_is_refused(self, app, wired):
+        async with await _client(app) as c:
+            client_id = await self._register(c)
+            r = await c.get(
+                "/oauth/authorize",
+                params={
+                    "client_id": client_id,
+                    "redirect_uri": _REDIRECT,
+                    "response_type": "code",
+                    "code_challenge": "anything",
+                    "code_challenge_method": "plain",
+                },
+            )
+
+        assert r.status_code == 400
+
+
+class TestClientInfo:
+    """The consent screen resolves the app's name server-side, not from the URL."""
+
+    async def test_returns_the_registered_name(self, app, wired):
+        async with await _client(app) as c:
+            reg = await c.post(
+                "/oauth/register", json={"client_name": "Claude.ai", "redirect_uris": [_REDIRECT]}
+            )
+            r = await c.get("/api/oauth/client-info", params={"client_id": reg.json()["client_id"]})
+
+        assert r.status_code == 200
+        assert r.json()["client_name"] == "Claude.ai"
+
+    async def test_unknown_client_is_404(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.get("/api/oauth/client-info", params={"client_id": "mcp_nope"})
+        assert r.status_code == 404
+
+
+class TestConsentAndToken:
+    async def _flow_to_code(self, c, jwt: str) -> tuple[str, str]:
+        """Register → consent → return (code, verifier)."""
+        verifier, challenge = _pkce()
+        reg = await c.post(
+            "/oauth/register", json={"client_name": "Claude.ai", "redirect_uris": [_REDIRECT]}
+        )
+        client_id = reg.json()["client_id"]
+
+        consent = await c.post(
+            "/api/oauth/consent",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "client_id": client_id,
+                "redirect_uri": _REDIRECT,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "xyz",
+            },
+        )
+        assert consent.status_code == 200, consent.text
+        redirect_to = consent.json()["redirect_to"]
+        code = redirect_to.split("code=")[1].split("&")[0]
+        return code, verifier
+
+    async def test_consent_requires_the_app_session(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.post("/api/oauth/consent", json={"client_id": "mcp_x"})
+        assert r.status_code == 401
+
+    async def test_consent_rejects_a_forged_jwt(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.post(
+                "/api/oauth/consent",
+                headers={"Authorization": "Bearer not-a-real-jwt"},
+                json={"client_id": "mcp_x"},
+            )
+        assert r.status_code == 401
+
+    async def test_full_flow_issues_a_token(self, app, wired, jwt):
+        with patch("datanika.services.mcp_oauth_routes.settings.secret_key", _SECRET):
+            async with await _client(app) as c:
+                code, verifier = await self._flow_to_code(c, jwt)
+                # Form-encoded, as an OAuth client posts it.
+                r = await c.post(
+                    "/oauth/token",
+                    data={
+                        "grant_type": "authorization_code",
+                        "code": code,
+                        "code_verifier": verifier,
+                        "redirect_uri": _REDIRECT,
+                    },
+                )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["token_type"] == "Bearer"
+        assert body["access_token"].startswith("dtk_at_")
+        # Tokens must never be cached by an intermediary.
+        assert r.headers["cache-control"] == "no-store"
+
+    async def test_wrong_verifier_is_refused_at_the_token_endpoint(self, app, wired, jwt):
+        with patch("datanika.services.mcp_oauth_routes.settings.secret_key", _SECRET):
+            async with await _client(app) as c:
+                code, _verifier = await self._flow_to_code(c, jwt)
+                r = await c.post(
+                    "/oauth/token",
+                    data={
+                        "grant_type": "authorization_code",
+                        "code": code,
+                        "code_verifier": "wrong" * 13,
+                        "redirect_uri": _REDIRECT,
+                    },
+                )
+
+        assert r.status_code == 400
+        assert r.json()["error"] == "invalid_grant"
+
+    async def test_unsupported_grant_type(self, app, wired):
+        async with await _client(app) as c:
+            r = await c.post("/oauth/token", data={"grant_type": "password"})
+        assert r.status_code == 400
+        assert r.json()["error"] == "unsupported_grant_type"
+
+
+class TestResourceServerAcceptsIssuedTokens:
+    """The `/mcp` side of P2: discovery pointer + OAuth tokens as credentials."""
+
+    async def test_401_carries_the_resource_metadata_pointer(self):
+        """This header is how an MCP client finds the AS at all."""
+        import datanika.services.mcp_routes as mcp_routes
+
+        app = mcp_routes.BearerSessionApp(_unused_asgi)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp")
+
+        assert r.status_code == 401
+        challenge = r.headers["www-authenticate"]
+        assert "resource_metadata=" in challenge
+        assert "/.well-known/oauth-protected-resource" in challenge
+
+    async def test_oauth_token_resolves_to_the_granted_api_key(self, monkeypatch):
+        """A `dtk_at_` bearer is exchanged for the minted key before forwarding."""
+        import datanika.services.mcp_routes as mcp_routes
+
+        monkeypatch.setattr(
+            mcp_routes, "_resolve_oauth_token_sync", lambda token: "etf_resolved_key"
+        )
+        seen = {}
+
+        class _FakeClient:
+            def __init__(self, base_url, key):
+                seen["key"] = key
+
+            async def aclose(self):
+                pass
+
+        monkeypatch.setattr(mcp_routes, "DatanikaClient", _FakeClient)
+
+        app = mcp_routes.BearerSessionApp(_ok_asgi)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp", headers={"Authorization": "Bearer dtk_at_something"})
+
+        assert r.status_code == 200
+        # The forwarded credential is the API key, never the OAuth token.
+        assert seen["key"] == "etf_resolved_key"
+
+    async def test_unresolvable_oauth_token_401s(self, monkeypatch):
+        import datanika.services.mcp_routes as mcp_routes
+
+        monkeypatch.setattr(mcp_routes, "_resolve_oauth_token_sync", lambda token: None)
+
+        app = mcp_routes.BearerSessionApp(_unused_asgi)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp", headers={"Authorization": "Bearer dtk_at_revoked"})
+
+        assert r.status_code == 401
+
+    async def test_raw_api_key_still_works(self, monkeypatch):
+        """P1 back-compat: a pasted key is forwarded untouched, no DB lookup."""
+        import datanika.services.mcp_routes as mcp_routes
+
+        def _explode(token):  # pragma: no cover - must not be called
+            raise AssertionError("a raw API key must not hit the OAuth token table")
+
+        monkeypatch.setattr(mcp_routes, "_resolve_oauth_token_sync", _explode)
+        seen = {}
+
+        class _FakeClient:
+            def __init__(self, base_url, key):
+                seen["key"] = key
+
+            async def aclose(self):
+                pass
+
+        monkeypatch.setattr(mcp_routes, "DatanikaClient", _FakeClient)
+
+        app = mcp_routes.BearerSessionApp(_ok_asgi)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post("/mcp", headers={"Authorization": "Bearer etf_pasted"})
+
+        assert r.status_code == 200
+        assert seen["key"] == "etf_pasted"
+
+
+async def _ok_asgi(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def _unused_asgi(scope, receive, send):  # pragma: no cover - must not run
+    raise AssertionError("the transport must not be reached on a rejected credential")


### PR DESCRIPTION
Closes #393. Remote-MCP **P2** per `SPEC_REMOTE_MCP.md` §5.3/§8/§10 — Datanika becomes the OAuth 2.1 Authorization Server for its own `/mcp` Resource Server, so Claude.ai / ChatGPT / Cursor can add Datanika with one click instead of a hand-pasted API key.

## The decision the spec deferred to now

§11.2 endorsed an own AS but explicitly required a re-check **"at the point P2 actually starts"**. Re-validated, verdict unchanged: a managed AS is new vendor spend before the first paid user, we already own accounts, orgs, JWT login and an API-key model with scopes/expiry/revocation, and this AS is deliberately tiny — **one** resource, **public** clients only, no third-party IdP role. That narrowness is what makes own-AS defensible; a general-purpose AS would not be.

## Endpoints

| Endpoint | |
|---|---|
| `GET /.well-known/oauth-protected-resource` | RS metadata |
| `GET /.well-known/oauth-authorization-server` | AS metadata |
| `POST /oauth/register` | RFC 7591 dynamic client registration |
| `GET /oauth/authorize` | validates, then hands off to consent |
| `GET /api/oauth/client-info` | what the consent screen displays |
| `POST /api/oauth/consent` | app-JWT authed; mints the key + code |
| `POST /oauth/token` | `authorization_code` + PKCE, rotating `refresh_token` |

## Two choices worth reviewing

**The credential.** Consent mints **one org-scoped API key per grant** (spec §5.3), so revocation is the existing Settings → API Keys screen and the MCP layer stays a pure forwarder with no authz of its own. That forces one thing that deserves scrutiny: the raw key is stored **Fernet-encrypted** on the grant, because the tool path has to *replay* it on every call — unlike `api_keys.key_hash`, which only ever verifies. Same treatment connection credentials already get. The alternative (issuing the API key itself as the access token) would have avoided encryption but churned a new key row per hourly refresh and cluttered the user's key list.

**Read-only, and no write option.** A grant carries the eight `*:read` scopes — exactly what the 17 read tools need (`introspect`/`preview`/`query`/`compile` are `:read` despite being POSTs; I checked rather than assumed). The spec allows P2 consent to grant read-write, but write tools are P3 behind the #338 egress guard, so a write grant would unlock nothing today. Offering one would be consent theatre, so it isn't offered.

## Where consent lives, and why

Datanika's browser session is a **JWT the Reflex frontend holds** (social login lands on `/auth/complete?token=…`), so a backend Starlette route cannot read it from a cookie. `/oauth/authorize` therefore validates the OAuth request and 302s to the frontend `/oauth/consent`, which carries the user's JWT to `POST /api/oauth/consent` in an `Authorization` header. **No token ever rides in a query string.**

The screen itself is Product's (spec §10) — filed as **#394** against the contract this PR fixes, so it can be built independently. `GET /api/oauth/client-info` exists because that screen must resolve the app's name **server-side**: a crafted consent link could otherwise label a real `client_id` with any name it liked, and the user would be consenting to something other than what they read.

## Security (spec §10)

- **PKCE S256 required**, `plain` refused *and* not advertised in metadata.
- **Codes are single-use** — the hash is cleared on redemption, before anything is issued, so a concurrent replay finds nothing; 5-minute TTL.
- **`redirect_uri` exact-matched** against the registration at both authorize and consent.
- **Validation failures never redirect.** An unvalidated `redirect_uri` is exactly what an attacker supplies, so bouncing an error there would be an open redirect. They render as JSON instead.
- **RFC 8707 resource binding** — we refuse to mint for anyone else's resource, and the RS only accepts what we issued (confused deputy).
- **Refresh rotates**; reusing a rotated token is rejected.
- **The org comes from the signed session**, never the request body — otherwise a consent screen could be talked into granting access to an org the user isn't in.
- Tokens hashed at rest; `Cache-Control: no-store` on token responses.

## Resource server

`/mcp` now accepts an issued token — resolved **up front**, so unknown, expired, revoked-grant and *revoked-API-key* all 401 before the transport is touched — alongside the P1 pasted key, which is unchanged and still lazy. Two details:

- The token lookup runs in a **worker thread**. This handler sits on the event loop that has to serve the tool's own loopback request, and holding it is precisely what made every hosted tool call time out in #388.
- 401s now carry `WWW-Authenticate: … resource_metadata="…"`. That header is how an MCP client discovers the AS at all; without it there is no flow to start.

## Tests — 39, no browser required

The state machine is where the security is, and state is what mocks can't express, so the service tests run against real rows in a real session: a code redeemed twice, an expired code, a wrong verifier, a mismatched redirect, a rotated refresh reused, and a **revoked API key killing a live token**. The route tests drive the endpoints in the order a client calls them — discovery → registration → authorize → consent → token — plus CORS preflight (browser clients fetch discovery cross-origin; no CORS, no one-click) and form-encoded bodies.

3 new tables + migration (`PUBLIC_TABLES` updated). The migration-coverage guard caught my `_timestamps()` helper hiding columns from its static scan — inlined, as every other migration does.

Full precheck green: ruff + format clean, **2347 passed, 19 skipped**.

## What this does not do

**A human cannot complete the flow yet** — `/oauth/authorize` redirects to `/oauth/consent`, a route the frontend doesn't serve until #394 lands. The protocol is proven end-to-end over HTTP in tests, but "one-click Add Datanika" isn't real until that screen exists. Worth a live smoke against staging with a real client (`mcp-remote` / Claude.ai) once both are promoted — spec §13 asks for it, and #388 is a fresh reminder that in-process tests don't prove a hosted path.
