### PR TITLE
[Engineering] OpenAPI P2: spec-driven pagination detection (closes #411)

### DIFF
--- a/datanika/services/openapi_import.py
+++ b/datanika/services/openapi_import.py
@@ -110,7 +110,7 @@ def parse_openapi_spec(raw: str | dict, *, base_url_override: str | None = None)
         op = item.get("get")
         if not isinstance(op, dict):
             continue
-        resource = _resource_from_get(spec, path, op, warnings)
+        resource = _resource_from_get(spec, path, item, op, warnings)
         if resource is not None:
             resources.append(resource)
         if len(resources) > MAX_RESOURCES:
@@ -165,7 +165,9 @@ def _extract_auth(spec: dict, warnings: list[str]) -> list[dict]:
     return out
 
 
-def _resource_from_get(spec: dict, path: str, op: dict, warnings: list[str]) -> dict | None:
+def _resource_from_get(
+    spec: dict, path: str, path_item: dict, op: dict, warnings: list[str]
+) -> dict | None:
     item_schema, data_selector = _response_item_schema(spec, op)
     if item_schema is None:
         warnings.append(f"Skipped GET {path} — no array/collection JSON response schema.")
@@ -174,6 +176,17 @@ def _resource_from_get(spec: dict, path: str, op: dict, warnings: list[str]) -> 
     endpoint: dict = {"path": path.lstrip("/"), "method": "GET"}
     if data_selector:
         endpoint["data_selector"] = data_selector
+
+    response = _success_response(spec, op) or {}
+    envelope = resolve_ref(
+        spec, (((response.get("content") or {}).get("application/json")) or {}).get("schema")
+    )
+    envelope_props = (envelope or {}).get("properties") or {}
+    paginator = _paginator_from_operation(
+        spec, path_item, op, envelope_props, response.get("headers") or {}
+    )
+    if paginator:
+        endpoint["paginator"] = paginator
     resource: dict = {
         "name": _resource_name(path),
         "endpoint": endpoint,
@@ -184,6 +197,122 @@ def _resource_from_get(spec: dict, path: str, op: dict, warnings: list[str]) -> 
     if pk:
         resource["primary_key"] = pk
     return resource
+
+
+# --- Pagination detection (P2, core#411) -----------------------------------
+#
+# P1 emitted nothing and relied on dlt's runtime auto-detection, which fails
+# *silently*: a wrong guess stops after page 1 and looks like a small table
+# rather than an error. These heuristics are the shapes real specs declare,
+# ordered most-authoritative first — a next-link in the body or a Link header
+# is a statement of fact, whereas query-parameter names are inference.
+#
+# Emitted configs match dlt's own paginator constructors (PAGINATOR_MAP);
+# nothing here invents a config shape dlt would reject.
+
+_OFFSET_PARAMS = (("offset", "limit"), ("skip", "top"), ("skip", "take"), ("start", "count"))
+_PAGE_PARAMS = ("page", "page_number", "pagenum")
+_CURSOR_PARAMS = ("cursor", "after", "page_token", "next_token", "starting_after")
+_NEXT_LINK_KEYS = ("next", "next_url", "next_page_url", "nextPageUrl", "next_page")
+_CURSOR_RESPONSE_KEYS = ("next_cursor", "cursor", "next_page_token", "next_token", "end_cursor")
+_TOTAL_KEYS = ("total", "total_count", "totalCount", "count", "total_results")
+
+_DEFAULT_PAGE_SIZE = 100
+
+
+def _query_params(spec: dict, path_item: dict, op: dict) -> dict[str, dict]:
+    """Query parameters for an operation, including path-level inherited ones."""
+    out: dict[str, dict] = {}
+    for raw in list(path_item.get("parameters") or []) + list(op.get("parameters") or []):
+        param = resolve_ref(spec, raw)
+        if isinstance(param, dict) and param.get("in") == "query" and param.get("name"):
+            out[str(param["name"])] = param
+    return out
+
+
+def _page_size(param: dict | None) -> int:
+    """Prefer the API's declared ceiling over a number we made up."""
+    schema = (param or {}).get("schema") or {}
+    for key in ("maximum", "default"):
+        value = schema.get(key)
+        if isinstance(value, int) and value > 0:
+            return value
+    return _DEFAULT_PAGE_SIZE
+
+
+def _first_key(props: dict, candidates) -> str | None:
+    lowered = {k.lower(): k for k in props}
+    for candidate in candidates:
+        if candidate.lower() in lowered:
+            return lowered[candidate.lower()]
+    return None
+
+
+def _paginator_from_operation(
+    spec: dict, path_item: dict, op: dict, envelope_props: dict, response_headers: dict
+) -> dict | None:
+    """Derive a dlt paginator config, or ``None`` to leave dlt's guess alone."""
+    # 1. A next-URL in the body: authoritative, no inference needed.
+    next_key = _first_key(envelope_props, _NEXT_LINK_KEYS)
+    if next_key:
+        return {"type": "json_link", "next_url_path": next_key}
+
+    # 2. A declared Link header: RFC 5988, equally authoritative.
+    if _first_key(response_headers, ("link",)):
+        return {"type": "header_link"}
+
+    params = _query_params(spec, path_item, op)
+    total_key = _first_key(envelope_props, _TOTAL_KEYS)
+
+    # 3. Cursor: only when the request carries one *and* the response returns
+    #    one — a lone `cursor` param with nowhere to read the next value from
+    #    would page forever against the same cursor.
+    cursor_param = _first_key(params, _CURSOR_PARAMS)
+    cursor_key = _first_key(envelope_props, _CURSOR_RESPONSE_KEYS)
+    if cursor_param and cursor_key:
+        return {"type": "cursor", "cursor_param": cursor_param, "cursor_path": cursor_key}
+
+    # 4. Offset/limit under any of its common spellings.
+    for offset_name, limit_name in _OFFSET_PARAMS:
+        offset_param = _first_key(params, (offset_name,))
+        limit_param = _first_key(params, (limit_name,))
+        if offset_param and limit_param:
+            return {
+                "type": "offset",
+                "offset_param": offset_param,
+                "limit_param": limit_param,
+                "limit": _page_size(params.get(limit_param)),
+                # dlt defaults total_path to "total"; leaving that in place for
+                # an API with no such field makes it hunt for a key that never
+                # arrives. None falls back to stop-on-empty-page.
+                "total_path": total_key,
+            }
+
+    # 5. Page number.
+    page_param = _first_key(params, _PAGE_PARAMS)
+    if page_param:
+        return {"type": "page_number", "page_param": page_param, "total_path": total_key}
+
+    # Nothing declared — stay silent rather than guess; dlt's runtime
+    # auto-detection is still there and is a better guess than ours.
+    return None
+
+
+def _success_response(spec: dict, op: dict) -> dict | None:
+    """The resolved success response object for a GET, if any."""
+    responses = op.get("responses") or {}
+    resp = None
+    for code in ("200", "201", "2XX", "default"):
+        if code in responses:
+            resp = responses[code]
+            break
+    if resp is None:
+        for code, r in responses.items():
+            if str(code).startswith("2"):
+                resp = r
+                break
+    resp = resolve_ref(spec, resp)
+    return resp if isinstance(resp, dict) else None
 
 
 def _response_item_schema(spec: dict, op: dict) -> tuple[dict | None, str | None]:

--- a/tests/test_services/test_openapi_pagination.py
+++ b/tests/test_services/test_openapi_pagination.py
@@ -1,0 +1,227 @@
+"""Spec-driven pagination detection (core#411, OpenAPI P2).
+
+P1 emitted no paginator and leaned on dlt's *runtime* auto-detection. When that
+guesses wrong the extract silently stops after page 1 — which surfaces as an
+empty or short table, not an error. That is the same silent-green class as the
+MCP deadlock (a 200 carrying an error string) and the e2e teardown (an opaque
+setup failure): the pipeline reports success and the data is wrong.
+
+So the load-bearing test here is **behavioural**, not structural:
+``TestPaginationActuallyPagesThroughData`` serves two real pages over a real
+socket and asserts a row that **cannot appear on page one** arrives. A test that
+only asserts the emitted config "looks right" passes just as happily against a
+paginator that never advances — which is precisely the bug being prevented.
+
+Emitted configs are the shapes dlt actually accepts (verified against
+``dlt.sources.rest_api.config_setup.PAGINATOR_MAP`` and the paginator
+constructors), not invented ones.
+"""
+
+import http.server
+import json
+import threading
+
+import pytest
+
+from datanika.services.openapi_import import parse_openapi_spec
+
+
+def _spec(*, params=None, response_props=None, headers=None, items_key="data") -> dict:
+    """A minimal one-collection spec with pluggable pagination hints."""
+    props = {items_key: {"type": "array", "items": {"$ref": "#/components/schemas/Widget"}}}
+    props.update(response_props or {})
+    response: dict = {
+        "description": "ok",
+        "content": {"application/json": {"schema": {"type": "object", "properties": props}}},
+    }
+    if headers:
+        response["headers"] = headers
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "t", "version": "1"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/widgets": {
+                "get": {
+                    "operationId": "listWidgets",
+                    "parameters": params or [],
+                    "responses": {"200": response},
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Widget": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+                }
+            }
+        },
+    }
+
+
+def _query(name: str, **schema) -> dict:
+    return {"name": name, "in": "query", "schema": schema or {"type": "integer"}}
+
+
+def _paginator_of(spec: dict) -> dict | None:
+    parsed = parse_openapi_spec(spec)
+    return parsed.resources[0]["endpoint"].get("paginator")
+
+
+class TestDetection:
+    def test_offset_limit_params(self):
+        pag = _paginator_of(_spec(params=[_query("offset"), _query("limit")]))
+        assert pag["type"] == "offset"
+        assert pag["offset_param"] == "offset"
+        assert pag["limit_param"] == "limit"
+
+    def test_offset_limit_uses_the_specs_declared_maximum(self):
+        """Respect the API's own ceiling instead of guessing a page size."""
+        pag = _paginator_of(
+            _spec(params=[_query("offset"), _query("limit", type="integer", maximum=250)])
+        )
+        assert pag["limit"] == 250
+
+    def test_skip_top_are_recognised_as_offset(self):
+        """OData-style names are the same pattern under different words."""
+        pag = _paginator_of(_spec(params=[_query("skip"), _query("top")]))
+        assert pag["type"] == "offset"
+        assert pag["offset_param"] == "skip"
+
+    def test_page_number_params(self):
+        pag = _paginator_of(_spec(params=[_query("page"), _query("per_page")]))
+        assert pag["type"] == "page_number"
+        assert pag["page_param"] == "page"
+
+    def test_json_link_beats_query_params(self):
+        """A next-URL in the body is authoritative; params are inference."""
+        pag = _paginator_of(
+            _spec(
+                params=[_query("page")],
+                response_props={"next": {"type": "string"}},
+            )
+        )
+        assert pag["type"] == "json_link"
+        assert pag["next_url_path"] == "next"
+
+    def test_link_header(self):
+        pag = _paginator_of(_spec(headers={"Link": {"schema": {"type": "string"}}}))
+        assert pag["type"] == "header_link"
+
+    def test_cursor_param_with_matching_response_field(self):
+        pag = _paginator_of(
+            _spec(
+                params=[_query("cursor", type="string")],
+                response_props={"next_cursor": {"type": "string"}},
+            )
+        )
+        assert pag["type"] == "cursor"
+        assert pag["cursor_param"] == "cursor"
+        assert pag["cursor_path"] == "next_cursor"
+
+    def test_total_path_only_when_the_spec_declares_one(self):
+        """OffsetPaginator defaults total_path='total'; a spec without that
+        field must get None or dlt looks for a key that never arrives."""
+        without = _paginator_of(_spec(params=[_query("offset"), _query("limit")]))
+        assert without["total_path"] is None
+
+        with_total = _paginator_of(
+            _spec(
+                params=[_query("offset"), _query("limit")],
+                response_props={"total": {"type": "integer"}},
+            )
+        )
+        assert with_total["total_path"] == "total"
+
+    def test_no_hints_emits_no_paginator(self):
+        """Silence beats a guess — dlt's runtime auto-detection still applies."""
+        assert _paginator_of(_spec()) is None
+
+
+class _PagedHandler(http.server.BaseHTTPRequestHandler):
+    """Two pages of widgets, offset/limit style. Page 2 holds id=99."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        offset = 0
+        if "offset=" in self.path:
+            offset = int(self.path.split("offset=")[1].split("&")[0])
+        rows = [{"id": 1, "name": "first"}] if offset == 0 else []
+        if offset == 1:
+            rows = [{"id": 99, "name": "only-on-page-two"}]
+        body = json.dumps({"data": rows}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def paged_api():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _PagedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestPaginationActuallyPagesThroughData:
+    def test_second_page_rows_arrive(self, paged_api, monkeypatch):
+        """The row on page two cannot be produced by a paginator that never
+        advances, so this fails on exactly the bug we are preventing.
+
+        Driven through ``DltRunnerService._build_openapi_source`` — the real
+        production path — rather than hand-assembling a dlt config. The parser
+        emits a *catalog* (with our private ``columns``/``_source`` keys) that
+        dlt rejects outright until the runtime strips them, so a test that
+        built its own config would prove the parser works in a shape nothing
+        actually uses.
+        """
+        import datanika.services.dlt_runner as dlt_runner
+
+        # The egress guard blocks loopback by design; it has its own tests.
+        monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+
+        parsed = parse_openapi_spec(
+            _spec(params=[_query("offset"), _query("limit", type="integer", maximum=1)]),
+            base_url_override=paged_api,
+        )
+        source = dlt_runner.DltRunnerService()._build_openapi_source(
+            {"base_url": paged_api, "resources": parsed.resources}, {}
+        )
+        rows = list(source.resources["widgets"])
+
+        ids = {r["id"] for r in rows}
+        assert 1 in ids, f"page one missing: {rows}"
+        assert 99 in ids, f"never advanced past page one: {rows}"
+
+    def test_control_without_hints_stops_at_page_one(self, paged_api, monkeypatch):
+        """Proves the test above discriminates.
+
+        If dlt's runtime auto-detection reached page two on its own, the
+        assertion above would pass no matter what this parser emitted — a green
+        that measures nothing. With no offset/limit params declared, no
+        paginator is emitted and the extract must stop at page one.
+        """
+        import datanika.services.dlt_runner as dlt_runner
+
+        monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+
+        parsed = parse_openapi_spec(_spec(), base_url_override=paged_api)
+        assert parsed.resources[0]["endpoint"].get("paginator") is None
+        source = dlt_runner.DltRunnerService()._build_openapi_source(
+            {"base_url": paged_api, "resources": parsed.resources}, {}
+        )
+        rows = list(source.resources["widgets"])
+
+        assert {r["id"] for r in rows} == {1}, f"expected page one only, got {rows}"


### PR DESCRIPTION
Closes #411 (the pagination slice; data-selector, incremental and the Swagger 2.0 shim remain on that issue).

P1 emitted no paginator and leaned on dlt's **runtime** auto-detection. When that guesses wrong the extract stops after page one and reports success — an empty or short table, never an error. Same silent-green class as the MCP deadlock (a 200 carrying an error string) and the e2e teardown (an opaque setup failure).

## Detection, most-authoritative first

A next-link in the body is a statement of fact; a parameter name is inference. So:

| order | signal | emits |
|---|---|---|
| 1 | `next` / `next_url` / `next_page_url` in the response body | `json_link` |
| 2 | a declared `Link` response header (RFC 5988) | `header_link` |
| 3 | a cursor-ish query param **and** a matching response field | `cursor` |
| 4 | `offset`+`limit`, `skip`+`top`, `skip`+`take`, `start`+`count` | `offset` |
| 5 | `page` / `page_number` / `pagenum` | `page_number` |

**No hints → emit nothing.** Silence beats a guess, and dlt's auto-detection is still there.

Cursor deliberately requires *both* halves: a lone `cursor` param with no response field to read the next value from would page forever against the same cursor.

Two details that matter more than the heuristics themselves:

- **`limit` comes from the spec's declared `maximum`/`default`**, not a number I invented.
- **`total_path` is `None` unless the spec declares a total field.** `OffsetPaginator` defaults it to `"total"`, so inheriting that against an API without one makes dlt hunt for a key that never arrives.

Configs are the shapes dlt actually accepts — verified against `PAGINATOR_MAP` and the paginator constructors, not written from memory.

## The test that would have caught the bug

Structural assertions on the emitted config pass just as happily against a paginator that never advances. So the load-bearing test serves **two real pages over a real socket** and asserts a row that **cannot appear on page one** arrives.

It's paired with a **control** proving it discriminates: with no hints declared, the same path must stop at page one. Without that control, dlt's own auto-detection reaching page two would make the first test green regardless of anything this parser emits — a green that measures nothing.

Both run through `DltRunnerService._build_openapi_source`, the real production path. That wasn't cosmetic: my first draft hand-assembled a dlt config and **failed validation**, because the parser emits a *catalog* carrying our private `columns` / `_source` keys that dlt rejects until the runtime strips them. A test that built its own config would have proved the parser works in a shape nothing actually uses.

11 tests. Full precheck green: ruff + format clean, **2410 passed**.
