### PR TITLE
[Infra] Staging: resolve the live app container instead of hardcoding its name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Wait for staging health
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
-            'for i in $(seq 1 40); do h=$(docker inspect --format "{{.State.Health.Status}}" datanika-staging-app 2>/dev/null); [ "$h" = healthy ] && { echo staging-healthy; exit 0; }; sleep 5; done; echo "staging NOT healthy"; docker logs --tail 40 datanika-staging-app; exit 1'
+            'for i in $(seq 1 40); do h=$(docker inspect --format "{{.State.Health.Status}}" $(/opt/datanika-staging/active-app.sh) 2>/dev/null); [ "$h" = healthy ] && { echo staging-healthy; exit 0; }; sleep 5; done; echo "staging NOT healthy"; docker logs --tail 40 $(/opt/datanika-staging/active-app.sh); exit 1'
 
   smoke-staging:
     needs: [deploy-staging]
@@ -247,7 +247,7 @@ jobs:
           DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
           DATANIKA_E2E_SEED_CMD: >-
             ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
-            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 datanika-staging-app uv run python -m datanika.scripts.e2e_seed'
+            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
 
       - name: Upload Playwright report
@@ -388,7 +388,7 @@ jobs:
             echo "Network connect failed or already connected"
 
           # Verify staging can reach Authentik by the alias
-          ssh root@$SSH_HOST "docker exec datanika-staging-app curl -sf --max-time 5 http://e2e-authentik-server:9000/-/health/ready/" && \
+          ssh root@$SSH_HOST "docker exec \$(/opt/datanika-staging/active-app.sh) curl -sf --max-time 5 http://e2e-authentik-server:9000/-/health/ready/" && \
             echo "Staging → Authentik OK" || \
             { echo "FATAL: staging can't reach e2e-authentik-server:9000"; exit 1; }
 
@@ -404,8 +404,8 @@ jobs:
         env:
           SSH_HOST: ${{ secrets.HETZNER_HOST }}
         run: |
-          ssh root@$SSH_HOST "docker cp /opt/datanika/e2e-sso/.sso-fixture.json datanika-staging-app:/app/e2e/.sso-fixture.json"
-          ssh root@$SSH_HOST "docker exec datanika-staging-app uv run python e2e/scripts/seed-sso-configs.py"
+          ssh root@$SSH_HOST "docker cp /opt/datanika/e2e-sso/.sso-fixture.json \$(/opt/datanika-staging/active-app.sh):/app/e2e/.sso-fixture.json"
+          ssh root@$SSH_HOST "docker exec \$(/opt/datanika-staging/active-app.sh) uv run python e2e/scripts/seed-sso-configs.py"
 
       - name: Open SSH tunnel to Authentik + hosts entry
         env:
@@ -458,7 +458,7 @@ jobs:
           curl -sI --max-time 10 http://e2e-authentik-server:9000/-/health/ready/ 2>&1 | head -5 || true
           echo ""
           echo "=== Staging → Authentik reachability ==="
-          ssh root@${{ secrets.HETZNER_HOST }} "docker exec datanika-staging-app curl -sI --max-time 5 http://e2e-authentik-server:9000/-/health/ready/ 2>&1 | head -3" || true
+          ssh root@${{ secrets.HETZNER_HOST }} "docker exec \$(/opt/datanika-staging/active-app.sh) curl -sI --max-time 5 http://e2e-authentik-server:9000/-/health/ready/ 2>&1 | head -3" || true
 
       - name: Run SSO specs
         working-directory: e2e

