### PR TITLE
[Infra] Promote dev -> master: OpenAPI P2, e2e teardown fix, consent same-tab, silent-green sweep

### DIFF
--- a/datanika-mcp/src/datanika_mcp/session.py
+++ b/datanika-mcp/src/datanika_mcp/session.py
@@ -42,18 +42,38 @@ class DatanikaSession:
     ``allow_write`` — whether mutation tools are permitted for this session
     (the stdio ``--allow-write`` flag; the OAuth write-consent grant on
     remote).
+
+    ``transport`` — ``"stdio"`` or ``"remote"``. Carried only so the write
+    refusal can give advice the reader can act on (core#409): telling a hosted
+    caller to restart a server with a flag describes a machine they do not
+    operate. Defaults to ``"stdio"``, which is what the CLI builds.
     """
 
     client: DatanikaClient | None = None
     allow_write: bool = False
+    transport: str = "stdio"
 
     def require_write(self, action: str) -> None:
-        """Raise ``RuntimeError`` if this session may not perform ``action``."""
-        if not self.allow_write:
+        """Raise ``RuntimeError`` if this session may not perform ``action``.
+
+        The message is a product surface: agents are its primary reader, and
+        they act on it. So the two transports say different things — on stdio
+        the ``--allow-write`` flag is a real fix, while over the hosted
+        endpoint nothing the caller does client-side changes the outcome, and
+        wording that implies otherwise invites a retry loop.
+        """
+        if self.allow_write:
+            return
+
+        prefix = f"Write access required for '{action}'."
+        if self.transport == "remote":
             raise RuntimeError(
-                f"Write access required for '{action}'. "
-                "Restart the server with --allow-write to enable mutations."
+                f"{prefix} This hosted Datanika endpoint is read-only — write "
+                "tools are not enabled on it, and no client-side setting or "
+                "retry will change that. For write access, run the local "
+                "datanika-mcp server with --allow-write."
             )
+        raise RuntimeError(f"{prefix} Restart the server with --allow-write to enable mutations.")
 
 
 # Per-request binding. Unset (``None``) on stdio and in unit tests, where the

--- a/datanika/scripts/e2e_seed.py
+++ b/datanika/scripts/e2e_seed.py
@@ -49,6 +49,7 @@ from datanika.models.catalog_entry import CatalogEntry
 from datanika.models.connection import Connection, ConnectionType
 from datanika.models.dependency import Dependency, NodeType
 from datanika.models.invitation import Invitation
+from datanika.models.mcp_oauth import OAuthGrant, OAuthToken
 from datanika.models.notification import Notification
 from datanika.models.notification_channel import NotificationChannel
 from datanika.models.pipeline import DbtCommand, Pipeline
@@ -181,6 +182,31 @@ def _assert_safe_target() -> None:
                 )
 
 
+def _delete_oauth_chain(session: Session, api_key_ids) -> None:
+    """Remove OAuth grants/tokens hanging off the API keys about to be deleted.
+
+    Remote-MCP P2 (core#395) added ``oauth_grants.api_key_id -> api_keys.id`` and
+    ``oauth_tokens.grant_id -> oauth_grants.id``, which made ``api_keys``
+    undeletable once anyone completes a hosted-MCP consent in a fixture org.
+    The teardown wasn't extended, so a single authorization wedged **every**
+    later ``e2e-staging`` run in global setup with a ForeignKeyViolation, and
+    it did not self-heal (core#415). Revoking doesn't help: revocation is a soft
+    delete, so the row and its references survive.
+
+    ``api_key_ids`` is a select() rather than a list so the caller doesn't have
+    to materialise ids it is about to delete anyway.
+    """
+    grant_ids = list(
+        session.execute(select(OAuthGrant.id).where(OAuthGrant.api_key_id.in_(api_key_ids)))
+        .scalars()
+        .all()
+    )
+    if not grant_ids:
+        return
+    session.execute(OAuthToken.__table__.delete().where(OAuthToken.grant_id.in_(grant_ids)))
+    session.execute(OAuthGrant.__table__.delete().where(OAuthGrant.id.in_(grant_ids)))
+
+
 def _tear_down_fixture(session: Session) -> None:
     """Hard-delete both fixture orgs and everything scoped to them.
 
@@ -223,6 +249,13 @@ def _tear_down_fixture(session: Session) -> None:
         session.execute(Upload.__table__.delete().where(Upload.org_id.in_(org_ids)))
         session.execute(Pipeline.__table__.delete().where(Pipeline.org_id.in_(org_ids)))
         session.execute(Transformation.__table__.delete().where(Transformation.org_id.in_(org_ids)))
+        # Two different FKs reach these tables, so both axes are needed:
+        # by api_key (they block the api_keys delete just below) and by org
+        # (they are TenantMixin rows and would block the organizations delete
+        # at the end of this list).
+        _delete_oauth_chain(session, select(ApiKey.id).where(ApiKey.org_id.in_(org_ids)))
+        session.execute(OAuthToken.__table__.delete().where(OAuthToken.org_id.in_(org_ids)))
+        session.execute(OAuthGrant.__table__.delete().where(OAuthGrant.org_id.in_(org_ids)))
         session.execute(ApiKey.__table__.delete().where(ApiKey.org_id.in_(org_ids)))
         session.execute(Connection.__table__.delete().where(Connection.org_id.in_(org_ids)))
         session.execute(Membership.__table__.delete().where(Membership.org_id.in_(org_ids)))
@@ -231,6 +264,7 @@ def _tear_down_fixture(session: Session) -> None:
     users = list(session.execute(select(User).where(User.email.in_(fixture_user_emails))).scalars())
     user_ids = [u.id for u in users]
     if user_ids:
+        _delete_oauth_chain(session, select(ApiKey.id).where(ApiKey.user_id.in_(user_ids)))
         session.execute(ApiKey.__table__.delete().where(ApiKey.user_id.in_(user_ids)))
         session.execute(Membership.__table__.delete().where(Membership.user_id.in_(user_ids)))
         session.execute(User.__table__.delete().where(User.id.in_(user_ids)))

--- a/datanika/services/api_v1_routes.py
+++ b/datanika/services/api_v1_routes.py
@@ -277,19 +277,22 @@ def create_connection(request, api_key, session):
 
 @api_endpoint(required_scope="connections:read")
 def parse_openapi(request, api_key, session):
-    """Parse an OpenAPI 3.x spec (paste-mode) into a preview of the derived
-    connector — base_url, auth schemes, and readable resources with columns.
+    """Parse an OpenAPI 3.x spec into a preview of the derived connector —
+    base_url, auth schemes, and readable resources with columns.
+
+    Takes the document inline (``spec_inline``) or fetches it from
+    ``spec_url`` (P2, core#410) behind the SPEC §7 guards: https only, public
+    host, every redirect hop re-checked, 10s timeout, 5 MB streamed cap.
 
     Stateless: creates no connection, so an agent/UI can preview before
-    committing. See SPEC_OPENAPI_CONNECTOR.md (#325).
+    committing. See SPEC_OPENAPI_CONNECTOR.md (#325, #410).
     """
+    from datanika.services.openapi_fetch import resolve_spec
     from datanika.services.openapi_import import OpenApiImportError, parse_openapi_spec
 
     data = _body_sync(request)
-    spec = data.get("spec_inline")
-    if not spec or not isinstance(spec, str):
-        return _error(400, "spec_inline (the OpenAPI 3.x document as a string) is required")
     try:
+        spec = resolve_spec(data.get("spec_inline"), data.get("spec_url"))
         parsed = parse_openapi_spec(spec, base_url_override=data.get("base_url"))
     except OpenApiImportError as exc:
         return JSONResponse({"error": str(exc), "code": exc.code}, status_code=400)

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -157,7 +157,10 @@ class BearerSessionApp:
             return
 
         client = DatanikaClient(self._base_url, credential)
-        session = DatanikaSession(client=client, allow_write=False)
+        # transport="remote" only shapes the write-refusal wording: the hosted
+        # caller runs no server, so the stdio "--allow-write" advice would send
+        # them (or their agent) after a switch that does not exist (core#409).
+        session = DatanikaSession(client=client, allow_write=False, transport="remote")
         try:
             with use_session(session):
                 await self._app(scope, receive, send)

--- a/datanika/services/openapi_fetch.py
+++ b/datanika/services/openapi_fetch.py
@@ -1,0 +1,125 @@
+"""Fetch an OpenAPI spec from a user-supplied URL (core#410, OpenAPI P2).
+
+Kept out of ``openapi_import.py`` on purpose: that module is deterministic and
+touches no network, which is what makes it cheap to fuzz and reason about. This
+module is the *only* place the spec path talks to the outside world, so all of
+SPEC_OPENAPI_CONNECTOR §7's guards live here and nowhere else:
+
+  * **https only** — stricter than ``validate_egress_host`` (which allows http
+    for connector base URLs), because a spec URL has no reason to be plaintext;
+  * **host must resolve public** — the same ``validate_egress_host`` the
+    connector family uses, not a second implementation (§7: "reuse/centralize
+    with any existing outbound-fetch guard");
+  * **every redirect hop re-checked** — via the guarded session from core#403,
+    so a public host cannot bounce us into ``10.0.0.0/8``;
+  * **10 s timeout** and a **5 MB cap enforced while streaming** — applied to
+    bytes actually read, never to a header or a finished body. The case that
+    needs it is a response with **no ``Content-Length``**, delimited by
+    connection close: urllib3 then reads until EOF and nothing but this cap
+    bounds it. (An *understated* ``Content-Length`` is not the danger — urllib3
+    stops at the declared length and truncates. Measured, not assumed.)
+
+**Inherited residual:** core#405 (DNS-rebinding TOCTOU) applies here too, and
+bites slightly harder than it does in the worker — this runs in the web tier,
+where loopback reaches the app's own API and, compose-internally, Postgres and
+Redis. §7 does not require closing it and §13.1 signed off "URL in P2 behind §7
+guards", so it ships knowingly, not unnoticed.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from datanika.services.egress_guard import (
+    EgressValidationError,
+    build_guarded_session,
+    validate_egress_host,
+)
+from datanika.services.openapi_import import MAX_SPEC_BYTES, OpenApiImportError
+
+FETCH_TIMEOUT_SECONDS = 10
+_CHUNK_BYTES = 64_000
+
+#: §7: spec URLs are https-only. A module constant rather than a literal so the
+#: streaming/size tests can point at a plaintext local server without weakening
+#: the rule itself (which has its own tests against the real code path).
+REQUIRED_SCHEME = "https"
+
+
+def fetch_openapi_spec(url: str) -> str:
+    """Return the spec document at *url* as text.
+
+    Raises :class:`OpenApiImportError` with ``code`` ∈ {``invalid_spec_url``,
+    ``spec_too_large``, ``spec_fetch_failed``} so the endpoint can branch
+    without matching on messages — the same contract the parser already uses.
+    """
+    parsed = urlparse(url or "")
+    if parsed.scheme != REQUIRED_SCHEME:
+        raise OpenApiImportError(
+            "Spec URL must use https (paste the document instead if the host is http-only).",
+            "invalid_spec_url",
+        )
+
+    session = build_guarded_session()
+    try:
+        # The guarded session validates this URL and every redirect hop anyway;
+        # calling it explicitly first means an internal host is refused before a
+        # socket is opened, and surfaces as a URL problem rather than a generic
+        # fetch failure.
+        validate_egress_host(url)
+        with session.get(url, timeout=FETCH_TIMEOUT_SECONDS, stream=True) as response:
+            response.raise_for_status()
+            return _read_capped(response)
+    except EgressValidationError as exc:
+        raise OpenApiImportError(str(exc), "invalid_spec_url") from exc
+    except OpenApiImportError:
+        raise
+    except Exception as exc:  # network/TLS/HTTP status — one typed failure
+        raise OpenApiImportError(f"Could not fetch the spec: {exc}", "spec_fetch_failed") from exc
+    finally:
+        session.close()
+
+
+def resolve_spec(spec_inline, spec_url) -> str:
+    """Return the spec text from whichever source the caller supplied.
+
+    Lives here rather than in the route so the "exactly one of" decision is
+    unit-testable: the endpoint is decorated for auth and cannot be called
+    directly, which is how this branch would otherwise ship untested.
+    """
+    if bool(spec_inline) == bool(spec_url):
+        # Both or neither — ambiguous rather than merely incomplete, so the
+        # message names both options instead of demanding one.
+        raise OpenApiImportError(
+            "Provide exactly one of spec_inline (the document) or spec_url (where to fetch it).",
+            "invalid_request",
+        )
+    if spec_url is not None and spec_url != "":
+        if not isinstance(spec_url, str):
+            raise OpenApiImportError("spec_url must be a string", "invalid_request")
+        return fetch_openapi_spec(spec_url)
+    if not isinstance(spec_inline, str):
+        raise OpenApiImportError(
+            "spec_inline (the OpenAPI 3.x document as a string) is required", "invalid_request"
+        )
+    return spec_inline
+
+
+def _read_capped(response) -> str:
+    """Read at most ``MAX_SPEC_BYTES``, aborting as soon as the cap is passed."""
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=_CHUNK_BYTES):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > MAX_SPEC_BYTES:
+            # Stop pulling immediately — do not buffer the rest to measure it.
+            raise OpenApiImportError("Spec exceeds the size limit", "spec_too_large")
+        chunks.append(chunk)
+
+    body = b"".join(chunks)
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OpenApiImportError("Spec is not valid UTF-8 text", "invalid_spec") from exc

--- a/datanika/services/openapi_import.py
+++ b/datanika/services/openapi_import.py
@@ -110,7 +110,7 @@ def parse_openapi_spec(raw: str | dict, *, base_url_override: str | None = None)
         op = item.get("get")
         if not isinstance(op, dict):
             continue
-        resource = _resource_from_get(spec, path, op, warnings)
+        resource = _resource_from_get(spec, path, item, op, warnings)
         if resource is not None:
             resources.append(resource)
         if len(resources) > MAX_RESOURCES:
@@ -165,7 +165,9 @@ def _extract_auth(spec: dict, warnings: list[str]) -> list[dict]:
     return out
 
 
-def _resource_from_get(spec: dict, path: str, op: dict, warnings: list[str]) -> dict | None:
+def _resource_from_get(
+    spec: dict, path: str, path_item: dict, op: dict, warnings: list[str]
+) -> dict | None:
     item_schema, data_selector = _response_item_schema(spec, op)
     if item_schema is None:
         warnings.append(f"Skipped GET {path} — no array/collection JSON response schema.")
@@ -174,6 +176,17 @@ def _resource_from_get(spec: dict, path: str, op: dict, warnings: list[str]) -> 
     endpoint: dict = {"path": path.lstrip("/"), "method": "GET"}
     if data_selector:
         endpoint["data_selector"] = data_selector
+
+    response = _success_response(spec, op) or {}
+    envelope = resolve_ref(
+        spec, (((response.get("content") or {}).get("application/json")) or {}).get("schema")
+    )
+    envelope_props = (envelope or {}).get("properties") or {}
+    paginator = _paginator_from_operation(
+        spec, path_item, op, envelope_props, response.get("headers") or {}
+    )
+    if paginator:
+        endpoint["paginator"] = paginator
     resource: dict = {
         "name": _resource_name(path),
         "endpoint": endpoint,
@@ -184,6 +197,122 @@ def _resource_from_get(spec: dict, path: str, op: dict, warnings: list[str]) -> 
     if pk:
         resource["primary_key"] = pk
     return resource
+
+
+# --- Pagination detection (P2, core#411) -----------------------------------
+#
+# P1 emitted nothing and relied on dlt's runtime auto-detection, which fails
+# *silently*: a wrong guess stops after page 1 and looks like a small table
+# rather than an error. These heuristics are the shapes real specs declare,
+# ordered most-authoritative first — a next-link in the body or a Link header
+# is a statement of fact, whereas query-parameter names are inference.
+#
+# Emitted configs match dlt's own paginator constructors (PAGINATOR_MAP);
+# nothing here invents a config shape dlt would reject.
+
+_OFFSET_PARAMS = (("offset", "limit"), ("skip", "top"), ("skip", "take"), ("start", "count"))
+_PAGE_PARAMS = ("page", "page_number", "pagenum")
+_CURSOR_PARAMS = ("cursor", "after", "page_token", "next_token", "starting_after")
+_NEXT_LINK_KEYS = ("next", "next_url", "next_page_url", "nextPageUrl", "next_page")
+_CURSOR_RESPONSE_KEYS = ("next_cursor", "cursor", "next_page_token", "next_token", "end_cursor")
+_TOTAL_KEYS = ("total", "total_count", "totalCount", "count", "total_results")
+
+_DEFAULT_PAGE_SIZE = 100
+
+
+def _query_params(spec: dict, path_item: dict, op: dict) -> dict[str, dict]:
+    """Query parameters for an operation, including path-level inherited ones."""
+    out: dict[str, dict] = {}
+    for raw in list(path_item.get("parameters") or []) + list(op.get("parameters") or []):
+        param = resolve_ref(spec, raw)
+        if isinstance(param, dict) and param.get("in") == "query" and param.get("name"):
+            out[str(param["name"])] = param
+    return out
+
+
+def _page_size(param: dict | None) -> int:
+    """Prefer the API's declared ceiling over a number we made up."""
+    schema = (param or {}).get("schema") or {}
+    for key in ("maximum", "default"):
+        value = schema.get(key)
+        if isinstance(value, int) and value > 0:
+            return value
+    return _DEFAULT_PAGE_SIZE
+
+
+def _first_key(props: dict, candidates) -> str | None:
+    lowered = {k.lower(): k for k in props}
+    for candidate in candidates:
+        if candidate.lower() in lowered:
+            return lowered[candidate.lower()]
+    return None
+
+
+def _paginator_from_operation(
+    spec: dict, path_item: dict, op: dict, envelope_props: dict, response_headers: dict
+) -> dict | None:
+    """Derive a dlt paginator config, or ``None`` to leave dlt's guess alone."""
+    # 1. A next-URL in the body: authoritative, no inference needed.
+    next_key = _first_key(envelope_props, _NEXT_LINK_KEYS)
+    if next_key:
+        return {"type": "json_link", "next_url_path": next_key}
+
+    # 2. A declared Link header: RFC 5988, equally authoritative.
+    if _first_key(response_headers, ("link",)):
+        return {"type": "header_link"}
+
+    params = _query_params(spec, path_item, op)
+    total_key = _first_key(envelope_props, _TOTAL_KEYS)
+
+    # 3. Cursor: only when the request carries one *and* the response returns
+    #    one — a lone `cursor` param with nowhere to read the next value from
+    #    would page forever against the same cursor.
+    cursor_param = _first_key(params, _CURSOR_PARAMS)
+    cursor_key = _first_key(envelope_props, _CURSOR_RESPONSE_KEYS)
+    if cursor_param and cursor_key:
+        return {"type": "cursor", "cursor_param": cursor_param, "cursor_path": cursor_key}
+
+    # 4. Offset/limit under any of its common spellings.
+    for offset_name, limit_name in _OFFSET_PARAMS:
+        offset_param = _first_key(params, (offset_name,))
+        limit_param = _first_key(params, (limit_name,))
+        if offset_param and limit_param:
+            return {
+                "type": "offset",
+                "offset_param": offset_param,
+                "limit_param": limit_param,
+                "limit": _page_size(params.get(limit_param)),
+                # dlt defaults total_path to "total"; leaving that in place for
+                # an API with no such field makes it hunt for a key that never
+                # arrives. None falls back to stop-on-empty-page.
+                "total_path": total_key,
+            }
+
+    # 5. Page number.
+    page_param = _first_key(params, _PAGE_PARAMS)
+    if page_param:
+        return {"type": "page_number", "page_param": page_param, "total_path": total_key}
+
+    # Nothing declared — stay silent rather than guess; dlt's runtime
+    # auto-detection is still there and is a better guess than ours.
+    return None
+
+
+def _success_response(spec: dict, op: dict) -> dict | None:
+    """The resolved success response object for a GET, if any."""
+    responses = op.get("responses") or {}
+    resp = None
+    for code in ("200", "201", "2XX", "default"):
+        if code in responses:
+            resp = responses[code]
+            break
+    if resp is None:
+        for code, r in responses.items():
+            if str(code).startswith("2"):
+                resp = r
+                break
+    resp = resolve_ref(spec, resp)
+    return resp if isinstance(resp, dict) else None
 
 
 def _response_item_schema(spec: dict, op: dict) -> tuple[dict | None, str | None]:

--- a/datanika/ui/state/mcp_consent_state.py
+++ b/datanika/ui/state/mcp_consent_state.py
@@ -250,7 +250,14 @@ class McpConsentState(rx.State):
             return
         # ``is_submitting`` deliberately stays set: the button holds its
         # "Approving…" state until the browser leaves for the client.
-        yield rx.redirect(redirect_to, is_external=True)
+        #
+        # Not ``is_external=True`` (#417). That flag reads like "this URL is
+        # off-site" but Reflex means it literally — ``window.open(path,
+        # "_blank")`` — so the callback opened in a second tab and left this
+        # one on a disabled button forever. The default path already handles
+        # cross-origin: it compares hosts and calls ``window.location.assign``,
+        # which is what an authorization-code redirect is supposed to do.
+        yield rx.redirect(redirect_to)
 
     def deny(self):
         """Send the user back empty-handed, per RFC 6749 §4.1.2.1."""
@@ -261,9 +268,8 @@ class McpConsentState(rx.State):
         if state:
             query["state"] = state
         separator = "&" if "?" in self.verified_redirect_uri else "?"
-        return rx.redirect(
-            f"{self.verified_redirect_uri}{separator}{urlencode(query)}", is_external=True
-        )
+        # Same tab, for the same reason as ``allow`` — see #417.
+        return rx.redirect(f"{self.verified_redirect_uri}{separator}{urlencode(query)}")
 
     @staticmethod
     def _describe(response: httpx.Response) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ dev = [
     "ruff>=0.9",
     "httpx>=0.28",
     "mcp>=1.0.0",
+    # Used by tests/test_mcp/test_registry_manifests.py to parse smithery.yaml.
+    # Previously relied on as an undeclared transitive dep, which let those
+    # manifest-drift guards skip themselves if it ever went missing (core#407 sweep).
+    "pyyaml>=6.0",
     # Round-trip migration test auto-provisions Postgres via Docker.
     # Skipped gracefully if Docker is unavailable (see tests/test_migrations/test_roundtrip.py).
     "testcontainers[postgres]>=4.0",

--- a/tests/test_mcp/test_mcp_remote.py
+++ b/tests/test_mcp/test_mcp_remote.py
@@ -198,5 +198,34 @@ class TestToolRouting:
 
         assert call.status_code == 200
         # Read-only session -> the write guard fires; the tool never calls the client.
-        assert "Write access required" in json.dumps(call.json())
+        body = json.dumps(call.json())
+        assert "Write access required" in body
         fake_client.create_connection.assert_not_called()
+
+        # ...and the advice must fit the hosted transport (#409). The stdio
+        # wording ("restart the server with --allow-write") is unactionable
+        # here — there is no server the caller runs — and an agent reads it as
+        # a recoverable condition and retries. This is the string an agent
+        # actually receives, which is why it is asserted end-to-end and not
+        # just on the session object.
+        assert "Restart the server" not in body
+        assert "read-only" in body.lower()
+
+    async def test_bearer_session_is_marked_remote(self, monkeypatch):
+        """The wording above can only differ if the transport reaches the session."""
+        from datanika_mcp.session import current_session
+
+        monkeypatch.setattr(routes, "DatanikaClient", lambda base_url, token: AsyncMock())
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen["transport"] = current_session().transport
+            await _ok_asgi(scope, receive, send)
+
+        app = routes.BearerSessionApp(inner)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            await c.post("/mcp", headers={"Authorization": "Bearer etf_x"})
+
+        assert seen["transport"] == "remote"

--- a/tests/test_mcp/test_mcp_session.py
+++ b/tests/test_mcp/test_mcp_session.py
@@ -123,3 +123,53 @@ class TestSessionWriteGuard:
 
         with pytest.raises(RuntimeError, match="Write access required"):
             srv._require_write("create_connection")  # unbound, global False → blocked
+
+
+class TestWriteRefusalWordingByTransport:
+    """The refusal message must be actionable for whoever is reading it (#409).
+
+    The gate itself is correct on both transports — this is only about the
+    advice. Over the hosted endpoint there is no server the caller runs, no
+    ``--allow-write`` they can pass and no restart they can perform, so the
+    stdio wording is not merely unhelpful: an agent reads it as a recoverable
+    condition and either retries or instructs a human to do something
+    impossible. Agents are the primary consumer of this string.
+    """
+
+    def test_stdio_keeps_the_flag_advice(self, srv):
+        """On stdio the advice is correct and must not regress."""
+        from datanika_mcp.session import DatanikaSession
+
+        session = DatanikaSession(allow_write=False)
+        with pytest.raises(RuntimeError) as exc:
+            session.require_write("create_connection")
+
+        assert "--allow-write" in str(exc.value)
+
+    def test_remote_does_not_tell_the_caller_to_restart_anything(self, srv):
+        from datanika_mcp.session import DatanikaSession
+
+        session = DatanikaSession(allow_write=False, transport="remote")
+        with pytest.raises(RuntimeError) as exc:
+            session.require_write("create_connection")
+
+        message = str(exc.value)
+        assert "Restart" not in message
+        # It must not imply a client-side switch exists over the hosted path.
+        assert "read-only" in message.lower()
+
+    def test_both_keep_the_stable_prefix(self, srv):
+        """Callers (and our own tests) match on this prefix — keep it stable."""
+        from datanika_mcp.session import DatanikaSession
+
+        for transport in ("stdio", "remote"):
+            session = DatanikaSession(allow_write=False, transport=transport)
+            with pytest.raises(RuntimeError) as exc:
+                session.require_write("trigger_pipeline")
+            assert str(exc.value).startswith("Write access required for 'trigger_pipeline'.")
+
+    def test_default_transport_is_stdio(self, srv):
+        """Back-compat: the stdio server constructs sessions positionally."""
+        from datanika_mcp.session import DatanikaSession
+
+        assert DatanikaSession().transport == "stdio"

--- a/tests/test_mcp/test_registry_manifests.py
+++ b/tests/test_mcp/test_registry_manifests.py
@@ -11,7 +11,12 @@ import re
 import tomllib
 from pathlib import Path
 
-import pytest
+# Imported unconditionally, not via ``pytest.importorskip``. These tests are the
+# only guard against smithery.yaml drifting from the shipped package, so a skip
+# here means the manifest ships unchecked while CI stays green. PyYAML was an
+# undeclared transitive dependency until this was noticed — it is now an explicit
+# dev dependency so the guard cannot quietly stop running (core#407 sweep).
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MCP_DIR = _REPO_ROOT / "datanika-mcp"
@@ -104,7 +109,6 @@ class TestPypiOwnershipMarker:
 
 class TestSmitheryYaml:
     def test_stdio_startcommand_with_api_key_required(self):
-        yaml = pytest.importorskip("yaml")
         data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
         start = data["startCommand"]
         assert start["type"] == "stdio"
@@ -113,7 +117,6 @@ class TestSmitheryYaml:
         assert set(schema["properties"]) == {"url", "apiKey", "allowWrite"}
 
     def test_command_invokes_the_package(self):
-        yaml = pytest.importorskip("yaml")
         data = yaml.safe_load((_MCP_DIR / "smithery.yaml").read_text(encoding="utf-8"))
         cmd = data["startCommand"]["commandFunction"]
         assert "datanika-mcp" in cmd

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -57,6 +57,30 @@ def _docker_available() -> bool:
         return False
 
 
+def _no_postgres(reason: str) -> None:
+    """Skip locally when Postgres is unavailable — but FAIL in CI.
+
+    The ``migration-roundtrip`` job runs *only* this file, so if these tests
+    skip, the job exits 0 and reports green having verified nothing — while
+    the thing it guards (a downgrade that only matters at 2 AM during a prod
+    rollback) goes unchecked. CI always has both Docker and
+    ``DATABASE_URL_SYNC_TEST``, so reaching here in CI means the workflow
+    broke, and that must be loud.
+
+    Locally, skipping stays correct: devs without Docker shouldn't be blocked.
+    Same reasoning as the connector smoke suite's strict mode (core#407).
+    """
+    if os.environ.get("CI"):
+        pytest.fail(
+            f"{reason}\n\n"
+            "This is a hard failure because CI is expected to provide Postgres "
+            "(DATABASE_URL_SYNC_TEST, or Docker for testcontainers). Skipping here "
+            "would let the migration-roundtrip job pass without testing a single "
+            "migration. Check the job's env block and service container."
+        )
+    pytest.skip(reason)
+
+
 @pytest.fixture(scope="session")
 def roundtrip_db_url():
     """Postgres URL for round-trip tests.
@@ -64,7 +88,7 @@ def roundtrip_db_url():
     Priority:
     1. ``DATABASE_URL_SYNC_TEST`` env var (CI, or manual override)
     2. testcontainers[postgres] auto-provisioned container (local with Docker)
-    3. skip the test (local without Docker)
+    3. skip the test locally — but **fail** in CI (see ``_no_postgres``)
 
     Must be a generator (yield-based) on every path — pytest treats a
     function with any `yield` as a generator, and hitting `return` on
@@ -77,15 +101,15 @@ def roundtrip_db_url():
         return
 
     if not _docker_available():
-        pytest.skip(
+        _no_postgres(
             "Round-trip test requires Postgres. Set DATABASE_URL_SYNC_TEST or run "
-            "with Docker Desktop running. CI always has Docker + the env var set."
+            "with Docker Desktop running."
         )
 
     try:
         from testcontainers.postgres import PostgresContainer
     except ImportError:
-        pytest.skip(
+        _no_postgres(
             "testcontainers not installed. Install with: "
             "`uv pip install 'testcontainers[postgres]'` or run CI instead."
         )

--- a/tests/test_scripts/test_e2e_seed.py
+++ b/tests/test_scripts/test_e2e_seed.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from datanika.models.api_key import ApiKey
 from datanika.models.connection import Connection, ConnectionType
+from datanika.models.mcp_oauth import OAuthGrant, OAuthToken
 from datanika.models.pipeline import Pipeline
 from datanika.models.schedule import Schedule
 from datanika.models.transformation import Transformation
@@ -494,3 +496,130 @@ def test_fixture_duckdb_path_is_platform_agnostic():
 
     assert FIXTURE_DUCKDB_PATH.startswith(tempfile.gettempdir())
     assert FIXTURE_DUCKDB_PATH.endswith("e2e_fixture.duckdb")
+
+
+class TestTeardownWithOAuthGrants:
+    """Regression: Remote-MCP P2 made api_keys undeletable by the teardown (#415).
+
+    P2 (#395) added ``oauth_grants.api_key_id -> api_keys.id`` and
+    ``oauth_tokens.grant_id -> oauth_grants.id``. ``_tear_down_fixture`` hard-
+    deletes ``api_keys`` for the fixture orgs and was never extended, so a
+    single completed OAuth consent in a fixture org **permanently wedges the
+    e2e seed** — every later ``e2e-staging`` run dies in global setup with a
+    ForeignKeyViolation until someone deletes rows by hand. Not self-healing,
+    and it surfaces as an opaque setup error rather than a test failure.
+
+    Revocation does not save us: it is a soft delete, so the row and its FK
+    references remain.
+
+    **These tests enable ``PRAGMA foreign_keys``.** SQLite ignores foreign keys
+    by default (verified: the pragma reads 0 on this engine), so without it the
+    teardown would "pass" here while still failing on Postgres — the guard
+    would assert nothing, which is worse than no guard at all.
+    """
+
+    @pytest.fixture
+    def fk_enforced(self):
+        """A session on its own engine, with foreign keys actually enforced.
+
+        The shared ``db_session`` fixture cannot be used: it holds an open
+        transaction, and SQLite silently ignores ``PRAGMA foreign_keys`` inside
+        one — the pragma read back as 0. So enforcement is set on *connect*,
+        and asserted, because a guard that quietly runs without foreign keys
+        would pass while the production path stays broken.
+        """
+        from sqlalchemy import create_engine, event
+        from sqlalchemy.orm import Session as SaSession
+
+        from datanika.models.base import Base
+
+        engine = create_engine("sqlite:///:memory:")
+
+        @event.listens_for(engine, "connect")
+        def _enable_fk(dbapi_connection, _record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+        Base.metadata.create_all(engine)
+        session = SaSession(bind=engine)
+        assert session.execute(text("PRAGMA foreign_keys")).scalar() == 1
+        try:
+            yield session
+        finally:
+            session.close()
+            engine.dispose()
+
+    def _grant_for_fixture_org(self, session):
+        """Mimic a completed hosted-MCP consent inside the fixture org."""
+        org = session.execute(
+            select(Organization).where(Organization.slug == FIXTURE_ORG_SLUG)
+        ).scalar_one()
+        user = session.execute(select(User).where(User.email == FIXTURE_USER_EMAIL)).scalar_one()
+        # Consent mints the key (SPEC_REMOTE_MCP §5.3), so create it here rather
+        # than relying on the seed — this is what a hosted authorization leaves
+        # behind in a fixture org.
+        key = ApiKey(org_id=org.id, user_id=user.id, name="MCP: Claude.ai", key_hash="k" * 64)
+        session.add(key)
+        session.flush()
+        grant = OAuthGrant(
+            client_id="mcp_e2e_client",
+            org_id=org.id,
+            user_id=user.id,
+            api_key_id=key.id,
+            encrypted_api_key="not-a-real-token",
+            code_hash=None,
+            code_challenge="x" * 43,
+            redirect_uri="https://claude.ai/api/mcp/auth_callback",
+            scope="connections:read",
+            resource="https://app.datanika.io/mcp",
+            code_expires_at=datetime.now(UTC),
+        )
+        session.add(grant)
+        session.flush()
+        session.add(
+            OAuthToken(
+                grant_id=grant.id,
+                org_id=org.id,
+                access_token_hash="a" * 64,
+                refresh_token_hash="r" * 64,
+                expires_at=datetime.now(UTC),
+            )
+        )
+        session.flush()
+        return grant
+
+    def test_teardown_succeeds_after_a_consent(self, fk_enforced):
+        session = fk_enforced
+        seed(session=session)
+        self._grant_for_fixture_org(session)
+
+        # Re-seeding tears the fixture down first — this is the exact path that
+        # blew up in e2e-staging global setup.
+        seed(session=session)
+
+        assert session.execute(select(OAuthToken)).scalars().first() is None
+        assert session.execute(select(OAuthGrant)).scalars().first() is None
+
+    def test_teardown_clears_grants_owned_via_the_user_branch(self, fk_enforced):
+        """api_keys are deleted twice — by org *and* by user. Both need the chain."""
+        session = fk_enforced
+        seed(session=session)
+        grant = self._grant_for_fixture_org(session)
+        # Point the grant at a key reached only through the user-id delete.
+        user = session.execute(select(User).where(User.email == FIXTURE_USER_EMAIL)).scalar_one()
+        # A real org that is *not* a fixture org: the org-branch delete skips it,
+        # so the key is only reachable through the user-id delete. (It has to
+        # exist — with foreign keys on, an invented org_id fails on insert.)
+        other_org = Organization(name="Not A Fixture", slug="not-a-fixture-org")
+        session.add(other_org)
+        session.flush()
+        orphan = ApiKey(org_id=other_org.id, user_id=user.id, name="user-scoped", key_hash="h" * 64)
+        session.add(orphan)
+        session.flush()
+        grant.api_key_id = orphan.id
+        session.flush()
+
+        seed(session=session)
+
+        assert session.execute(select(OAuthGrant)).scalars().first() is None

--- a/tests/test_services/test_openapi_fetch.py
+++ b/tests/test_services/test_openapi_fetch.py
@@ -1,0 +1,160 @@
+"""Tests for OpenAPI spec URL-fetch (core#410, OpenAPI P2 slice 1).
+
+SPEC_OPENAPI_CONNECTOR §7 makes this a ship gate, and §14 calls SSRF "the
+headline risk" — so the guards are the test subject, not the happy path.
+
+The size cap is the one that needs a **real server**: a hostile origin can lie
+about ``Content-Length`` or simply never stop sending, so checking the header
+or the finished body proves nothing. The test streams more than the cap from a
+local server and asserts we abort mid-flight.
+
+Host/redirect rejection reuses ``validate_egress_host`` and the guarded session
+from #403 — these tests pin that they are *wired in*, not that they work
+(``test_egress_guarded_session.py`` owns that).
+"""
+
+import http.server
+import threading
+
+import pytest
+
+from datanika.services.openapi_fetch import fetch_openapi_spec, resolve_spec
+from datanika.services.openapi_import import MAX_SPEC_BYTES, OpenApiImportError
+
+_SPEC = '{"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{}}'
+
+
+class _SpecHandler(http.server.BaseHTTPRequestHandler):
+    """``/spec`` returns a small spec; ``/huge`` streams past the cap forever."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        if self.path == "/huge":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            # No Content-Length: the body is delimited by connection close, so
+            # the client reads until EOF and nothing but our own cap bounds it.
+            # (An *understated* Content-Length is not the dangerous case —
+            # urllib3 stops at the declared length and truncates. Unbounded is.)
+            self.end_headers()
+            chunk = b"x" * 64_000
+            try:
+                for _ in range((MAX_SPEC_BYTES // len(chunk)) + 20):
+                    self.wfile.write(chunk)
+            except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                pass  # expected: the client aborts at the cap
+            return
+
+        body = _SPEC.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def spec_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _SpecHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def allow_loopback(monkeypatch):
+    """Let the local test server through the public-IP guard.
+
+    Only for tests about *other* properties — the guard's own behaviour is
+    asserted with it left alone.
+    """
+    monkeypatch.setattr("datanika.services.openapi_fetch.validate_egress_host", lambda url: None)
+    monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    # stdlib http.server speaks plaintext; the https rule is asserted separately
+    # against the real code path in TestSchemeIsHttpsOnly.
+    monkeypatch.setattr("datanika.services.openapi_fetch.REQUIRED_SCHEME", "http")
+
+
+class TestSchemeIsHttpsOnly:
+    def test_http_is_refused(self):
+        """§7 is stricter than the connector guard: https only for spec fetch."""
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("http://example.com/openapi.json")
+        assert exc.value.code == "invalid_spec_url"
+
+    def test_file_scheme_is_refused(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("file:///etc/passwd")
+        assert exc.value.code == "invalid_spec_url"
+
+
+class TestHostGuardIsWiredIn:
+    def test_private_host_is_refused(self):
+        """Reuses validate_egress_host rather than a second implementation."""
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("https://127.0.0.1/openapi.json")
+        assert exc.value.code == "invalid_spec_url"
+
+    def test_cloud_metadata_is_refused(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec("https://169.254.169.254/latest/meta-data/")
+        assert exc.value.code == "invalid_spec_url"
+
+
+class TestSizeCapIsEnforcedWhileStreaming:
+    def test_oversized_body_aborts_and_does_not_buffer(self, spec_server, allow_loopback):
+        """A hostile origin can understate Content-Length or never stop."""
+        with pytest.raises(OpenApiImportError) as exc:
+            fetch_openapi_spec(f"{spec_server}/huge")
+        assert exc.value.code == "spec_too_large"
+
+
+class TestResolveSpecSource:
+    """The 'exactly one of' decision, which the route itself cannot be tested on.
+
+    ``parse_openapi`` is wrapped by ``@api_endpoint`` for auth and exposes no
+    ``__wrapped__``, so this branch would ship untested if it lived inline —
+    which is why it doesn't.
+    """
+
+    def test_neither_source_is_an_error(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            resolve_spec(None, None)
+        assert exc.value.code == "invalid_request"
+
+    def test_both_sources_is_an_error(self):
+        """Ambiguous, not incomplete — silently preferring one would surprise."""
+        with pytest.raises(OpenApiImportError) as exc:
+            resolve_spec(_SPEC, "https://example.com/openapi.json")
+        assert exc.value.code == "invalid_request"
+
+    def test_inline_passes_through_untouched(self):
+        assert resolve_spec(_SPEC, None) == _SPEC
+
+    def test_non_string_inline_is_rejected(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            resolve_spec({"openapi": "3.0.0"}, None)
+        assert exc.value.code == "invalid_request"
+
+    def test_url_is_fetched(self, spec_server, allow_loopback):
+        assert resolve_spec(None, f"{spec_server}/spec") == _SPEC
+
+
+class TestHappyPath:
+    def test_returns_the_body(self, spec_server, allow_loopback):
+        assert fetch_openapi_spec(f"{spec_server}/spec") == _SPEC
+
+    def test_result_feeds_the_parser_unchanged(self, spec_server, allow_loopback):
+        """The fetcher's only job is bytes; parsing stays deterministic."""
+        from datanika.services.openapi_import import parse_openapi_spec
+
+        parsed = parse_openapi_spec(
+            fetch_openapi_spec(f"{spec_server}/spec"), base_url_override="https://api.example.com"
+        )
+        assert parsed.base_url == "https://api.example.com"

--- a/tests/test_services/test_openapi_pagination.py
+++ b/tests/test_services/test_openapi_pagination.py
@@ -1,0 +1,227 @@
+"""Spec-driven pagination detection (core#411, OpenAPI P2).
+
+P1 emitted no paginator and leaned on dlt's *runtime* auto-detection. When that
+guesses wrong the extract silently stops after page 1 — which surfaces as an
+empty or short table, not an error. That is the same silent-green class as the
+MCP deadlock (a 200 carrying an error string) and the e2e teardown (an opaque
+setup failure): the pipeline reports success and the data is wrong.
+
+So the load-bearing test here is **behavioural**, not structural:
+``TestPaginationActuallyPagesThroughData`` serves two real pages over a real
+socket and asserts a row that **cannot appear on page one** arrives. A test that
+only asserts the emitted config "looks right" passes just as happily against a
+paginator that never advances — which is precisely the bug being prevented.
+
+Emitted configs are the shapes dlt actually accepts (verified against
+``dlt.sources.rest_api.config_setup.PAGINATOR_MAP`` and the paginator
+constructors), not invented ones.
+"""
+
+import http.server
+import json
+import threading
+
+import pytest
+
+from datanika.services.openapi_import import parse_openapi_spec
+
+
+def _spec(*, params=None, response_props=None, headers=None, items_key="data") -> dict:
+    """A minimal one-collection spec with pluggable pagination hints."""
+    props = {items_key: {"type": "array", "items": {"$ref": "#/components/schemas/Widget"}}}
+    props.update(response_props or {})
+    response: dict = {
+        "description": "ok",
+        "content": {"application/json": {"schema": {"type": "object", "properties": props}}},
+    }
+    if headers:
+        response["headers"] = headers
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "t", "version": "1"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/widgets": {
+                "get": {
+                    "operationId": "listWidgets",
+                    "parameters": params or [],
+                    "responses": {"200": response},
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Widget": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+                }
+            }
+        },
+    }
+
+
+def _query(name: str, **schema) -> dict:
+    return {"name": name, "in": "query", "schema": schema or {"type": "integer"}}
+
+
+def _paginator_of(spec: dict) -> dict | None:
+    parsed = parse_openapi_spec(spec)
+    return parsed.resources[0]["endpoint"].get("paginator")
+
+
+class TestDetection:
+    def test_offset_limit_params(self):
+        pag = _paginator_of(_spec(params=[_query("offset"), _query("limit")]))
+        assert pag["type"] == "offset"
+        assert pag["offset_param"] == "offset"
+        assert pag["limit_param"] == "limit"
+
+    def test_offset_limit_uses_the_specs_declared_maximum(self):
+        """Respect the API's own ceiling instead of guessing a page size."""
+        pag = _paginator_of(
+            _spec(params=[_query("offset"), _query("limit", type="integer", maximum=250)])
+        )
+        assert pag["limit"] == 250
+
+    def test_skip_top_are_recognised_as_offset(self):
+        """OData-style names are the same pattern under different words."""
+        pag = _paginator_of(_spec(params=[_query("skip"), _query("top")]))
+        assert pag["type"] == "offset"
+        assert pag["offset_param"] == "skip"
+
+    def test_page_number_params(self):
+        pag = _paginator_of(_spec(params=[_query("page"), _query("per_page")]))
+        assert pag["type"] == "page_number"
+        assert pag["page_param"] == "page"
+
+    def test_json_link_beats_query_params(self):
+        """A next-URL in the body is authoritative; params are inference."""
+        pag = _paginator_of(
+            _spec(
+                params=[_query("page")],
+                response_props={"next": {"type": "string"}},
+            )
+        )
+        assert pag["type"] == "json_link"
+        assert pag["next_url_path"] == "next"
+
+    def test_link_header(self):
+        pag = _paginator_of(_spec(headers={"Link": {"schema": {"type": "string"}}}))
+        assert pag["type"] == "header_link"
+
+    def test_cursor_param_with_matching_response_field(self):
+        pag = _paginator_of(
+            _spec(
+                params=[_query("cursor", type="string")],
+                response_props={"next_cursor": {"type": "string"}},
+            )
+        )
+        assert pag["type"] == "cursor"
+        assert pag["cursor_param"] == "cursor"
+        assert pag["cursor_path"] == "next_cursor"
+
+    def test_total_path_only_when_the_spec_declares_one(self):
+        """OffsetPaginator defaults total_path='total'; a spec without that
+        field must get None or dlt looks for a key that never arrives."""
+        without = _paginator_of(_spec(params=[_query("offset"), _query("limit")]))
+        assert without["total_path"] is None
+
+        with_total = _paginator_of(
+            _spec(
+                params=[_query("offset"), _query("limit")],
+                response_props={"total": {"type": "integer"}},
+            )
+        )
+        assert with_total["total_path"] == "total"
+
+    def test_no_hints_emits_no_paginator(self):
+        """Silence beats a guess — dlt's runtime auto-detection still applies."""
+        assert _paginator_of(_spec()) is None
+
+
+class _PagedHandler(http.server.BaseHTTPRequestHandler):
+    """Two pages of widgets, offset/limit style. Page 2 holds id=99."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        offset = 0
+        if "offset=" in self.path:
+            offset = int(self.path.split("offset=")[1].split("&")[0])
+        rows = [{"id": 1, "name": "first"}] if offset == 0 else []
+        if offset == 1:
+            rows = [{"id": 99, "name": "only-on-page-two"}]
+        body = json.dumps({"data": rows}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def paged_api():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _PagedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestPaginationActuallyPagesThroughData:
+    def test_second_page_rows_arrive(self, paged_api, monkeypatch):
+        """The row on page two cannot be produced by a paginator that never
+        advances, so this fails on exactly the bug we are preventing.
+
+        Driven through ``DltRunnerService._build_openapi_source`` — the real
+        production path — rather than hand-assembling a dlt config. The parser
+        emits a *catalog* (with our private ``columns``/``_source`` keys) that
+        dlt rejects outright until the runtime strips them, so a test that
+        built its own config would prove the parser works in a shape nothing
+        actually uses.
+        """
+        import datanika.services.dlt_runner as dlt_runner
+
+        # The egress guard blocks loopback by design; it has its own tests.
+        monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+
+        parsed = parse_openapi_spec(
+            _spec(params=[_query("offset"), _query("limit", type="integer", maximum=1)]),
+            base_url_override=paged_api,
+        )
+        source = dlt_runner.DltRunnerService()._build_openapi_source(
+            {"base_url": paged_api, "resources": parsed.resources}, {}
+        )
+        rows = list(source.resources["widgets"])
+
+        ids = {r["id"] for r in rows}
+        assert 1 in ids, f"page one missing: {rows}"
+        assert 99 in ids, f"never advanced past page one: {rows}"
+
+    def test_control_without_hints_stops_at_page_one(self, paged_api, monkeypatch):
+        """Proves the test above discriminates.
+
+        If dlt's runtime auto-detection reached page two on its own, the
+        assertion above would pass no matter what this parser emitted — a green
+        that measures nothing. With no offset/limit params declared, no
+        paginator is emitted and the extract must stop at page one.
+        """
+        import datanika.services.dlt_runner as dlt_runner
+
+        monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+
+        parsed = parse_openapi_spec(_spec(), base_url_override=paged_api)
+        assert parsed.resources[0]["endpoint"].get("paginator") is None
+        source = dlt_runner.DltRunnerService()._build_openapi_source(
+            {"base_url": paged_api, "resources": parsed.resources}, {}
+        )
+        rows = list(source.resources["widgets"])
+
+        assert {r["id"] for r in rows} == {1}, f"expected page one only, got {rows}"

--- a/tests/test_services/test_sso_saml_forgery.py
+++ b/tests/test_services/test_sso_saml_forgery.py
@@ -12,8 +12,15 @@ issues no token.** The Redis request-id gate is patched OPEN so the forgery is
 rejected by the SAML *validator* (the fix), not the replay defence — a future
 regression that weakened signature validation would flip this red.
 
-python3-saml/xmlsec is a main dependency, so CI + Docker always run this; the
-``importorskip`` only guards a stale local venv.
+python3-saml/xmlsec is a **main** dependency, so this imports it unconditionally
+rather than via ``pytest.importorskip``. That is deliberate: a security regression
+probe must never be able to stop guarding quietly. ``xmlsec`` is a compiled binding
+that installs cleanly and then fails to import when its system libs are missing
+(``libxmlsec1.so.1: cannot open shared object file``) — under ``importorskip`` that
+would silently skip this probe and leave CI green while the auth-bypass invariant
+went unchecked. Exactly the failure mode that nearly hid a broken Kafka probe in
+core#407. A hard import turns the same situation into a red build, which is the
+only safe direction for this particular test.
 """
 
 import base64
@@ -21,14 +28,16 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-import pytest
+# Import guard, deliberately mirroring the production import path: sso_routes
+# imports OneLogin_Saml2_Auth *inside* the callback (not at module scope), so
+# importing sso_routes below would NOT surface a broken xmlsec. Importing it
+# here means a runtime-broken dependency fails collection instead of quietly
+# un-guarding the auth-bypass invariant.
+from onelogin.saml2.auth import OneLogin_Saml2_Auth  # noqa: F401
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
 
-pytest.importorskip("onelogin.saml2")  # xmlsec/python3-saml needed to drive the real validator
-
-from starlette.applications import Starlette  # noqa: E402
-from starlette.testclient import TestClient  # noqa: E402
-
-from datanika.services.sso_routes import _sign_state, sso_routes  # noqa: E402
+from datanika.services.sso_routes import _sign_state, sso_routes
 
 
 def _self_signed_idp_cert() -> str:

--- a/tests/test_ui/test_mcp_consent_state.py
+++ b/tests/test_ui/test_mcp_consent_state.py
@@ -84,13 +84,18 @@ def _fake_state(params: dict | None = None, *, access_token: str = "jwt-token", 
     return state
 
 
-def _redirect_target(spec) -> str:
-    """The URL an ``rx.redirect`` EventSpec sends the browser to."""
+def _redirect_arg(spec, arg: str):
+    """One argument of an ``rx.redirect`` EventSpec, by name."""
     assert spec is not None, "expected a redirect, got None"
     for name, value in spec.args:
-        if name._js_expr == "path":
+        if name._js_expr == arg:
             return value._var_value
-    raise AssertionError("EventSpec is not a redirect")
+    raise AssertionError(f"EventSpec has no {arg!r} argument")
+
+
+def _redirect_target(spec) -> str:
+    """The URL an ``rx.redirect`` EventSpec sends the browser to."""
+    return _redirect_arg(spec, "path")
 
 
 async def _events(result) -> list:
@@ -234,6 +239,43 @@ class TestAllowPreconditions:
         assert target.startswith("/login?next=")
         resumed = parse_qs(urlparse(target).query)["next"][0]
         assert parse_qs(urlparse(resumed).query)["client_id"] == ["mcp_test"]
+
+
+class TestLeavesInTheSameTab:
+    """Both outcomes must navigate *this* tab, not open a second one (#417).
+
+    ``rx.redirect(..., is_external=True)`` reads like "this URL is off-site"
+    but Reflex means it literally — ``window.open(path, "_blank")``. The
+    callback opened in a new tab and left the consent screen sitting on a
+    disabled "Approving…" button forever. The flow still completed, which is
+    why it survived: every assertion here checked the destination URL, and the
+    destination was right. Only the tab was wrong.
+
+    Reflex's default path already handles cross-origin — it compares hosts and
+    calls ``window.location.assign`` — so the fix was to stop asking.
+    """
+
+    async def test_allow_does_not_open_a_new_tab(self, backend, registered, session_jwt):
+        state = _fake_state(_params(client_id=registered["client_id"]), access_token=session_jwt)
+
+        with patch("datanika.services.mcp_oauth_routes.settings.secret_key", _SECRET):
+            await McpConsentState.load_consent.fn(state)
+            emitted = await _events(McpConsentState.allow.fn(state))
+
+        assert _redirect_arg(emitted[0], "external") is False
+
+    def test_deny_does_not_open_a_new_tab(self):
+        state = _fake_state(verified_redirect_uri=_REDIRECT, request_params=_params())
+
+        assert _redirect_arg(McpConsentState.deny.fn(state), "external") is False
+
+    async def test_the_login_bounce_stays_in_the_tab_too(self):
+        """A second tab here would leave the request behind in the first."""
+        state = _fake_state(_params(), access_token="")
+
+        spec = await McpConsentState.load_consent.fn(state)
+
+        assert _redirect_arg(spec, "external") is False
 
 
 class TestConsentCopyMatchesTheGrant:

--- a/uv.lock
+++ b/uv.lock
@@ -968,6 +968,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "testcontainers" },
 ]
@@ -1008,6 +1009,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
     { name = "python3-saml", specifier = ">=1.16,<2" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "redis", specifier = ">=5.0" },
     { name = "reflex", specifier = ">=0.7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },


### PR DESCRIPTION
Promotion of the current `dev` to production.

**Included**
- **core#423** (Eng) — `e2e_seed` teardown deletes the OAuth chain (`oauth_tokens` → `oauth_grants`) before `api_keys`. Closes #415: previously *any* completed consent in a fixture org wedged the seed permanently, and the flow we publicly document does exactly that.
- **core#412** (Eng) — OpenAPI P2: spec URL-fetch behind the §7 SSRF guards (closes #410).
- **core#427** (Eng) — OpenAPI P2: spec-driven pagination detection (closes #411).
- **core#420** (Product) — consent screen redirects in the same tab instead of opening a new one (closes #417). Fixes the "Approving…" dead-end I hit during the SPEC §13 browser smoke.
- **core#424** (QA) — closes the remaining silent-green skips outside the smoke suite.
- **core#428** (Eng) — hosted `/mcp` write-refusal message gives advice a hosted caller can act on (closes #409); the old text told them to restart a server they don't run.

Merge strategy: `--merge` per `plans/infra/RUNBOOK_DEV_TO_MASTER.md`, keeping `master` a descendant of `dev` so the resync is a clean fast-forward.