### PR TITLE
[QA] Un-quarantine the Kafka smoke — Redpanda re-provisioned (closes #342)

### DIFF
--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -164,12 +164,6 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
-@pytest.mark.skip(
-    reason="core#342: the Redpanda Serverless cluster is unreachable (bootstrap timeout) — "
-    "almost certainly paused/decommissioned after the ~2-month idle. #333 fixed the invalid "
-    "kwarg (that fix stays, below); this is a separate infra issue. Re-quarantined so the "
-    "nightly stays green. Remove this skip once the cluster is re-provisioned (see #342)."
-)
 def test_kafka_auth_and_list_topics(require_env):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 


### PR DESCRIPTION
## What

Removes the `@pytest.mark.skip` that #343 put on `test_kafka_auth_and_list_topics`. Skip decorator only — **#333's kwarg fix stays**.

## Why it's safe now

The Redpanda Serverless cluster has been **re-provisioned** (see [#342](https://github.com/datanika-io/datanika-core/issues/342) for the full write-up). The original org had been *reclaimed* after ~2 months idle — `client requires organization membership, but user does not belong to any organization` — so this was a re-create, not a resume, and the **bootstrap URL changed**.

`secrets/qa-connectors.env` and the GHA secret `QA_CONNECTOR_CREDENTIALS` now carry the new `KAFKA_*` values (new org `redpanda-org-lz7viy`, cluster `welcome` / `d9flkbft37dmf9l7dvtg`, topic `qa-smoke-events` RF=3, SCRAM-SHA-256 user `qa-smoke`).

## Verified before un-skipping

Ran the actual test against the live cluster rather than assuming:

```
DATANIKA_CONNECTOR_SMOKE=1 pytest tests/test_connector_smoke/test_paid_connectors.py -k kafka -v
tests/.../test_kafka_auth_and_list_topics PASSED
1 passed, 7 deselected in 3.59s
```

SASL_SSL + SCRAM-SHA-256 handshake succeeds and `list_topics()` returns `['hello-world', 'qa-smoke-events']`, so the `KAFKA_TOPIC` assertion holds.

## Watch

30-day / $100-credit trial, and the previous cluster died from idling. The nightly keeps it warm, but re-check ~day 28 — on lapse the bootstrap URL changes again and this test will fail loudly (which is the intent).

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)