### PR TITLE
[Growth] README audit: 36 connectors, MCP both paths, Helm shipped — plus a count guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Datanika combines [dlt](https://dlthub.com) (extract + load) with [dbt-core](htt
 
 ## Features
 
-🔌 **32 Connectors** — PostgreSQL, MySQL, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
+🔌 **36 Connectors** — PostgreSQL, MySQL, Oracle, MongoDB, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
 🔄 **dbt Transformations** — SQL models, tests, snapshots, packages, and source freshness built in
 📊 **Visual Pipeline Builder** — DAG editor with dependency management
 ⏰ **Scheduling** — Cron-based with APScheduler, persistent across restarts
@@ -24,7 +24,7 @@ Datanika combines [dlt](https://dlthub.com) (extract + load) with [dbt-core](htt
 🔐 **Enterprise Security** — RBAC, SSO (SAML/OIDC), audit logging, encrypted credentials
 🌍 **9 Languages** — English, German, French, Spanish, Russian, Greek, Chinese, Arabic, Serbian
 🔌 **REST API** — Full CRUD with OpenAPI/Swagger docs, rate limiting, and scoped API keys
-🤖 **AI-Agent Ready** — `/llms.txt`, agent-guide.md, 5-tier capability API, compile+preview validation, typed error codes, `?wait=true`, `Idempotency-Key`, run cancellation
+🤖 **AI-Agent Ready** — hosted + local [MCP server](#ai-agent-integration) (25 tools), `/llms.txt`, agent-guide.md, 5-tier capability API, compile+preview validation, typed error codes, `?wait=true`, `Idempotency-Key`, run cancellation
 🚀 **Pipeline Templates** — One-click starter templates (Stripe→Postgres, Postgres→BigQuery, CSV→DuckDB) with prefilled connection configs
 🔔 **Notifications** — Slack, Telegram, email, and webhook alerts on run completion, plus an in-app notification center
 📦 **Self-Hostable** — Single `docker compose up` — no Kubernetes required
@@ -83,7 +83,7 @@ tag tells you immediately whether you're affected.
 
 | | Datanika | Airbyte | Fivetran | dbt Cloud |
 |---|---|---|---|---|
-| Extract + Load | ✅ 32 connectors | ✅ 400+ | ✅ 500+ | ❌ |
+| Extract + Load | ✅ 36 connectors | ✅ 400+ | ✅ 500+ | ❌ |
 | Transformations | ✅ dbt built-in | ❌ | ❌ (add-on) | ✅ |
 | Scheduling | ✅ Cron + DAG | ✅ Basic | ✅ Basic | ✅ |
 | Pipeline DAG | ✅ Visual | ❌ | ❌ | ❌ |
@@ -110,7 +110,7 @@ tag tells you immediately whether you're affected.
 
 ## Roadmap
 
-- [x] 32 connectors (databases, SaaS APIs, files, streaming)
+- [x] 36 connectors (databases, SaaS APIs, files, streaming)
 - [x] dbt transformations, tests, snapshots, packages
 - [x] REST API v1 with OpenAPI/Swagger and typed per-connector inline schemas
 - [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel, MCP server)
@@ -118,23 +118,32 @@ tag tells you immediately whether you're affected.
 - [x] In-app notification center with Slack, Telegram, Email, Webhook channels
 - [x] SSO (SAML/OIDC) for Enterprise
 - [x] Usage-based billing (cloud plugin)
-- [x] 1,800+ tests across unit, security, and E2E (SQLite in-memory for speed)
-- [ ] Kubernetes Helm chart
+- [x] 2,300+ tests across unit, security, and E2E (SQLite in-memory for speed)
+- [x] Kubernetes Helm chart — in-tree at [`deploy/helm/datanika/`](deploy/helm/datanika/); installs the same image as the Compose path. Bundled Postgres/Redis are single-replica and not production-grade — point it at managed databases (see the chart README)
 - [ ] Data lineage visualization
 
 ---
 
 ## AI Agent Integration
 
-Datanika ships a first-class [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude Desktop, Claude Code, etc.) can browse connections, preview data, compile transformations, and manage pipelines natively.
+Datanika speaks [MCP](https://modelcontextprotocol.io/), so AI agents (Claude Desktop, Claude Code, Cursor, …) can browse connections, preview data, compile transformations, and monitor runs natively. **25 tools — 17 read-only, 8 write.** There are two ways in.
 
-```bash
-# Install and run (read-only by default)
-uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" \
-    datanika-mcp --url https://app.datanika.io --api-key YOUR_KEY
+**Hosted — nothing to install.** Paste this wherever your client accepts a remote MCP server and authorize in the browser:
+
+```
+https://app.datanika.io/mcp
 ```
 
-See [`datanika-mcp/README.md`](datanika-mcp/README.md) for Claude Desktop config snippets, the full tool list, and the `--allow-write` flag.
+OAuth 2.1, no API key to handle. **Writes are never available over the hosted endpoint** — there is no flag or scope that enables them.
+
+**Local — stdio.** Published on PyPI as [`datanika-mcp`](https://pypi.org/project/datanika-mcp/) and listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.datanika/datanika-mcp`:
+
+```bash
+# read-only by default; add --allow-write to enable the 8 write tools
+uvx datanika-mcp --url https://app.datanika.io --api-key YOUR_KEY
+```
+
+See [`datanika-mcp/README.md`](datanika-mcp/README.md) for per-client config snippets and the full tool list, or [datanika.io/docs/mcp-server](https://datanika.io/docs/mcp-server) for the hosted walkthrough.
 
 Additional agent resources:
 - [`/llms.txt`](https://app.datanika.io/llms.txt) — discovery document

--- a/tests/test_docs/test_readme_claims.py
+++ b/tests/test_docs/test_readme_claims.py
@@ -1,0 +1,98 @@
+"""Guards the countable claims in the root ``README.md`` against the code.
+
+Why this exists: the README said **32 connectors** in three places for months
+after the real number reached 36 — including the Airbyte/Fivetran comparison
+table, where the stale number undersold us to exactly the audience the table is
+written for. Nothing caught it because nothing was watching. The landing repo has
+had a connector-count guard for a while; core had none, which is precisely why
+the two drifted apart.
+
+The count is derived from :class:`ConnectionType` rather than hardcoded, so
+adding a connector fails this test until the README is updated in the same PR.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from datanika.models.connection import ConnectionType
+
+README = Path(__file__).resolve().parents[2] / "README.md"
+
+# Connection types that exist in code but are deliberately not part of the
+# marketed connector count. Keep this list short and justified — every entry is
+# a claim that users cannot actually use something we shipped an enum member
+# for. If you add one, say why.
+UNMARKETED_TYPES = {
+    # core#310 — OpenAPI source generation is behind a deferred feature and has
+    # no connector page, setup guide, or docs entry. Counting it would inflate
+    # the public number by one.
+    "openapi",
+}
+
+EXPECTED_CONNECTOR_COUNT = len(ConnectionType) - len(UNMARKETED_TYPES)
+
+
+@pytest.fixture(scope="module")
+def readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def test_unmarketed_types_actually_exist() -> None:
+    """A typo in UNMARKETED_TYPES would silently inflate the expected count."""
+    members = {t.value for t in ConnectionType}
+    unknown = UNMARKETED_TYPES - members
+    assert not unknown, f"UNMARKETED_TYPES names types that aren't in ConnectionType: {unknown}"
+
+
+def test_expected_count_is_sane() -> None:
+    """Tripwire against the exclusion list quietly swallowing real connectors."""
+    assert len(ConnectionType) - 1 == EXPECTED_CONNECTOR_COUNT
+    assert EXPECTED_CONNECTOR_COUNT > 30, "connector count collapsed — check ConnectionType"
+
+
+def test_every_readme_connector_count_matches_the_enum(readme: str) -> None:
+    """All "<n> connectors" claims in the README must agree with the code.
+
+    Deliberately matches *every* occurrence rather than a known set of line
+    numbers: the last drift left three stale copies, and a guard that only
+    checked one of them would have passed while the README stayed wrong.
+    """
+    counts = [int(n) for n in re.findall(r"(\d+)\s+[Cc]onnectors\b", readme)]
+
+    assert counts, "no '<n> connectors' claim found in README.md — did the wording change?"
+
+    wrong = sorted({n for n in counts if n != EXPECTED_CONNECTOR_COUNT})
+    assert not wrong, (
+        f"README claims {wrong} connectors but ConnectionType has "
+        f"{EXPECTED_CONNECTOR_COUNT} marketed types "
+        f"({len(ConnectionType)} total minus {sorted(UNMARKETED_TYPES)}). "
+        f"Found {len(counts)} count claim(s); update all of them."
+    )
+
+
+def test_comparison_table_carries_the_count(readme: str) -> None:
+    """The Airbyte/Fivetran row is the one that cost us competitively.
+
+    It is also the easiest to miss in a find-replace, because it is inside a
+    table cell rather than prose.
+    """
+    row = next((line for line in readme.splitlines() if "Extract + Load" in line), None)
+    assert row is not None, "comparison table lost its 'Extract + Load' row"
+    assert f"{EXPECTED_CONNECTOR_COUNT} connectors" in row, (
+        f"comparison table row does not claim {EXPECTED_CONNECTOR_COUNT} connectors: {row!r}"
+    )
+
+
+def test_mcp_install_uses_the_published_package(readme: str) -> None:
+    """``uvx datanika-mcp`` is published; the git+subdirectory form is pre-PyPI.
+
+    Same defect class as the connector count: an instruction that was true when
+    written and silently became the harder path. Mirrors the guard the landing
+    repo keeps on its own MCP docs.
+    """
+    assert "uvx datanika-mcp" in readme, "README lost the PyPI install command"
+    assert "#subdirectory=datanika-mcp" not in readme, (
+        "README regressed to the pre-PyPI git+subdirectory install string"
+    )


### PR DESCRIPTION
The README said **"32 connectors" in three places**. The real number is 36. One of the three is the Airbyte/Fivetran comparison row — so the stale figure was undercutting us in front of exactly the audience that table exists for.

Scoped as an audit rather than a find-replace, which turned up four more claims that had gone stale the same way:

| Claim | Was | Now |
|---|---|---|
| Connectors (×3) | 32 | **36** |
| Test count | "1,800+" | **2,300+** (2,472 pass today) |
| Helm chart | roadmap `[ ]` | `[x]` — the chart has been in-tree at `deploy/helm/datanika/`, with the honest caveat that its bundled Postgres/Redis are single-replica and not production-grade |
| MCP install | `uvx --from "git+…#subdirectory=datanika-mcp"` | `uvx datanika-mcp` |
| Hosted `/mcp` | absent entirely | documented, alongside the local path |

The MCP install line was the one actively costing us: anyone following the README was taking the hard path to a package we've been publishing to PyPI for days. The section now leads with the hosted endpoint (`https://app.datanika.io/mcp`, OAuth, nothing to install) and states plainly that **writes are never available over it** — no flag, no scope.

## 36 is derived, not typed

`ConnectionType` has **37** members. One — `openapi` — sits behind deferred feature #310 with no connector page, setup guide, or docs entry. 37 − 1 = 36, which is exactly what the landing site markets. The two now agree *for a reason* rather than by luck, and the guard breaks correctly when a 38th connector lands.

## The guard

`tests/test_docs/test_readme_claims.py` derives the expected count from the enum and:

- checks **every** `<n> connectors` occurrence, not a known set of line numbers — the last drift left three stale copies, and a guard checking one would have passed while the README stayed wrong;
- pins the comparison-table row specifically, since it's a table cell and the easiest to miss;
- blocks a regression to the pre-PyPI git install string;
- validates the exclusion list itself, so a typo in it can't silently inflate the expected number.

Verified it goes **red on the exact regression it exists to catch** (re-introducing "32 connectors" fails 2 of the 5) and green again on restore.

Landing has had a connector-count guard for a while. Core had none — which is why the two drifted apart in the first place.

## Precheck

`ruff check` + `ruff format --check` clean; **2472 passed, 20 skipped** via the pre-push hook.

> Getting a green local run required `UV_NO_SYNC=1` (WORKFLOW_RULES §3): `test_head_downgrade_upgrade_roundtrip` shells out to `uv run`, which prunes the venv mid-run on Windows and half-deletes native packages. Filed the durable fix as #442; the workaround is documented and this PR is unaffected.
