### PR TITLE
[Engineering] Hosted /mcp write refusal: advice the caller can act on (closes #409)

### DIFF
--- a/datanika-mcp/src/datanika_mcp/session.py
+++ b/datanika-mcp/src/datanika_mcp/session.py
@@ -42,18 +42,38 @@ class DatanikaSession:
     ``allow_write`` — whether mutation tools are permitted for this session
     (the stdio ``--allow-write`` flag; the OAuth write-consent grant on
     remote).
+
+    ``transport`` — ``"stdio"`` or ``"remote"``. Carried only so the write
+    refusal can give advice the reader can act on (core#409): telling a hosted
+    caller to restart a server with a flag describes a machine they do not
+    operate. Defaults to ``"stdio"``, which is what the CLI builds.
     """
 
     client: DatanikaClient | None = None
     allow_write: bool = False
+    transport: str = "stdio"
 
     def require_write(self, action: str) -> None:
-        """Raise ``RuntimeError`` if this session may not perform ``action``."""
-        if not self.allow_write:
+        """Raise ``RuntimeError`` if this session may not perform ``action``.
+
+        The message is a product surface: agents are its primary reader, and
+        they act on it. So the two transports say different things — on stdio
+        the ``--allow-write`` flag is a real fix, while over the hosted
+        endpoint nothing the caller does client-side changes the outcome, and
+        wording that implies otherwise invites a retry loop.
+        """
+        if self.allow_write:
+            return
+
+        prefix = f"Write access required for '{action}'."
+        if self.transport == "remote":
             raise RuntimeError(
-                f"Write access required for '{action}'. "
-                "Restart the server with --allow-write to enable mutations."
+                f"{prefix} This hosted Datanika endpoint is read-only — write "
+                "tools are not enabled on it, and no client-side setting or "
+                "retry will change that. For write access, run the local "
+                "datanika-mcp server with --allow-write."
             )
+        raise RuntimeError(f"{prefix} Restart the server with --allow-write to enable mutations.")
 
 
 # Per-request binding. Unset (``None``) on stdio and in unit tests, where the

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -157,7 +157,10 @@ class BearerSessionApp:
             return
 
         client = DatanikaClient(self._base_url, credential)
-        session = DatanikaSession(client=client, allow_write=False)
+        # transport="remote" only shapes the write-refusal wording: the hosted
+        # caller runs no server, so the stdio "--allow-write" advice would send
+        # them (or their agent) after a switch that does not exist (core#409).
+        session = DatanikaSession(client=client, allow_write=False, transport="remote")
         try:
             with use_session(session):
                 await self._app(scope, receive, send)

--- a/tests/test_mcp/test_mcp_remote.py
+++ b/tests/test_mcp/test_mcp_remote.py
@@ -198,5 +198,34 @@ class TestToolRouting:
 
         assert call.status_code == 200
         # Read-only session -> the write guard fires; the tool never calls the client.
-        assert "Write access required" in json.dumps(call.json())
+        body = json.dumps(call.json())
+        assert "Write access required" in body
         fake_client.create_connection.assert_not_called()
+
+        # ...and the advice must fit the hosted transport (#409). The stdio
+        # wording ("restart the server with --allow-write") is unactionable
+        # here — there is no server the caller runs — and an agent reads it as
+        # a recoverable condition and retries. This is the string an agent
+        # actually receives, which is why it is asserted end-to-end and not
+        # just on the session object.
+        assert "Restart the server" not in body
+        assert "read-only" in body.lower()
+
+    async def test_bearer_session_is_marked_remote(self, monkeypatch):
+        """The wording above can only differ if the transport reaches the session."""
+        from datanika_mcp.session import current_session
+
+        monkeypatch.setattr(routes, "DatanikaClient", lambda base_url, token: AsyncMock())
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen["transport"] = current_session().transport
+            await _ok_asgi(scope, receive, send)
+
+        app = routes.BearerSessionApp(inner)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            await c.post("/mcp", headers={"Authorization": "Bearer etf_x"})
+
+        assert seen["transport"] == "remote"

--- a/tests/test_mcp/test_mcp_session.py
+++ b/tests/test_mcp/test_mcp_session.py
@@ -123,3 +123,53 @@ class TestSessionWriteGuard:
 
         with pytest.raises(RuntimeError, match="Write access required"):
             srv._require_write("create_connection")  # unbound, global False → blocked
+
+
+class TestWriteRefusalWordingByTransport:
+    """The refusal message must be actionable for whoever is reading it (#409).
+
+    The gate itself is correct on both transports — this is only about the
+    advice. Over the hosted endpoint there is no server the caller runs, no
+    ``--allow-write`` they can pass and no restart they can perform, so the
+    stdio wording is not merely unhelpful: an agent reads it as a recoverable
+    condition and either retries or instructs a human to do something
+    impossible. Agents are the primary consumer of this string.
+    """
+
+    def test_stdio_keeps_the_flag_advice(self, srv):
+        """On stdio the advice is correct and must not regress."""
+        from datanika_mcp.session import DatanikaSession
+
+        session = DatanikaSession(allow_write=False)
+        with pytest.raises(RuntimeError) as exc:
+            session.require_write("create_connection")
+
+        assert "--allow-write" in str(exc.value)
+
+    def test_remote_does_not_tell_the_caller_to_restart_anything(self, srv):
+        from datanika_mcp.session import DatanikaSession
+
+        session = DatanikaSession(allow_write=False, transport="remote")
+        with pytest.raises(RuntimeError) as exc:
+            session.require_write("create_connection")
+
+        message = str(exc.value)
+        assert "Restart" not in message
+        # It must not imply a client-side switch exists over the hosted path.
+        assert "read-only" in message.lower()
+
+    def test_both_keep_the_stable_prefix(self, srv):
+        """Callers (and our own tests) match on this prefix — keep it stable."""
+        from datanika_mcp.session import DatanikaSession
+
+        for transport in ("stdio", "remote"):
+            session = DatanikaSession(allow_write=False, transport=transport)
+            with pytest.raises(RuntimeError) as exc:
+                session.require_write("trigger_pipeline")
+            assert str(exc.value).startswith("Write access required for 'trigger_pipeline'.")
+
+    def test_default_transport_is_stdio(self, srv):
+        """Back-compat: the stdio server constructs sessions positionally."""
+        from datanika_mcp.session import DatanikaSession
+
+        assert DatanikaSession().transport == "stdio"


### PR DESCRIPTION
Closes #409.

The gate was already right — every hosted session is built read-only and nothing was ever created. Only the **advice** was wrong: *"Restart the server with `--allow-write`"* describes a machine the hosted caller doesn't operate. No server they run, no flag they can pass, no restart they can perform.

That's not just unhelpful. **Agents are the primary reader of this string, and they act on it** — a fixable-sounding condition invites either a retry or an instruction to a human to do something impossible.

## What changed

`DatanikaSession` gains a `transport` field (`"stdio" | "remote"`, defaulting to stdio so the CLI path is untouched), and `BearerSessionApp` marks hosted sessions remote. The transports now say different things because different things are true:

| | message |
|---|---|
| **stdio** | `Restart the server with --allow-write to enable mutations.` |
| **remote** | `This hosted Datanika endpoint is read-only — write tools are not enabled on it, and no client-side setting or retry will change that. For write access, run the local datanika-mcp server with --allow-write.` |

*"no … retry will change that"* is deliberate, and aimed squarely at the agent — the reader most likely to try again.

Both keep the `Write access required for '<action>'.` prefix, which callers and our own tests match on.

## Tests

Asserted **end-to-end through a real `tools/call` over the remote transport** — the string an agent actually receives — rather than only on the session object. Plus a wiring test that the transport reaches the session at all (without it the field is decoration and the message silently stays stdio-flavoured), and a guard that stdio's advice doesn't regress, since there the flag *is* the fix.

Full precheck green: ruff + format clean, **2404 passed**.

## Out of scope, worth knowing

The 8 write-tool docstrings still read *"Requires `--allow-write`"* and appear in `tools/list` **on both transports**. They're static and shared by design (one tool surface, two transports), so they can't vary the way this message does — making them true in both places means rewording them, not branching them. Not folded in here because it changes the published tool descriptions, which is a product-surface decision rather than a bug fix. Happy to take it if you want it.
