### PR TITLE
[Infra] Promote dev -> master: Glama listing (#408) + connector smoke matrix (#407)

### DIFF
--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -107,7 +107,21 @@ jobs:
         id: smoke
         env:
           DATANIKA_CONNECTOR_SMOKE: "1"
-        run: pytest tests/test_connector_smoke/ -v --tb=short
+        # A skipped probe is worse than a failing one: it reports green while
+        # testing nothing. Missing creds and un-importable client libs now FAIL
+        # rather than skip (tests/test_connector_smoke/conftest.py), so a healthy
+        # run has ZERO skips — which makes "any skip at all" a usable alarm.
+        #
+        # This catches the one hole strict mode cannot: if DATANIKA_CONNECTOR_SMOKE
+        # above were dropped or misspelled, the gate would skip all probes at
+        # collection time and pytest would still exit 0 — a perfectly green
+        # nightly that tested nothing.
+        run: |
+          pytest tests/test_connector_smoke/ -v --tb=short -rs | tee /tmp/smoke.log
+          if grep -qE '[0-9]+ skipped' /tmp/smoke.log; then
+            echo "::error::Smoke probes were SKIPPED — a skipped probe reports green while testing nothing. Check that DATANIKA_CONNECTOR_SMOKE=1 is still set on this step and that every credential is present in QA_CONNECTOR_CREDENTIALS."
+            exit 1
+          fi
 
       - name: Telegram alert on failure
         if: failure()

--- a/.github/workflows/nightly-connector-smoke.yml
+++ b/.github/workflows/nightly-connector-smoke.yml
@@ -40,8 +40,15 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install -e ".[dev]" --system
-          # Connector-specific libs not in core deps
-          uv pip install --system "google-cloud-bigquery>=3.0" "kafka-python>=2.0"
+          # Connector-specific libs not in core deps.
+          # kafka-python must be >=2.1 — 2.0.x imports kafka.vendor.six.moves,
+          # which is gone in Python 3.12, so the probe would die at import and
+          # the test's `except ImportError: pytest.skip` would turn a broken
+          # Kafka smoke into a silent green. Pin the floor, don't rely on the skip.
+          uv pip install --system \
+            "google-cloud-bigquery>=3.0" \
+            "google-analytics-data>=0.18" \
+            "kafka-python>=2.1"
 
       - name: Materialize connector credentials
         env:

--- a/datanika-mcp/Dockerfile
+++ b/datanika-mcp/Dockerfile
@@ -1,0 +1,27 @@
+# check=skip=SecretsUsedInArgOrEnv
+#
+# (The skip is for the ENV below: BuildKit flags any ENV named *API_KEY* as a
+# baked secret. This one is a placeholder string, not a credential — see the
+# comment at that line. Older BuildKit ignores the directive as a comment.)
+#
+# Image Glama build-tests to produce a release for the directory listing (core#402).
+#
+# Glama only needs the server to start and answer an MCP introspection request:
+# all 25 tools register statically via @mcp.tool(), the httpx client opens no
+# connection at construction time, and main() only checks that an API key is
+# *present*. So no live Datanika instance is required to build or introspect.
+#
+# Build context is the REPO ROOT (the COPY below reaches into datanika-mcp/):
+#   docker build -f datanika-mcp/Dockerfile -t datanika-mcp .
+FROM python:3.12-slim
+
+WORKDIR /srv
+COPY datanika-mcp/ /srv/
+RUN pip install --no-cache-dir .
+
+# Not a credential: a placeholder that lets the stdio server start for
+# introspection. A real deployment passes --api-key / DATANIKA_API_KEY.
+ENV DATANIKA_URL=https://app.datanika.io \
+    DATANIKA_API_KEY=glama-introspection-placeholder
+
+ENTRYPOINT ["datanika-mcp"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Timev"]
+}

--- a/tests/test_connector_smoke/conftest.py
+++ b/tests/test_connector_smoke/conftest.py
@@ -12,15 +12,49 @@ and exports all ``*`` pairs before pytest runs. Locally:
 
     set -a && source secrets/qa-connectors.env && set +a
     DATANIKA_CONNECTOR_SMOKE=1 uv run pytest tests/test_connector_smoke/ -v
+
+## Missing dependencies FAIL — they do not skip
+
+Once the gate is on, a missing credential or an un-importable client
+library is a **hard failure**, not a skip.
+
+That is deliberate, and it is the whole point of a monitoring probe. A
+probe that skips when its dependency is missing reports green while
+testing nothing — strictly worse than one that fails, because the
+matrix looks healthiest exactly when it has stopped watching.
+
+Real instance (core#407): the nightly pinned ``kafka-python>=2.0``, but
+2.0.x cannot import on Python 3.12 (``kafka.vendor.six.moves`` is
+gone). The Kafka probe would have died at import and its
+``except ImportError: pytest.skip`` would have turned a completely
+broken connector into a passing nightly.
+
+The failure this guards against is mundane and therefore likely:
+someone rotates a credential and renames its var, or the base64 bundle
+decodes partially. Under skip-on-missing, that connector silently drops
+out of the matrix and nobody finds out until a customer does.
+
+Running a subset locally without every credential is the one legitimate
+reason to skip instead, so that is an explicit opt-in:
+
+    DATANIKA_CONNECTOR_SMOKE=1 DATANIKA_CONNECTOR_SMOKE_LENIENT=1 pytest ...
+
+Note the direction: lenient mode must be switched **on**. Dropping or
+misspelling any env var can only make the suite stricter, never
+quieter — so a typo in the workflow surfaces as a red nightly rather
+than a silent one. Do not invert this.
 """
 
 from __future__ import annotations
 
+import importlib
 import os
+from typing import Any
 
 import pytest
 
 _GATE_ENV = "DATANIKA_CONNECTOR_SMOKE"
+_LENIENT_ENV = "DATANIKA_CONNECTOR_SMOKE_LENIENT"
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -28,6 +62,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
     Done at collection time so the skip reason is visible in `pytest --collect-only`
     and doesn't count toward "slow test" budget in normal PR runs.
+
+    This gate is the one skip that stays a skip: PR CI legitimately has no
+    sandbox credentials. The nightly workflow guards the corresponding risk
+    — the gate silently being off there — by failing the job if *any* test
+    reports skipped. See `.github/workflows/nightly-connector-smoke.yml`.
     """
     if os.environ.get(_GATE_ENV) == "1":
         return
@@ -39,15 +78,54 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(skip_marker)
 
 
+def _missing_dependency(reason: str) -> None:
+    """Fail on a missing dependency — or skip, if lenient mode is on.
+
+    See the module docstring for why failing is the default. Never call
+    ``pytest.skip`` directly from a probe on a missing dependency: that
+    is precisely the silent-green bug this helper exists to prevent.
+    """
+    if os.environ.get(_LENIENT_ENV) == "1":
+        pytest.skip(f"{reason} [lenient mode]")
+    pytest.fail(
+        f"{reason}\n\n"
+        f"Failing rather than skipping is intentional: a smoke probe that skips "
+        f"on a missing dependency reports green while testing nothing, so the "
+        f"matrix looks healthy exactly when it has stopped watching.\n"
+        f"If this is a deliberate partial run on a machine without every "
+        f"credential, set {_LENIENT_ENV}=1 to downgrade this to a skip."
+    )
+
+
 def _require_env(*names: str) -> dict[str, str]:
-    """Fetch required env vars or skip with a clear message."""
+    """Fetch required env vars, or fail loudly if any are absent."""
     missing = [n for n in names if not os.environ.get(n)]
     if missing:
-        pytest.skip(f"Missing env vars: {', '.join(missing)}")
+        _missing_dependency(f"Missing env vars: {', '.join(missing)}")
     return {n: os.environ[n] for n in names}
+
+
+def _require_import(module: str, attr: str | None = None) -> Any:
+    """Import a connector client library, or fail loudly if it is absent.
+
+    Use this instead of ``try: import x / except ImportError: pytest.skip``.
+    An un-importable client library means the probe *cannot run*, which is
+    a broken probe — not an absent one, and not something to pass over.
+    """
+    try:
+        mod = importlib.import_module(module)
+    except ImportError as exc:
+        _missing_dependency(f"Cannot import {module!r} ({exc}). Is it in the nightly's deps?")
+    return getattr(mod, attr) if attr else mod
 
 
 @pytest.fixture
 def require_env():
     """Fixture wrapper so tests read `env = require_env('FOO', 'BAR')`."""
     return _require_env
+
+
+@pytest.fixture
+def require_import():
+    """Fixture wrapper so tests read `Client = require_import('mod', 'Client')`."""
+    return _require_import

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -17,15 +17,18 @@ PR CI (gated by ``DATANIKA_CONNECTOR_SMOKE=1``; see conftest.py).
 | BigQuery       | ✅ |   |
 | Databricks     | ✅ |   |
 | Stripe         | ✅ |   |
-| Kafka/Redpanda | ✅ |   |
+| Kafka/Redpanda | ✅ | re-provisioned 2026-07-21 (core#342) |
 | HubSpot        | ✅ |   |
-| Shopify        | ⬜ | creds not yet provisioned |
-| GA4            | ⬜ | creds not yet provisioned |
-| Salesforce     | ⬜ | creds not yet provisioned |
-| Snowflake      | ⬜ | signup blocked (see `PLAN_HUMAN_LOCKERS.md`) |
+| Shopify        | ✅ | provisioned 2026-07-21 |
+| GA4            | ✅ | provisioned 2026-07-21 |
+| Salesforce     | ⬜ | signup blocked on bot detection — one human click |
+| Snowflake      | ⬜ | **parked** — trial denied by Snowflake's risk engine |
 
-When the remaining 4 land in `qa-connectors.env`, add a test here and
-the nightly workflow picks it up automatically.
+Salesforce and Snowflake are the last two gaps; both are documented in
+`PLAN_HUMAN_LOCKERS.md`. Snowflake is *parked*, not pending: signup
+returns `SUPPRESSED_GENERIC` from the vendor's risk engine and is
+probably unwinnable from our egress IP, so treat it as an accepted
+coverage gap rather than a to-do.
 """
 
 from __future__ import annotations
@@ -264,4 +267,166 @@ def test_hubspot_contacts_schema_introspectable(require_env):
     assert len(properties) >= 50, (
         f"Only {len(properties)} contact properties returned — HubSpot usually ships "
         "300+ by default. Scope or API-shape change?"
+    )
+
+
+# ---------- Shopify ----------
+#
+# Sandbox is the `datanika-qa-smoke` development store (Partner org
+# `Datanika`), read via the legacy custom app `qa-smoke-readonly`.
+#
+# ⚠️ The store's generated test data seeds products, customers and
+# locations but **zero orders**. Asserting non-empty orders here would
+# fail against a perfectly healthy store, so the orders probe checks
+# reachability (the scope works) and deliberately not the count.
+
+
+def test_shopify_auth_and_shop_metadata(require_env):
+    """Admin API token auth + shop identity check.
+
+    Catches: token revoked/uninstalled, store deleted or reclaimed for
+    inactivity, API version retired (Shopify sunsets versions yearly),
+    and — via the token-shape guard — a write-scoped or production
+    token silently replacing the read-only sandbox one.
+    """
+    env = require_env("SHOPIFY_SHOP_DOMAIN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_API_VERSION")
+    assert env["SHOPIFY_ACCESS_TOKEN"].startswith("shpat_"), (
+        "SHOPIFY_ACCESS_TOKEN must be an Admin API access token (shpat_*). "
+        "A storefront (shpss_/shpca_) or OAuth token means the wrong secret "
+        "was copied into qa-connectors.env."
+    )
+
+    t0 = time.monotonic()
+    r = httpx.get(
+        f"https://{env['SHOPIFY_SHOP_DOMAIN']}/admin/api/{env['SHOPIFY_API_VERSION']}/shop.json",
+        headers={"X-Shopify-Access-Token": env["SHOPIFY_ACCESS_TOKEN"]},
+        timeout=15.0,
+    )
+    elapsed = int((time.monotonic() - t0) * 1000)
+    assert r.status_code == 200, f"Shopify shop.json returned {r.status_code}: {r.text[:200]}"
+    shop = r.json()["shop"]
+    _log(
+        f"shopify: domain={shop['myshopify_domain']} plan={shop.get('plan_name')} "
+        f"elapsed={elapsed}ms"
+    )
+    assert shop["myshopify_domain"] == env["SHOPIFY_SHOP_DOMAIN"], (
+        f"Token belongs to {shop['myshopify_domain']!r}, not the configured "
+        f"{env['SHOPIFY_SHOP_DOMAIN']!r} — secrets may have been crossed."
+    )
+
+
+def test_shopify_read_scopes_cover_core_resources(require_env):
+    """Exercise each granted read scope — the introspect() coverage check.
+
+    Catches: an individual scope being dropped when the app is
+    reconfigured. Separate from the auth probe so a partial scope
+    revoke is reported specifically instead of hiding behind shop.json.
+    """
+    env = require_env("SHOPIFY_SHOP_DOMAIN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_API_VERSION")
+    base = f"https://{env['SHOPIFY_SHOP_DOMAIN']}/admin/api/{env['SHOPIFY_API_VERSION']}"
+    headers = {"X-Shopify-Access-Token": env["SHOPIFY_ACCESS_TOKEN"]}
+
+    def _get(path: str) -> dict:
+        r = httpx.get(f"{base}/{path}", headers=headers, timeout=15.0)
+        assert r.status_code == 200, (
+            f"Shopify {path} returned {r.status_code}: {r.text[:200]}. A 403 here "
+            f"means the corresponding read_* scope was dropped from qa-smoke-readonly."
+        )
+        return r.json()
+
+    products = _get("products/count.json")["count"]
+    customers = _get("customers/count.json")["count"]
+    locations = len(_get("locations.json")["locations"])
+    # read_orders: assert the scope *works*, not that orders exist. The dev
+    # store's test-data generator creates none, so `== 0` is the healthy state.
+    orders = _get("orders/count.json?status=any")["count"]
+
+    _log(
+        f"shopify: products={products} customers={customers} locations={locations} "
+        f"orders={orders} (orders=0 is expected — test data seeds none)"
+    )
+    assert products >= 1, (
+        f"Expected seeded products, got {products}. The dev store's generated "
+        "test data may have been wiped, or read_products was revoked."
+    )
+    assert locations >= 1, f"Expected at least one location, got {locations}"
+
+
+# ---------- Google Analytics 4 ----------
+#
+# Sandbox is property `QA Smoke Property` (546388994) on account
+# `Datanika QA`, read by the shared `qa-smoke@…gserviceaccount.com`
+# service account (same key as BigQuery).
+#
+# ⚠️ The property has **no data stream**, so every report legitimately
+# returns zero rows. Row counts prove nothing here — the metadata probe
+# below is what actually distinguishes "working" from "broken".
+
+
+def test_ga4_auth_and_run_report(require_env):
+    """Service-account auth + a runReport call against the QA property.
+
+    Catches: key revoked, property deleted, SA's Viewer grant removed,
+    Data API disabled on the GCP project (the failure mode that cost us
+    an hour during provisioning — the Analytics UI shows the grant as
+    fine while the API returns PERMISSION_DENIED).
+    """
+    env = require_env("GA4_PROPERTY_ID", "GA4_CREDENTIALS_FILE")
+
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient  # type: ignore[import-untyped]
+    from google.analytics.data_v1beta.types import DateRange, Metric, RunReportRequest
+    from google.oauth2 import service_account
+
+    t0 = time.monotonic()
+    creds = service_account.Credentials.from_service_account_file(env["GA4_CREDENTIALS_FILE"])
+    client = BetaAnalyticsDataClient(credentials=creds)
+    response = client.run_report(
+        RunReportRequest(
+            property=f"properties/{env['GA4_PROPERTY_ID']}",
+            date_ranges=[DateRange(start_date="7daysAgo", end_date="today")],
+            metrics=[Metric(name="activeUsers")],
+        )
+    )
+    _log(
+        f"ga4: property={env['GA4_PROPERTY_ID']} row_count={response.row_count} "
+        f"elapsed={int((time.monotonic() - t0) * 1000)}ms"
+    )
+    # Neither `row_count > 0` NOR `metric_headers` may be asserted here: with
+    # no data stream GA4 returns zero rows *and* an empty metric_headers list
+    # (verified live 2026-07-21 — an earlier draft of this test asserted
+    # metric_headers and failed against a perfectly healthy property, the same
+    # trap as Shopify's orders=0 above).
+    #
+    # The response metadata block IS always populated — it carries the
+    # property's real configuration — so that's what proves the call worked.
+    assert response.metadata.time_zone, (
+        "runReport returned no metadata.time_zone. The property answered but "
+        "not with a well-formed report — API shape changed?"
+    )
+
+
+def test_ga4_property_metadata_introspectable(require_env):
+    """List the property's dimension/metric definitions.
+
+    This is the assertion with teeth: getMetadata returns GA4's full
+    schema regardless of whether the property has any traffic, so —
+    unlike a row count — a non-empty result genuinely proves auth,
+    property access, and API enablement all work.
+    """
+    env = require_env("GA4_PROPERTY_ID", "GA4_CREDENTIALS_FILE")
+
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient  # type: ignore[import-untyped]
+    from google.oauth2 import service_account
+
+    creds = service_account.Credentials.from_service_account_file(env["GA4_CREDENTIALS_FILE"])
+    client = BetaAnalyticsDataClient(credentials=creds)
+    metadata = client.get_metadata(name=f"properties/{env['GA4_PROPERTY_ID']}/metadata")
+
+    _log(f"ga4: dimensions={len(metadata.dimensions)} metrics={len(metadata.metrics)}")
+    assert len(metadata.dimensions) >= 50, (
+        f"Only {len(metadata.dimensions)} dimensions returned — GA4 ships 100+ by "
+        "default. Property misconfigured or API shape changed?"
+    )
+    assert len(metadata.metrics) >= 50, (
+        f"Only {len(metadata.metrics)} metrics returned — GA4 ships 100+ by default."
     )

--- a/tests/test_connector_smoke/test_paid_connectors.py
+++ b/tests/test_connector_smoke/test_paid_connectors.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import time
 
 import httpx
-import pytest
 
 
 def _log(msg: str) -> None:
@@ -167,7 +166,7 @@ def test_stripe_list_charges_read_scope(require_env):
 # ---------- Kafka / Redpanda ----------
 
 
-def test_kafka_auth_and_list_topics(require_env):
+def test_kafka_auth_and_list_topics(require_env, require_import):
     """SASL/SCRAM-SHA-256 handshake + admin list_topics on Redpanda Serverless.
 
     Catches: credentials rotated, cluster paused, network block,
@@ -185,10 +184,11 @@ def test_kafka_auth_and_list_topics(require_env):
         "KAFKA_TOPIC",
     )
 
-    try:
-        from kafka.admin import KafkaAdminClient  # type: ignore[import-untyped]
-    except ImportError:
-        pytest.skip("kafka-python not installed — add to nightly workflow requirements")
+    # NOT try/except ImportError -> pytest.skip. kafka-python 2.0.x cannot
+    # import on Python 3.12 (kafka.vendor.six.moves is gone), so a skip here
+    # would have converted a completely broken Kafka probe into a passing
+    # nightly. require_import fails instead — see conftest for the rationale.
+    KafkaAdminClient = require_import("kafka.admin", "KafkaAdminClient")  # noqa: N806 (a class)
 
     t0 = time.monotonic()
     admin = KafkaAdminClient(


### PR DESCRIPTION
Promotion of the current `dev` to production.

**Included**
- **core#408** (Eng) — `glama.json` + `datanika-mcp/Dockerfile` for the Glama listing. Built and run, not just specified: `initialize` → protocol 2025-06-18, `tools/list` → 25 tools from the real container. **This is the last gate on Growth's Glama chain → the dofollow backlink.**
- **core#407** (QA) — connector smoke matrix 5 → 7 (Shopify + GA4) against live vendor APIs, and a fix for the matrix reporting green while testing nothing. Gate intact: 12 skip in 0.15s without `DATANIKA_CONNECTOR_SMOKE=1`.

Merge strategy: `--merge` (merge commit) per `plans/infra/RUNBOOK_DEV_TO_MASTER.md`, so `master` stays a descendant of `dev` and the post-promotion resync is a clean fast-forward.