### PR TITLE
[Engineering] Share the endpoint-test harness; cover /openapi/parse (closes #416)

### DIFF
--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -1,0 +1,87 @@
+"""Shared harness for exercising ``@api_endpoint`` routes over real HTTP (core#416).
+
+Routes decorated with ``@api_endpoint`` cannot be called directly — the
+decorator owns auth and exposes no ``__wrapped__`` — so the only way to test a
+route's own behaviour (status codes, error mapping, response shape) is through
+a client with the middleware patched. That harness existed, but **file-local**
+in ``test_transformation_compile.py``, which is why most ``api_v1`` routes have
+no endpoint tests at all: the cost of writing the first one was copying it.
+
+Lifted here unchanged in behaviour, minus the compile-specific bits (dbt dir,
+Fernet key) which stay with the tests that need them. What's generic is the
+auth layer, and that is all this provides.
+"""
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+
+@pytest.fixture
+def fake_api_key():
+    """An authenticated key with full access (``scopes=None`` = unscoped)."""
+    key = MagicMock()
+    key.id = 1
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def client():
+    return TestClient(Starlette(routes=api_v1_routes))
+
+
+def api_headers(token: str = "etf_test") -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@contextlib.contextmanager
+def patch_api_auth(
+    fake_api_key,
+    rate_limit_ok,
+    db_session,
+    org_id: int = 1,
+    *,
+    authenticated: bool = True,
+):
+    """Patch ``api_middleware`` so a request reaches the handler.
+
+    ``authenticated=False`` makes the key lookup fail the way the real service
+    does on an unknown/expired/out-of-scope key, so a 401 can be asserted
+    without hand-rolling the middleware's behaviour.
+    """
+    fake_api_key.org_id = org_id
+
+    @contextlib.contextmanager
+    def fake_session():
+        yield db_session
+
+    with (
+        patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+        patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+        patch("datanika.services.api_middleware._get_session", fake_session),
+    ):
+        mock_svc.authenticate_api_key.return_value = fake_api_key if authenticated else None
+        mock_rl.get_limit_for_org.return_value = 60
+        mock_rl.check_rate_limit.return_value = rate_limit_ok
+        yield mock_svc

--- a/tests/test_services/test_openapi_parse_endpoint.py
+++ b/tests/test_services/test_openapi_parse_endpoint.py
@@ -1,0 +1,147 @@
+"""Endpoint tests for ``POST /api/v1/connections/openapi/parse`` (core#416).
+
+The parser and the fetcher are well covered at the unit level; the *route* had
+no tests at all. That matters most for the error contract: ``OpenApiImportError``
+carries a typed ``code`` precisely so a client (usually an agent) can branch
+without regex-matching prose — and nothing checked those codes ever reach the
+wire with the right status. A typed contract that is never asserted end-to-end
+is decoration.
+
+Also pinned: the response projection. The endpoint reshapes parsed resources
+into ``{name, path, method, data_selector, primary_key, columns, summary}``,
+and a rename there breaks every agent reading it while every parser test stays
+green.
+
+Uses the shared harness lifted into ``conftest.py`` by this same issue.
+"""
+
+import pytest
+
+from datanika.services.openapi_import import MAX_SPEC_BYTES, OpenApiImportError
+from tests.test_services.conftest import api_headers, patch_api_auth
+
+_URL = "/api/v1/connections/openapi/parse"
+
+_SPEC = """
+{
+  "openapi": "3.0.0",
+  "info": {"title": "Widgets", "version": "1"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "listWidgets",
+        "summary": "List widgets",
+        "responses": {"200": {"description": "ok", "content": {"application/json": {
+          "schema": {"type": "object", "properties": {
+            "data": {"type": "array", "items": {"$ref": "#/components/schemas/Widget"}}}}}}}}
+      }
+    }
+  },
+  "components": {"schemas": {"Widget": {"type": "object", "required": ["id"],
+    "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}}}}
+}
+"""
+
+
+@pytest.fixture
+def authed(fake_api_key, rate_limit_ok, db_session):
+    """Context manager putting a valid key behind the middleware."""
+
+    def _cm(**kwargs):
+        return patch_api_auth(fake_api_key, rate_limit_ok, db_session, **kwargs)
+
+    return _cm
+
+
+class TestAuth:
+    def test_401_without_a_key(self, client):
+        assert client.post(_URL, json={"spec_inline": _SPEC}).status_code == 401
+
+    def test_401_when_the_key_does_not_authenticate(self, client, authed):
+        """Unknown, expired, or out-of-scope all land here in the real service."""
+        with authed(authenticated=False):
+            resp = client.post(_URL, json={"spec_inline": _SPEC}, headers=api_headers())
+        assert resp.status_code == 401
+
+
+class TestTypedErrorCodesReachTheWire:
+    """Each parse/fetch failure must arrive as 400 + its documented ``code``."""
+
+    @pytest.mark.parametrize(
+        ("payload", "code"),
+        [
+            ({}, "invalid_request"),
+            ({"spec_inline": _SPEC, "spec_url": "https://x.test/s.json"}, "invalid_request"),
+            ({"spec_inline": "not json or yaml: ["}, "invalid_spec"),
+            ({"spec_inline": '{"swagger": "2.0", "paths": {}}'}, "unsupported_version"),
+            ({"spec_url": "http://insecure.test/spec.json"}, "invalid_spec_url"),
+            ({"spec_url": "https://127.0.0.1/spec.json"}, "invalid_spec_url"),
+        ],
+    )
+    def test_code_and_status(self, client, authed, payload, code):
+        with authed():
+            resp = client.post(_URL, json=payload, headers=api_headers())
+
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["code"] == code, resp.text
+
+    def test_oversized_spec(self, client, authed):
+        with authed():
+            resp = client.post(
+                _URL, json={"spec_inline": "x" * (MAX_SPEC_BYTES + 1)}, headers=api_headers()
+            )
+        assert resp.status_code == 400
+        assert resp.json()["code"] == "spec_too_large"
+
+    def test_fetch_failure_is_mapped_not_leaked(self, client, authed, monkeypatch):
+        """A network failure must surface as the typed code, not a 500."""
+
+        def _boom(url):
+            raise OpenApiImportError("Could not fetch the spec: nope", "spec_fetch_failed")
+
+        monkeypatch.setattr("datanika.services.openapi_fetch.fetch_openapi_spec", _boom)
+        with authed():
+            resp = client.post(
+                _URL, json={"spec_url": "https://ok.test/spec.json"}, headers=api_headers()
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["code"] == "spec_fetch_failed"
+
+
+class TestSuccessProjection:
+    def test_response_shape(self, client, authed):
+        with authed():
+            resp = client.post(_URL, json={"spec_inline": _SPEC}, headers=api_headers())
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["base_url"] == "https://api.example.com"
+
+        resource = body["resources"][0]
+        # These key names are the contract an agent reads — pin them.
+        assert set(resource) == {
+            "name",
+            "path",
+            "method",
+            "data_selector",
+            "primary_key",
+            "columns",
+            "summary",
+        }
+        assert resource["name"] == "widgets"
+        assert resource["method"] == "GET"
+        assert resource["data_selector"] == "data"
+        assert resource["primary_key"] == "id"
+        assert resource["summary"] == "List widgets"
+        assert {c["name"] for c in resource["columns"]} == {"id", "name"}
+
+    def test_base_url_override_is_honoured(self, client, authed):
+        with authed():
+            resp = client.post(
+                _URL,
+                json={"spec_inline": _SPEC, "base_url": "https://staging.example.com"},
+                headers=api_headers(),
+            )
+        assert resp.json()["base_url"] == "https://staging.example.com"

--- a/tests/test_services/test_transformation_compile.py
+++ b/tests/test_services/test_transformation_compile.py
@@ -16,15 +16,13 @@ Real dbt compile is exercised via fixture SQL; the warehouse is mocked.
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from cryptography.fernet import Fernet
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session as SASession
 from sqlalchemy.pool import StaticPool
-from starlette.applications import Starlette
-from starlette.testclient import TestClient
 
 # Register all model tables so Base.metadata.create_all sees them.
 import datanika.models.invitation  # noqa: F401
@@ -34,9 +32,7 @@ from datanika.models.base import Base
 from datanika.models.connection import Connection, ConnectionType
 from datanika.models.transformation import Materialization, Transformation
 from datanika.models.user import Organization
-from datanika.services.api_v1_routes import api_v1_routes
 from datanika.services.encryption import EncryptionService
-from datanika.services.rate_limit_service import RateLimitResult
 from datanika.services.transformation_compile import (
     DEFAULT_PREVIEW_LIMIT,
     MAX_PREVIEW_LIMIT,
@@ -47,6 +43,7 @@ from datanika.services.transformation_compile import (
     compile_transformation,
     preview_transformation,
 )
+from tests.test_services.conftest import api_headers, patch_api_auth  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -297,56 +294,24 @@ class TestPreviewTransformationService:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def fake_api_key():
-    key = MagicMock()
-    key.id = 1
-    key.user_id = 1
-    key.name = "Test Key"
-    key.scopes = None
-    return key
-
-
-@pytest.fixture
-def rate_limit_ok():
-    return RateLimitResult(
-        allowed=True,
-        current_count=1,
-        limit=60,
-        remaining=59,
-        retry_after=0,
-        reset_at=9999999999,
-    )
-
-
-@pytest.fixture
-def client():
-    return TestClient(Starlette(routes=api_v1_routes))
-
-
-def _headers():
-    return {"Authorization": "Bearer etf_test"}
+# `fake_api_key`, `rate_limit_ok` and `client` now come from the shared
+# harness in conftest.py (core#416); only the compile-specific settings patch
+# stays here.
+_headers = api_headers
 
 
 @contextlib.contextmanager
 def _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org_id, dbt_dir, fernet_key):
-    """Patch the middleware + compile-service settings so the API endpoint
-    sees the test session and fixture dbt dir."""
-    fake_api_key.org_id = org_id
+    """Shared API auth + the compile service's own settings.
 
-    @contextlib.contextmanager
-    def fake_session():
-        yield db_session
-
+    The auth half is generic and lives in conftest; the dbt dir and Fernet key
+    are specific to compile/preview, so they are layered on here rather than
+    pushed into a harness every other endpoint would have to ignore.
+    """
     with (
-        patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
-        patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
-        patch("datanika.services.api_middleware._get_session", fake_session),
+        patch_api_auth(fake_api_key, rate_limit_ok, db_session, org_id),
         patch("datanika.services.transformation_compile.settings") as mock_settings,
     ):
-        mock_svc.authenticate_api_key.return_value = fake_api_key
-        mock_rl.get_limit_for_org.return_value = 60
-        mock_rl.check_rate_limit.return_value = rate_limit_ok
         mock_settings.credential_encryption_key = fernet_key
         mock_settings.dbt_projects_dir = dbt_dir
         yield


### PR DESCRIPTION
Closes #416.

## Why the first endpoint test was expensive

Routes decorated with `@api_endpoint` can't be called directly — the decorator owns auth and exposes no `__wrapped__` — so the only way to test a route's *own* behaviour is through a client with the middleware patched. That harness existed, but **file-local** in `test_transformation_compile.py`. Which is why most `api_v1` routes have no endpoint tests at all: the cost of writing the first one was copying it.

Lifted into `tests/test_services/conftest.py`, minus the compile-specific bits (dbt dir, Fernet key) which stay with the tests that need them. What's generic is the auth layer, and that's all the shared harness provides — a harness every endpoint has to ignore half of isn't shared, it's just moved. Added an `authenticated=False` switch so a 401 can be asserted the way the real service produces one.

## The coverage this was filed for

`/api/v1/connections/openapi/parse` had none, and that mattered most for the **error contract**. `OpenApiImportError` carries a typed `code` precisely so a client — usually an agent — can branch without regex-matching prose, and nothing verified those codes ever reached the wire with the right status. A typed contract that's never asserted end-to-end is decoration.

Now pinned:

| case | expected |
|---|---|
| no key / key fails to authenticate | `401` |
| neither or both of `spec_inline`/`spec_url` | `400 invalid_request` |
| unparseable document | `400 invalid_spec` |
| Swagger 2.0 | `400 unsupported_version` |
| over 5 MB | `400 spec_too_large` |
| `http://` URL, or a private host | `400 invalid_spec_url` |
| fetch blows up | `400 spec_fetch_failed`, not a leaked 500 |

Plus the **success projection**: the endpoint reshapes resources into `{name, path, method, data_selector, primary_key, columns, summary}`, and a rename there breaks every agent reading it while every parser test stays green. Asserted with exact key-set equality for that reason.

## How the gap was found

While shipping #412, the "exactly one of `spec_inline` / `spec_url`" branch had to move out of the route into `resolve_spec()` **because the route was untestable in place**. That was the right call for that PR on its own merits — but the pattern it implies, *push logic out of routes because routes can't be tested*, stops working the moment something genuinely route-shaped (status codes, auth, serialization) needs covering. This removes the excuse.

Full precheck green: ruff + format clean, **2444 passed**.

Worth a follow-on scan now that it's cheap: the other `api_v1` routes are in the same position, and the harness no longer has to be copied to check one.
