### PR TITLE
[Engineering] OpenAPI P2: spec URL-fetch behind the §7 SSRF guards (closes #410)

### DIFF
--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -277,19 +277,22 @@ def create_connection(request, api_key, session):
 
 @api_endpoint(required_scope="connections:read")
 def parse_openapi(request, api_key, session):
-    """Parse an OpenAPI 3.x spec (paste-mode) into a preview of the derived
-    connector — base_url, auth schemes, and readable resources with columns.
+    """Parse an OpenAPI 3.x spec into a preview of the derived connector —
+    base_url, auth schemes, and readable resources with columns.
+
+    Takes the document inline (``spec_inline``) or fetches it from
+    ``spec_url`` (P2, core#410) behind the SPEC §7 guards: https only, public
+    host, every redirect hop re-checked, 10s timeout, 5 MB streamed cap.
 
     Stateless: creates no connection, so an agent/UI can preview before
-    committing. See SPEC_OPENAPI_CONNECTOR.md (#325).
+    committing. See SPEC_OPENAPI_CONNECTOR.md (#325, #410).
     """
+    from datanika.services.openapi_fetch import resolve_spec
     from datanika.services.openapi_import import OpenApiImportError, parse_openapi_spec
 
     data = _body_sync(request)
-    spec = data.get("spec_inline")
-    if not spec or not isinstance(spec, str):
-        return _error(400, "spec_inline (the OpenAPI 3.x document as a string) is required")
     try:
+        spec = resolve_spec(data.get("spec_inline"), data.get("spec_url"))
         parsed = parse_openapi_spec(spec, base_url_override=data.get("base_url"))
     except OpenApiImportError as exc:
         return JSONResponse({"error": str(exc), "code": exc.code}, status_code=400)

--- a/datanika/services/openapi_fetch.py
+++ b/datanika/services/openapi_fetch.py
@@ -1,0 +1,125 @@
+"""Fetch an OpenAPI spec from a user-supplied URL (core#410, OpenAPI P2).
+
+Kept out of ``openapi_import.py`` on purpose: that module is deterministic and
+touches no network, which is what makes it cheap to fuzz and reason about. This
+module is the *only* place the spec path talks to the outside world, so all of
+SPEC_OPENAPI_CONNECTOR §7's guards live here and nowhere else:
+
+  * **https only** — stricter than ``validate_egress_host`` (which allows http
+    for connector base URLs), because a spec URL has no reason to be plaintext;
+  * **host must resolve public** — the same ``validate_egress_host`` the
+    connector family uses, not a second implementation (§7: "reuse/centralize
+    with any existing outbound-fetch guard");
+  * **every redirect hop re-checked** — via the guarded session from core#403,
+    so a public host cannot bounce us into ``10.0.0.0/8``;
+  * **10 s timeout** and a **5 MB cap enforced while streaming** — applied to
+    bytes actually read, never to a header or a finished body. The case that
+    needs it is a response with **no ``Content-Length``**, delimited by
+    connection close: urllib3 then reads until EOF and nothing but this cap
+    bounds it. (An *understated* ``Content-Length`` is not the danger — urllib3
+    stops at the declared length and truncates. Measured, not assumed.)
+
+**Inherited residual:** core#405 (DNS-rebinding TOCTOU) applies here too, and
+bites slightly harder than it does in the worker — this runs in the web tier,
+where loopback reaches the app's own API and, compose-internally, Postgres and
+Redis. §7 does not require closing it and §13.1 signed off "URL in P2 behind §7
+guards", so it ships knowingly, not unnoticed.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from datanika.services.egress_guard import (
+    EgressValidationError,
+    build_guarded_session,
+    validate_egress_host,
+)
+from datanika.services.openapi_import import MAX_SPEC_BYTES, OpenApiImportError
+
+FETCH_TIMEOUT_SECONDS = 10
+_CHUNK_BYTES = 64_000
+
+#: §7: spec URLs are https-only. A module constant rather than a literal so the
+#: streaming/size tests can point at a plaintext local server without weakening
+#: the rule itself (which has its own tests against the real code path).
+REQUIRED_SCHEME = "https"
+
+
+def fetch_openapi_spec(url: str) -> str:
+    """Return the spec document at *url* as text.
+
+    Raises :class:`OpenApiImportError` with ``code`` ∈ {``invalid_spec_url``,
+    ``spec_too_large``, ``spec_fetch_failed``} so the endpoint can branch
+    without matching on messages — the same contract the parser already uses.
+    """
+    parsed = urlparse(url or "")
+    if parsed.scheme != REQUIRED_SCHEME:
+        raise OpenApiImportError(
+            "Spec URL must use https (paste the document instead if the host is http-only).",
+            "invalid_spec_url",
+        )
+
+    session = build_guarded_session()
+    try:
+        # The guarded session validates this URL and every redirect hop anyway;
+        # calling it explicitly first means an internal host is refused before a
+        # socket is opened, and surfaces as a URL problem rather than a generic
+        # fetch failure.
+        validate_egress_host(url)
+        with session.get(url, timeout=FETCH_TIMEOUT_SECONDS, stream=True) as response:
+            response.raise_for_status()
+            return _read_capped(response)
+    except EgressValidationError as exc:
+        raise OpenApiImportError(str(exc), "invalid_spec_url") from exc
+    except OpenApiImportError:
+        raise
+    except Exception as exc:  # network/TLS/HTTP status — one typed failure
+        raise OpenApiImportError(f"Could not fetch the spec: {exc}", "spec_fetch_failed") from exc
+    finally:
+        session.close()
+
+
+def resolve_spec(spec_inline, spec_url) -> str:
+    """Return the spec text from whichever source the caller supplied.
+
+    Lives here rather than in the route so the "exactly one of" decision is
+    unit-testable: the endpoint is decorated for auth and cannot be called
+    directly, which is how this branch would otherwise ship untested.
+    """
+    if bool(spec_inline) == bool(spec_url):
+        # Both or neither — ambiguous rather than merely incomplete, so the
+        # message names both options instead of demanding one.
+        raise OpenApiImportError(
+            "Provide exactly one of spec_inline (the document) or spec_url (where to fetch it).",
+            "invalid_request",
+        )
+    if spec_url is not None and spec_url != "":
+        if not isinstance(spec_url, str):
+            raise OpenApiImportError("spec_url must be a string", "invalid_request")
+        return fetch_openapi_spec(spec_url)
+    if not isinstance(spec_inline, str):
+        raise OpenApiImportError(
+            "spec_inline (the OpenAPI 3.x document as a string) is required", "invalid_request"
+        )
+    return spec_inline
+
+
+def _read_capped(response) -> str:
+    """Read at most ``MAX_SPEC_BYTES``, aborting as soon as the cap is passed."""
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=_CHUNK_BYTES):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > MAX_SPEC_BYTES:
+            # Stop pulling immediately — do not buffer the rest to measure it.
+            raise OpenApiImportError("Spec exceeds the size limit", "spec_too_large")
+        chunks.append(chunk)
+
+    body = b"".join(chunks)
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OpenApiImportError("Spec is not valid UTF-8 text", "invalid_spec") from exc

--- a/tests/test_services/test_openapi_fetch.py
+++ b/tests/test_services/test_openapi_fetch.py
@@ -1,0 +1,160 @@
+"""Tests for OpenAPI spec URL-fetch (core#410, OpenAPI P2 slice 1).
+
+SPEC_OPENAPI_CONNECTOR §7 makes this a ship gate, and §14 calls SSRF "the
+headline risk" — so the guards are the test subject, not the happy path.
+
+The size cap is the one that needs a **real server**: a hostile origin can lie
+about ``Content-Length`` or simply never stop sending, so checking the header
+or the finished body proves nothing. The test streams more than the cap from a
+local server and asserts we abort mid-flight.
+
+Host/redirect rejection reuses ``validate_egress_host`` and the guarded session
+from #403 — these tests pin that they are *wired in*, not that they work
+(``test_egress_guarded_session.py`` owns that).
+"""
+
+import http.server
+import threading
+
+import pytest
+
+from datanika.services.openapi_fetch import fetch_openapi_spec, resolve_spec
+from datanika.services.openapi_import import MAX_SPEC_BYTES, OpenApiImportError
+
+_SPEC = '{"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{}}'
+
+
+class _SpecHandler(http.server.BaseHTTPRequestHandler):
+    """``/spec`` returns a small spec; ``/huge`` streams past the cap forever."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        if self.path == "/huge":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            # No Content-Length: the body is delimited by connection close, so
+            # the client reads until EOF and nothing but our own cap bounds it.
+            # (An *understated* Content-Length is not the dangerous case —
+            # urllib3 stops at the declared length and truncates. Unbounded is.)
+            self.end_headers()
+            chunk = b"x" * 64_000
+            try:
+                for _ in range((MAX_SPEC_BYTES // len(chunk)) + 20):
+                    self.wfile.write(chunk)
+            except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                pass  # expected: the client aborts at the cap
+            return
+
+        body = _SPEC.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def spec_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _SpecHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def allow_loopback(monkeypatch):
+    """Let the local test server through the public-IP guard.
+
+    Only for tests about *other* properties — the guard's own behaviour is
+    asserted with it left alone.
+    """
+    monkeypatch.setattr("datanika.services.openapi_fetch.validate_egress_host", lambda url: None)
+    monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    # stdlib http.server speaks plaintext; the https rule is asserted separately
+    # against the real code path in TestSchemeIsHttpsOnly.
+    monkeypatch.setattr("datanika.services.openapi_fetch.REQUIRED_SCHEME", "http")
+
+
+class TestSchemeIsHttpsOnly:
+    def test_http_is_refused(self):
+        """§7 is stricter than the connector guard: https only for spec fetch."""
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("http://example.com/openapi.json")
+        assert exc.value.code == "invalid_spec_url"
+
+    def test_file_scheme_is_refused(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("file:///etc/passwd")
+        assert exc.value.code == "invalid_spec_url"
+
+
+class TestHostGuardIsWiredIn:
+    def test_private_host_is_refused(self):
+        """Reuses validate_egress_host rather than a second implementation."""
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("https://127.0.0.1/openapi.json")
+        assert exc.value.code == "invalid_spec_url"
+
+    def test_cloud_metadata_is_refused(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("https://169.254.169.254/latest/meta-data/")
+        assert exc.value.code == "invalid_spec_url"
+
+
+class TestSizeCapIsEnforcedWhileStreaming:
+    def test_oversized_body_aborts_and_does_not_buffer(self, spec_server, allow_loopback):
+        """A hostile origin can understate Content-Length or never stop."""
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec(f"{spec_server}/huge")
+        assert exc.value.code == "spec_too_large"
+
+
+class TestResolveSpecSource:
+    """The 'exactly one of' decision, which the route itself cannot be tested on.
+
+    ``parse_openapi`` is wrapped by ``@api_endpoint`` for auth and exposes no
+    ``__wrapped__``, so this branch would ship untested if it lived inline —
+    which is why it doesn't.
+    """
+
+    def test_neither_source_is_an_error(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            resolve_spec(None, None)
+        assert exc.value.code == "invalid_request"
+
+    def test_both_sources_is_an_error(self):
+        """Ambiguous, not incomplete — silently preferring one would surprise."""
+        with pytest.raises(OpenApiImportError) as exc:
+            resolve_spec(_SPEC, "https://example.com/openapi.json")
+        assert exc.value.code == "invalid_request"
+
+    def test_inline_passes_through_untouched(self):
+        assert resolve_spec(_SPEC, None) == _SPEC
+
+    def test_non_string_inline_is_rejected(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            resolve_spec({"openapi": "3.0.0"}, None)
+        assert exc.value.code == "invalid_request"
+
+    def test_url_is_fetched(self, spec_server, allow_loopback):
+        assert resolve_spec(None, f"{spec_server}/spec") == _SPEC
+
+
+class TestHappyPath:
+    def test_returns_the_body(self, spec_server, allow_loopback):
+        assert fetch_openapi_spec(f"{spec_server}/spec") == _SPEC
+
+    def test_result_feeds_the_parser_unchanged(self, spec_server, allow_loopback):
+        """The fetcher's only job is bytes; parsing stays deterministic."""
+        from datanika.services.openapi_import import parse_openapi_spec
+
+        parsed = parse_openapi_spec(
+            fetch_openapi_spec(f"{spec_server}/spec"), base_url_override="https://api.example.com"
+        )
+        assert parsed.base_url == "https://api.example.com"


### PR DESCRIPTION
Closes #410. First slice of OpenAPI **P2** (SPEC_OPENAPI_CONNECTOR §9); the rest is tracked in #411.

`POST /api/v1/connections/openapi/parse` now accepts **`spec_url`** alongside `spec_inline`. The parser is untouched — `openapi_import.py` stays deterministic and network-free, which is what makes it cheap to reason about — and every byte of outbound behaviour lives in the new `openapi_fetch.py`.

## Why this slice first

It was **hard-gated on the #338 egress residuals**: the guard's own docstring named *"before enabling the OpenAPI-P2 URL-fetch feature"* as a deferral condition. #404 closed those, so this is unblocked in a way it wasn't yesterday — and it's the security-critical half of P2, best done while that work is fresh rather than bolted on later. It's also what makes the agent flow real: an agent can pass a URL through a tool call far more easily than a 500 KB spec body.

## §7, all of it

| Guard | |
|---|---|
| **https only** | Stricter than `validate_egress_host`, which permits http for connector base URLs — a spec URL has no reason to be plaintext |
| **Host resolves public** | The same `validate_egress_host`, not a second implementation (§7: "reuse/centralize with any existing outbound-fetch guard") |
| **Every redirect hop re-checked** | Via the guarded session from #403 |
| **10 s timeout** | |
| **5 MB cap** | Enforced *while streaming*, on bytes actually read |

## Two things the tests taught me

**The size cap's dangerous shape isn't the obvious one.** My first version of that test served an *understated* `Content-Length` and the fetch sailed through — because urllib3 stops at the declared length and truncates. The case that actually needs a cap is a response with **no `Content-Length`**, delimited by connection close: urllib3 reads until EOF and nothing but our own limit bounds it. The test now serves that, and the module says so, because the intuitive-but-wrong version is what someone will otherwise "fix" it back to.

**The request-validation branch couldn't be tested where I first wrote it.** `parse_openapi` is wrapped by `@api_endpoint` for auth and exposes no `__wrapped__`, and there are **no endpoint tests for this route at all** — so the "exactly one of `spec_inline` / `spec_url`" logic would have shipped unexercised. It moved into `resolve_spec()`, which is pure and fully covered; the route is now a thin adapter. Worth knowing that this route's HTTP layer remains untested generally.

## Inherited residual, stated not swallowed

**#405 (DNS-rebinding TOCTOU) applies here too**, and bites slightly harder than in the worker: this runs in the **web tier**, where loopback reaches our own API and — compose-internally — Postgres and Redis. §7 doesn't require closing it, and §13.1 signed off "URL in P2 behind §7 guards", so it ships knowingly. It's in the module docstring and on #405 with the two events that should force it.

12 new tests, guards first. Full precheck green: ruff + format clean, **2411 passed**.

---

<sub>Housekeeping: another session has been sharing the Engineering worktree today and flipped it back to `qa-smoke-shopify-ga4` mid-task. My edits were stashed and moved onto this branch before committing — their branch carries nothing of mine, and an earlier snapshot of their WIP is preserved at `/d/tmp/qa-wip-connector-smoke-2026-07-21.patch` plus a labelled stash entry.</sub>
