### PR TITLE
[Engineering] Close the #338 egress residuals with a guarded session (closes #403)

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -9,7 +9,7 @@ from dlt.sources.filesystem import filesystem
 from dlt.sources.rest_api import rest_api_source
 from dlt.sources.sql_database import sql_database, sql_table
 
-from datanika.services.egress_guard import validate_egress_host
+from datanika.services.egress_guard import build_guarded_session, validate_egress_host
 
 logger = logging.getLogger(__name__)
 
@@ -379,8 +379,13 @@ class DltRunnerService:
         Shared by the generic ``rest_api`` connector and the ``openapi``
         connector (whose resources are derived from a spec).
         """
-        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
-        client_config: dict = {"base_url": base_url}
+        # Two layers, because the pre-flight can only see base_url (core#338):
+        # it rejects an obviously-internal target before any request is built,
+        # while the guarded session re-checks every URL the worker actually
+        # sends — redirect hops, an absolute resource path that overrides
+        # base_url, and paginator `next` links (core#403).
+        validate_egress_host(base_url)
+        client_config: dict = {"base_url": base_url, "session": build_guarded_session()}
         if headers:
             client_config["headers"] = headers
         if auth:

--- a/datanika/services/egress_guard.py
+++ b/datanika/services/egress_guard.py
@@ -8,25 +8,38 @@ from inside the worker. Without a guard, a user could point a connector at
 ``192.168.0.0/16`` service and exfiltrate it via the pipeline. ``validate_egress_host``
 resolves the hostname and rejects the request if ANY resolved IP is non-public.
 
-This is a pre-flight check only. It has TWO KNOWN RESIDUAL GAPS, deferred to P3
-(to be closed before any cloud-worker migration, and before enabling the
-OpenAPI-P2 URL-fetch feature):
+``validate_egress_host`` alone is only a **pre-flight** check on ``base_url``.
+Three things happen *after* it passes that it cannot see, so
+:func:`build_guarded_session` re-validates every request the worker actually
+sends (core#403 — the gate for MCP P3 write tools):
 
-  (c) **Redirect hops are NOT re-validated.** dlt's REST client is ``requests``
-      based and follows redirects inside ``.session.send()``; a public host that
-      responds with a 30x redirect to a private IP would bypass this guard.
-      Closing it needs a custom ``requests.Session`` / ``HTTPAdapter`` that
-      re-validates every hop's resolved address.
+  (c) **Redirect hops.** ``requests`` follows 30x inside ``Session.send``, so a
+      public host can bounce the worker to a private address.
 
-  (d) **A resource ``path`` that is itself an absolute ``http(s)://`` URL bypasses
-      ``base_url``** (dlt ``rest_client`` ``client.py:122-124`` joins/overrides the
-      base with an absolute path) and is not validated here — only ``base_url`` is
-      checked.
+  (d) **An absolute resource path overrides ``base_url``.** dlt's
+      ``RESTClient._create_request`` uses ``path_or_url`` verbatim when it parses
+      as http(s), and ``resources`` comes straight from user-supplied
+      ``dlt_config``.
+
+  (+) **Paginator ``next`` URLs**, which dlt reads out of the *response body* —
+      attacker-controlled by definition in this threat model.
+
+All three dispatch through ``requests.Session.send``, which is why the guard
+lives there rather than being enumerated vector by vector.
+
+**Still open — DNS rebinding (TOCTOU).** We resolve a hostname to validate it and
+``requests`` resolves it again to connect; a hostile resolver can answer
+differently each time. Closing that needs IP pinning at the adapter (connect to
+the validated address while preserving SNI/Host). This module is therefore
+defense-in-depth, not a boundary — say so out loud rather than let a future
+reader assume the gap is covered.
 """
 
 import ipaddress
 import socket
 from urllib.parse import urlparse
+
+import requests
 
 _ALLOWED_SCHEMES = {"http", "https"}
 
@@ -79,3 +92,41 @@ def validate_egress_host(url: str) -> None:
             )
 
     return None
