### PR TITLE
[Infra] Promotion refs: don't harvest closing keywords out of prose

### DIFF
--- a/.github/scripts/promotion_refs.py
+++ b/.github/scripts/promotion_refs.py
@@ -33,6 +33,24 @@ KEYWORD = re.compile(
     re.IGNORECASE,
 )
 
+# Prose that *talks about* closing keywords is not a closing reference. The first live
+# run of this script harvested `(closes #142)` and `Closes #415.` out of its own PR body,
+# where they were regex examples in backticks -- issues that were not being promoted at
+# all. This is not cosmetic: GitHub parses the raw body, so a bogus `Closes #N` on a
+# promotion PR really does close that issue on merge. Strip the constructs people use to
+# quote or illustrate, and keep only declarations.
+FENCED = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+INLINE_CODE = re.compile(r"`[^`]*`")
+QUOTED_LINE = re.compile(r"^\s*>.*$", re.MULTILINE)
+
+
+def strip_non_declarative(text: str) -> str:
+    """Remove code blocks, inline code and block quotes before scanning for keywords."""
+    text = FENCED.sub(" ", text)
+    text = INLINE_CODE.sub(" ", text)
+    text = QUOTED_LINE.sub(" ", text)
+    return text
+
 
 def run(*args: str) -> str:
     result = subprocess.run(args, capture_output=True, text=True)
@@ -79,7 +97,9 @@ def main() -> int:
         for pull in pulls:
             if pull.get("base", {}).get("ref") == "master":
                 continue  # a previous promotion PR, not a feature PR
-            text = f"{pull.get('title', '')}\n{pull.get('body') or ''}"
+            # The title is a declaration by convention ("[Dept] ... (closes #N)"); the
+            # body is prose and may merely discuss keywords, so strip it first.
+            text = f"{pull.get('title', '')}\n{strip_non_declarative(pull.get('body') or '')}"
             for num in KEYWORD.findall(text):
                 refs.setdefault(int(num), set()).add(f"#{pull['number']}")
 
@@ -100,7 +120,11 @@ def main() -> int:
         title = (issue.get("title") or "").strip()
         via = ", ".join(sorted(refs[num]))
         if state == "closed":
-            lines.append(f"- ~~Closes #{num}~~ — {title} _(already closed)_ · via {via}")
+            # Deliberately NOT the "Closes" keyword. Strikethrough is cosmetic -- GitHub
+            # parses the raw text, so `~~Closes #N~~` still fires. An already-closed
+            # issue needs no keyword, and omitting it means a stale or false-positive
+            # reference cannot act on an issue this promotion does not own.
+            lines.append(f"- #{num} — {title} _(already closed)_ · via {via}")
         else:
             lines.append(f"- Closes #{num} — {title} · via {via}")
 


### PR DESCRIPTION
Follow-up to #436 (same work as #435), fixing a defect its **own first live run** exposed.

**What happened.** The generated block on promotion PR #437 listed `#19`, `#142` and `#415` — none of which were being promoted. They were harvested from the body of #436 itself, where they appear as regex examples in backticks.

**Why it matters more than it looks.** I had listed already-closed issues struck through, which reads as safe but isn't: GitHub parses the raw body, so `~~Closes #N~~` **still fires the keyword**. Those three were already closed, so the run was harmless — but the same false positive on an **open** issue would silently close an issue the promotion doesn't own. That is exactly the class of bug this automation exists to eliminate.

**Fix**
1. Strip fenced code blocks, inline code and block quotes from PR **bodies** before scanning — those are where people *discuss* keywords rather than declare them. PR **titles** stay authoritative, since `[Dept] … (closes #N)` is our declaration convention.
2. Emit already-closed issues **without** the keyword, so a stale or bogus reference cannot act on anything.

**Regression test against the real text that caused it** (the actual body of #436):
```
refs harvested BEFORE the fix : [12, 13, 19, 55, 73, 142, 415, 435]
refs harvested AFTER  the fix : [435]
```
Plus cases for declaration-in-title, declaration-in-prose, inline-code example, fenced example, quoted-from-a-doc and a mixed line — all pass.

Merging re-triggers the workflow on the open promotion #437, which should regenerate with only the issues it genuinely closes.