### PR TITLE
[Engineering] e2e_seed teardown: delete the OAuth chain before api_keys (closes #415)

### DIFF
--- a/datanika/scripts/e2e_seed.py
+++ b/datanika/scripts/e2e_seed.py
@@ -49,6 +49,7 @@ from datanika.models.catalog_entry import CatalogEntry
 from datanika.models.connection import Connection, ConnectionType
 from datanika.models.dependency import Dependency, NodeType
 from datanika.models.invitation import Invitation
+from datanika.models.mcp_oauth import OAuthGrant, OAuthToken
 from datanika.models.notification import Notification
 from datanika.models.notification_channel import NotificationChannel
 from datanika.models.pipeline import DbtCommand, Pipeline
@@ -181,6 +182,31 @@ def _assert_safe_target() -> None:
                 )
 
 
+def _delete_oauth_chain(session: Session, api_key_ids) -> None:
+    """Remove OAuth grants/tokens hanging off the API keys about to be deleted.
+
+    Remote-MCP P2 (core#395) added ``oauth_grants.api_key_id -> api_keys.id`` and
+    ``oauth_tokens.grant_id -> oauth_grants.id``, which made ``api_keys``
+    undeletable once anyone completes a hosted-MCP consent in a fixture org.
+    The teardown wasn't extended, so a single authorization wedged **every**
+    later ``e2e-staging`` run in global setup with a ForeignKeyViolation, and
+    it did not self-heal (core#415). Revoking doesn't help: revocation is a soft
+    delete, so the row and its references survive.
+
+    ``api_key_ids`` is a select() rather than a list so the caller doesn't have
+    to materialise ids it is about to delete anyway.
+    """
+    grant_ids = list(
+        session.execute(select(OAuthGrant.id).where(OAuthGrant.api_key_id.in_(api_key_ids)))
+        .scalars()
+        .all()
+    )
+    if not grant_ids:
+        return
+    session.execute(OAuthToken.__table__.delete().where(OAuthToken.grant_id.in_(grant_ids)))
+    session.execute(OAuthGrant.__table__.delete().where(OAuthGrant.id.in_(grant_ids)))
+
+
 def _tear_down_fixture(session: Session) -> None:
     """Hard-delete both fixture orgs and everything scoped to them.
 
@@ -223,6 +249,13 @@ def _tear_down_fixture(session: Session) -> None:
         session.execute(Upload.__table__.delete().where(Upload.org_id.in_(org_ids)))
         session.execute(Pipeline.__table__.delete().where(Pipeline.org_id.in_(org_ids)))
         session.execute(Transformation.__table__.delete().where(Transformation.org_id.in_(org_ids)))
+        # Two different FKs reach these tables, so both axes are needed:
+        # by api_key (they block the api_keys delete just below) and by org
+        # (they are TenantMixin rows and would block the organizations delete
+        # at the end of this list).
+        _delete_oauth_chain(session, select(ApiKey.id).where(ApiKey.org_id.in_(org_ids)))
+        session.execute(OAuthToken.__table__.delete().where(OAuthToken.org_id.in_(org_ids)))
+        session.execute(OAuthGrant.__table__.delete().where(OAuthGrant.org_id.in_(org_ids)))
         session.execute(ApiKey.__table__.delete().where(ApiKey.org_id.in_(org_ids)))
         session.execute(Connection.__table__.delete().where(Connection.org_id.in_(org_ids)))
         session.execute(Membership.__table__.delete().where(Membership.org_id.in_(org_ids)))
@@ -231,6 +264,7 @@ def _tear_down_fixture(session: Session) -> None:
     users = list(session.execute(select(User).where(User.email.in_(fixture_user_emails))).scalars())
     user_ids = [u.id for u in users]
     if user_ids:
+        _delete_oauth_chain(session, select(ApiKey.id).where(ApiKey.user_id.in_(user_ids)))
         session.execute(ApiKey.__table__.delete().where(ApiKey.user_id.in_(user_ids)))
         session.execute(Membership.__table__.delete().where(Membership.user_id.in_(user_ids)))
         session.execute(User.__table__.delete().where(User.id.in_(user_ids)))

--- a/tests/test_scripts/test_e2e_seed.py
+++ b/tests/test_scripts/test_e2e_seed.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from datanika.models.api_key import ApiKey
 from datanika.models.connection import Connection, ConnectionType
+from datanika.models.mcp_oauth import OAuthGrant, OAuthToken
 from datanika.models.pipeline import Pipeline
 from datanika.models.schedule import Schedule
 from datanika.models.transformation import Transformation
@@ -494,3 +496,130 @@ def test_fixture_duckdb_path_is_platform_agnostic():
 
     assert FIXTURE_DUCKDB_PATH.startswith(tempfile.gettempdir())
     assert FIXTURE_DUCKDB_PATH.endswith("e2e_fixture.duckdb")
+
+
+class TestTeardownWithOAuthGrants:
+    """Regression: Remote-MCP P2 made api_keys undeletable by the teardown (#415).
+
+    P2 (#395) added ``oauth_grants.api_key_id -> api_keys.id`` and
+    ``oauth_tokens.grant_id -> oauth_grants.id``. ``_tear_down_fixture`` hard-
+    deletes ``api_keys`` for the fixture orgs and was never extended, so a
+    single completed OAuth consent in a fixture org **permanently wedges the
+    e2e seed** — every later ``e2e-staging`` run dies in global setup with a
+    ForeignKeyViolation until someone deletes rows by hand. Not self-healing,
+    and it surfaces as an opaque setup error rather than a test failure.
+
+    Revocation does not save us: it is a soft delete, so the row and its FK
+    references remain.
+
+    **These tests enable ``PRAGMA foreign_keys``.** SQLite ignores foreign keys
+    by default (verified: the pragma reads 0 on this engine), so without it the
+    teardown would "pass" here while still failing on Postgres — the guard
+    would assert nothing, which is worse than no guard at all.
+    """
+
+    @pytest.fixture
+    def fk_enforced(self):
+        """A session on its own engine, with foreign keys actually enforced.
+
+        The shared ``db_session`` fixture cannot be used: it holds an open
+        transaction, and SQLite silently ignores ``PRAGMA foreign_keys`` inside
+        one — the pragma read back as 0. So enforcement is set on *connect*,
+        and asserted, because a guard that quietly runs without foreign keys
+        would pass while the production path stays broken.
+        """
+        from sqlalchemy import create_engine, event
+        from sqlalchemy.orm import Session as SaSession
+
+        from datanika.models.base import Base
+
+        engine = create_engine("sqlite:///:memory:")
+
+        @event.listens_for(engine, "connect")
+        def _enable_fk(dbapi_connection, _record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+        Base.metadata.create_all(engine)
+        session = SaSession(bind=engine)
+        assert session.execute(text("PRAGMA foreign_keys")).scalar() == 1
+        try:
+            yield session
+        finally:
+            session.close()
+            engine.dispose()
+
+    def _grant_for_fixture_org(self, session):
+        """Mimic a completed hosted-MCP consent inside the fixture org."""
+        org = session.execute(
+            select(Organization).where(Organization.slug == FIXTURE_ORG_SLUG)
+        ).scalar_one()
+        user = session.execute(select(User).where(User.email == FIXTURE_USER_EMAIL)).scalar_one()
+        # Consent mints the key (SPEC_REMOTE_MCP §5.3), so create it here rather
+        # than relying on the seed — this is what a hosted authorization leaves
+        # behind in a fixture org.
+        key = ApiKey(org_id=org.id, user_id=user.id, name="MCP: Claude.ai", key_hash="k" * 64)
+        session.add(key)
+        session.flush()
+        grant = OAuthGrant(
+            client_id="mcp_e2e_client",
+            org_id=org.id,
+            user_id=user.id,
+            api_key_id=key.id,
+            encrypted_api_key="not-a-real-token",
+            code_hash=None,
+            code_challenge="x" * 43,
+            redirect_uri="https://claude.ai/api/mcp/auth_callback",
+            scope="connections:read",
+            resource="https://app.datanika.io/mcp",
+            code_expires_at=datetime.now(UTC),
+        )
+        session.add(grant)
+        session.flush()
+        session.add(
+            OAuthToken(
+                grant_id=grant.id,
+                org_id=org.id,
+                access_token_hash="a" * 64,
+                refresh_token_hash="r" * 64,
+                expires_at=datetime.now(UTC),
+            )
+        )
+        session.flush()
+        return grant
+
+    def test_teardown_succeeds_after_a_consent(self, fk_enforced):
+        session = fk_enforced
+        seed(session=session)
+        self._grant_for_fixture_org(session)
+
+        # Re-seeding tears the fixture down first — this is the exact path that
+        # blew up in e2e-staging global setup.
+        seed(session=session)
+
+        assert session.execute(select(OAuthToken)).scalars().first() is None
+        assert session.execute(select(OAuthGrant)).scalars().first() is None
+
+    def test_teardown_clears_grants_owned_via_the_user_branch(self, fk_enforced):
+        """api_keys are deleted twice — by org *and* by user. Both need the chain."""
+        session = fk_enforced
+        seed(session=session)
+        grant = self._grant_for_fixture_org(session)
+        # Point the grant at a key reached only through the user-id delete.
+        user = session.execute(select(User).where(User.email == FIXTURE_USER_EMAIL)).scalar_one()
+        # A real org that is *not* a fixture org: the org-branch delete skips it,
+        # so the key is only reachable through the user-id delete. (It has to
+        # exist — with foreign keys on, an invented org_id fails on insert.)
+        other_org = Organization(name="Not A Fixture", slug="not-a-fixture-org")
+        session.add(other_org)
+        session.flush()
+        orphan = ApiKey(org_id=other_org.id, user_id=user.id, name="user-scoped", key_hash="h" * 64)
+        session.add(orphan)
+        session.flush()
+        grant.api_key_id = orphan.id
+        session.flush()
+
+        seed(session=session)
+
+        assert session.execute(select(OAuthGrant)).scalars().first() is None


### PR DESCRIPTION
Closes #415. My own regression from Remote-MCP P2 (#395).

P2 added `oauth_grants.api_key_id → api_keys.id` and `oauth_tokens.grant_id → oauth_grants.id`. `_tear_down_fixture()` hard-deletes `api_keys` and was never extended, so **one completed hosted-MCP consent in a fixture org permanently wedged the e2e seed** — every later `e2e-staging` run died in global setup, didn't self-heal, and surfaced as an opaque setup error rather than a test failure. Revoking doesn't help: revocation is a soft delete, so the row and its references survive.

## Both axes, not one

The teardown now clears the chain on **two** axes, because two different foreign keys reach these tables:

| axis | what it unblocks |
|---|---|
| by `api_key` | the `api_keys` delete — the reported failure |
| by `org` | the `organizations` delete at the end of the same list, since these are TenantMixin rows |

`api_keys` are deleted **twice** (once by org, once by user), so the chain runs before each.

**The second axis wasn't in the report and I didn't spot it by reading.** After fixing only the `api_key` path the tests went green on one case and red on the other — teardown had simply moved on to failing at `DELETE FROM organizations`. Worth stating plainly: the fix as described in the issue would have shipped a still-broken teardown.

## Why these tests are honest

They run on their **own engine** with `PRAGMA foreign_keys=ON` set at connect time, and assert the pragma actually took. Two things would otherwise have made this guard worthless:

- **SQLite ignores foreign keys by default** — verified, the pragma reads `0` on the shared test engine. A regression test for an FK violation on a database not enforcing FKs asserts nothing.
- **The pragma is silently a no-op inside an open transaction**, which is exactly what the shared `db_session` fixture holds. My first attempt did it that way; the assertion caught it reading back as `0`.

Written the obvious way, this test passes while production stays broken. As written it reproduces the exact staging error before the fix:

```
IntegrityError ... DELETE FROM api_keys WHERE api_keys.org_id IN (?, ?)
```

## On `ON DELETE CASCADE`

Raised on the issue; **not doing it here.** Production revokes keys *softly*, so a cascade would never fire on the real path — only on test teardown and any future hard-delete — while silently destroying the grant rows that record who authorized what. That's an audit trail, and deleting it should be a decision someone makes when org deletion is built, not a side effect of a hotfix. The explicit ordered delete is narrow, visible, and testable.

Full precheck green: ruff + format clean, **2401 passed**.