--- a/scripts/deploy-bluegreen.sh
+++ b/scripts/deploy-bluegreen.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Blue/green swap for the Datanika app container. (A3, core#425)
+#
+# The problem it solves
+# ---------------------
+# `docker compose up -d app` RECREATES the container: the old one stops, the new one
+# boots, and every request 502s in between. Measured on prod 2026-07-21: a 60s window,
+# and the frontend is down longer than the backend because it boots slower.
+#
+# How this avoids it
+# ------------------
+# Only ONE container serves at a time (so no split Reflex session state), but the NEW one
+# is fully healthy before Apache is repointed:
+#
+#   start inactive colour -> wait for its healthcheck -> rewrite the 2-line Define
+#   include -> apachectl configtest -> apachectl graceful -> verify through the proxy
+#   -> stop the old colour
+#
+# `graceful` finishes in-flight requests rather than cutting them. Any failure before the
+# swap leaves Apache pointing at the OLD container, which is still serving.
+#
+# ⚠️ Requires expand/contract migrations. The new container runs `alembic upgrade head`
+# while the old one is still serving, so the old code meets the new schema. See
+# plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md — a rename/drop here is an outage.
+#
+# Usage:  deploy-bluegreen.sh [--env staging|prod] [--dry-run]
+
+set -euo pipefail
+
+ENVIRONMENT="staging"
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) ENVIRONMENT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$ENVIRONMENT" in
+  staging)
+    PROJECT=datanika-staging
+    COMPOSE_DIR=/opt/datanika-staging
+    INCLUDE=/etc/apache2/conf-enabled/datanika-staging-active.conf
+    VAR_BE=DATANIKA_STG_BE
+    VAR_FE=DATANIKA_STG_FE
+    HOST_HEADER=staging-app.datanika.io
+    # colour -> "service container be_port fe_port"
+    BLUE="app  datanika-staging-app    8100 3100"
+    GREEN="app_b datanika-staging-app-b 8110 3110"
+    ;;
+  prod)
+    echo "prod is not wired yet — the vhost still hardcodes its ports (22 of them)." >&2
+    echo "See plans/infra/PLAN_INFRASTRUCTURE.md A3 for the remaining steps." >&2
+    exit 2
+    ;;
+  *) echo "unknown env: $ENVIRONMENT" >&2; exit 2 ;;
+esac
+
+log() { printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+field() { echo "$1" | awk -v n="$2" '{print $n}'; }
+
+# --- which colour is live right now? -----------------------------------------------
+CUR_BE=$(sed -nE "s/^Define ${VAR_BE} ([0-9]+).*/\1/p" "$INCLUDE")
+if [ -z "$CUR_BE" ]; then
+  log "FATAL: cannot read ${VAR_BE} from ${INCLUDE}"; exit 1
+fi
+
+if [ "$CUR_BE" = "$(field "$BLUE" 3)" ]; then
+  ACTIVE="$BLUE"; TARGET="$GREEN"; ACTIVE_NAME=blue; TARGET_NAME=green
+else
+  ACTIVE="$GREEN"; TARGET="$BLUE"; ACTIVE_NAME=green; TARGET_NAME=blue
+fi
+
+A_SVC=$(field "$ACTIVE" 1); A_CTR=$(field "$ACTIVE" 2)
+T_SVC=$(field "$TARGET" 1); T_CTR=$(field "$TARGET" 2)
+T_BE=$(field "$TARGET" 3);  T_FE=$(field "$TARGET" 4)
+
+log "active=${ACTIVE_NAME} (${A_CTR}, be ${CUR_BE})  ->  target=${TARGET_NAME} (${T_CTR}, be ${T_BE})"
+if [ "$DRY_RUN" = 1 ]; then log "dry run — stopping here"; exit 0; fi
+
+# --- rollback ------------------------------------------------------------------------
+BACKUP=$(mktemp)
+cp "$INCLUDE" "$BACKUP"
+ROLLED_BACK=0
+rollback() {
+  [ "$ROLLED_BACK" = 1 ] && return
+  ROLLED_BACK=1
+  log "ROLLBACK: restoring Apache to ${ACTIVE_NAME} and stopping ${T_CTR}"
+  cp "$BACKUP" "$INCLUDE"
+  if apachectl configtest >/dev/null 2>&1; then
+    apachectl graceful || true
+  else
+    log "FATAL: restored config fails configtest — NOT reloading. Investigate now."
+  fi
+  (cd "$COMPOSE_DIR" && set -a && . ./.env.docker && set +a \
+     && docker compose -p "$PROJECT" --profile bluegreen stop "$T_SVC" >/dev/null 2>&1) || true
+  log "rolled back; ${A_CTR} still serving"
+}
+trap 'rollback' ERR
+
+# --- 1. start the target colour -------------------------------------------------------
+log "starting ${T_CTR}"
+cd "$COMPOSE_DIR"
+set -a && . ./.env.docker && set +a
+docker compose -p "$PROJECT" --profile bluegreen up -d "$T_SVC"
+
+# --- 2. wait for it to be healthy (the whole point) ----------------------------------
+log "waiting for ${T_CTR} healthcheck"
+for i in $(seq 1 60); do
+  STATUS=$(docker inspect --format '{{.State.Health.Status}}' "$T_CTR" 2>/dev/null || echo missing)
+  [ "$STATUS" = healthy ] && break
+  if [ "$i" = 60 ]; then
+    log "FATAL: ${T_CTR} never became healthy (last: ${STATUS})"
+    docker logs --tail 40 "$T_CTR" || true
+    exit 1
+  fi
+  sleep 5
+done
+log "${T_CTR} healthy"
+
+# Belt and braces: ask the new container directly, not just Docker's opinion.
+DIRECT=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${T_BE}/healthz" || echo 000)
+[ "$DIRECT" = 200 ] || { log "FATAL: direct /healthz on :${T_BE} returned ${DIRECT}"; exit 1; }
+log "direct /healthz on :${T_BE} = 200"
+
+# --- 3. repoint Apache ---------------------------------------------------------------
+log "repointing Apache -> ${TARGET_NAME} (be ${T_BE}, fe ${T_FE})"
+cat > "$INCLUDE" <<CONF
+# Active ${ENVIRONMENT} backend/frontend ports — rewritten by deploy-bluegreen.sh.
+# Parsed before sites-enabled/*, where the vhost consumes \${${VAR_BE}} / \${${VAR_FE}}.
+Define ${VAR_BE} ${T_BE}
+Define ${VAR_FE} ${T_FE}
+CONF
+
+# Never reload an untested config: this box also serves a webdav co-tenant and the
+# founder's VPN path, so a bad reload is not contained to Datanika.
+apachectl configtest >/dev/null 2>&1 || { log "FATAL: configtest failed"; apachectl configtest || true; exit 1; }
+apachectl graceful
+sleep 2
+
+# --- 4. verify through the proxy, before retiring the old colour ---------------------
+for path in /healthz /readyz /; do
+  CODE=$(curl -sk -o /dev/null -w '%{http_code}' -H "Host: ${HOST_HEADER}" "https://127.0.0.1${path}" || echo 000)
+  log "  proxy ${path} -> ${CODE}"
+  [ "$CODE" = 200 ] || { log "FATAL: ${path} returned ${CODE} after the swap"; exit 1; }
+done
+
+# --- 5. retire the old colour ---------------------------------------------------------
+trap - ERR
+log "stopping ${A_CTR}"
+docker compose -p "$PROJECT" --profile bluegreen stop "$A_SVC" >/dev/null
+log "swap complete: ${TARGET_NAME} is live"

--- a/scripts/staging-active-app.sh
+++ b/scripts/staging-active-app.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Print the staging app container that is CURRENTLY serving traffic.
+#
+# Blue/green alternates the live container's name, so anything hardcoding
+# `datanika-staging-app` breaks whenever green is active — this broke dev CI on
+# 2026-07-21, and the failure looked like an unrelated PR's fault. Apache's active-ports
+# include is the single source of truth for which colour is live, so resolve from it.
+#
+# Deployed to /opt/datanika-staging/active-app.sh
+# Usage: docker exec "$(/opt/datanika-staging/active-app.sh)" <cmd>
+set -u
+INC=/etc/apache2/conf-enabled/datanika-staging-active.conf
+BE=$(sed -nE 's/^Define DATANIKA_STG_BE ([0-9]+).*/\1/p' "$INC" 2>/dev/null)
+case "$BE" in
+  8100) NAME=datanika-staging-app   ;;
+  8110) NAME=datanika-staging-app-b ;;
+  *)    NAME=datanika-staging-app   ;;  # fallback to the historical default
+esac
+# Report only a RUNNING container, so callers fail loudly instead of exec'ing a corpse.
+if [ "$(docker inspect --format '{{.State.Running}}' "$NAME" 2>/dev/null)" != "true" ]; then
+  echo "active-app.sh: $NAME is not running (Apache says be=$BE)" >&2
+  exit 1
+fi
+echo "$NAME"


