### PR TITLE
[Engineering] MCP P3: write tools via consent-time scope (closes #442, #409)

### DIFF
--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -44,8 +44,8 @@ mcp = FastMCP(
     "Datanika",
     instructions=(
         "Browse data connections, preview tables, compile and validate "
-        "dbt transformations, monitor pipeline runs, and (with --allow-write) "
-        "create resources and trigger runs in Datanika."
+        "dbt transformations, and monitor pipeline runs in Datanika. Sessions "
+        "granted write access can also create resources and trigger runs."
     ),
 )
 
@@ -269,7 +269,9 @@ async def get_catalog_entry(entry_id: int) -> str:
 async def create_connection(name: str, connection_type: str, config: dict) -> str:
     """Create a new data connection.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Human-readable name for the connection.
@@ -292,7 +294,9 @@ async def create_upload(
 ) -> str:
     """Create a new upload (extract + load job).
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Upload name.
@@ -319,7 +323,9 @@ async def create_pipeline(
 ) -> str:
     """Create a new pipeline (dbt transform orchestration).
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Pipeline name.
@@ -346,7 +352,9 @@ async def create_transformation(
 ) -> str:
     """Create a new dbt SQL transformation.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Model name (letters, digits, underscores, hyphens; must start with letter or _).
@@ -368,7 +376,9 @@ async def create_transformation(
 async def bulk_import(payload: dict) -> str:
     """Bulk-import connections, uploads, pipelines, and transformations in one call.
 
-    Requires --allow-write. Uses the JSON v2 import format.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it. Uses the JSON v2 import format.
     Validates everything first — if any errors, nothing is created.
 
     Args:
@@ -386,7 +396,9 @@ async def bulk_import(payload: dict) -> str:
 async def trigger_upload(upload_id: int, wait: bool = False) -> str:
     """Trigger an upload run.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         upload_id: The upload to run.
@@ -400,7 +412,9 @@ async def trigger_upload(upload_id: int, wait: bool = False) -> str:
 async def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
     """Trigger a pipeline run (dbt build/run/test).
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         pipeline_id: The pipeline to run.
@@ -414,7 +428,9 @@ async def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
 async def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
     """Trigger a transformation run.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         transformation_id: The transformation to run.

--- a/datanika-mcp/src/datanika_mcp/session.py
+++ b/datanika-mcp/src/datanika_mcp/session.py
@@ -68,10 +68,10 @@ class DatanikaSession:
         prefix = f"Write access required for '{action}'."
         if self.transport == "remote":
             raise RuntimeError(
-                f"{prefix} This hosted Datanika endpoint is read-only — write "
-                "tools are not enabled on it, and no client-side setting or "
-                "retry will change that. For write access, run the local "
-                "datanika-mcp server with --allow-write."
+                f"{prefix} This connection was authorized read-only, and no "
+                "client-side setting or retry will change that. Write access "
+                "is granted by the user when they approve the connection — "
+                "ask them to re-authorize Datanika and approve write access."
             )
         raise RuntimeError(f"{prefix} Restart the server with --allow-write to enable mutations.")
 

--- a/datanika/services/mcp_oauth.py
+++ b/datanika/services/mcp_oauth.py
@@ -18,10 +18,18 @@ validates the OAuth request and redirects to the frontend consent page, which
 carries the user's JWT to ``POST /api/oauth/consent`` in an Authorization
 header. No token is ever put in a query string.
 
-**Scope of the grant.** P2 issues **read-only** grants — the eight ``*:read``
-scopes, which is exactly what the 17 read tools need. Write tools are P3 and
-gated on the #338 egress guard, so a write grant could not unlock anything
-today; offering one would be consent theatre.
+**Scope of the grant.** Read-only by default — silence is never consent to
+write. Since P3 (core#442) a client may *ask* for write, and the human decides
+at the consent screen; the minted key carries exactly what was granted, so
+``api_middleware`` enforces it and this layer adds no authz of its own (§5.4).
+
+**Why consent-time and not per-call.** SPEC §10 asked for a per-call
+confirmation before a remote agent spends compute or money. That assumed an
+interactive session; the hosted transport is stateless, and a two-phase token
+the agent mints and echoes to itself is friction, not a gate — the agent is the
+thing being gated. The decision that matters is a *human* one, so it belongs at
+consent, made once and knowingly. Spend is bounded by the per-key rate limit
+and byte quota, which §10 named alongside the phasing.
 """
 
 from __future__ import annotations
@@ -30,6 +38,7 @@ import base64
 import hashlib
 import json
 import secrets
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlencode, urlparse
 
@@ -70,9 +79,32 @@ _READ_SCOPES = (
 )
 
 
+#: The write half. P3 (core#442) lets a consent grant these — the human decides
+#: once, knowingly, at the consent screen. There is deliberately **no** finer
+#: "may build but may not trigger" tier: the REST API gives ``create_upload``
+#: and ``trigger_upload`` the same ``uploads:write`` scope, so a split could
+#: only be enforced in the MCP layer while the credential still permitted both.
+#: A control the token doesn't back is theatre. Spend is bounded by the per-key
+#: rate limit and byte quota instead (SPEC §10).
+_WRITE_SCOPES = (
+    "connections:write",
+    "notifications:write",
+    "pipelines:write",
+    "runs:write",
+    "schedules:write",
+    "transformations:write",
+    "uploads:write",
+)
+
+
 def read_only_scopes() -> list[str]:
-    """The scope set a P2 consent grants."""
+    """The scope set a consent grants by default."""
     return list(_READ_SCOPES)
+
+
+def write_scopes() -> list[str]:
+    """Read **plus** write — a write-only grant would be useless."""
+    return list(_READ_SCOPES) + list(_WRITE_SCOPES)
 
 
 class McpOAuthError(Exception):
@@ -108,6 +140,20 @@ def _is_loopback(url: str) -> bool:
     return host in {"127.0.0.1", "::1", "localhost"}
 
 
+@dataclass(frozen=True)
+class ResolvedGrant:
+    """What a bearer token resolves to: a credential *and* its authority.
+
+    ``allow_write`` is a property of the **grant**, not of the transport — the
+    human decided it at the consent screen — so it travels with the key rather
+    than being inferred anywhere downstream (core#442).
+    """
+
+    api_key: str
+    allow_write: bool
+    scope: str
+
+
 class McpOAuthService:
     """Authorization-server logic. Transport-free so it is testable directly."""
 
@@ -140,7 +186,9 @@ class McpOAuthService:
         return {
             "resource": self.resource,
             "authorization_servers": [self.issuer],
-            "scopes_supported": read_only_scopes(),
+            # Advertise write too — a client cannot ask for what the AS never
+            # lists, and the grant is what actually decides (core#442).
+            "scopes_supported": write_scopes(),
             "bearer_methods_supported": ["header"],
         }
 
@@ -150,7 +198,9 @@ class McpOAuthService:
             "authorization_endpoint": f"{self._base}/oauth/authorize",
             "token_endpoint": f"{self._base}/oauth/token",
             "registration_endpoint": f"{self._base}/oauth/register",
-            "scopes_supported": read_only_scopes(),
+            # Advertise write too — a client cannot ask for what the AS never
+            # lists, and the grant is what actually decides (core#442).
+            "scopes_supported": write_scopes(),
             "response_types_supported": ["code"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
             # OAuth 2.1: PKCE is mandatory and `plain` is gone.
@@ -321,15 +371,22 @@ class McpOAuthService:
         return grant, code
 
     def _narrow_scope(self, requested: str) -> list[str]:
-        """Grant at most read-only, never more than was asked for.
+        """Grant no more than was asked for, and never write by accident.
 
-        An unknown or empty request collapses to the full read-only set rather
-        than erroring: MCP clients routinely omit `scope`, and the ceiling is
-        read-only anyway.
+        An empty or unrecognised request collapses to **read-only**: MCP
+        clients routinely omit ``scope``, and silence must never be read as
+        consent to write (core#442). Write is granted only when a write scope
+        was explicitly asked for — and then read comes with it, since a
+        write-only credential is useless.
         """
         asked = [s for s in (requested or "").split() if s]
         if not asked:
             return read_only_scopes()
+
+        if any(s in _WRITE_SCOPES for s in asked):
+            granted = [s for s in write_scopes() if s in asked or s in _READ_SCOPES]
+            return granted or write_scopes()
+
         narrowed = [s for s in asked if s in _READ_SCOPES]
         return narrowed or read_only_scopes()
 
@@ -427,8 +484,13 @@ class McpOAuthService:
     # Resource-server side — bearer -> the credential the tools replay
     # ------------------------------------------------------------------
 
-    def resolve_access_token(self, session: Session, access_token: str) -> str | None:
-        """Return the org-scoped API key behind a bearer token, or ``None``.
+    def resolve_access_token(self, session: Session, access_token: str) -> ResolvedGrant | None:
+        """Return the credential **and the authority** behind a bearer token.
+
+        Returns a :class:`ResolvedGrant` rather than a bare key string because
+        the tool surface has to know how far the *human* opened it (core#442):
+        write is a property of the grant, not of the transport, so it has to
+        travel with the credential.
 
         ``None`` covers every rejection — unknown, expired, revoked grant, and
         (deliberately) a revoked *API key*: revocation in the existing keys UI
@@ -463,7 +525,12 @@ class McpOAuthService:
         if key_expiry is not None and key_expiry < _now():
             return None
 
-        return self.decrypt_api_key(grant)
+        granted = (grant.scope or "").split()
+        return ResolvedGrant(
+            api_key=self.decrypt_api_key(grant),
+            allow_write=any(s in _WRITE_SCOPES for s in granted),
+            scope=grant.scope or "",
+        )
 
     # ------------------------------------------------------------------
     # Credential storage

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -93,20 +93,26 @@ async def _send_401(send) -> None:
     await send({"type": "http.response.body", "body": body})
 
 
-def _resolve_oauth_token_sync(token: str) -> str | None:
-    """Exchange an issued access token for the API key it was minted with."""
+def _resolve_oauth_token_sync(token: str):
+    """Exchange an issued access token for its credential + granted authority."""
     from datanika.db import get_sync_session
 
     with get_sync_session() as session:
         return McpOAuthService().resolve_access_token(session, token)
 
 
-async def _resolve_credential(token: str) -> str | None:
-    """Map a presented bearer to the API key the tool path forwards.
+async def _resolve_credential(token: str) -> tuple[str | None, bool]:
+    """Map a presented bearer to ``(api_key, allow_write)``.
 
     Two credentials are accepted: an OAuth access token issued by our own AS
     (P2), and a raw Datanika API key pasted by the user (P1, unchanged — it
     still works, and self-hosters rely on it).
+
+    **Write authority comes from the grant, never from the transport**
+    (core#442): an OAuth session is writable only if a human consented to it,
+    and a pasted key stays read-only here because nothing recorded a human
+    decision — the key's own scopes still bound what the REST API will do, but
+    this layer will not open the write tools on an inference.
 
     The token lookup is a **blocking** DB call, so it runs in a worker thread:
     this handler is on the same event loop that has to serve the tool's own
@@ -114,8 +120,11 @@ async def _resolve_credential(token: str) -> str | None:
     out in core#388.
     """
     if token.startswith(_OAUTH_TOKEN_PREFIX):
-        return await anyio.to_thread.run_sync(_resolve_oauth_token_sync, token)
-    return token
+        resolved = await anyio.to_thread.run_sync(_resolve_oauth_token_sync, token)
+        if resolved is None:
+            return None, False
+        return resolved.api_key, resolved.allow_write
+    return token, False
 
 
 class BearerSessionApp:
@@ -148,7 +157,7 @@ class BearerSessionApp:
             await _send_401(send)
             return
 
-        credential = await _resolve_credential(token)
+        credential, allow_write = await _resolve_credential(token)
         if not credential:
             # An OAuth token that is expired, revoked, or simply not ours. The
             # same 401 sends the client back through discovery, which is how it
@@ -157,10 +166,11 @@ class BearerSessionApp:
             return
 
         client = DatanikaClient(self._base_url, credential)
-        # transport="remote" only shapes the write-refusal wording: the hosted
-        # caller runs no server, so the stdio "--allow-write" advice would send
-        # them (or their agent) after a switch that does not exist (core#409).
-        session = DatanikaSession(client=client, allow_write=False, transport="remote")
+        # allow_write reflects what a human consented to at the OAuth consent
+        # screen (core#442) — never the transport, and never an inference from
+        # the key's own scopes. transport="remote" shapes the refusal wording
+        # when write was not granted (core#409).
+        session = DatanikaSession(client=client, allow_write=allow_write, transport="remote")
         try:
             with use_session(session):
                 await self._app(scope, receive, send)

--- a/tests/test_services/test_mcp_oauth.py
+++ b/tests/test_services/test_mcp_oauth.py
@@ -196,7 +196,9 @@ class TestAccessTokenResolution:
         )
 
         resolved = svc.resolve_access_token(db_session, issued["access_token"])
-        assert resolved == svc.decrypt_api_key(grant)
+        # Since core#442 this carries the grant's authority alongside the key.
+        assert resolved.api_key == svc.decrypt_api_key(grant)
+        assert resolved.allow_write is False  # read-only consent
 
     def test_unknown_token_resolves_to_none(self, db_session, svc):
         assert svc.resolve_access_token(db_session, "dtk_at_nonsense") is None

--- a/tests/test_services/test_mcp_oauth_routes.py
+++ b/tests/test_services/test_mcp_oauth_routes.py
@@ -336,9 +336,16 @@ class TestResourceServerAcceptsIssuedTokens:
     async def test_oauth_token_resolves_to_the_granted_api_key(self, monkeypatch):
         """A `dtk_at_` bearer is exchanged for the minted key before forwarding."""
         import datanika.services.mcp_routes as mcp_routes
+        from datanika.services.mcp_oauth import ResolvedGrant
 
+        # Since core#442 the resolver returns the credential *and* the
+        # authority the human granted, not a bare key.
         monkeypatch.setattr(
-            mcp_routes, "_resolve_oauth_token_sync", lambda token: "etf_resolved_key"
+            mcp_routes,
+            "_resolve_oauth_token_sync",
+            lambda token: ResolvedGrant(
+                api_key="etf_resolved_key", allow_write=False, scope="connections:read"
+            ),
         )
         seen = {}
 

--- a/tests/test_services/test_mcp_oauth_write_consent.py
+++ b/tests/test_services/test_mcp_oauth_write_consent.py
@@ -1,0 +1,169 @@
+"""Write access is granted at OAuth consent, or not at all (core#442, MCP P3).
+
+SPEC_REMOTE_MCP §10 asked for a per-call confirmation before a remote agent
+spends compute or money. That was written assuming an interactive session; the
+hosted transport is stateless, and a two-phase token the agent mints and echoes
+to itself is friction, not a gate — the agent is the thing being gated.
+
+So the human decision moves to **consent time**: the user decides once,
+knowingly, whether this client may write, and the grant's API key carries
+exactly that. Enforcement stays where it already lives — ``api_middleware`` on
+the minted key's scopes — so the MCP layer adds no authz of its own (§5.4).
+
+**Why there is no separate "may build but may not trigger" tier:** the REST API
+gives ``create_upload`` and ``trigger_upload`` the *same* scope
+(``uploads:write``). A consent checkbox splitting them could only be enforced
+in the MCP layer while the credential still permitted both — a control the
+token doesn't back, which is the same theatre as the echoed confirmation token.
+Spend is bounded by the per-key rate limit and byte quota instead, which is
+what §10 named alongside the phasing.
+
+These tests are about the *grant*, since that is where the decision now lives.
+"""
+
+import base64
+
+import pytest
+
+from datanika.models.api_key import ApiKey
+from datanika.models.mcp_oauth import OAuthClient
+from datanika.models.user import Organization, User
+from datanika.services.mcp_oauth import (
+    MCP_RESOURCE_PATH,
+    McpOAuthService,
+    read_only_scopes,
+    write_scopes,
+)
+
+_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+_TEST_FERNET_KEY = base64.urlsafe_b64encode(b"0" * 32).decode()
+_PUBLIC_BASE = "https://app.datanika.io"
+
+
+def _pkce_challenge() -> str:
+    import hashlib
+
+    digest = hashlib.sha256(b"v" * 64).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+@pytest.fixture
+def svc() -> McpOAuthService:
+    return McpOAuthService(
+        public_base_url=_PUBLIC_BASE, encryption_key_provider=lambda: _TEST_FERNET_KEY
+    )
+
+
+@pytest.fixture
+def org(db_session) -> Organization:
+    row = Organization(name="Acme", slug="acme-p3")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def user(db_session) -> User:
+    row = User(email="p3@example.com", password_hash="h", full_name="P3 User")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def client_row(db_session) -> OAuthClient:
+    row = OAuthClient(client_id="mcp_p3", client_name="Claude.ai", redirect_uris=[_REDIRECT])
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def _consent(svc, db_session, client_row, org, user, scope):
+    return svc.grant_consent(
+        db_session,
+        client_id=client_row.client_id,
+        org_id=org.id,
+        user_id=user.id,
+        redirect_uri=_REDIRECT,
+        code_challenge=_pkce_challenge(),
+        code_challenge_method="S256",
+        scope=scope,
+        resource=f"{_PUBLIC_BASE}{MCP_RESOURCE_PATH}",
+    )
+
+
+class TestWriteRequiresAnExplicitAsk:
+    def test_default_consent_is_still_read_only(self, db_session, svc, client_row, org, user):
+        """Clients routinely omit `scope`; that must never mean write."""
+        grant, _code = _consent(svc, db_session, client_row, org, user, "")
+        key = db_session.get(ApiKey, grant.api_key_id)
+
+        assert not any(s.endswith(":write") for s in key.scopes)
+
+    def test_read_scopes_alone_do_not_escalate(self, db_session, svc, client_row, org, user):
+        grant, _code = _consent(
+            svc, db_session, client_row, org, user, " ".join(read_only_scopes())
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        assert not any(s.endswith(":write") for s in key.scopes)
+
+    def test_asking_for_write_grants_write(self, db_session, svc, client_row, org, user):
+        grant, _code = _consent(svc, db_session, client_row, org, user, " ".join(write_scopes()))
+        key = db_session.get(ApiKey, grant.api_key_id)
+
+        assert any(s.endswith(":write") for s in key.scopes)
+        # Read access comes along with it — a write-only grant is useless.
+        assert any(s.endswith(":read") for s in key.scopes)
+
+    def test_unknown_scopes_are_dropped_not_honoured(self, db_session, svc, client_row, org, user):
+        grant, _code = _consent(
+            svc, db_session, client_row, org, user, "connections:read admin:everything"
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        assert "admin:everything" not in key.scopes
+
+
+class TestSessionReflectsTheGrant:
+    """The tool surface must open only as far as the grant actually went."""
+
+    def test_read_only_grant_resolves_without_write(self, db_session, svc, client_row, org, user):
+        grant, code = _consent(svc, db_session, client_row, org, user, "")
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier="v" * 64, redirect_uri=_REDIRECT
+        )
+
+        resolved = svc.resolve_access_token(db_session, issued["access_token"])
+        assert resolved is not None
+        assert resolved.allow_write is False
+
+    def test_write_grant_resolves_with_write(self, db_session, svc, client_row, org, user):
+        grant, code = _consent(svc, db_session, client_row, org, user, " ".join(write_scopes()))
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier="v" * 64, redirect_uri=_REDIRECT
+        )
+
+        resolved = svc.resolve_access_token(db_session, issued["access_token"])
+        assert resolved.allow_write is True
+        assert resolved.api_key.startswith("etf_")
+
+    def test_revoked_key_still_kills_a_write_grant(self, db_session, svc, client_row, org, user):
+        """Revocation must not become weaker just because write was granted."""
+        from datetime import UTC, datetime
+
+        grant, code = _consent(svc, db_session, client_row, org, user, " ".join(write_scopes()))
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier="v" * 64, redirect_uri=_REDIRECT
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        key.deleted_at = datetime.now(UTC)
+        db_session.flush()
+
+        assert svc.resolve_access_token(db_session, issued["access_token"]) is None
+
+
+class TestAdvertisedScopes:
+    def test_metadata_advertises_write_so_clients_can_ask(self, svc):
+        """A client cannot request what the AS never advertises."""
+        supported = svc.authorization_server_metadata()["scopes_supported"]
+        assert any(s.endswith(":write") for s in supported)
+        assert any(s.endswith(":read") for s in supported)


### PR DESCRIPTION
Closes #442 and #409.

## The confirmation model, settled

SPEC §10 asked for a per-call confirmation before a remote agent spends compute or money. That was written assuming an interactive session; the hosted transport is stateless, and **a two-phase token the agent mints and echoes to itself is friction, not a gate** — the agent is the thing being gated.

The decision that matters is a *human* one, so it moves to **consent time**: the user decides once, knowingly, and the grant's API key carries exactly that. Enforcement stays where it already lives — `api_middleware` on the key's scopes — so this layer adds no authz of its own (§5.4).

**No "may build but may not trigger" tier**, and this is the one place I'd otherwise have built something worse. The REST API gives `create_upload` and `trigger_upload` the **same** scope (`uploads:write`). A consent checkbox splitting them could only be enforced in the MCP layer while the credential still permitted both — a control the token doesn't back, which is the same theatre as the echoed confirmation token. I checked this before designing around it; it's what killed the refinement.

Spend is bounded by the per-key **rate limit and byte quota** instead — which is what §10 named alongside the phasing, so the mitigation it wanted is present, just not as a ritual.

## Changes

- `write_scopes()` alongside `read_only_scopes()`; AS metadata advertises both, since a client cannot ask for what the AS never lists.
- `_narrow_scope` grants write **only when write was explicitly asked for**. Empty or unrecognised scope collapses to read-only — clients routinely omit `scope`, and silence must never be read as consent to write.
- `resolve_access_token` returns a `ResolvedGrant` (credential **+ authority**) rather than a bare key: write is a property of the grant, not of the transport, so it travels with the credential rather than being inferred downstream.
- `BearerSessionApp` binds `allow_write` from the grant. A **pasted API key (P1) stays read-only here** — nothing recorded a human decision, and this layer won't open write tools on an inference. (The key's own scopes still bound what REST will do.)

## #409, landing here because the same strings change

- The 8 write-tool docstrings said *"Requires `--allow-write`"* and are shown in `tools/list` on **both** transports, where that instruction is unactionable. They now state the **condition** rather than an instruction: available only to sessions granted write, via the flag or an OAuth consent.
- The remote refusal now names the actual remedy — *ask the user to re-authorize and approve write access* — instead of a server the caller doesn't run. Your principle, applied: say what the reader can do in **their** context.

## Tests

14 new, aimed at the grant, since that's where the decision now lives: silence is not consent · read scopes don't escalate · unknown scopes are dropped · the session reflects the grant in both directions · **revoking the key still kills a write grant**.

Full precheck green: ruff + format clean, **2472 passed**.

## Worth flagging for the consent screen

The screen (#394, Product) currently describes access as read-only in fixed copy. With write now grantable it needs to render what's actually being requested — and the copy/grant mismatch guard added there will catch it, which is the good outcome. I'd rather Product make that change knowingly than have me edit their strings from here.
