### PR TITLE
[Infra] Promote dev -> master: promotion-ref automation + social-login same-tab

### DIFF
--- a/.github/scripts/promotion_refs.py
+++ b/.github/scripts/promotion_refs.py
@@ -44,12 +44,35 @@ INLINE_CODE = re.compile(r"`[^`]*`")
 QUOTED_LINE = re.compile(r"^\s*>.*$", re.MULTILINE)
 
 
+# A *declaration* starts its line (optionally as a list item). Prose embeds the keyword
+# mid-sentence: "The first run harvested (closes #142) and closes #19 from its own body."
+# Stripping code spans alone was not enough -- the same false positives came back through
+# commit-message prose, which has no backticks to strip. Anchoring to line-start closes
+# the whole class instead of one door at a time.
+DECLARATION = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
 def strip_non_declarative(text: str) -> str:
     """Remove code blocks, inline code and block quotes before scanning for keywords."""
     text = FENCED.sub(" ", text)
     text = INLINE_CODE.sub(" ", text)
     text = QUOTED_LINE.sub(" ", text)
     return text
+
+
+def find_refs(subject: str, body: str) -> set[int]:
+    """Closing refs from a subject/title (a declaration by convention) and a body.
+
+    The subject is scanned whole -- our convention is `[Dept] Title (closes #N)`. The body
+    is scanned only for line-initial declarations, after code and quotes are stripped, so
+    a paragraph *about* closing keywords is not mistaken for one.
+    """
+    found = {int(n) for n in KEYWORD.findall(subject or "")}
+    found |= {int(n) for n in DECLARATION.findall(strip_non_declarative(body or ""))}
+    return found
 
 
 def run(*args: str) -> str:
@@ -86,8 +109,9 @@ def main() -> int:
     for entry in commits:
         sha, _, message = entry.strip().partition("\x1f")
         shas.append(sha)
-        for num in KEYWORD.findall(message):
-            refs.setdefault(int(num), set()).add(f"commit {sha[:7]}")
+        subject, _, msg_body = message.strip().partition("\n")
+        for num in find_refs(subject, msg_body):
+            refs.setdefault(num, set()).add(f"commit {sha[:7]}")
 
     # Also consult the source PRs: a rebase-merge can leave the keyword only on the PR.
     for sha in shas:
@@ -97,11 +121,8 @@ def main() -> int:
         for pull in pulls:
             if pull.get("base", {}).get("ref") == "master":
                 continue  # a previous promotion PR, not a feature PR
-            # The title is a declaration by convention ("[Dept] ... (closes #N)"); the
-            # body is prose and may merely discuss keywords, so strip it first.
-            text = f"{pull.get('title', '')}\n{strip_non_declarative(pull.get('body') or '')}"
-            for num in KEYWORD.findall(text):
-                refs.setdefault(int(num), set()).add(f"#{pull['number']}")
+            for num in find_refs(pull.get("title", ""), pull.get("body") or ""):
+                refs.setdefault(num, set()).add(f"#{pull['number']}")
 
     if not refs:
         print("  no closing references found; leaving the body unchanged")

