### PR TITLE
[QA] Close the remaining silent-green skips outside the smoke suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ dev = [
     "ruff>=0.9",
     "httpx>=0.28",
     "mcp>=1.0.0",
+    # Used by tests/test_mcp/test_registry_manifests.py to parse smithery.yaml.
+    # Previously relied on as an undeclared transitive dep, which let those
+    # manifest-drift guards skip themselves if it ever went missing (core#407 sweep).
+    "pyyaml>=6.0",
     # Round-trip migration test auto-provisions Postgres via Docker.
     # Skipped gracefully if Docker is unavailable (see tests/test_migrations/test_roundtrip.py).
     "testcontainers[postgres]>=4.0",

--- a/tests/test_mcp/test_registry_manifests.py
+++ b/tests/test_mcp/test_registry_manifests.py
@@ -11,7 +11,12 @@ import re
 import tomllib
 from pathlib import Path
 
-import pytest
+# Imported unconditionally, not via ``pytest.importorskip``. These tests are the
+# only guard against smithery.yaml drifting from the shipped package, so a skip
+# here means the manifest ships unchecked while CI stays green. PyYAML was an
+# undeclared transitive dependency until this was noticed — it is now an explicit
+# dev dependency so the guard cannot quietly stop running (core#407 sweep).
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MCP_DIR = _REPO_ROOT / "datanika-mcp"
@@ -104,7 +109,6 @@ class TestPypiOwnershipMarker:
 
 class TestSmitheryYaml:
     def test_stdio_startcommand_with_api_key_required(self):
-        yaml = pytest.importorskip("yaml")
         data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
         start = data["startCommand"]
         assert start["type"] == "stdio"
@@ -113,7 +117,6 @@ class TestSmitheryYaml:
         assert set(schema["properties"]) == {"url", "apiKey", "allowWrite"}
 
     def test_command_invokes_the_package(self):
-        yaml = pytest.importorskip("yaml")
         data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
         cmd = data["startCommand"]["commandFunction"]
         assert "datanika-mcp" in cmd

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -57,6 +57,30 @@ def _docker_available() -> bool:
         return False
 
 
+def _no_postgres(reason: str) -> None:
+    """Skip locally when Postgres is unavailable — but FAIL in CI.
+
+    The ``migration-roundtrip`` job runs *only* this file, so if these tests
+    skip, the job exits 0 and reports green having verified nothing — while
+    the thing it guards (a downgrade that only matters at 2 AM during a prod
+    rollback) goes unchecked. CI always has both Docker and
+    ``DATABASE_URL_SYNC_TEST``, so reaching here in CI means the workflow
+    broke, and that must be loud.
+
+    Locally, skipping stays correct: devs without Docker shouldn't be blocked.
+    Same reasoning as the connector smoke suite's strict mode (core#407).
+    """
+    if os.environ.get("CI"):
+        pytest.fail(
+            f"{reason}\n\n"
+            "This is a hard failure because CI is expected to provide Postgres "
+            "(DATABASE_URL_SYNC_TEST, or Docker for testcontainers). Skipping here "
+            "would let the migration-roundtrip job pass without testing a single "
+            "migration. Check the job's env block and service container."
+        )
+    pytest.skip(reason)
+
+
 @pytest.fixture(scope="session")
 def roundtrip_db_url():
     """Postgres URL for round-trip tests.
@@ -64,7 +88,7 @@ def roundtrip_db_url():
     Priority:
     1. ``DATABASE_URL_SYNC_TEST`` env var (CI, or manual override)
     2. testcontainers[postgres] auto-provisioned container (local with Docker)
-    3. skip the test (local without Docker)
+    3. skip the test locally — but **fail** in CI (see ``_no_postgres``)
 
     Must be a generator (yield-based) on every path — pytest treats a
     function with any `yield` as a generator, and hitting `return` on
@@ -77,15 +101,15 @@ def roundtrip_db_url():
         return
 
     if not _docker_available():
-        pytest.skip(
+        _no_postgres(
             "Round-trip test requires Postgres. Set DATABASE_URL_SYNC_TEST or run "
-            "with Docker Desktop running. CI always has Docker + the env var set."
+            "with Docker Desktop running."
         )
 
     try:
         from testcontainers.postgres import PostgresContainer
     except ImportError:
-        pytest.skip(
+        _no_postgres(
             "testcontainers not installed. Install with: "
             "`uv pip install 'testcontainers[postgres]'` or run CI instead."
         )

--- a/tests/test_services/test_sso_saml_forgery.py
+++ b/tests/test_services/test_sso_saml_forgery.py
@@ -12,8 +12,15 @@ issues no token.** The Redis request-id gate is patched OPEN so the forgery is
 rejected by the SAML *validator* (the fix), not the replay defence — a future
 regression that weakened signature validation would flip this red.
 
-python3-saml/xmlsec is a main dependency, so CI + Docker always run this; the
-``importorskip`` only guards a stale local venv.
+python3-saml/xmlsec is a **main** dependency, so this imports it unconditionally
+rather than via ``pytest.importorskip``. That is deliberate: a security regression
+probe must never be able to stop guarding quietly. ``xmlsec`` is a compiled binding
+that installs cleanly and then fails to import when its system libs are missing
+(``libxmlsec1.so.1: cannot open shared object file``) — under ``importorskip`` that
+would silently skip this probe and leave CI green while the auth-bypass invariant
+went unchecked. Exactly the failure mode that nearly hid a broken Kafka probe in
+core#407. A hard import turns the same situation into a red build, which is the
+only safe direction for this particular test.
 """
 
 import base64
@@ -21,14 +28,16 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-import pytest
+# Import guard, deliberately mirroring the production import path: sso_routes
+# imports OneLogin_Saml2_Auth *inside* the callback (not at module scope), so
+# importing sso_routes below would NOT surface a broken xmlsec. Importing it
+# here means a runtime-broken dependency fails collection instead of quietly
+# un-guarding the auth-bypass invariant.
+from onelogin.saml2.auth import OneLogin_Saml2_Auth  # noqa: F401
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
 
-pytest.importorskip("onelogin.saml2")  # xmlsec/python3-saml needed to drive the real validator
-
-from starlette.applications import Starlette  # noqa: E402
-from starlette.testclient import TestClient  # noqa: E402
-
-from datanika.services.sso_routes import _sign_state, sso_routes  # noqa: E402
+from datanika.services.sso_routes import _sign_state, sso_routes
 
 
 def _self_signed_idp_cert() -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -968,6 +968,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "testcontainers" },
 ]
