### PR TITLE
[Product] Social login stays in the current tab (closes #418)

### DIFF
--- a/datanika/ui/components/cost_estimator_card.py
+++ b/datanika/ui/components/cost_estimator_card.py
@@ -99,7 +99,10 @@ def cost_estimator_card() -> rx.Component:
             _mode_split_hint(),
             rx.link(
                 _t["cost.learn_more"],
-                href="/pricing/",
+                # Absolute: /pricing/ lives on the landing site, and a
+                # root-relative href would resolve against the app origin and
+                # open app.datanika.io/pricing/, a route we do not serve (#418).
+                href="https://datanika.io/pricing/",
                 size="1",
                 color="var(--violet-11)",
                 is_external=True,

--- a/datanika/ui/components/elt_nudge_card.py
+++ b/datanika/ui/components/elt_nudge_card.py
@@ -68,7 +68,9 @@ def elt_nudge_card() -> rx.Component:
                 ),
                 rx.link(
                     _t["nudge.learn_more"],
-                    href="/pricing/",
+                    # Absolute for the same reason as cost_estimator_card (#418):
+                    # /pricing/ is a landing-site page, not an app route.
+                    href="https://datanika.io/pricing/",
                     size="1",
                     color="var(--violet-11)",
                     is_external=True,

--- a/datanika/ui/pages/login.py
+++ b/datanika/ui/pages/login.py
@@ -1,5 +1,7 @@
 """Login page."""
 
+import json
+
 import reflex as rx
 
 from datanika.config import settings
@@ -9,6 +11,35 @@ from datanika.ui.state.i18n_state import I18nState
 
 _backend = settings.oauth_redirect_base_url
 _t = I18nState.translations
+
+
+def _social_login_button(label: str, provider: str) -> rx.Component:
+    """Start a social login in the current tab (#418).
+
+    This has to be a real browser navigation: ``/api/auth/login/<provider>``
+    is a backend Starlette route that 302s to the provider, so nothing the
+    frontend router does can serve it. It also has to stay in *this* tab —
+    the previous ``rx.link(..., is_external=True)`` compiled to
+    ``target="_blank"``, so the user authenticated in a second tab and ended
+    up signed in there while the original still showed the sign-in form.
+
+    Neither ``rx.link`` nor ``rx.el.a`` can express that: both render a
+    react-router ``Link``, which treats a *same-origin* absolute URL as an
+    in-app route — and in production the backend and frontend share
+    ``app.datanika.io``, so the click would be swallowed by the router.
+    (In dev the origins differ, so that breakage would not show up locally.)
+    ``rx.redirect`` has the same same-origin branch. Hence an explicit
+    assignment, which is unambiguous whatever the router does.
+    """
+    target = f"{_backend}/api/auth/login/{provider}"
+    return rx.button(
+        label,
+        variant="outline",
+        size="3",
+        width="100%",
+        type="button",
+        on_click=rx.call_script(f"window.location.assign({json.dumps(target)})"),
+    )
 
 
 def login_page() -> rx.Component:
@@ -68,28 +99,8 @@ def login_page() -> rx.Component:
             rx.divider(),
             rx.text(_t["auth.or_continue_with"], size="2", color="gray", text_align="center"),
             rx.hstack(
-                rx.link(
-                    rx.button(
-                        "Google",
-                        variant="outline",
-                        size="3",
-                        width="100%",
-                    ),
-                    href=f"{_backend}/api/auth/login/google",
-                    is_external=True,
-                    width="100%",
-                ),
-                rx.link(
-                    rx.button(
-                        "GitHub",
-                        variant="outline",
-                        size="3",
-                        width="100%",
-                    ),
-                    href=f"{_backend}/api/auth/login/github",
-                    is_external=True,
-                    width="100%",
-                ),
+                _social_login_button("Google", "google"),
+                _social_login_button("GitHub", "github"),
                 width="100%",
                 spacing="3",
             ),

--- a/tests/test_ui/test_external_links.py
+++ b/tests/test_ui/test_external_links.py
@@ -1,0 +1,104 @@
+"""Links must not strand the user in a second tab (#418, sibling of #417).
+
+``is_external=True`` reads like "this URL is off-site". Reflex means it
+literally: ``rx.link`` compiles it to ``target="_blank"`` and ``rx.redirect``
+to ``window.open(path, "_blank")``. That is right for a link *out* of the
+product and wrong for anything the user is meant to come back from.
+
+It was wrong twice. On ``/oauth/consent`` the callback opened in a new tab and
+left the original on a disabled "Approving…" button (#417). On ``/login`` the
+provider opened in a new tab, so the user authenticated *there* and ended up
+signed in in that tab while the original still showed the sign-in form.
+
+The login case could not simply drop the flag. ``/api/auth/login/<provider>``
+is a backend route, and both ``rx.link`` and ``rx.el.a`` render a react-router
+``Link``, which treats a same-origin absolute URL as an in-app route. In
+production the backend and frontend share ``app.datanika.io``, so dropping the
+flag would have handed the click to the router and broken sign-in — *and it
+would still have worked in dev*, where the origins differ. Hence the explicit
+``window.location.assign``.
+"""
+
+import ast
+import inspect
+
+import datanika.ui.components.cost_estimator_card as cost_estimator_card
+import datanika.ui.components.elt_nudge_card as elt_nudge_card
+import datanika.ui.pages.login as login_page_module
+from datanika.ui.pages.login import login_page
+
+
+def _rendered(component) -> str:
+    return str(component.render())
+
+
+class TestSocialLoginStaysInTheTab:
+    def test_no_new_tab_anywhere_on_the_login_page(self):
+        assert "_blank" not in _rendered(login_page()), (
+            "A social-login button opening in a new tab leaves the user signed "
+            "in there while the original tab still shows the form (#418)."
+        )
+
+    def test_both_providers_do_a_real_browser_navigation(self):
+        """Not a router push — the endpoint is served by the backend."""
+        html = _rendered(login_page())
+
+        for provider in ("google", "github"):
+            assert f"/api/auth/login/{provider}" in html, provider
+        assert html.count("window.location.assign") == 2
+
+    def test_the_providers_are_not_react_router_links(self):
+        """A router Link would swallow the click in production.
+
+        Same-origin absolute URLs are treated as in-app routes, and prod serves
+        the API and the frontend from one host. Dev would not have shown it.
+        """
+        html = _rendered(login_page())
+        start = html.find("/api/auth/login/google")
+        assert start != -1
+        # The surrounding markup must not be a router link carrying `to=`.
+        assert "ReactRouterLink" not in html[max(0, start - 600) : start + 600]
+
+
+class TestOffSiteLinksAreAbsolute:
+    """A root-relative href with ``is_external`` opens the *app* origin.
+
+    ``/pricing/`` is a landing-site page; opening ``app.datanika.io/pricing/``
+    lands on a route the Reflex app does not serve. Both call sites are behind
+    ``datanika_dual_mode_ux_enabled`` (off), so this was dormant rather than
+    broken in production — worth pinning before that flag flips.
+    """
+
+    def test_pricing_links_point_at_the_landing_site(self):
+        for module in (cost_estimator_card, elt_nudge_card):
+            source = inspect.getsource(module)
+            assert 'href="/pricing/"' not in source, (
+                f"{module.__name__} links /pricing/ root-relative; with "
+                "is_external it opens app.datanika.io/pricing/ (#418)."
+            )
+            assert "https://datanika.io/pricing/" in source, module.__name__
+
+
+class TestNoStrayExternalRedirects:
+    """No call on the login page may ask for a new tab.
+
+    AST rather than a substring scan (the repo's convention — see
+    ``test_rbac_ui_visibility.py``) so the prose explaining *why* the flag is
+    wrong here doesn't trip its own guard. State-level redirects are covered by
+    ``test_mcp_consent_state.py::TestLeavesInTheSameTab``.
+    """
+
+    def test_login_module_never_asks_for_a_new_tab(self):
+        tree = ast.parse(inspect.getsource(login_page_module))
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            for keyword in node.keywords
+            if keyword.arg == "is_external"
+        ]
+
+        assert not offenders, (
+            f"login.py passes is_external at line(s) {offenders}. Social login "
+            "must stay in the current tab — see _social_login_button's docstring."
+        )


### PR DESCRIPTION
Closes #418. The audit that fell out of #417 — same flag, two more places.

## Social login (live, user-facing)

`login.py` sent Google and GitHub through `rx.link(..., is_external=True)`, which compiles to `target="_blank"`. The provider opened in a **second tab**; the user authenticated there, landed on `/auth/complete?token=…` in that tab, and was signed in — while the original `/login` tab still showed the sign-in form. Which tab they returned to decided whether the product looked logged in.

### Why this could not be fixed the way #417 was

#417 was fixed by deleting the flag, because `rx.redirect`'s default path already does `window.location.assign` for a cross-origin URL. **That reasoning does not carry over here**, and I checked instead of assuming:

- `rx.link` with an `href` renders a **react-router `Link`** — `link.py:106` says so outright: *"If user does not use `as_child`, by default we render using react_router_link to avoid page refresh during internal navigation."*
- `rx.el.a` is not an escape hatch: `type(rx.el.a(...))` is literally `ReactRouterLink` (it subclasses `A`).
- `as_child=True` does skip the rewrite, but Radix `asChild` merges props onto the child, so `href` lands on the `<button>` — where it does nothing.

React-router treats a **same-origin absolute URL as an in-app route**. `/api/auth/login/<provider>` is a backend Starlette route, and in production the API and the frontend share `app.datanika.io`. So dropping the flag would have handed the click to the router, which cannot serve that path — **breaking sign-in in production while continuing to work in dev**, where `oauth_redirect_base_url` (`localhost:8000`) and the frontend (`:3000`) are different origins. That's the worst shape a bug can have, and it's the one the obvious fix would have produced.

### What it does instead

A button with an explicit `window.location.assign`. Unambiguous whatever the router does, and it stays correct if react-router's absolute-URL handling changes. `rx.call_script` is an established pattern here (`pipeline_state.py:470`, `upload_state.py:596`).

The trade is anchor semantics — no middle-click-to-new-tab on those two buttons. Acceptable: this initiates an auth flow rather than pointing at a document, and "open in a new tab" is precisely the behaviour being removed.

## `/pricing/` links (dormant)

`cost_estimator_card.py` and `elt_nudge_card.py` used `href="/pricing/"` with `is_external=True`. Root-relative, so it resolved against the app origin and opened `app.datanika.io/pricing/` — a route the Reflex app does not serve. Now absolute (`https://datanika.io/pricing/`), where `is_external` is genuinely right and a new tab is wanted.

Never reachable in production: both surfaces sit behind `datanika_dual_mode_ux_enabled`, which is off. Fixed now so it isn't discovered by whoever flips that flag.

`dashboard.py:243` → `https://datanika.io/docs` was already correct and is untouched.

## Tests

New `tests/test_ui/test_external_links.py`, 5 guards: no `_blank` anywhere on the login page, both providers doing a real browser navigation, neither wrapped in a react-router link, the pricing hrefs absolute, and an AST check that no call in `login.py` passes `is_external` again.

Verified they bite: with the old markup restored, **4 of the 5 fail**. (First cut of that AST guard was a substring scan, which tripped on the docstring explaining the bug — a test that forbids documenting the thing it guards. AST matches the repo convention in `test_rbac_ui_visibility.py`.)

Precheck green: ruff + format clean, **2407 passed, 23 skipped**.

## Still open, and not fixable here

`?next=` does not survive social login — `services/oauth_routes.py` propagates neither `next` nor `template` through the provider round-trip. So a logged-out user who reaches `/login?next=/oauth/consent?…` and clicks Google now stays in one tab (this PR) but still lands on the dashboard rather than back at the consent screen. Self-heals on retry; the real fix means threading state through Engineering's OAuth routes. Tracked in `PLAN_PRODUCT.md`.