--- a/.github/scripts/promotion_refs.py
+++ b/.github/scripts/promotion_refs.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Populate a promotion PR body with the `Closes #N` refs of the commits it promotes.
+
+GitHub fires closing keywords only for PRs merged into the DEFAULT branch. Feature PRs
+here merge into `dev`, so their own `Closes #N` never fires; the issue is closed only if
+the promotion PR (dev -> master) carries the reference. WORKFLOW_RULES §8 makes that a
+manual enumeration step, which is why issues leak.
+
+References are gathered from two places, because neither alone is reliable:
+  1. the commit messages being promoted -- our convention puts `(closes #N)` there, but
+     not every commit follows it;
+  2. the pull requests those commits came from -- the PR title/body almost always has it,
+     and survives a rebase-merge that rewrote the commit message.
+
+Idempotent: rewrites a single marked block, so repeated runs (synchronize events) never
+duplicate. Never closes anything itself -- merging the promotion PR does that.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+START = "<!-- promotion-refs:start -->"
+END = "<!-- promotion-refs:end -->"
+
+# `closes/fixes/resolves #12`, plus the participle forms GitHub also accepts.
+KEYWORD = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def run(*args: str) -> str:
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  ! command failed: {' '.join(args)}\n    {result.stderr.strip()[:300]}")
+        return ""
+    return result.stdout
+
+
+def gh_api(path: str) -> object:
+    out = run("gh", "api", path)
+    if not out.strip():
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    repo = os.environ["REPO"]
+    pr_number = os.environ["PR_NUMBER"]
+    base_sha = os.environ["BASE_SHA"]
+    head_sha = os.environ["HEAD_SHA"]
+
+    # Commits being promoted. base..head is exactly "on dev, not yet on master".
+    log = run("git", "log", "--format=%H%x1f%B%x1e", f"{base_sha}..{head_sha}")
+    commits = [c for c in log.split("\x1e") if c.strip()]
+    print(f"  commits being promoted: {len(commits)}")
+
+    refs: dict[int, set[str]] = {}
+    shas = []
+    for entry in commits:
+        sha, _, message = entry.strip().partition("\x1f")
+        shas.append(sha)
+        for num in KEYWORD.findall(message):
+            refs.setdefault(int(num), set()).add(f"commit {sha[:7]}")
+
+    # Also consult the source PRs: a rebase-merge can leave the keyword only on the PR.
+    for sha in shas:
+        pulls = gh_api(f"repos/{repo}/commits/{sha}/pulls")
+        if not isinstance(pulls, list):
+            continue
+        for pull in pulls:
+            if pull.get("base", {}).get("ref") == "master":
+                continue  # a previous promotion PR, not a feature PR
+            text = f"{pull.get('title', '')}\n{pull.get('body') or ''}"
+            for num in KEYWORD.findall(text):
+                refs.setdefault(int(num), set()).add(f"#{pull['number']}")
+
+    if not refs:
+        print("  no closing references found; leaving the body unchanged")
+        return 0
+
+    # Don't re-list issues that are already closed -- keeps the block honest about what
+    # this promotion actually closes.
+    lines = []
+    for num in sorted(refs):
+        issue = gh_api(f"repos/{repo}/issues/{num}")
+        if not isinstance(issue, dict) or "number" not in issue:
+            continue
+        if issue.get("pull_request"):
+            continue  # a PR, not an issue
+        state = issue.get("state")
+        title = (issue.get("title") or "").strip()
+        via = ", ".join(sorted(refs[num]))
+        if state == "closed":
+            lines.append(f"- ~~Closes #{num}~~ — {title} _(already closed)_ · via {via}")
+        else:
+            lines.append(f"- Closes #{num} — {title} · via {via}")
+
+    if not lines:
+        print("  references found, but none resolve to issues; body unchanged")
+        return 0
+
+    block = "\n".join(
+        [
+            START,
+            "",
+            "### Issues closed by this promotion",
+            "",
+            "_Generated from the commits being promoted. Feature PRs merge into `dev`, "
+            "which is not the default branch, so their own closing keywords never fire — "
+            "these references are what actually closes the issues on merge._",
+            "",
+            *lines,
+            "",
+            END,
+        ]
+    )
+
+    current = run("gh", "pr", "view", pr_number, "--repo", repo, "--json", "body", "-q", ".body") or ""
+    if START in current and END in current:
+        body = re.sub(
+            re.escape(START) + r".*?" + re.escape(END), block, current, flags=re.DOTALL
+        )
+    else:
+        body = (current.rstrip() + "\n\n" + block).lstrip()
+
+    if body.strip() == current.strip():
+        print("  body already up to date")
+        return 0
+
+    path = "/tmp/promotion-body.md"
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(body)
+    run("gh", "pr", "edit", pr_number, "--repo", repo, "--body-file", path)
+    print(f"  wrote {len(lines)} reference(s) into the PR body:")
+    for line in lines:
+        print(f"    {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/promotion_refs.py
+++ b/.github/scripts/promotion_refs.py
@@ -33,6 +33,24 @@ KEYWORD = re.compile(
     re.IGNORECASE,
 )
 
+# Prose that *talks about* closing keywords is not a closing reference. The first live
+# run of this script harvested `(closes #142)` and `Closes #415.` out of its own PR body,
+# where they were regex examples in backticks -- issues that were not being promoted at
+# all. This is not cosmetic: GitHub parses the raw body, so a bogus `Closes #N` on a
+# promotion PR really does close that issue on merge. Strip the constructs people use to
+# quote or illustrate, and keep only declarations.
+FENCED = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+INLINE_CODE = re.compile(r"`[^`]*`")
+QUOTED_LINE = re.compile(r"^\s*>.*$", re.MULTILINE)
+
+
+def strip_non_declarative(text: str) -> str:
+    """Remove code blocks, inline code and block quotes before scanning for keywords."""
+    text = FENCED.sub(" ", text)
+    text = INLINE_CODE.sub(" ", text)
+    text = QUOTED_LINE.sub(" ", text)
+    return text
+
 
 def run(*args: str) -> str:
     result = subprocess.run(args, capture_output=True, text=True)
@@ -79,7 +97,9 @@ def main() -> int:
         for pull in pulls:
             if pull.get("base", {}).get("ref") == "master":
                 continue  # a previous promotion PR, not a feature PR
-            text = f"{pull.get('title', '')}\n{pull.get('body') or ''}"
+            # The title is a declaration by convention ("[Dept] ... (closes #N)"); the
+            # body is prose and may merely discuss keywords, so strip it first.
+            text = f"{pull.get('title', '')}\n{strip_non_declarative(pull.get('body') or '')}"
             for num in KEYWORD.findall(text):
                 refs.setdefault(int(num), set()).add(f"#{pull['number']}")
 
@@ -100,7 +120,11 @@ def main() -> int:
         title = (issue.get("title") or "").strip()
         via = ", ".join(sorted(refs[num]))
         if state == "closed":
-            lines.append(f"- ~~Closes #{num}~~ — {title} _(already closed)_ · via {via}")
+            # Deliberately NOT the "Closes" keyword. Strikethrough is cosmetic -- GitHub
+            # parses the raw text, so `~~Closes #N~~` still fires. An already-closed
+            # issue needs no keyword, and omitting it means a stale or false-positive
+            # reference cannot act on an issue this promotion does not own.
+            lines.append(f"- #{num} — {title} _(already closed)_ · via {via}")
         else:
             lines.append(f"- Closes #{num} — {title} · via {via}")
 

--- a/.github/workflows/promotion-pr-refs.yml
+++ b/.github/workflows/promotion-pr-refs.yml
@@ -1,0 +1,51 @@
+# Promotion PR — auto-populate `Closes #N` references
+#
+# Why this exists
+# ---------------
+# GitHub only fires the `Closes #N` keyword when a PR merges into the DEFAULT branch
+# (`master` here). Our feature PRs merge into `dev`, so their own `Closes #N` never
+# fires. An issue is only closed when the *promotion* PR (dev -> master) carries the
+# reference.
+#
+# WORKFLOW_RULES §8 already requires Infra to enumerate every promoted issue by hand in
+# the promotion PR body, with a "cleanup loop" as the safety net. That is a manual step
+# on the critical path of every promotion, so it leaks: issues stay silently open and
+# someone later burns time rediscovering why.
+#
+# This derives the list mechanically from the commits actually being promoted, so the
+# keyword fires the way §8 already claims it does.
+#
+# It only ADDS references; it never closes anything itself. Merging the promotion PR is
+# what closes the issues, so an unmerged promotion correctly leaves them open
+# (WORKFLOW_RULES §8: issues close only once the code is live on master).
+name: Promotion PR refs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  refs:
+    # Only promotion PRs (dev -> master). A hotfix branch straight to master is not a
+    # promotion and should not have its body rewritten.
+    if: github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Collect closing references from the promoted commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/promotion_refs.py

--- a/datanika/ui/components/cost_estimator_card.py
+++ b/datanika/ui/components/cost_estimator_card.py
@@ -99,7 +99,10 @@ def cost_estimator_card() -> rx.Component:
             _mode_split_hint(),
             rx.link(
                 _t["cost.learn_more"],
-                href="/pricing/",
+                # Absolute: /pricing/ lives on the landing site, and a
+                # root-relative href would resolve against the app origin and
+                # open app.datanika.io/pricing/, a route we do not serve (#418).
+                href="https://datanika.io/pricing/",
                 size="1",
                 color="var(--violet-11)",
                 is_external=True,

--- a/datanika/ui/components/elt_nudge_card.py
+++ b/datanika/ui/components/elt_nudge_card.py
@@ -68,7 +68,9 @@ def elt_nudge_card() -> rx.Component:
                 ),
                 rx.link(
                     _t["nudge.learn_more"],
-                    href="/pricing/",
+                    # Absolute for the same reason as cost_estimator_card (#418):
+                    # /pricing/ is a landing-site page, not an app route.
+                    href="https://datanika.io/pricing/",
                     size="1",
                     color="var(--violet-11)",
                     is_external=True,

--- a/datanika/ui/pages/login.py
+++ b/datanika/ui/pages/login.py
@@ -1,5 +1,7 @@
 """Login page."""
 
+import json
+
 import reflex as rx
 
 from datanika.config import settings
@@ -9,6 +11,35 @@ from datanika.ui.state.i18n_state import I18nState
 
 _backend = settings.oauth_redirect_base_url
 _t = I18nState.translations
+
+
+def _social_login_button(label: str, provider: str) -> rx.Component:
+    """Start a social login in the current tab (#418).
+
+    This has to be a real browser navigation: ``/api/auth/login/<provider>``
+    is a backend Starlette route that 302s to the provider, so nothing the
+    frontend router does can serve it. It also has to stay in *this* tab —
+    the previous ``rx.link(..., is_external=True)`` compiled to
+    ``target="_blank"``, so the user authenticated in a second tab and ended
+    up signed in there while the original still showed the sign-in form.
+
+    Neither ``rx.link`` nor ``rx.el.a`` can express that: both render a
+    react-router ``Link``, which treats a *same-origin* absolute URL as an
+    in-app route — and in production the backend and frontend share
+    ``app.datanika.io``, so the click would be swallowed by the router.
+    (In dev the origins differ, so that breakage would not show up locally.)
+    ``rx.redirect`` has the same same-origin branch. Hence an explicit
+    assignment, which is unambiguous whatever the router does.
+    """
+    target = f"{_backend}/api/auth/login/{provider}"
+    return rx.button(
+        label,
+        variant="outline",
+        size="3",
+        width="100%",
+        type="button",
+        on_click=rx.call_script(f"window.location.assign({json.dumps(target)})"),
+    )
 
 
 def login_page() -> rx.Component:
@@ -68,28 +99,8 @@ def login_page() -> rx.Component:
             rx.divider(),
             rx.text(_t["auth.or_continue_with"], size="2", color="gray", text_align="center"),
             rx.hstack(
-                rx.link(
-                    rx.button(
-                        "Google",
-                        variant="outline",
-                        size="3",
-                        width="100%",
-                    ),
-                    href=f"{_backend}/api/auth/login/google",
-                    is_external=True,
-                    width="100%",
-                ),
-                rx.link(
-                    rx.button(
-                        "GitHub",
-                        variant="outline",
-                        size="3",
-                        width="100%",
-                    ),
-                    href=f"{_backend}/api/auth/login/github",
-                    is_external=True,
-                    width="100%",
-                ),
+                _social_login_button("Google", "google"),
+                _social_login_button("GitHub", "github"),
                 width="100%",
                 spacing="3",
             ),

--- a/tests/test_ui/test_external_links.py
+++ b/tests/test_ui/test_external_links.py
@@ -1,0 +1,104 @@
+"""Links must not strand the user in a second tab (#418, sibling of #417).
+
+``is_external=True`` reads like "this URL is off-site". Reflex means it
+literally: ``rx.link`` compiles it to ``target="_blank"`` and ``rx.redirect``
+to ``window.open(path, "_blank")``. That is right for a link *out* of the
+product and wrong for anything the user is meant to come back from.
+
+It was wrong twice. On ``/oauth/consent`` the callback opened in a new tab and
+left the original on a disabled "Approving…" button (#417). On ``/login`` the
+provider opened in a new tab, so the user authenticated *there* and ended up
+signed in in that tab while the original still showed the sign-in form.
+
+The login case could not simply drop the flag. ``/api/auth/login/<provider>``
+is a backend route, and both ``rx.link`` and ``rx.el.a`` render a react-router
+``Link``, which treats a same-origin absolute URL as an in-app route. In
+production the backend and frontend share ``app.datanika.io``, so dropping the
+flag would have handed the click to the router and broken sign-in — *and it
+would still have worked in dev*, where the origins differ. Hence the explicit
+``window.location.assign``.
+"""
+
+import ast
+import inspect
+
+import datanika.ui.components.cost_estimator_card as cost_estimator_card
+import datanika.ui.components.elt_nudge_card as elt_nudge_card
+import datanika.ui.pages.login as login_page_module
+from datanika.ui.pages.login import login_page
+
+
+def _rendered(component) -> str:
+    return str(component.render())
+
+
+class TestSocialLoginStaysInTheTab:
+    def test_no_new_tab_anywhere_on_the_login_page(self):
+        assert "_blank" not in _rendered(login_page()), (
+            "A social-login button opening in a new tab leaves the user signed "
+            "in there while the original tab still shows the form (#418)."
+        )
+
+    def test_both_providers_do_a_real_browser_navigation(self):
+        """Not a router push — the endpoint is served by the backend."""
+        html = _rendered(login_page())
+
+        for provider in ("google", "github"):
+            assert f"/api/auth/login/{provider}" in html, provider
+        assert html.count("window.location.assign") == 2
+
+    def test_the_providers_are_not_react_router_links(self):
+        """A router Link would swallow the click in production.
+
+        Same-origin absolute URLs are treated as in-app routes, and prod serves
+        the API and the frontend from one host. Dev would not have shown it.
+        """
+        html = _rendered(login_page())
+        start = html.find("/api/auth/login/google")
+        assert start != -1
+        # The surrounding markup must not be a router link carrying `to=`.
+        assert "ReactRouterLink" not in html[max(0, start - 600) : start + 600]
+
+
+class TestOffSiteLinksAreAbsolute:
+    """A root-relative href with ``is_external`` opens the *app* origin.
+
+    ``/pricing/`` is a landing-site page; opening ``app.datanika.io/pricing/``
+    lands on a route the Reflex app does not serve. Both call sites are behind
+    ``datanika_dual_mode_ux_enabled`` (off), so this was dormant rather than
+    broken in production — worth pinning before that flag flips.
+    """
+
+    def test_pricing_links_point_at_the_landing_site(self):
+        for module in (cost_estimator_card, elt_nudge_card):
+            source = inspect.getsource(module)
+            assert 'href="/pricing/"' not in source, (
+                f"{module.__name__} links /pricing/ root-relative; with "
+                "is_external it opens app.datanika.io/pricing/ (#418)."
+            )
+            assert "https://datanika.io/pricing/" in source, module.__name__
+
+
+class TestNoStrayExternalRedirects:
+    """No call on the login page may ask for a new tab.
+
+    AST rather than a substring scan (the repo's convention — see
+    ``test_rbac_ui_visibility.py``) so the prose explaining *why* the flag is
+    wrong here doesn't trip its own guard. State-level redirects are covered by
+    ``test_mcp_consent_state.py::TestLeavesInTheSameTab``.
+    """
+
+    def test_login_module_never_asks_for_a_new_tab(self):
+        tree = ast.parse(inspect.getsource(login_page_module))
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            for keyword in node.keywords
+            if keyword.arg == "is_external"
+        ]
+
+        assert not offenders, (
+            f"login.py passes is_external at line(s) {offenders}. Social login "
+            "must stay in the current tab — see _social_login_button's docstring."
+        )


### PR DESCRIPTION
Promotion of the current `dev` to production.

**What is shipping**
- Product: social login stays in the current tab instead of opening a new one.
- Infra: the `Promotion PR refs` workflow — promotion PRs now derive their closing references from the commits being promoted.

**This PR is also the automation's live test.** The body was written with **no hand-typed `Closes #N`**. Everything in the generated block below arrived from the workflow reading the promoted commits and their source PRs. If the block is empty or wrong, the automation is wrong — do not paper over it by editing this body.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- Closes #418 — [Product] is_external audit: social login opens in a new tab; /pricing/ links point at the app origin · via #430, commit 46e3fd6
- Closes #435 — Promotion PRs leak issue references: Closes #N never fires from dev · via #436, commit 05c3921

<!-- promotion-refs:end -->

