### PR TITLE
[QA] Wire Shopify + GA4 into the smoke matrix, and stop it reporting green while testing nothing

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -107,7 +107,21 @@ jobs:
         id: smoke
         env:
           DATANIKA_CONNECTOR_SMOKE: "1"
-        run: pytest tests/test_connector_smoke/ -v --tb=short
+        # A skipped probe is worse than a failing one: it reports green while
+        # testing nothing. Missing creds and un-importable client libs now FAIL
+        # rather than skip (tests/test_connector_smoke/conftest.py), so a healthy
+        # run has ZERO skips — which makes "any skip at all" a usable alarm.
+        #
+        # This catches the one hole strict mode cannot: if DATANIKA_CONNECTOR_SMOKE
+        # above were dropped or misspelled, the gate would skip all probes at
+        # collection time and pytest would still exit 0 — a perfectly green
+        # nightly that tested nothing.
+        run: |
+          pytest tests/test_connector_smoke/ -v --tb=short -rs | tee /tmp/smoke.log
+          if grep -qE '[0-9]+ skipped' /tmp/smoke.log; then
+            echo "::error::Smoke probes were SKIPPED — a skipped probe reports green while testing nothing. Check that DATANIKA_CONNECTOR_SMOKE=1 is still set on this step and that every credential is present in QA_CONNECTOR_CREDENTIALS."
+            exit 1
+          fi
 
       - name: Telegram alert on failure
         if: failure()

--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -40,8 +40,15 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install -e ".[dev]" --system
-          # Connector-specific libs not in core deps
-          uv pip install --system "google-cloud-bigquery>=3.0" "kafka-python>=2.0"
+          # Connector-specific libs not in core deps.
+          # kafka-python must be >=2.1 — 2.0.x imports kafka.vendor.six.moves,
+          # which is gone in Python 3.12, so the probe would die at import and
+          # the test's `except ImportError: pytest.skip` would turn a broken
+          # Kafka smoke into a silent green. Pin the floor, don't rely on the skip.
+          uv pip install --system \
+            "google-cloud-bigquery>=3.0" \
+            "google-analytics-data>=0.18" \
+            "kafka-python>=2.1"
 
       - name: Materialize connector credentials
         env:

--- a/tests/test_connector_smoke/conftest.py
+++ b/tests/test_connector_smoke/conftest.py
@@ -12,15 +12,49 @@ and exports all ``*`` pairs before pytest runs. Locally:
 
     set -a && source secrets/qa-connectors.env && set +a
     DATANIKA_CONNECTOR_SMOKE=1 uv run pytest tests/test_connector_smoke/ -v
