### PR TITLE
[Engineering] Add glama.json + datanika-mcp/Dockerfile for the Glama listing (closes #402)

### DIFF
--- a/datanika-mcp/Dockerfile
+++ b/datanika-mcp/Dockerfile
@@ -1,0 +1,27 @@
+# check=skip=SecretsUsedInArgOrEnv
+#
+# (The skip is for the ENV below: BuildKit flags any ENV named *API_KEY* as a
+# baked secret. This one is a placeholder string, not a credential — see the
+# comment at that line. Older BuildKit ignores the directive as a comment.)
+#
+# Image Glama build-tests to produce a release for the directory listing (core#402).
+#
+# Glama only needs the server to start and answer an MCP introspection request:
+# all 25 tools register statically via @mcp.tool(), the httpx client opens no
+# connection at construction time, and main() only checks that an API key is
+# *present*. So no live Datanika instance is required to build or introspect.
+#
+# Build context is the REPO ROOT (the COPY below reaches into datanika-mcp/):
+#   docker build -f datanika-mcp/Dockerfile -t datanika-mcp .
+FROM python:3.12-slim
+
+WORKDIR /srv
+COPY datanika-mcp/ /srv/
+RUN pip install --no-cache-dir .
+
+# Not a credential: a placeholder that lets the stdio server start for
+# introspection. A real deployment passes --api-key / DATANIKA_API_KEY.
+ENV DATANIKA_URL=https://app.datanika.io \
+    DATANIKA_API_KEY=glama-introspection-placeholder
+
+ENTRYPOINT ["datanika-mcp"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Timev"]
+}


### PR DESCRIPTION
Closes #402. Refs #355.

Two files, no code. They're the last Eng-side gate on the Glama release, which gates the `awesome-mcp-servers` backlink ([#10453](https://github.com/punkpeye/awesome-mcp-servers/pull/10453)).

- **`glama.json`** (repo root) — required before Glama will accept a claim on an org-owned repo, and clears the standalone `No glama.json` check.
- **`datanika-mcp/Dockerfile`** — the image Glama build-tests. Repo-root build context; installs the **in-tree** package rather than pinning `datanika-mcp==0.2.0` from PyPI, so the image tracks the source instead of drifting from it at the next release.

## Verified by building and running it, not by reading the spec

```
docker build -f datanika-mcp/Dockerfile .   -> clean, no warnings
initialize                                  -> Datanika, protocol 2025-06-18
tools/list                                  -> 25 tools
```

Driven as a real stdio MCP session against the built container. Two things that would otherwise bite whoever picks this up:

- **The smoke needs stdin held open after the last message.** On EOF the stdio server shuts down and the `tools/list` reply is lost in the race — my first run showed `Processing request of type ListToolsRequest` with no response, which reads exactly like a broken image but isn't.
- **BuildKit flags any `ENV` matching `*API_KEY*` as a baked secret.** It isn't one: the server only checks a key is *present*, and the httpx client opens no connection at construction, so introspection needs no live instance. Rather than emit a scary warning on every Glama build, the file carries `# check=skip=SecretsUsedInArgOrEnv` with the reason next to it. Older BuildKit treats the directive as a comment, so it's safe either way.

Full precheck green (2399 passed) — no Python changed, but the repo gate ran anyway.

## After merge — Growth, no Eng involvement

claim → Deploy → Make Release → append the score badge to #10453.

---

<sub>Housekeeping: my first commit of these files landed on `qa-smoke-shopify-ga4`, which another session had left checked out in the Engineering worktree. Caught before pushing; that branch is restored to exactly `34253fa` (verified identical to origin) and this PR is the commit cherry-picked onto `dev`. Nothing of QA's was pushed or lost.</sub>