+
+
+def build_guarded_session() -> requests.Session:
+    """Return dlt's retrying session, hardened to validate **every** request.
+
+    Wrapping the instance's ``send`` (rather than subclassing ``Session``) is
+    deliberate on two counts:
+
+    * ``Session.send`` is the single choke point every dispatch passes through —
+      the first request, an absolute-path override, each redirect hop, and each
+      paginator ``next``. Guarding it covers vectors nobody has enumerated yet.
+      ``resolve_redirects`` calls ``self.send``, so the instance attribute set
+      here intercepts hops as well as the initial call.
+
+    * The session must stay **dlt's own retrying session**. ``RESTClient`` builds
+      ``Client(raise_for_status=False).session`` only when it is passed nothing,
+      so handing it a bare ``requests.Session`` would quietly drop retry and
+      backoff for every rest_api connector — a reliability regression bought
+      with a security fix.
+
+    One DNS resolution is added per request. That is deliberate: caching the
+    result is exactly what would reopen the rebinding window this guard is
+    already weakest against.
+    """
+    from dlt.sources.helpers.requests.retry import Client
+
+    session = Client(raise_for_status=False).session
+    original_send = session.send
+
+    def guarded_send(request, **kwargs):
+        validate_egress_host(request.url)
+        return original_send(request, **kwargs)
+
+    session.send = guarded_send
+    # Lets callers (and tests) assert a session came from here rather than
+    # trusting that some session was passed along.
+    session._datanika_egress_guarded = True
+    return session