@@ -1008,6 +1009,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
     { name = "python3-saml", specifier = ">=1.16,<2" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "redis", specifier = ">=5.0" },
     { name = "reflex", specifier = ">=0.7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },


### PR DESCRIPTION
Follow-on sweep from #407. The connector smoke suite itself is now clean — no `except → pytest.skip` remains there. But the **same idiom** was still live in three places outside it, each guarding something that matters.

## What could silently stop guarding

| Site | What it guards | Why the skip was dangerous |
|---|---|---|
| `test_sso_saml_forgery` — `importorskip("onelogin.saml2")` | The **P0 SAML auth-bypass** regression invariant | `xmlsec` is a compiled binding: it installs cleanly and then fails to import when its system libs are absent (`libxmlsec1.so.1: cannot open shared object file`). Under `importorskip` that silently un-guards an account-takeover bug while CI stays green |
| `test_registry_manifests` — `importorskip("yaml")` ×2 | `smithery.yaml` not drifting from the shipped package | PyYAML was an **undeclared transitive dep**, so the guard could vanish on any lockfile change |
| `test_roundtrip` — `pytest.skip` when Postgres is unreachable | Alembic downgrade correctness | The `migration-roundtrip` job runs **only this file**, so all-skipped means the job exits 0 having verified no migration — on the path that only matters at 2 AM during a prod rollback |

## Fixes

1. **SAML probe: hard import.** It deliberately imports `OneLogin_Saml2_Auth`, mirroring the production path — `sso_routes` imports it *inside* the callback, not at module scope, so importing `sso_routes` would **not** have surfaced a broken xmlsec. Verified by reading the source, not assumed.
2. **Manifest guards: hard import**, plus `pyyaml` declared in dev deps (with the `uv.lock` entry) so the dependency can't quietly disappear again.
3. **Roundtrip: skips locally, FAILS when `CI` is set.** Devs without Docker are still unblocked; CI can no longer pass the job without testing a migration.

## Verified by breaking each thing

```
SAML probe                         3 passed   (previously able to skip itself)
manifest guards                   10 passed   (previously able to skip themselves)
roundtrip, docker hidden, no CI    3 skipped   <- local dev unaffected
roundtrip, docker hidden, CI=true  hard failure with triage message
full suite                      2402 passed, 20 skipped, 0 failed
```

## Checked and deliberately left alone

`contextlib.suppress(Exception)` in `test_wave1_connectors_extract_load` is correctly scoped to a single idempotent `DROP TABLE`; the `CREATE`/`INSERT` that follow are unsuppressed, so a real failure still surfaces. Not every suppression is a silent-green — this one is right.

## Note for reviewers

The remaining 20 skips in the full suite are the connector smoke suite, which correctly skips in PR CI (no sandbox credentials). #407 added a guard so that *any* skip fails the nightly, where those probes are supposed to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)