+
+## Missing dependencies FAIL — they do not skip
+
+Once the gate is on, a missing credential or an un-importable client
+library is a **hard failure**, not a skip.
+
+That is deliberate, and it is the whole point of a monitoring probe. A
+probe that skips when its dependency is missing reports green while
+testing nothing — strictly worse than one that fails, because the
+matrix looks healthiest exactly when it has stopped watching.
+
+Real instance (core#407): the nightly pinned ``kafka-python>=2.0``, but
+2.0.x cannot import on Python 3.12 (``kafka.vendor.six.moves`` is
+gone). The Kafka probe would have died at import and its
+``except ImportError: pytest.skip`` would have turned a completely
+broken connector into a passing nightly.
+
+The failure this guards against is mundane and therefore likely:
+someone rotates a credential and renames its var, or the base64 bundle
+decodes partially. Under skip-on-missing, that connector silently drops
+out of the matrix and nobody finds out until a customer does.
+
+Running a subset locally without every credential is the one legitimate
+reason to skip instead, so that is an explicit opt-in:
+
+    DATANIKA_CONNECTOR_SMOKE=1 DATANIKA_CONNECTOR_SMOKE_LENIENT=1 pytest ...
+
+Note the direction: lenient mode must be switched **on**. Dropping or
+misspelling any env var can only make the suite stricter, never
+quieter — so a typo in the workflow surfaces as a red nightly rather
+than a silent one. Do not invert this.
 """
 
 from __future__ import annotations
 
+import importlib
 import os
+from typing import Any
 
 import pytest
 
 _GATE_ENV = "DATANIKA_CONNECTOR_SMOKE"
+_LENIENT_ENV = "DATANIKA_CONNECTOR_SMOKE_LENIENT"
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -28,6 +62,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
     Done at collection time so the skip reason is visible in `pytest --collect-only`
     and doesn't count toward "slow test" budget in normal PR runs.
+
+    This gate is the one skip that stays a skip: PR CI legitimately has no
+    sandbox credentials. The nightly workflow guards the corresponding risk
+    — the gate silently being off there — by failing the job if *any* test
+    reports skipped. See `.github/workflows/nightly-connector-smoke.yml`.
     """
     if os.environ.get(_GATE_ENV) == "1":
         return
@@ -39,15 +78,54 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(skip_marker)
 
 
+def _missing_dependency(reason: str) -> None:
+    """Fail on a missing dependency — or skip, if lenient mode is on.
+
+    See the module docstring for why failing is the default. Never call
+    ``pytest.skip`` directly from a probe on a missing dependency: that
+    is precisely the silent-green bug this helper exists to prevent.
+    """
+    if os.environ.get(_LENIENT_ENV) == "1":
+        pytest.skip(f"{reason} [lenient mode]")
+    pytest.fail(
+        f"{reason}\n\n"
+        f"Failing rather than skipping is intentional: a smoke probe that skips "
+        f"on a missing dependency reports green while testing nothing, so the "
+        f"matrix looks healthy exactly when it has stopped watching.\n"
+        f"If this is a deliberate partial run on a machine without every "
+        f"credential, set {_LENIENT_ENV}=1 to downgrade this to a skip."
+    )
+
+
 def _require_env(*names: str) -> dict[str, str]:
-    """Fetch required env vars or skip with a clear message."""
+    """Fetch required env vars, or fail loudly if any are absent."""
     missing = [n for n in names if not os.environ.get(n)]
     if missing:
-        pytest.skip(f"Missing env vars: {', '.join(missing)}")
+        _missing_dependency(f"Missing env vars: {', '.join(missing)}")
     return {n: os.environ[n] for n in names}
+
+
+def _require_import(module: str, attr: str | None = None) -> Any:
+    """Import a connector client library, or fail loudly if it is absent.
+
+    Use this instead of ``try: import x / except ImportError: pytest.skip``.
+    An un-importable client library means the probe *cannot run*, which is
+    a broken probe — not an absent one, and not something to pass over.
+    """
+    try:
+        mod = importlib.import_module(module)
+    except ImportError as exc:
+        _missing_dependency(f"Cannot import {module!r} ({exc}). Is it in the nightly's deps?")
+    return getattr(mod, attr) if attr else mod
 
 
 @pytest.fixture
 def require_env():
     """Fixture wrapper so tests read `env = require_env('FOO', 'BAR')`."""
     return _require_env
+
+
+@pytest.fixture
+def require_import():
+    """Fixture wrapper so tests read `Client = require_import('mod', 'Client')`."""
+    return _require_import

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -17,15 +17,18 @@ PR CI (gated by ``DATANIKA_CONNECTOR_SMOKE=1``; see conftest.py).
 | BigQuery       | ✅ |   |
 | Databricks     | ✅ |   |
 | Stripe         | ✅ |   |
-| Kafka/Redpanda | ✅ |   |
+| Kafka/Redpanda | ✅ | re-provisioned 2026-07-21 (core#342) |
 | HubSpot        | ✅ |   |
-| Shopify        | ⬜ | creds not yet provisioned |
-| GA4            | ⬜ | creds not yet provisioned |
-| Salesforce     | ⬜ | creds not yet provisioned |
-| Snowflake      | ⬜ | signup blocked (see `PLAN_HUMAN_LOCKERS.md`) |
+| Shopify        | ✅ | provisioned 2026-07-21 |
+| GA4            | ✅ | provisioned 2026-07-21 |
+| Salesforce     | ⬜ | signup blocked on bot detection — one human click |
+| Snowflake      | ⬜ | **parked** — trial denied by Snowflake's risk engine |
 
-When the remaining 4 land in `qa-connectors.env`, add a test here and
-the nightly workflow picks it up automatically.
+Salesforce and Snowflake are the last two gaps; both are documented in
+`PLAN_HUMAN_LOCKERS.md`. Snowflake is *parked*, not pending: signup
+returns `SUPPRESSED_GENERIC` from the vendor's risk engine and is
+probably unwinnable from our egress IP, so treat it as an accepted
+coverage gap rather than a to-do.
 """
 
 from __future__ import annotations
@@ -264,4 +267,166 @@ def test_hubspot_contacts_schema_introspectable(require_env):
     assert len(properties) >= 50, (
         f"Only {len(properties)} contact properties returned — HubSpot usually ships "
         "300+ by default. Scope or API-shape change?"
+    )
+
+
+# ---------- Shopify ----------
+#
+# Sandbox is the `datanika-qa-smoke` development store (Partner org
+# `Datanika`), read via the legacy custom app `qa-smoke-readonly`.
+#
+# ⚠️ The store's generated test data seeds products, customers and
+# locations but **zero orders**. Asserting non-empty orders here would
+# fail against a perfectly healthy store, so the orders probe checks
+# reachability (the scope works) and deliberately not the count.
+
+
+def test_shopify_auth_and_shop_metadata(require_env):
+    """Admin API token auth + shop identity check.
+
+    Catches: token revoked/uninstalled, store deleted or reclaimed for
+    inactivity, API version retired (Shopify sunsets versions yearly),
+    and — via the token-shape guard — a write-scoped or production
+    token silently replacing the read-only sandbox one.
+    """
+    env = require_env("SHOPIFY_SHOP_DOMAIN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_API_VERSION")
+    assert env["SHOPIFY_ACCESS_TOKEN"].startswith("shpat_"), (
+        "SHOPIFY_ACCESS_TOKEN must be an Admin API access token (shpat_*). "
+        "A storefront (shpss_/shpca_) or OAuth token means the wrong secret "
+        "was copied into qa-connectors.env."
+    )
+
+    t0 = time.monotonic()
+    r = httpx.get(
+        f"https://{env['SHOPIFY_SHOP_DOMAIN']}/admin/api/{env['SHOPIFY_API_VERSION']}/shop.json",
+        headers={"X-Shopify-Access-Token": env["SHOPIFY_ACCESS_TOKEN"]},
+        timeout=15.0,
+    )
+    elapsed = int((time.monotonic() - t0) * 1000)
+    assert r.status_code == 200, f"Shopify shop.json returned {r.status_code}: {r.text[:200]}"
+    shop = r.json()["shop"]
+    _log(
+        f"shopify: domain={shop['myshopify_domain']} plan={shop.get('plan_name')} "
+        f"elapsed={elapsed}ms"
+    )
+    assert shop["myshopify_domain"] == env["SHOPIFY_SHOP_DOMAIN"], (
+        f"Token belongs to {shop['myshopify_domain']!r}, not the configured "
+        f"{env['SHOPIFY_SHOP_DOMAIN']!r} — secrets may have been crossed."
+    )
+
+
+def test_shopify_read_scopes_cover_core_resources(require_env):
+    """Exercise each granted read scope — the introspect() coverage check.
+
+    Catches: an individual scope being dropped when the app is
+    reconfigured. Separate from the auth probe so a partial scope
+    revoke is reported specifically instead of hiding behind shop.json.
+    """
+    env = require_env("SHOPIFY_SHOP_DOMAIN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_API_VERSION")
+    base = f"https://{env['SHOPIFY_SHOP_DOMAIN']}/admin/api/{env['SHOPIFY_API_VERSION']}"
+    headers = {"X-Shopify-Access-Token": env["SHOPIFY_ACCESS_TOKEN"]}
+
+    def _get(path: str) -> dict:
+        r = httpx.get(f"{base}/{path}", headers=headers, timeout=15.0)
+        assert r.status_code == 200, (
+            f"Shopify {path} returned {r.status_code}: {r.text[:200]}. A 403 here "
+            f"means the corresponding read_* scope was dropped from qa-smoke-readonly."
+        )
+        return r.json()
+
+    products = _get("products/count.json")["count"]
+    customers = _get("customers/count.json")["count"]
+    locations = len(_get("locations.json")["locations"])
+    # read_orders: assert the scope *works*, not that orders exist. The dev
+    # store's test-data generator creates none, so `== 0` is the healthy state.
+    orders = _get("orders/count.json?status=any")["count"]
+
+    _log(
+        f"shopify: products={products} customers={customers} locations={locations} "
+        f"orders={orders} (orders=0 is expected — test data seeds none)"
+    )
+    assert products >= 1, (
+        f"Expected seeded products, got {products}. The dev store's generated "
+        "test data may have been wiped, or read_products was revoked."
+    )
+    assert locations >= 1, f"Expected at least one location, got {locations}"
+
+
+# ---------- Google Analytics 4 ----------
+#
+# Sandbox is property `QA Smoke Property` (546388994) on account
+# `Datanika QA`, read by the shared `qa-smoke@…gserviceaccount.com`
+# service account (same key as BigQuery).
+#
+# ⚠️ The property has **no data stream**, so every report legitimately
+# returns zero rows. Row counts prove nothing here — the metadata probe
+# below is what actually distinguishes "working" from "broken".
+
+
+def test_ga4_auth_and_run_report(require_env):
+    """Service-account auth + a runReport call against the QA property.
+
+    Catches: key revoked, property deleted, SA's Viewer grant removed,
+    Data API disabled on the GCP project (the failure mode that cost us
+    an hour during provisioning — the Analytics UI shows the grant as
+    fine while the API returns PERMISSION_DENIED).
+    """
+    env = require_env("GA4_PROPERTY_ID", "GA4_CREDENTIALS_FILE")
+
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient  # type: ignore[import-untyped]
+    from google.analytics.data_v1beta.types import DateRange, Metric, RunReportRequest
+    from google.oauth2 import service_account
+
+    t0 = time.monotonic()
+    creds = service_account.Credentials.from_service_account_file(env["GA4_CREDENTIALS_FILE"])
+    client = BetaAnalyticsDataClient(credentials=creds)
+    response = client.run_report(
+        RunReportRequest(
+            property=f"properties/{env['GA4_PROPERTY_ID']}",
+            date_ranges=[DateRange(start_date="7daysAgo", end_date="today")],
+            metrics=[Metric(name="activeUsers")],
+        )
+    )
+    _log(
+        f"ga4: property={env['GA4_PROPERTY_ID']} row_count={response.row_count} "
+        f"elapsed={int((time.monotonic() - t0) * 1000)}ms"
+    )
+    # Neither `row_count > 0` NOR `metric_headers` may be asserted here: with
+    # no data stream GA4 returns zero rows *and* an empty metric_headers list
+    # (verified live 2026-07-21 — an earlier draft of this test asserted
+    # metric_headers and failed against a perfectly healthy property, the same
+    # trap as Shopify's orders=0 above).
+    #
+    # The response metadata block IS always populated — it carries the
+    # property's real configuration — so that's what proves the call worked.
+    assert response.metadata.time_zone, (
+        "runReport returned no metadata.time_zone. The property answered but "
+        "not with a well-formed report — API shape changed?"
+    )
+
+
+def test_ga4_property_metadata_introspectable(require_env):
+    """List the property's dimension/metric definitions.
+
+    This is the assertion with teeth: getMetadata returns GA4's full
+    schema regardless of whether the property has any traffic, so —
+    unlike a row count — a non-empty result genuinely proves auth,
+    property access, and API enablement all work.
+    """
+    env = require_env("GA4_PROPERTY_ID", "GA4_CREDENTIALS_FILE")
+
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient  # type: ignore[import-untyped]
+    from google.oauth2 import service_account
+
+    creds = service_account.Credentials.from_service_account_file(env["GA4_CREDENTIALS_FILE"])
+    client = BetaAnalyticsDataClient(credentials=creds)
+    metadata = client.get_metadata(name=f"properties/{env['GA4_PROPERTY_ID']}/metadata")
+
+    _log(f"ga4: dimensions={len(metadata.dimensions)} metrics={len(metadata.metrics)}")
+    assert len(metadata.dimensions) >= 50, (
+        f"Only {len(metadata.dimensions)} dimensions returned — GA4 ships 100+ by "
+        "default. Property misconfigured or API shape changed?"
+    )
+    assert len(metadata.metrics) >= 50, (
+        f"Only {len(metadata.metrics)} metrics returned — GA4 ships 100+ by default."
     )

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import time
 
 import httpx
-import pytest
 
 
 def _log(msg: str) -> None:
@@ -167,7 +166,7 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
-def test_kafka_auth_and_list_topics(require_env):
+def test_kafka_auth_and_list_topics(require_env, require_import):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 
     Catches: credentials rotated, cluster paused, network block,
@@ -185,10 +184,11 @@ def test_kafka_auth_and_list_topics(require_env):
         "KAFKA_TOPIC",
     )
 
-    try:
-        from kafka.admin import KafkaAdminClient  # type: ignore[import-untyped]
-    except ImportError:
-        pytest.skip("kafka-python not installed — add to nightly workflow requirements")
+    # NOT try/except ImportError -> pytest.skip. kafka-python 2.0.x cannot
+    # import on Python 3.12 (kafka.vendor.six.moves is gone), so a skip here
+    # would have converted a completely broken Kafka probe into a passing
+    # nightly. require_import fails instead — see conftest for the rationale.
+    KafkaAdminClient = require_import("kafka.admin", "KafkaAdminClient")  # noqa: N806 (a class)
 
     t0 = time.monotonic()
     admin = KafkaAdminClient(


### PR DESCRIPTION
Two commits: wire up the newly provisioned sandboxes, then sweep the suite for the class of bug the first commit surfaced.

---

# 1. Wire Shopify + GA4 into the matrix

The matrix was claiming **5 live connectors while 7 had credentials**. Redpanda/Kafka needed no new test — already covered, un-quarantined separately in #399.

| Connector | Probes added |
|---|---|
| **Shopify** | auth + shop identity; per-scope coverage (products / customers / locations / orders) |
| **GA4** | `runReport`; `getMetadata` |

### Two data-independence traps, both found by running against the live APIs

Each would have produced a test that fails against a **perfectly healthy sandbox**:

1. **Shopify seeds zero orders.** The dev store's test data creates products, customers and locations but no orders. `orders/count` is asserted **reachable** (proving `read_orders` works) and deliberately *not* non-empty.
2. **GA4 returns empty `metric_headers` when there are no rows.** An earlier draft asserted `metric_headers` and **failed live** against the QA property, which has no data stream. It now asserts `response.metadata.time_zone` — populated regardless of traffic.

`getMetadata` is the GA4 assertion with teeth: it returns the property's full schema whether or not traffic exists, so a non-empty result proves auth **and** property access **and** Data API enablement. A row count proves none of the three.

---

# 2. Stop the matrix reporting green while testing nothing

Pinning `kafka-python>=2.1` (commit 1) fixed one instance of a **general** bug: 2.0.x can't import on Python 3.12, so the probe would die at import and its `except ImportError: pytest.skip` would turn a broken connector into a passing nightly. Swept the suite for the same pattern.

### Three sites could mask a dead dependency

| Site | Blast radius |
|---|---|
| `conftest._require_env` → `pytest.skip` | **Systemic — all 20 probes**, including every Wave-1 connector. Rename a var during a credential rotation, or decode the base64 bundle partially, and that connector silently leaves the matrix |
| kafka `except ImportError` → `pytest.skip` | The concrete instance already found |
| `conftest` gate skip | If `DATANIKA_CONNECTOR_SMOKE` were dropped from the workflow, **all 20 skip at collection and pytest still exits 0** |

### The fix inverts the default

Missing credentials and un-importable client libraries now **fail**. Skipping is an explicit opt-in (`DATANIKA_CONNECTOR_SMOKE_LENIENT=1`) for partial local runs.

**The direction is the point**: dropping or misspelling any env var can now only make the suite *stricter*, never quieter. A typo in the workflow surfaces as a red nightly instead of a silent one.

- New `require_import` fixture replaces the `try/except ImportError` idiom. (`test_paid_connectors.py` no longer imports `pytest` at all — there is no `pytest.skip` left in it.)
- Strict mode means a healthy nightly has **zero skips**, so the workflow now fails the job if any test reports skipped. That covers the gate hole, which strict mode alone cannot — and without coupling to the workflow name, which would have been a fresh silent hole of its own.

The gate skip itself stays a skip: PR CI legitimately has no sandbox credentials, and it costs 1.6s.

---

## Verified

Live vendor APIs, plus each guard exercised by actually breaking the thing it guards:

```
1. healthy run                    5 passed
2. unset SHOPIFY_ACCESS_TOKEN     E Failed: Missing env vars: SHOPIFY_ACCESS_TOKEN     (was: silent skip)
3. shadowed a broken kafka module E Failed: Cannot import 'kafka.admin' (...)          (was: silent skip)
4. LENIENT=1 escape hatch         1 skipped
5. gate off (PR CI)               20 skipped in 1.60s
```

#3 shadows `kafka/__init__.py` with a raising stub, reproducing the real Python 3.12 breakage rather than trusting that the fix works.

`ruff check` + `ruff format --check` clean; workflow YAML `safe_load`s; full pre-push precheck green.

## Guards against silent credential swaps

`SHOPIFY_ACCESS_TOKEN` must start with `shpat_`, mirroring Stripe's existing `rk_test_` guard, so a write-scoped or production token can't quietly replace the read-only sandbox one. The Shopify auth probe also asserts the returned `myshopify_domain` matches the configured host, so crossed secrets fail loudly instead of testing the wrong store.

## Watch

- Redpanda is a **30-day / $100-credit trial** and the previous cluster died from idling — re-check ~2026-08-18.
- Shopify sunsets API versions yearly; `SHOPIFY_API_VERSION` is pinned to `2026-04` in the creds bundle.
- Wave-1 probes now fail rather than skip if `QA_WAVE1_CREDENTIALS` is missing. That is intended, but it means a genuinely absent Wave-1 bundle turns the nightly red — which is the correct signal, not a regression.

Remaining matrix gaps are Salesforce (one human click past bot detection) and Snowflake (**parked** — vendor risk-engine denial), both documented in `PLAN_HUMAN_LOCKERS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)