### PR TITLE
[Infra] Tagged releases: v* release workflow + :v0.x.y images + README pin note

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -11,10 +11,17 @@ name: Build & push image
 # Tagging:
 #   push to dev    → :dev and :dev-<short-sha>
 #   push to master → :latest and :<short-sha>
+#   push v* tag    → :v0.x.y and :<short-sha>   (pinnable release image)
+#
+# The v* tag build exists so self-hosters can pin a release instead of tracking
+# :latest — see plans/infra/SPEC_RELEASE_VERSIONING.md. `v*` is disjoint from
+# release-mcp.yml's `mcp-v*` trigger (globs anchor at the start), so tagging the
+# platform never publishes the MCP sub-package.
 
 on:
   push:
     branches: [dev, master]
+    tags: ["v*"]
   workflow_dispatch:
   # No paths filter: deploy jobs wait on the build-push check completing
   # on the exact commit SHA, so every push to dev/master MUST produce
@@ -42,7 +49,10 @@ jobs:
         with:
           repository: datanika-io/datanika-cloud
           token: ${{ secrets.CLOUD_REPO_TOKEN }}
-          ref: ${{ github.ref_name }}
+          # Branch builds track the same-named cloud branch. A v* release tag does
+          # NOT exist in the cloud repo, so release images build against cloud master
+          # (which is what master-built prod images already use).
+          ref: ${{ github.ref_type == 'tag' && 'master' || github.ref_name }}
           path: cloud
 
       # Dockerfile assumes monorepo layout with datanika/ + datanika-cloud/
@@ -66,10 +76,15 @@ jobs:
         id: tags
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
-          if [ "${GITHUB_REF_NAME}" = "master" ]; then
-            TAGS="ghcr.io/datanika-io/datanika-core:latest,ghcr.io/datanika-io/datanika-core:${SHORT_SHA}"
+          REPO="ghcr.io/datanika-io/datanika-core"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            # Release tag -> pinnable version image, e.g. :v0.1.0
+            # (:latest already points at this same SHA from the master build)
+            TAGS="${REPO}:${GITHUB_REF_NAME},${REPO}:${SHORT_SHA}"
+          elif [ "${GITHUB_REF_NAME}" = "master" ]; then
+            TAGS="${REPO}:latest,${REPO}:${SHORT_SHA}"
           else
-            TAGS="ghcr.io/datanika-io/datanika-core:dev,ghcr.io/datanika-io/datanika-core:dev-${SHORT_SHA}"
+            TAGS="${REPO}:dev,${REPO}:dev-${SHORT_SHA}"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "Computed tags: ${TAGS}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+# Publishes a GitHub Release when a `v*` tag is pushed.
+# Policy: plans/infra/SPEC_RELEASE_VERSIONING.md (CEO-decided 2026-07-21).
+#
+#   - Scheme is 0.x SemVer; pre-1.0 breaking changes bump the MINOR.
+#   - A release is just a LABEL on a `master` SHA that already deployed green —
+#     it is not a gate, a freeze, or a branch. It must cost ~nothing.
+#   - Notes are auto-generated from merged PR titles; our "[Dept] … (closes #N)"
+#     convention makes that nearly free.
+#
+# ⚠️ Tag patterns are deliberately DISJOINT from release-mcp.yml, which triggers on
+# `mcp-v*` and publishes the datanika-mcp sub-package to PyPI. Glob patterns anchor
+# at the start, so `v*` does NOT match `mcp-v0.1.0` — the two workflows never collide.
+# Never tag the platform with `mcp-v*`.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create the GitHub Release
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so generated notes can diff against the previous tag.
+          fetch-depth: 0
+
+      - name: Publish GitHub Release (notes generated from merged PRs)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "Publishing release for tag: ${TAG}"
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${TAG}" \
+            --generate-notes \
+            --verify-tag
+          echo "Release published: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ uv run reflex run                     # starts on :3000 + :8000
 
 ---
 
+## Releases & versioning
+
+Datanika uses **`0.x` SemVer** with tagged releases (`v0.1.0`, …). While pre-1.0, breaking
+changes bump the **minor**. There is no `1.0` yet — that will mean a committed, stable
+public API contract.
+
+**Self-hosting? Pin a release instead of tracking `master`.** `master` is continuously
+deployed to our hosted app and moves several times a day.
+
+```bash
+git checkout v0.1.0                                    # source
+docker pull ghcr.io/datanika-io/datanika-core:v0.1.0   # image (:latest follows master)
+```
+
+Every version's notes are on the [Releases page](https://github.com/datanika-io/datanika-core/releases).
+Security advisories cite the first patched release (e.g. `Patched: v0.1.0`), so a pinned
+tag tells you immediately whether you're affected.
+
+> The `datanika-mcp` sub-package is versioned and released independently (`mcp-v*` tags,
+> published to PyPI).
+
+---
+
 ## Why Datanika?
 
 | | Datanika | Airbyte | Fivetran | dbt Cloud |


### PR DESCRIPTION
Implements the Infra checklist in `plans/infra/SPEC_RELEASE_VERSIONING.md` (CEO-decided 2026-07-21) — tagged releases yes, release *cycles* no.

- **`release.yml` (new)** — a `v*` tag publishes a GitHub Release with notes auto-generated from merged PR titles.
- **`build-push-image.yml`** — also builds on `v*` tags and pushes a pinnable `ghcr.io/datanika-io/datanika-core:v0.x.y` alongside `:latest`. **Bug caught while implementing:** tag builds would have failed the private cloud checkout (`ref: github.ref_name` → `v0.1.0`, which doesn't exist in datanika-cloud), so tag builds now pin cloud to `master`.
- **README** — "Releases & versioning": self-hosters pin a tag/image instead of tracking `master`; advisories cite the first patched release.

**No collision with `release-mcp.yml`:** globs anchor at the start, so `v*` never matches `mcp-v0.1.0` — verified both directions. Both workflow YAMLs validated with `yaml.safe_load` (this repo has been bitten by a silently-uncompilable workflow before, #77/#78). Local precheck: 2308 passed, 19 skipped.

Next: cut `v0.1.0` on the resulting green master SHA — starts the awesome-selfhosted eligibility clock.