### PR TITLE
[Product] Consent screen leaves in the same tab, not a new one (closes #417)

### DIFF
--- a/datanika/ui/state/mcp_consent_state.py
+++ b/datanika/ui/state/mcp_consent_state.py
@@ -250,7 +250,14 @@ class McpConsentState(rx.State):
             return
         # ``is_submitting`` deliberately stays set: the button holds its
         # "Approving…" state until the browser leaves for the client.
-        yield rx.redirect(redirect_to, is_external=True)
+        #
+        # Not ``is_external=True`` (#417). That flag reads like "this URL is
+        # off-site" but Reflex means it literally — ``window.open(path,
+        # "_blank")`` — so the callback opened in a second tab and left this
+        # one on a disabled button forever. The default path already handles
+        # cross-origin: it compares hosts and calls ``window.location.assign``,
+        # which is what an authorization-code redirect is supposed to do.
+        yield rx.redirect(redirect_to)
 
     def deny(self):
         """Send the user back empty-handed, per RFC 6749 §4.1.2.1."""
@@ -261,9 +268,8 @@ class McpConsentState(rx.State):
         if state:
             query["state"] = state
         separator = "&" if "?" in self.verified_redirect_uri else "?"
-        return rx.redirect(
-            f"{self.verified_redirect_uri}{separator}{urlencode(query)}", is_external=True
-        )
+        # Same tab, for the same reason as ``allow`` — see #417.
+        return rx.redirect(f"{self.verified_redirect_uri}{separator}{urlencode(query)}")
 
     @staticmethod
     def _describe(response: httpx.Response) -> str:

--- a/tests/test_ui/test_mcp_consent_state.py
+++ b/tests/test_ui/test_mcp_consent_state.py
@@ -84,13 +84,18 @@ def _fake_state(params: dict | None = None, *, access_token: str = "jwt-token", 
     return state
 
 
-def _redirect_target(spec) -> str:
-    """The URL an ``rx.redirect`` EventSpec sends the browser to."""
+def _redirect_arg(spec, arg: str):
+    """One argument of an ``rx.redirect`` EventSpec, by name."""
     assert spec is not None, "expected a redirect, got None"
     for name, value in spec.args:
-        if name._js_expr == "path":
+        if name._js_expr == arg:
             return value._var_value
-    raise AssertionError("EventSpec is not a redirect")
+    raise AssertionError(f"EventSpec has no {arg!r} argument")
+
+
+def _redirect_target(spec) -> str:
+    """The URL an ``rx.redirect`` EventSpec sends the browser to."""
+    return _redirect_arg(spec, "path")
 
 
 async def _events(result) -> list:
@@ -234,6 +239,43 @@ class TestAllowPreconditions:
         assert target.startswith("/login?next=")
         resumed = parse_qs(urlparse(target).query)["next"][0]
         assert parse_qs(urlparse(resumed).query)["client_id"] == ["mcp_test"]
+
+
+class TestLeavesInTheSameTab:
+    """Both outcomes must navigate *this* tab, not open a second one (#417).
+
+    ``rx.redirect(..., is_external=True)`` reads like "this URL is off-site"
+    but Reflex means it literally — ``window.open(path, "_blank")``. The
+    callback opened in a new tab and left the consent screen sitting on a
+    disabled "Approving…" button forever. The flow still completed, which is
+    why it survived: every assertion here checked the destination URL, and the
+    destination was right. Only the tab was wrong.
+
+    Reflex's default path already handles cross-origin — it compares hosts and
+    calls ``window.location.assign`` — so the fix was to stop asking.
+    """
+
+    async def test_allow_does_not_open_a_new_tab(self, backend, registered, session_jwt):
+        state = _fake_state(_params(client_id=registered["client_id"]), access_token=session_jwt)
+
+        with patch("datanika.services.mcp_oauth_routes.settings.secret_key", _SECRET):
+            await McpConsentState.load_consent.fn(state)
+            emitted = await _events(McpConsentState.allow.fn(state))
+
+        assert _redirect_arg(emitted[0], "external") is False
+
+    def test_deny_does_not_open_a_new_tab(self):
+        state = _fake_state(verified_redirect_uri=_REDIRECT, request_params=_params())
+
+        assert _redirect_arg(McpConsentState.deny.fn(state), "external") is False
+
+    async def test_the_login_bounce_stays_in_the_tab_too(self):
+        """A second tab here would leave the request behind in the first."""
+        state = _fake_state(_params(), access_token="")
+
+        spec = await McpConsentState.load_consent.fn(state)
+
+        assert _redirect_arg(spec, "external") is False
 
 
 class TestConsentCopyMatchesTheGrant:


### PR DESCRIPTION
Closes #417. Found by Infra in the SPEC_REMOTE_MCP §13 browser smoke.

Clicking **Allow** on `/oauth/consent` opened the callback in a **new tab** and left the original sitting on a disabled "Approving…" button forever. The flow completed — the client got its code, the grant was minted — but the screen we are about to point marketing at looked hung.

## Cause

Both outcomes ended with `rx.redirect(..., is_external=True)`. That argument reads like "this URL is off-site". Reflex means it literally — `reflex/event.py:1002` documents it as *"Whether to open in new tab or not"*, and the client obeys:

```js
if (event.payload.external) {
  window.open(event.payload.path, "_blank", "noopener" + (...));
  return false;
}
```

## Fix

Drop the flag from `allow` and `deny`. Reflex's **default** path already handles cross-origin correctly, a few lines further down the same handler:

```js
const url = urlFrom(event.payload.path);
if (url && url.host !== window.location.host) {
  window.location.assign(event.payload.path);   // same tab, external URL
  return false;
}
```

So `rx.redirect(redirect_to)` navigates the current tab to the client's `redirect_uri` — which is what an authorization-code redirect is supposed to do. No new API, no `call_script` escape hatch; the framework already had the right behaviour behind the flag I should not have set.

## Why the existing tests missed it

Every assertion checked the **destination URL**, and the destination was always right. Only the tab was wrong, and nothing looked at that. The new `TestLeavesInTheSameTab` asserts on the emitted `EventSpec`'s `external` argument instead.

I verified the guard bites rather than assuming: with `is_external=True` restored, `test_allow_does_not_open_a_new_tab` fails and **all 31 other tests still pass** — reproducing exactly the state this shipped in.

Covers all three redirects: Allow, Deny, and the logged-out bounce to `/login` (a second tab there would strand the authorization request in the first).

## Also filed, not fixed here

[#418](https://github.com/datanika-io/datanika-core/issues/418) — I audited the other five `is_external` uses in `ui/`:

- **`login.py:79/:90` — the Google and GitHub buttons have the same bug, live.** The provider opens in a second tab; the user ends up signed in *there* while the original `/login` tab still shows the form. It compounds the known `next`-through-social-login gap, so the one-click flow's worst path is a Google user.
- `cost_estimator_card.py:105` and `elt_nudge_card.py:74` link `href="/pricing/"` with `is_external=True` — root-relative, so it opens `app.datanika.io/pricing/`, a route the app does not serve. Dormant (both are behind `datanika_dual_mode_ux_enabled`, off).
- `dashboard.py:243` → `https://datanika.io/docs` is correct as-is.

Kept out of this PR deliberately: the login change alters sign-in behaviour for every user and deserves its own review, not a ride-along in a consent-screen fix.

Precheck green: ruff + format clean, **2402 passed, 23 skipped**.
