### PR TITLE
[Engineering] OpenAPI P2: nested data-selector, incremental cursor, Swagger 2.0 (closes #411)

### DIFF
--- a/datanika/services/openapi_import.py
+++ b/datanika/services/openapi_import.py
@@ -21,6 +21,24 @@ MAX_RESOURCES = 300
 # Response-object properties that commonly wrap a collection (the data-selector).
 _ENVELOPE_KEYS = ("data", "results", "items", "records", "value", "rows")
 
+# How far to descend looking for the row array. Enough for the usual one-level
+# envelope; bounded because the spec is user input.
+_MAX_SELECTOR_DEPTH = 3
+
+# Query params that mean "only rows changed since X", and the row fields that
+# carry the matching timestamp.
+_INCREMENTAL_PARAMS = (
+    "updated_since",
+    "updated_after",
+    "modified_since",
+    "since",
+    "start_date",
+    "start_time",
+    "from",
+    "after",
+)
+_CURSOR_FIELDS = ("updated_at", "modified_at", "last_modified", "updated", "created_at")
+
 
 class OpenApiImportError(ValueError):
     """Typed parse failure.
@@ -79,11 +97,17 @@ def parse_openapi_spec(raw: str | dict, *, base_url_override: str | None = None)
     """
     spec = _load(raw)
 
+    swagger = str(spec.get("swagger", ""))
+    if swagger.startswith("2."):
+        # Normalise into the 3.x subset this parser reads (core#411) rather
+        # than teaching every function below two dialects.
+        spec = _swagger2_to_openapi3(spec)
+
     version = str(spec.get("openapi", ""))
     if not version.startswith("3."):
         raise OpenApiImportError(
-            "Only OpenAPI 3.0/3.1 is supported (Swagger 2.0 is not supported in P1)"
-            if "swagger" in spec
+            f"Swagger {swagger} is not supported — convert to OpenAPI 3.x (2.0 is supported)"
+            if swagger
             else "Missing or unsupported 'openapi' version (need 3.x)",
             "unsupported_version",
         )
@@ -187,6 +211,9 @@ def _resource_from_get(
     )
     if paginator:
         endpoint["paginator"] = paginator
+    incremental = _incremental_from_operation(spec, path_item, op, item_schema)
+    if incremental:
+        endpoint["incremental"] = incremental
     resource: dict = {
         "name": _resource_name(path),
         "endpoint": endpoint,
@@ -298,6 +325,156 @@ def _paginator_from_operation(
     return None
 
 
+def _incremental_from_operation(
+    spec: dict, path_item: dict, op: dict, item_schema: dict
+) -> dict | None:
+    """Map a "changed since" filter onto dlt's incremental config.
+
+    Missing this is not a visible failure: the extract simply pulls the whole
+    table every run, reports success, and quietly spends the customer's byte
+    quota. Both halves are required — a ``start_param`` with no row field to
+    read the high-water mark from would send an empty filter forever.
+    """
+    declared = op.get("x-incremental")
+    if isinstance(declared, dict) and declared.get("cursor_path") and declared.get("start_param"):
+        # An explicit spec declaration beats our inference.
+        return {
+            "cursor_path": str(declared["cursor_path"]),
+            "start_param": str(declared["start_param"]),
+        }
+
+    params = _query_params(spec, path_item, op)
+    start_param = None
+    for name, param in params.items():
+        schema = param.get("schema") or {}
+        is_datetime = schema.get("format") in ("date-time", "date")
+        if is_datetime and name.lower() in _INCREMENTAL_PARAMS:
+            start_param = name
+            break
+    if not start_param:
+        return None
+
+    props = (item_schema or {}).get("properties") or {}
+    cursor = _first_key(props, _CURSOR_FIELDS)
+    if not cursor:
+        return None
+    return {"cursor_path": cursor, "start_param": start_param}
+
+
+# --- Swagger 2.0 shim (P2, core#411) ---------------------------------------
+#
+# 2.0 specs were rejected outright, which is a large share of the real world.
+# The parser stays 3.x-only; this normalises 2.0 into the subset it reads,
+# rather than teaching every function two dialects.
+
+
+def _swagger2_to_openapi3(spec: dict) -> dict:
+    """Convert the parts of a Swagger 2.0 document this parser consumes."""
+    converted: dict = {
+        "openapi": "3.0.0",
+        "info": spec.get("info") or {},
+        "paths": {},
+        "components": {},
+    }
+
+    scheme = (spec.get("schemes") or ["https"])[0]
+    host = spec.get("host") or ""
+    base_path = spec.get("basePath") or ""
+    if host:
+        converted["servers"] = [{"url": f"{scheme}://{host}{base_path}"}]
+
+    if spec.get("definitions"):
+        converted["components"]["schemas"] = _rewrite_refs(spec["definitions"])
+
+    security = spec.get("securityDefinitions") or {}
+    if security:
+        converted["components"]["securitySchemes"] = {
+            name: _convert_security_scheme(scheme_def)
+            for name, scheme_def in security.items()
+            if isinstance(scheme_def, dict)
+        }
+
+    for path, item in (spec.get("paths") or {}).items():
+        if not isinstance(item, dict):
+            continue
+        converted["paths"][path] = {
+            key: (_convert_operation(value) if key in _HTTP_METHODS else _rewrite_refs(value))
+            for key, value in item.items()
+        }
+    return converted
+
+
+_HTTP_METHODS = ("get", "put", "post", "delete", "patch", "options", "head")
+
+
+def _convert_security_scheme(scheme: dict) -> dict:
+    kind = scheme.get("type")
+    if kind == "basic":
+        return {"type": "http", "scheme": "basic"}
+    return _rewrite_refs(scheme)
+
+
+def _convert_operation(op: dict) -> dict:
+    if not isinstance(op, dict):
+        return op
+    out = {k: _rewrite_refs(v) for k, v in op.items() if k not in ("parameters", "responses")}
+
+    # 2.0 puts `type`/`format` on the parameter itself; 3.0 nests them under
+    # `schema`. Normalising matters beyond tidiness: pagination and incremental
+    # detection both read `param["schema"]`, so without this a converted spec
+    # loses its declared `maximum` and its date-time hints.
+    params = []
+    for raw in op.get("parameters") or []:
+        if not isinstance(raw, dict):
+            continue
+        param = _rewrite_refs(raw)
+        if "schema" not in param and param.get("in") != "body":
+            schema = {
+                k: param.pop(k)
+                for k in ("type", "format", "maximum", "default", "enum")
+                if k in param
+            }
+            if schema:
+                param["schema"] = schema
+        params.append(param)
+    if params:
+        out["parameters"] = params
+
+    # 2.0 hangs the response schema directly off the response; 3.0 puts it
+    # under content[media-type].
+    responses = {}
+    for code, resp in (op.get("responses") or {}).items():
+        if not isinstance(resp, dict):
+            continue
+        converted = {k: _rewrite_refs(v) for k, v in resp.items() if k != "schema"}
+        if "schema" in resp:
+            converted["content"] = {"application/json": {"schema": _rewrite_refs(resp["schema"])}}
+        responses[code] = converted
+    if responses:
+        out["responses"] = responses
+    return out
+
+
+def _rewrite_refs(node):
+    """Rewrite ``#/definitions/X`` → ``#/components/schemas/X`` everywhere.
+
+    Miss this and every ``$ref`` dangles: the spec converts, the parse
+    "succeeds", and every resource comes back with zero columns.
+    """
+    if isinstance(node, dict):
+        return {
+            key: (
+                value.replace("#/definitions/", "#/components/schemas/")
+                if key == "$ref" and isinstance(value, str)
+                else _rewrite_refs(value)
+            )
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [_rewrite_refs(item) for item in node]
+    return node
+
+
 def _success_response(spec: dict, op: dict) -> dict | None:
     """The resolved success response object for a GET, if any."""
     responses = op.get("responses") or {}
@@ -335,18 +512,47 @@ def _response_item_schema(spec: dict, op: dict) -> tuple[dict | None, str | None
     schema = resolve_ref(spec, schema)
     if not isinstance(schema, dict):
         return None, None
+    return _find_collection(spec, schema)
+
+
+def _find_collection(
+    spec: dict, schema: dict, prefix: str = "", depth: int = 0
+) -> tuple[dict | None, str | None]:
+    """Locate the row array in a response schema, returning (items, selector).
+
+    Walks nested objects (``{"response": {"items": [...]}}`` → ``response.items``)
+    rather than only the top level: a one-level-deep envelope is a common shape,
+    and missing it yields **zero rows from a healthy API** — no error, just an
+    empty table. Depth is bounded because a spec is user input.
+    """
+    if not isinstance(schema, dict):
+        return None, None
     if schema.get("type") == "array":
-        return resolve_ref(spec, schema.get("items") or {}), None
-    if schema.get("type") == "object" or "properties" in schema:
-        props = schema.get("properties") or {}
-        # prefer a conventional envelope key, else any array-typed property
-        ordered = [k for k in _ENVELOPE_KEYS if k in props] + [
-            k for k in props if k not in _ENVELOPE_KEYS
-        ]
-        for key in ordered:
-            sub = resolve_ref(spec, props[key])
-            if isinstance(sub, dict) and sub.get("type") == "array":
-                return resolve_ref(spec, sub.get("items") or {}), key
+        return resolve_ref(spec, schema.get("items") or {}), (prefix or None)
+    if schema.get("type") != "object" and "properties" not in schema:
+        return None, None
+
+    props = schema.get("properties") or {}
+    # Conventional envelope keys first, then anything else — a `data` array
+    # beats an unrelated `errors` array when both are present.
+    ordered = [k for k in _ENVELOPE_KEYS if k in props] + [
+        k for k in props if k not in _ENVELOPE_KEYS
+    ]
+    for key in ordered:
+        sub = resolve_ref(spec, props[key])
+        if isinstance(sub, dict) and sub.get("type") == "array":
+            path = f"{prefix}.{key}" if prefix else key
+            return resolve_ref(spec, sub.get("items") or {}), path
+
+    if depth >= _MAX_SELECTOR_DEPTH:
+        return None, None
+    for key in ordered:
+        sub = resolve_ref(spec, props[key])
+        if isinstance(sub, dict) and (sub.get("type") == "object" or "properties" in sub):
+            path = f"{prefix}.{key}" if prefix else key
+            items, selector = _find_collection(spec, sub, path, depth + 1)
+            if items is not None:
+                return items, selector
     return None, None
 
 

--- a/tests/test_services/test_openapi_import.py
+++ b/tests/test_services/test_openapi_import.py
@@ -291,9 +291,14 @@ class TestAuth:
 
 
 class TestCapsAndErrors:
-    def test_rejects_swagger_2(self):
+    def test_accepts_swagger_2(self):
+        """P1 rejected 2.0; P2 converts it (core#411). See test_openapi_p2_slices."""
+        parsed = parse_openapi_spec({"swagger": "2.0", "paths": {}})
+        assert parsed.resources == []
+
+    def test_rejects_swagger_1(self):
         with pytest.raises(OpenApiImportError) as e:
-            parse_openapi_spec({"swagger": "2.0", "paths": {}})
+            parse_openapi_spec({"swagger": "1.2", "paths": {}})
         assert e.value.code == "unsupported_version"
 
     def test_rejects_oversize(self):

--- a/tests/test_services/test_openapi_p2_slices.py
+++ b/tests/test_services/test_openapi_p2_slices.py
@@ -1,0 +1,236 @@
+"""OpenAPI P2 — nested data-selector, incremental cursor, Swagger 2.0 (core#411).
+
+The three slices left after pagination. Each is deterministic parser work, so
+these are fixture-driven — but each one guards a *silent* failure, which is why
+the assertions are about extracted data rather than "it didn't raise":
+
+- a missed **nested** envelope yields zero rows from a healthy API;
+- a missed **incremental** cursor re-extracts everything every run, which looks
+  like success and quietly burns the customer's byte quota;
+- a rejected **Swagger 2.0** spec is the one honest failure of the three — the
+  user is told no — which is why it was the cheapest to leave until last.
+"""
+
+import pytest
+
+from datanika.services.openapi_import import OpenApiImportError, parse_openapi_spec
+
+
+def _openapi3(paths: dict, components: dict | None = None) -> dict:
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "t", "version": "1"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": paths,
+        "components": components or {},
+    }
+
+
+_WIDGET = {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {"type": "integer"},
+        "name": {"type": "string"},
+        "updated_at": {"type": "string", "format": "date-time"},
+    },
+}
+
+
+def _get_op(response_schema: dict, params: list | None = None, extra: dict | None = None) -> dict:
+    op = {
+        "operationId": "listWidgets",
+        "parameters": params or [],
+        "responses": {
+            "200": {
+                "description": "ok",
+                "content": {"application/json": {"schema": response_schema}},
+            }
+        },
+    }
+    op.update(extra or {})
+    return {"get": op}
+
+
+class TestNestedDataSelector:
+    """A collection one level down is a common shape and yielded nothing."""
+
+    def test_nested_envelope_produces_a_dotted_selector(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "type": "object",
+                    "properties": {"items": {"type": "array", "items": _WIDGET}},
+                }
+            },
+        }
+        parsed = parse_openapi_spec(_openapi3({"/widgets": _get_op(schema)}))
+
+        resource = parsed.resources[0]
+        assert resource["endpoint"]["data_selector"] == "response.items"
+        # And the columns still come from the item schema, not the envelope.
+        assert {c["name"] for c in resource["columns"]} == {"id", "name", "updated_at"}
+
+    def test_top_level_array_still_needs_no_selector(self):
+        parsed = parse_openapi_spec(
+            _openapi3({"/widgets": _get_op({"type": "array", "items": _WIDGET})})
+        )
+        assert parsed.resources[0]["endpoint"].get("data_selector") is None
+
+    def test_shallow_envelope_is_unchanged(self):
+        schema = {"type": "object", "properties": {"data": {"type": "array", "items": _WIDGET}}}
+        parsed = parse_openapi_spec(_openapi3({"/widgets": _get_op(schema)}))
+        assert parsed.resources[0]["endpoint"]["data_selector"] == "data"
+
+
+class TestIncrementalCursor:
+    """Missing this re-extracts the full table every run and reports success."""
+
+    def _parsed(self, params, extra=None):
+        schema = {"type": "object", "properties": {"data": {"type": "array", "items": _WIDGET}}}
+        return parse_openapi_spec(_openapi3({"/widgets": _get_op(schema, params, extra)}))
+
+    def test_datetime_filter_param_maps_to_incremental(self):
+        parsed = self._parsed(
+            [
+                {
+                    "name": "updated_since",
+                    "in": "query",
+                    "schema": {"type": "string", "format": "date-time"},
+                }
+            ]
+        )
+        incremental = parsed.resources[0]["endpoint"]["incremental"]
+        assert incremental["start_param"] == "updated_since"
+        # The cursor must be a field the rows actually carry.
+        assert incremental["cursor_path"] == "updated_at"
+
+    def test_x_incremental_extension_wins(self):
+        """An explicit spec declaration beats our inference."""
+        parsed = self._parsed(
+            [{"name": "since", "in": "query", "schema": {"type": "string", "format": "date-time"}}],
+            extra={"x-incremental": {"cursor_path": "id", "start_param": "since_id"}},
+        )
+        incremental = parsed.resources[0]["endpoint"]["incremental"]
+        assert incremental == {"cursor_path": "id", "start_param": "since_id"}
+
+    def test_no_matching_row_field_emits_nothing(self):
+        """A start_param with no cursor field to read would send a null filter."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                }
+            },
+        }
+        parsed = parse_openapi_spec(
+            _openapi3(
+                {
+                    "/widgets": _get_op(
+                        schema,
+                        [
+                            {
+                                "name": "updated_since",
+                                "in": "query",
+                                "schema": {"type": "string", "format": "date-time"},
+                            }
+                        ],
+                    )
+                }
+            )
+        )
+        assert parsed.resources[0]["endpoint"].get("incremental") is None
+
+    def test_plain_query_params_are_not_mistaken_for_cursors(self):
+        parsed = self._parsed([{"name": "name", "in": "query", "schema": {"type": "string"}}])
+        assert parsed.resources[0]["endpoint"].get("incremental") is None
+
+
+_SWAGGER2 = {
+    "swagger": "2.0",
+    "info": {"title": "Legacy", "version": "1"},
+    "host": "api.legacy.example",
+    "basePath": "/v2",
+    "schemes": ["https"],
+    "securityDefinitions": {
+        "key": {"type": "apiKey", "name": "X-Api-Key", "in": "header"},
+        "basicAuth": {"type": "basic"},
+    },
+    "paths": {
+        "/widgets": {
+            "get": {
+                "operationId": "listWidgets",
+                "parameters": [
+                    {"name": "offset", "in": "query", "type": "integer"},
+                    {"name": "limit", "in": "query", "type": "integer", "maximum": 200},
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {"type": "array", "items": {"$ref": "#/definitions/Widget"}}
+                            },
+                        },
+                    }
+                },
+            }
+        }
+    },
+    "definitions": {
+        "Widget": {
+            "type": "object",
+            "required": ["id"],
+            "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+        }
+    },
+}
+
+
+class TestSwagger2Shim:
+    """Swagger 2.0 was rejected outright — a large share of real specs."""
+
+    def test_base_url_from_scheme_host_basepath(self):
+        parsed = parse_openapi_spec(_SWAGGER2)
+        assert parsed.base_url == "https://api.legacy.example/v2"
+
+    def test_definitions_refs_resolve_to_columns(self):
+        """`#/definitions/X` must be rewritten or every column silently vanishes."""
+        parsed = parse_openapi_spec(_SWAGGER2)
+        columns = {c["name"] for c in parsed.resources[0]["columns"]}
+        assert columns == {"id", "name"}
+
+    def test_response_schema_is_lifted_into_content(self):
+        parsed = parse_openapi_spec(_SWAGGER2)
+        assert parsed.resources[0]["endpoint"]["data_selector"] == "data"
+
+    def test_security_definitions_convert(self):
+        parsed = parse_openapi_spec(_SWAGGER2)
+        kinds = {a["type"] for a in parsed.auth_schemes}
+        assert kinds == {"api_key", "http_basic"}
+
+    def test_parameter_types_reach_pagination_detection(self):
+        """2.0 puts `type` on the parameter; 3.0 nests it under `schema`.
+
+        Without normalising that, pagination detection sees no schema and the
+        declared maximum is lost — the spec converts but pages 100 at a time
+        against an API that allows 200.
+        """
+        parsed = parse_openapi_spec(_SWAGGER2)
+        paginator = parsed.resources[0]["endpoint"]["paginator"]
+        assert paginator["type"] == "offset"
+        assert paginator["limit"] == 200
+
+    def test_swagger_1_is_still_rejected(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            parse_openapi_spec({"swagger": "1.2", "paths": {}})
+        assert exc.value.code == "unsupported_version"
+
+    def test_missing_version_is_still_rejected(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            parse_openapi_spec({"paths": {}})
+        assert exc.value.code == "unsupported_version"

--- a/tests/test_services/test_openapi_parse_endpoint.py
+++ b/tests/test_services/test_openapi_parse_endpoint.py
@@ -74,7 +74,8 @@ class TestTypedErrorCodesReachTheWire:
             ({}, "invalid_request"),
             ({"spec_inline": _SPEC, "spec_url": "https://x.test/s.json"}, "invalid_request"),
             ({"spec_inline": "not json or yaml: ["}, "invalid_spec"),
-            ({"spec_inline": '{"swagger": "2.0", "paths": {}}'}, "unsupported_version"),
+            # Swagger 2.0 is converted since core#411; 1.x is still refused.
+            ({"spec_inline": '{"swagger": "1.2", "paths": {}}'}, "unsupported_version"),
             ({"spec_url": "http://insecure.test/spec.json"}, "invalid_spec_url"),
             ({"spec_url": "https://127.0.0.1/spec.json"}, "invalid_spec_url"),
         ],


### PR DESCRIPTION
Closes #411 — the three slices left after pagination.

> **Stacked on #432** (the endpoint-test harness). Merge that first; this branch contains its commit until then. Stacked deliberately — see "A semantic conflict git wouldn't have caught" below.

Each slice guards a failure that **reports success**, which is why the tests assert extracted data rather than "it didn't raise".

## Nested data-selector

`_find_collection` now walks nested objects and returns a dotted path — `{"response": {"items": [...]}}` → `response.items` — bounded at depth 3 because the spec is user input.

A one-level envelope is a common shape, and missing it yielded **zero rows from a healthy API**: no error, just an empty table.

## Incremental cursor

A "changed since" query param maps to dlt's `IncrementalConfig`. **Both halves are required** — a `start_param` with no row field to read the high-water mark from would send an empty filter forever, so a spec offering `updated_since` with no timestamp column emits nothing rather than something broken. An explicit `x-incremental` in the spec beats our inference.

Missing this is invisible: the extract just pulls the whole table every run, succeeds, and quietly spends the customer's byte quota.

## Swagger 2.0

Converted into the 3.x subset this parser reads, rather than teaching every function two dialects. Base URL (`schemes`+`host`+`basePath`), `definitions` → `components.schemas`, `response.schema` → `content[json].schema`, `securityDefinitions` (`basic` → `http`/`basic`), and parameter shape.

Two of those are load-bearing rather than cosmetic, and both have tests:

- **Parameter shape.** 2.0 puts `type`/`format`/`maximum` on the parameter; 3.0 nests them under `schema`. Pagination *and* incremental detection both read `param["schema"]` — so without normalising, a converted spec loses its declared `maximum` and pages 100 at a time against an API that allows 200.
- **`$ref` rewriting.** Miss it and every ref dangles: the spec converts, the parse "succeeds", and every resource comes back with **zero columns**.

**Contract change:** Swagger 2.0 was rejected with `unsupported_version` and is now accepted. 1.x is still refused.

## A semantic conflict git wouldn't have caught

That contract change invalidates an assertion in `test_openapi_parse_endpoint.py` — which lives on the **unmerged** #432 branch, not on `dev`. Both PRs would have merged cleanly and then broken `dev`, because nothing textually overlaps: one changes the parser, the other asserts the old behaviour in a file the first one never touches.

So this is stacked on #432 and updates that assertion in the same lineage. Worth noting as a pattern — with several PRs open at once, "mergeable" is about text, not meaning.

14 new tests. Full precheck green: ruff + format clean, **2459 passed**.