### PR DESCRIPTION
Part of #425 (A3). Fixes the coupling that a real blue/green swap exposed.

**The problem, observed rather than predicted.** Blue/green alternates which container serves. CI reaches into staging with `docker exec datanika-staging-app` in **six** places, so the moment green is live those point at a stopped container. This is exactly how dev CI went red on 2026-07-21 — and it initially looked like an unrelated PR had broken it, which is the more expensive part of the failure.

**Fix**
- `scripts/staging-active-app.sh` resolves the live colour from Apache's active-ports include (the single source of truth for what is being served) and **refuses to name a container that isn't running**, so callers fail loudly instead of exec'ing into a corpse.
- `ci.yml` calls the resolver at all six sites.

**Quoting is the subtle part, and is asserted rather than assumed.** Inside **double-quoted** `ssh` strings the GitHub runner expands `$( )` *locally*, where the script doesn't exist — silently yielding an empty command. Those four sites escape the `$`; the two single-quoted sites must not. A check enumerates every call site and asserts `double_quoted == escaped`; all six pass. I caught this only by re-reading the replacements, not from the search-and-replace itself.

**Verified on the box:** the resolver returns `datanika-staging-app` with blue live, and `docker exec "$(...)"` works exactly as CI invokes it.

Also checks in `scripts/deploy-bluegreen.sh`, which had been untracked in the worktree.