--- a/tests/test_security/test_egress_guarded_session.py
+++ b/tests/test_security/test_egress_guarded_session.py
@@ -1,0 +1,158 @@
+"""Regression probe for the #338 egress residuals (core#403) — the MCP P3 gate.
+
+``validate_egress_host`` is a **pre-flight** check on ``base_url`` only, which
+leaves three ways to reach an internal address after it has passed, all of them
+live on the pinned dlt 1.21.0:
+
+  (c) **redirect hops** — ``requests`` follows 30x inside ``Session.send``, so a
+      public host can bounce the worker to ``10.0.0.0/8``;
+  (d) **an absolute resource path** — ``RESTClient._create_request`` uses
+      ``path_or_url`` verbatim when it parses as http(s), ignoring ``base_url``
+      entirely, and ``resources`` comes straight from user-supplied
+      ``dlt_config``;
+  (+) **paginator ``next`` URLs**, which dlt reads out of the *response body* —
+      attacker-controlled by definition in an SSRF threat model.
+
+All three dispatch through ``requests.Session.send``, so one guarded session
+closes them. These tests therefore pin the *seam*, not each vector.
+
+The hop test drives a **real local redirect server over a real socket**. Whether
+every hop actually re-enters ``Session.send`` is a fact about ``requests`` and
+dlt's retry session — exactly the kind of claim that reading the source can get
+wrong and an empirical check cannot.
+"""
+
+import http.server
+import threading
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+from datanika.services.egress_guard import (
+    EgressValidationError,
+    build_guarded_session,
+    validate_egress_host,
+)
+
+
+class _RedirectHandler(http.server.BaseHTTPRequestHandler):
+    """``/hop`` 302s to ``/final``; ``/final`` answers 200."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        if self.path == "/hop":
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{self.server.server_port}/final")
+            self.end_headers()
+            return
+        body = b'{"ok": true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # keep the test output clean
+        pass
+
+
+@pytest.fixture
+def redirect_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _RedirectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestEveryHopReachesTheGuard:
+    def test_redirect_target_is_validated_before_it_is_fetched(self, redirect_server, monkeypatch):
+        """The whole point of (c): the *second* hop must be checked too."""
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.validate_egress_host",
+            lambda url: seen.append(url),
+        )
+
+        session = build_guarded_session()
+        resp = session.get(f"{redirect_server}/hop")
+
+        assert resp.status_code == 200
+        paths = [urlparse(u).path for u in seen]
+        assert paths == ["/hop", "/final"], f"redirect hop escaped the guard: {seen}"
+
+    def test_a_redirect_to_a_private_address_is_blocked(self, redirect_server):
+        """With the real validator, the 127.0.0.1 hop must raise, not fetch."""
+        session = build_guarded_session()
+        with pytest.raises(EgressValidationError):
+            session.get(f"{redirect_server}/hop")
+
+    def test_absolute_url_request_is_validated(self):
+        """(d): an absolute resource path bypasses base_url — but not the session."""
+        session = build_guarded_session()
+        with pytest.raises(EgressValidationError):
+            session.get("http://169.254.169.254/latest/meta-data/")
+
+    def test_public_request_passes_through(self, monkeypatch, redirect_server):
+        """A public host must still work — the guard is a filter, not a wall."""
+        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        session = build_guarded_session()
+        assert session.get(f"{redirect_server}/final").json() == {"ok": True}
+
+
+class TestRetryBehaviourIsPreserved:
+    def test_session_is_dlts_retrying_session_not_a_bare_one(self):
+        """RESTClient only builds its retry session when none is passed in.
+
+        Handing dlt a plain ``requests.Session`` would silently drop retry and
+        backoff for every rest_api connector — a reliability regression bought
+        with a security fix. So the guard has to wrap dlt's session, and this
+        pins that it does.
+        """
+        from dlt.sources.helpers.requests.retry import Client
+
+        guarded = build_guarded_session()
+        reference = Client(raise_for_status=False).session
+
+        assert isinstance(guarded, requests.Session)
+        # Same concrete session class dlt would have constructed itself.
+        assert type(guarded) is type(reference)
+        # And its adapters still carry retry configuration.
+        adapter = guarded.get_adapter("https://example.com")
+        assert getattr(adapter, "max_retries", None) is not None
+
+
+class TestGuardIsWiredIntoTheRestApiBuild:
+    def test_rest_api_source_receives_the_guarded_session(self, monkeypatch):
+        """A guard nobody injects is decoration — pin the wiring."""
+        import datanika.services.dlt_runner as dlt_runner
+
+        captured = {}
+
+        def _fake_rest_api_source(config, **kwargs):
+            captured["config"] = config
+            return object()
+
+        monkeypatch.setattr(dlt_runner, "rest_api_source", _fake_rest_api_source)
+        monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+
+        dlt_runner.DltRunnerService._rest_api_from_parts(
+            "https://api.example.com",
+            [{"name": "r", "endpoint": {"path": "things"}}],
+        )
+
+        session = captured["config"]["client"].get("session")
+        assert session is not None, "rest_api client config must carry the guarded session"
+        # It must be the guarded one, not any old session.
+        assert getattr(session, "_datanika_egress_guarded", False) is True
+
+
+class TestPreFlightGuardStillApplies:
+    """The new session does not replace the pre-flight check; both hold."""
+
+    def test_base_url_is_still_rejected_up_front(self):
+        with pytest.raises(EgressValidationError):
+            validate_egress_host("http://127.0.0.1/admin")


### PR DESCRIPTION
Closes #403. Refs #338. **This is the actual gate for MCP P3 write tools** — see the bottom.

## The gate was not as clear as it looked

#338 shipped and promoted, so the hard gate is nominally lifted. But `egress_guard.py`'s own docstring defers **two residuals to P3**, and I checked both against the installed dlt **1.21.0** rather than trusting the note. Both are real, and there's a third nobody had listed.

**(d) An absolute resource path overrides `base_url`.** `RESTClient._create_request`:

```python
parsed_url = urlparse(path_or_url)
if parsed_url.scheme in ("http", "https"):
    url = path_or_url          # base_url ignored entirely
```

`resources` comes straight from user-supplied `dlt_config`, and only `base_url` was ever validated. (My first read of `join_url` suggested this had been fixed upstream — it hadn't; `join_url` is only the `else` branch.)

**(c) Redirect hops.** `requests` follows 30x inside `Session.send`; a public host bounces the worker to `10.0.0.0/8` after a clean pre-flight.

**(+) Paginator `next` URLs.** dlt reads them from the **response body** — attacker-controlled by definition here. Not in anyone's list, same class.

## One seam instead of three patches

Every one of those dispatches through `requests.Session.send`. Guarding there covers the enumerated vectors *and* the ones nobody has thought of, which for an SSRF surface is the difference that matters.

`build_guarded_session()` wraps **dlt's own retrying session** and intercepts `send`. Wrapping rather than subclassing earns its keep twice:

- `Session.resolve_redirects` calls `self.send`, so the instance attribute intercepts every hop, not just the first request.
- `RESTClient` builds `Client(raise_for_status=False).session` **only when passed nothing** — so handing it a bare `requests.Session` would have silently dropped retry and backoff for every `rest_api` connector. A reliability regression bought with a security fix is a bad trade, and there's a test pinning that it didn't happen.

Both layers stay: the pre-flight still rejects an obviously-internal `base_url` before any request is built, and the session re-checks what's actually sent.

## Proven, not reasoned

Whether every hop truly re-enters `Session.send` is a fact about `requests` + dlt's session — the kind of claim source-reading gets wrong. So the hop tests drive a **real local redirect server over a real socket**: one asserts both `/hop` and `/final` reached the guard, the other asserts the private-address hop actually raises instead of being fetched. Hermetic, no external network.

## Still open — and now written down

**DNS rebinding (TOCTOU).** We resolve a hostname to validate it; `requests` resolves again to connect. A hostile resolver can answer differently. Closing it needs IP pinning at the adapter (connect to the validated address, preserve SNI/Host). That's out of scope here, but it's now stated in the module rather than left for a future reader to assume covered — **this is defense-in-depth, not a boundary.**

Full precheck green: ruff + format clean, **2399 passed, 19 skipped**.

## What this means for P3

`create_upload(dlt_config=…)` is a P3 write tool, and `dlt_config.resources` is exactly the field that reaches (d). The pre-#338 threat model was a human filling in a form; P3's is a prompt-injected agent composing config. With this merged the gate is genuinely clear and write tools can be scoped — modulo the rebinding caveat above, which argues for keeping `trigger_*` behind the per-call confirmation the spec already wants (§10).
