### PR TITLE
[Infra] Promote dev -> master: CD reloads + verifies monitoring config (#431)

### DIFF
--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -70,6 +70,50 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
             'for i in $(seq 1 40); do h=$(docker inspect --format "{{.State.Health.Status}}" datanika-app 2>/dev/null); [ "$h" = healthy ] && { echo healthy; exit 0; }; sleep 5; done; echo "NOT healthy"; docker logs --tail 40 datanika-app; exit 1'
+
+      # Monitoring config (prometheus.yml, grafana provisioning) is BIND-MOUNTED, so the
+      # transfer updates it on disk but nothing re-reads it: the container spec is
+      # unchanged, so `compose up -d` won't recreate, and Grafana only reads provisioning
+      # at startup. Before this step, a deployed alerting change silently did nothing
+      # while CI and CD both reported success (#426).
+      - name: Reload monitoring config
+        run: |
+          ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
+            'cd /opt/datanika/datanika && set -a && . ./.env.docker && set +a && \
+             docker compose up -d prometheus grafana blackbox && \
+             for i in $(seq 1 20); do curl -fsS -X POST http://127.0.0.1:9090/-/reload >/dev/null 2>&1 && { echo "prometheus reloaded"; break; }; sleep 3; \
+               [ "$i" = 20 ] && { echo "prometheus /-/reload never succeeded"; exit 1; }; done && \
+             docker restart datanika-grafana >/dev/null && echo "grafana restarted"'
+
+      # Grafana logs provisioning errors and then quietly keeps the PREVIOUS rules, so a
+      # successful deploy is not evidence the rules are in effect. Assert that the number
+      # of rules live in Grafana matches the number defined in the repo.
+      - name: Verify alert rules are in effect
+        run: |
+          ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" 'bash -s' <<'VERIFY'
+          set -e
+          for i in $(seq 1 24); do
+            docker exec datanika-grafana sh -c \
+              'curl -sf -u "admin:$GF_SECURITY_ADMIN_PASSWORD" http://127.0.0.1:3000/api/v1/provisioning/alert-rules' \
+              > /tmp/live-rules.json 2>/dev/null && break
+            sleep 5
+          done
+          python3 - <<'PY'
+          import json, re, sys
+          expected = len(re.findall(r"^\s*-\s*uid:\s*\S+",
+              open("/opt/datanika/datanika/monitoring/grafana/provisioning/alerting/alerts.yml",
+                   encoding="utf-8").read(), re.M))
+          try:
+              live = len(json.load(open("/tmp/live-rules.json")))
+          except Exception as e:
+              print("could not read live rules from Grafana:", e); sys.exit(1)
+          print(f"alert rules: defined={expected} live={live}")
+          if live != expected:
+              print("MISMATCH - Grafana did not load the deployed rules (provisioning error?)")
+              sys.exit(1)
+          print("alert rules are in effect")
+          PY
+          VERIFY
       - name: Smoke through Cloudflare
         run: curl -fsS -o /dev/null -w "app.datanika.io/login -> %{http_code}\n" https://app.datanika.io/login
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,11 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.retention.time=30d"
+      # Enables POST /-/reload so CD can apply a changed prometheus.yml without a
+      # restart. Without it the endpoint 403s, and since the config is bind-mounted,
+      # `compose up -d` won't recreate the container either — so a deployed config
+      # change silently does nothing. See #426. Only reachable on 127.0.0.1.
+      - "--web.enable-lifecycle"
     restart: unless-stopped
 
   # Blackbox Exporter — probes external HTTP(S) endpoints and exposes metrics.


### PR DESCRIPTION
Promotion of the current `dev` to production.

**Included — core#431** (closes #426): CD transferred monitoring config but never reloaded it, so #421's alerting rules sat on disk with no effect while CI and CD both reported success. Adds `--web.enable-lifecycle` to Prometheus (its `/-/reload` previously 403'd), a **Reload monitoring config** step, and a **Verify alert rules are in effect** step that fails the deploy when the rule count live in Grafana doesn't match the repo.

**Self-testing:** the new steps run during this very deploy, so a green run is direct evidence the fix works. The verification gate was already dry-run against prod (`defined=28 live=28`).