### PR TITLE
[Engineering] Egress guard: pin the validated address (closes #405)

### DIFF
--- a/datanika/services/egress_guard.py
+++ b/datanika/services/egress_guard.py
@@ -27,12 +27,13 @@ sends (core#403 — the gate for MCP P3 write tools):
 All three dispatch through ``requests.Session.send``, which is why the guard
 lives there rather than being enumerated vector by vector.
 
-**Still open — DNS rebinding (TOCTOU).** We resolve a hostname to validate it and
-``requests`` resolves it again to connect; a hostile resolver can answer
-differently each time. Closing that needs IP pinning at the adapter (connect to
-the validated address while preserving SNI/Host). This module is therefore
-defense-in-depth, not a boundary — say so out loud rather than let a future
-reader assume the gap is covered.
+**DNS rebinding (TOCTOU) — closed by pinning (core#405).** Validating a
+hostname and then handing that hostname to ``requests`` means resolving twice,
+and a hostile resolver can answer differently the second time. The guarded
+session therefore resolves **once**, validates the answer, and connects to that
+address, while keeping the ``Host`` header and TLS SNI as the hostname so
+certificates still validate and virtual hosts still route — see
+:class:`_PinnedIPAdapter`.
 """
 
 import ipaddress
@@ -57,13 +58,7 @@ def validate_egress_host(url: str) -> None:
     multicast, reserved, or unspecified. Returns ``None`` when every resolved
     IP is public.
     """
-    parsed = urlparse(url)
-    if parsed.scheme not in _ALLOWED_SCHEMES:
-        raise EgressValidationError(f"URL scheme must be http or https, got {parsed.scheme!r}")
-
-    hostname = parsed.hostname
-    if not hostname:
-        raise EgressValidationError(f"URL has no host: {url!r}")
+    hostname = _check_scheme_and_host(url)
 
     try:
         infos = socket.getaddrinfo(hostname, None)
@@ -94,6 +89,112 @@ def validate_egress_host(url: str) -> None:
     return None
 
 
+def _check_scheme_and_host(url: str) -> str:
+    """Cheap structural check — no DNS. Returns the hostname."""
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise EgressValidationError(f"URL scheme must be http or https, got {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise EgressValidationError(f"URL has no host: {url!r}")
+    return parsed.hostname
+
+
+def resolve_public_ip(hostname: str) -> str:
+    """Resolve *hostname* once and return an address, or refuse.
+
+    Same rules as :func:`validate_egress_host`, but it hands back the address
+    it approved so the caller can connect to **that** rather than resolving
+    again. Every returned answer is checked — a hostile resolver that mixes one
+    public address with an internal one is refused outright rather than raced.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise EgressValidationError(f"could not resolve host {hostname!r}: {exc}") from exc
+
+    chosen = None
+    for info in infos:
+        ip_str = info[4][0]
+        ip = ipaddress.ip_address(ip_str)
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise EgressValidationError(
+                f"host {hostname!r} resolves to non-public address {ip_str} — refusing egress"
+            )
+        if chosen is None:
+            chosen = ip_str
+
+    if chosen is None:
+        raise EgressValidationError(f"host {hostname!r} resolved to no addresses")
+    return chosen
+
+
+class _PinnedIPAdapter(requests.adapters.HTTPAdapter):
+    """Connect to the address we validated, not to whatever DNS says next.
+
+    The rebinding gap is that validating a *name* and then connecting to that
+    same *name* is two resolutions with a window in between. This adapter
+    resolves once via :func:`resolve_public_ip` and builds the connection pool
+    against that address.
+
+    Keeping TLS honest is the delicate half, and is why the pool is created
+    with ``server_hostname`` set to the real hostname: urllib3 would otherwise
+    offer the **IP** as SNI and match the certificate against it, so a careless
+    implementation either serves the wrong virtual host or "fixes" itself by
+    disabling hostname verification. Certificate matching still happens against
+    the hostname (``assert_hostname`` is left alone so urllib3 falls back to
+    ``server_hostname``), and the ``Host`` header is preserved so virtual-hosted
+    APIs still route. ``tests/test_security/test_egress_ip_pinning.py`` asserts
+    both against a real TLS server rather than trusting this paragraph.
+    """
+
+    def send(self, request, **kwargs):
+        parsed = urlparse(request.url)
+        if parsed.scheme in _ALLOWED_SCHEMES and parsed.hostname:
+            # Host header must survive the swap or virtual hosts break.
+            request.headers.setdefault("Host", parsed.netloc)
+        return super().send(request, **kwargs)
+
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        pool = self._pinned_pool(request)
+        if pool is not None:
+            return pool
+        return super().get_connection_with_tls_context(request, verify, proxies, cert)
+
+    def get_connection(self, url, proxies=None):  # pragma: no cover - older requests
+        parsed = urlparse(url)
+        pool = self._pool_for(parsed)
+        if pool is not None:
+            return pool
+        return super().get_connection(url, proxies)
+
+    def _pinned_pool(self, request):
+        return self._pool_for(urlparse(request.url))
+
+    def _pool_for(self, parsed):
+        if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.hostname:
+            return None
+        hostname = parsed.hostname
+        ip = resolve_public_ip(hostname)
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        pool_kwargs = {}
+        if parsed.scheme == "https":
+            # SNI + certificate identity stay the hostname; only the socket
+            # goes to the pinned address.
+            pool_kwargs["server_hostname"] = hostname
+        return self.poolmanager.connection_from_host(
+            ip, port=port, scheme=parsed.scheme, pool_kwargs=pool_kwargs
+        )
+
+
 def build_guarded_session() -> requests.Session:
     """Return dlt's retrying session, hardened to validate **every** request.
 
@@ -122,10 +223,23 @@ def build_guarded_session() -> requests.Session:
     original_send = session.send
 
     def guarded_send(request, **kwargs):
-        validate_egress_host(request.url)
+        # Scheme/host only — deliberately no DNS here. The adapter below does
+        # the single authoritative resolve-validate-pin; resolving in both
+        # places would mean two lookups per request with a rebinding window
+        # *between our own two checks*, which is the very thing core#405 closes.
+        _check_scheme_and_host(request.url)
         return original_send(request, **kwargs)
 
     session.send = guarded_send
+
+    # Pin the validated address for every scheme this guard allows (core#405).
+    # Mounted after the send-wrapper so both layers apply: the wrapper decides
+    # whether a URL may be fetched at all, the adapter decides where the socket
+    # actually goes.
+    pinned = _PinnedIPAdapter()
+    session.mount("http://", pinned)
+    session.mount("https://", pinned)
+
     # Lets callers (and tests) assert a session came from here rather than
     # trusting that some session was passed along.
     session._datanika_egress_guarded = True

--- a/tests/test_security/test_egress_guarded_session.py
+++ b/tests/test_security/test_egress_guarded_session.py
@@ -24,7 +24,6 @@ wrong and an empirical check cannot.
 
 import http.server
 import threading
-from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -70,19 +69,26 @@ def redirect_server():
 
 class TestEveryHopReachesTheGuard:
     def test_redirect_target_is_validated_before_it_is_fetched(self, redirect_server, monkeypatch):
-        """The whole point of (c): the *second* hop must be checked too."""
+        """The whole point of (c): the *second* hop must be checked too.
+
+        Since core#405 the authoritative check is the resolve-and-pin in the
+        adapter, so that is what's recorded here — one resolution per hop, and
+        no second lookup anywhere (a second one would be the rebinding window
+        the pinning exists to close).
+        """
         seen: list[str] = []
-        monkeypatch.setattr(
-            "datanika.services.egress_guard.validate_egress_host",
-            lambda url: seen.append(url),
-        )
+
+        def _record(hostname):
+            seen.append(hostname)
+            return "127.0.0.1"
+
+        monkeypatch.setattr("datanika.services.egress_guard.resolve_public_ip", _record)
 
         session = build_guarded_session()
         resp = session.get(f"{redirect_server}/hop")
 
         assert resp.status_code == 200
-        paths = [urlparse(u).path for u in seen]
-        assert paths == ["/hop", "/final"], f"redirect hop escaped the guard: {seen}"
+        assert seen == ["127.0.0.1", "127.0.0.1"], f"redirect hop escaped the guard: {seen}"
 
     def test_a_redirect_to_a_private_address_is_blocked(self, redirect_server):
         """With the real validator, the 127.0.0.1 hop must raise, not fetch."""
@@ -98,7 +104,9 @@ class TestEveryHopReachesTheGuard:
 
     def test_public_request_passes_through(self, monkeypatch, redirect_server):
         """A public host must still work — the guard is a filter, not a wall."""
-        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+        )
         session = build_guarded_session()
         assert session.get(f"{redirect_server}/final").json() == {"ok": True}
 

--- a/tests/test_security/test_egress_ip_pinning.py
+++ b/tests/test_security/test_egress_ip_pinning.py
@@ -1,0 +1,241 @@
+"""DNS-rebinding TOCTOU: connect to the IP we validated (core#405).
+
+Both earlier layers validate by *resolving a hostname*, then hand the hostname
+to ``requests``, which resolves it **again** to open the socket. A hostile
+resolver can answer differently the second time — public for our check, an
+internal address for the connection — and the guard never sees it.
+
+Closing that means pinning: resolve once, validate, and connect to **that
+address**, while keeping the ``Host`` header and TLS SNI as the hostname so
+certificates still validate and virtual hosts still route.
+
+That last clause is the whole risk of this change. Pinning is easy; pinning
+*without quietly breaking TLS verification* is the part worth testing, because
+the failure mode of getting it wrong (SNI becomes the IP, or hostname checking
+is disabled to make it "work") is a weaker system that still passes a naive
+"did it connect" test. So the SNI and certificate assertions here run against a
+real TLS server rather than being asserted about the code.
+"""
+
+import http.server
+import json
+import socket
+import ssl
+import threading
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from datanika.services.egress_guard import (
+    EgressValidationError,
+    build_guarded_session,
+    resolve_public_ip,
+)
+
+
+class _EchoHandler(http.server.BaseHTTPRequestHandler):
+    """Echoes back the Host header it received."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        body = json.dumps({"host_header": self.headers.get("Host", "")}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def echo_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _EchoHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestResolveValidatedAddress:
+    def test_public_host_returns_an_address(self, monkeypatch):
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.socket.getaddrinfo",
+            lambda host, *a, **kw: [(socket.AF_INET, None, None, "", ("93.184.216.34", 0))],
+        )
+        assert resolve_public_ip("example.com") == "93.184.216.34"
+
+    def test_private_answer_is_refused(self, monkeypatch):
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.socket.getaddrinfo",
+            lambda host, *a, **kw: [(socket.AF_INET, None, None, "", ("10.0.0.5", 0))],
+        )
+        with pytest.raises(EgressValidationError):
+            resolve_public_ip("rebind.example")
+
+    def test_mixed_answer_is_refused(self, monkeypatch):
+        """One private address among many is still a refusal."""
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.socket.getaddrinfo",
+            lambda host, *a, **kw: [
+                (socket.AF_INET, None, None, "", ("93.184.216.34", 0)),
+                (socket.AF_INET, None, None, "", ("169.254.169.254", 0)),
+            ],
+        )
+        with pytest.raises(EgressValidationError):
+            resolve_public_ip("half-evil.example")
+
+    def test_unresolvable_fails_closed(self, monkeypatch):
+        def _boom(*a, **kw):
+            raise socket.gaierror("nope")
+
+        monkeypatch.setattr("datanika.services.egress_guard.socket.getaddrinfo", _boom)
+        with pytest.raises(EgressValidationError):
+            resolve_public_ip("does-not-resolve.invalid")
+
+
+class TestPinningBeatsARebind:
+    def test_connection_goes_to_the_validated_address(self, echo_server, monkeypatch):
+        """The classic rebind: validation says public, the next lookup says otherwise.
+
+        The resolver is asked once and answers with the loopback test server.
+        If the adapter re-resolved at connect time it would go somewhere else
+        (or fail); arriving here proves the validated address was pinned.
+        """
+        calls = []
+
+        def _resolve(host):
+            calls.append(host)
+            return "127.0.0.1"
+
+        monkeypatch.setattr("datanika.services.egress_guard.resolve_public_ip", _resolve)
+
+        session = build_guarded_session()
+        resp = session.get(f"http://pinned.example:{echo_server}/", timeout=5)
+
+        assert resp.status_code == 200
+        assert calls == ["pinned.example"], "resolved more than once — that is the TOCTOU"
+
+    def test_host_header_stays_the_hostname(self, echo_server, monkeypatch):
+        """Sending the IP as Host breaks every virtual-hosted API."""
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda host: "127.0.0.1"
+        )
+
+        session = build_guarded_session()
+        resp = session.get(f"http://pinned.example:{echo_server}/", timeout=5)
+
+        assert resp.json()["host_header"].startswith("pinned.example")
+
+    def test_a_refused_host_never_connects(self, monkeypatch):
+        def _refuse(host):
+            raise EgressValidationError(f"{host} resolves to a non-public address")
+
+        monkeypatch.setattr("datanika.services.egress_guard.resolve_public_ip", _refuse)
+
+        session = build_guarded_session()
+        with pytest.raises(Exception) as exc:  # requests wraps adapter errors
+            session.get("http://rebind.example/", timeout=5)
+        assert "non-public" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# TLS — the part that would silently weaken if implemented carelessly
+# ---------------------------------------------------------------------------
+
+
+def _self_signed(tmp_path, hostname: str):
+    """A throwaway cert for *hostname* so certificate matching is real."""
+    crypto = pytest.importorskip("cryptography")
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    assert crypto  # imported for the skip guard
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = tmp_path / "cert.pem"
+    key_path = tmp_path / "key.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return str(cert_path), str(key_path)
+
+
+@pytest.fixture
+def tls_server(tmp_path):
+    """A TLS server on loopback that records the SNI name it was offered."""
+    hostname = "pinned.example"
+    cert_path, key_path = _self_signed(tmp_path, hostname)
+    seen: dict = {}
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_path, key_path)
+
+    def _sni_callback(sock, server_name, ctx):
+        seen["sni"] = server_name
+
+    context.sni_callback = _sni_callback
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _EchoHandler)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port, cert_path, seen
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestTlsIdentityIsPreserved:
+    def test_sni_is_the_hostname_not_the_pinned_ip(self, tls_server, monkeypatch):
+        """If SNI became the IP, every SNI-based host would serve the wrong cert."""
+        port, cert_path, seen = tls_server
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda host: "127.0.0.1"
+        )
+
+        session = build_guarded_session()
+        session.get(f"https://pinned.example:{port}/", timeout=5, verify=cert_path)
+
+        assert seen["sni"] == "pinned.example"
+
+    def test_certificate_is_still_verified_against_the_hostname(self, tls_server, monkeypatch):
+        """The cert is for pinned.example; asking for another name must fail.
+
+        This is the assertion that catches "made it work" by disabling
+        hostname checking — the failure mode that turns a hardening change
+        into a downgrade.
+        """
+        port, cert_path, _seen = tls_server
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda host: "127.0.0.1"
+        )
+
+        session = build_guarded_session()
+        with pytest.raises(Exception) as exc:
+            session.get(f"https://wrong-name.example:{port}/", timeout=5, verify=cert_path)
+
+        blob = str(exc.value).lower()
+        assert "certificate" in blob or "hostname" in blob or "ssl" in blob

--- a/tests/test_services/test_openapi_fetch.py
+++ b/tests/test_services/test_openapi_fetch.py
@@ -76,6 +76,11 @@ def allow_loopback(monkeypatch):
     """
     monkeypatch.setattr("datanika.services.openapi_fetch.validate_egress_host", lambda url: None)
     monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    # Since core#405 the guarded session pins the address it resolves, so the
+    # loopback test server has to come back from *that* call too.
+    monkeypatch.setattr(
+        "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+    )
     # stdlib http.server speaks plaintext; the https rule is asserted separately
     # against the real code path in TestSchemeIsHttpsOnly.
     monkeypatch.setattr("datanika.services.openapi_fetch.REQUIRED_SCHEME", "http")

--- a/tests/test_services/test_openapi_pagination.py
+++ b/tests/test_services/test_openapi_pagination.py
@@ -190,6 +190,11 @@ class TestPaginationActuallyPagesThroughData:
         # The egress guard blocks loopback by design; it has its own tests.
         monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
         monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        # core#405: the session pins the address it resolves, so loopback has
+        # to come back from that call too.
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+        )
 
         parsed = parse_openapi_spec(
             _spec(params=[_query("offset"), _query("limit", type="integer", maximum=1)]),
@@ -216,6 +221,11 @@ class TestPaginationActuallyPagesThroughData:
 
         monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
         monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        # core#405: the session pins the address it resolves, so loopback has
+        # to come back from that call too.
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+        )
 
         parsed = parse_openapi_spec(_spec(), base_url_override=paged_api)
         assert parsed.resources[0]["endpoint"].get("paginator") is None


### PR DESCRIPTION
Closes #405.

Sequenced **before** MCP P3 deliberately: #405 names "P3 write-tools GA" as one of the two events that force it, so shipping write tools first would land in exactly the window the issue describes.

## The gap

Both earlier layers validated by *resolving a hostname*, then handed that hostname to `requests`, which resolved it **again** to open the socket. A hostile resolver can answer differently the second time — public for our check, internal for the connection.

`resolve_public_ip()` now resolves once, validates **every** answer (one private address among many is a refusal, not a race), and returns the address it approved. `_PinnedIPAdapter` builds the connection pool against that address, so the socket goes where we looked.

## Keeping TLS honest — the actual risk here

Pinning is easy. Pinning *without quietly breaking TLS* is the part worth care: urllib3 would otherwise offer the **IP** as SNI and match the certificate against it, so a careless implementation either serves the wrong virtual host or "fixes" itself by disabling hostname verification — turning a hardening change into a **downgrade**.

The pool is created with `server_hostname` = the real hostname, `assert_hostname` is left alone so urllib3 falls back to it for matching, and the `Host` header is preserved.

That claim is tested against a **real TLS server**, not asserted in prose:

- the server records the SNI it was offered — must be `pinned.example`, not `127.0.0.1`;
- requesting a name the certificate doesn't cover must **still fail**. That's the assertion that catches "made it work" by turning verification off.

## A design correction the tests forced

My first version left `validate_egress_host` in the send-wrapper **and** resolved again in the adapter — two lookups per request, with a rebinding window *between our own two checks*. Exactly the bug being fixed, reintroduced one layer up.

The send path now does a scheme/host check with **no DNS at all**, and the adapter is the single authoritative resolve-validate-pin. Hop coverage from #403/#404 is unchanged — every hop still goes through the adapter — and is now pinned as well.

`validate_egress_host` stays as the pre-flight API for callers that check before building a request (`dlt_runner`, `openapi_fetch`).

## Caller impact

Tests that reached a loopback server by patching `validate_egress_host` need to patch `resolve_public_ip` too, since that's where the address now comes from. Updated in `test_egress_guarded_session`, `test_openapi_fetch` and `test_openapi_pagination` — worth knowing if anything else grows a guarded-session test.

9 new tests. Full precheck green: ruff + format clean, **2446 passed**.

## Still not closed

Pinning removes the *resolve-twice* window. It does not make the guard a boundary: a host that is genuinely public at request time is still fetched, which is the intended behaviour and the reason `trigger_*` should keep its per-call confirmation (SPEC §10) when P3 lands.
