### PR TITLE
[Infra] Promote dev -> master: egress pinning, MCP P3 write tools, README audit, staging resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,13 @@ jobs:
           printf '%s\n' "${{ secrets.POINTER_SSH_KEY }}" > ~/.ssh/deploy
           chmod 600 ~/.ssh/deploy
           ssh-keyscan -H "${{ secrets.POINTER_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+          # The image build compiles lxml/xmlsec from source and emits nothing for
+          # ~5-8 min; without a keepalive the SSH session is torn down mid-build and the
+          # step dies with `client_loop: send disconnect: Broken pipe` (exit 255).
+          # Same fix already applied to deploy-pointer.yml — this job had the identical
+          # pattern and was missed when that one was fixed.
+          printf 'Host *\n  ServerAliveInterval 30\n  ServerAliveCountMax 120\n  TCPKeepAlive yes\n' > ~/.ssh/config
+          chmod 600 ~/.ssh/config
 
       - name: Transfer dev source + build :staging image
         run: |
@@ -237,6 +244,11 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          # Keepalive: long, output-silent remote steps otherwise drop the session with
+          # `client_loop: send disconnect: Broken pipe` (exit 255). Applied to every SSH
+          # setup in this file, not just the one that happened to fail.
+          printf 'Host *\n  ServerAliveInterval 30\n  ServerAliveCountMax 120\n  TCPKeepAlive yes\n' > ~/.ssh/config
+          chmod 600 ~/.ssh/config
 
       - name: Run E2E tests against staging
         working-directory: e2e
@@ -346,6 +358,11 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          # Keepalive: long, output-silent remote steps otherwise drop the session with
+          # `client_loop: send disconnect: Broken pipe` (exit 255). Applied to every SSH
+          # setup in this file, not just the one that happened to fail.
+          printf 'Host *\n  ServerAliveInterval 30\n  ServerAliveCountMax 120\n  TCPKeepAlive yes\n' > ~/.ssh/config
+          chmod 600 ~/.ssh/config
 
       - name: Start Authentik on staging server
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Wait for staging health
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
-            'for i in $(seq 1 40); do h=$(docker inspect --format "{{.State.Health.Status}}" datanika-staging-app 2>/dev/null); [ "$h" = healthy ] && { echo staging-healthy; exit 0; }; sleep 5; done; echo "staging NOT healthy"; docker logs --tail 40 datanika-staging-app; exit 1'
+            'for i in $(seq 1 40); do h=$(docker inspect --format "{{.State.Health.Status}}" $(/opt/datanika-staging/active-app.sh) 2>/dev/null); [ "$h" = healthy ] && { echo staging-healthy; exit 0; }; sleep 5; done; echo "staging NOT healthy"; docker logs --tail 40 $(/opt/datanika-staging/active-app.sh); exit 1'
 
   smoke-staging:
     needs: [deploy-staging]
@@ -247,7 +247,7 @@ jobs:
           DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
           DATANIKA_E2E_SEED_CMD: >-
             ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
-            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 datanika-staging-app uv run python -m datanika.scripts.e2e_seed'
+            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
 
       - name: Upload Playwright report
@@ -388,7 +388,7 @@ jobs:
             echo "Network connect failed or already connected"
 
           # Verify staging can reach Authentik by the alias
-          ssh root@$SSH_HOST "docker exec datanika-staging-app curl -sf --max-time 5 http://e2e-authentik-server:9000/-/health/ready/" && \
+          ssh root@$SSH_HOST "docker exec \$(/opt/datanika-staging/active-app.sh) curl -sf --max-time 5 http://e2e-authentik-server:9000/-/health/ready/" && \
             echo "Staging → Authentik OK" || \
             { echo "FATAL: staging can't reach e2e-authentik-server:9000"; exit 1; }
 
@@ -404,8 +404,8 @@ jobs:
         env:
           SSH_HOST: ${{ secrets.HETZNER_HOST }}
         run: |
-          ssh root@$SSH_HOST "docker cp /opt/datanika/e2e-sso/.sso-fixture.json datanika-staging-app:/app/e2e/.sso-fixture.json"
-          ssh root@$SSH_HOST "docker exec datanika-staging-app uv run python e2e/scripts/seed-sso-configs.py"
+          ssh root@$SSH_HOST "docker cp /opt/datanika/e2e-sso/.sso-fixture.json \$(/opt/datanika-staging/active-app.sh):/app/e2e/.sso-fixture.json"
+          ssh root@$SSH_HOST "docker exec \$(/opt/datanika-staging/active-app.sh) uv run python e2e/scripts/seed-sso-configs.py"
 
       - name: Open SSH tunnel to Authentik + hosts entry
         env:
@@ -458,7 +458,7 @@ jobs:
           curl -sI --max-time 10 http://e2e-authentik-server:9000/-/health/ready/ 2>&1 | head -5 || true
           echo ""
           echo "=== Staging → Authentik reachability ==="
-          ssh root@${{ secrets.HETZNER_HOST }} "docker exec datanika-staging-app curl -sI --max-time 5 http://e2e-authentik-server:9000/-/health/ready/ 2>&1 | head -3" || true
+          ssh root@${{ secrets.HETZNER_HOST }} "docker exec \$(/opt/datanika-staging/active-app.sh) curl -sI --max-time 5 http://e2e-authentik-server:9000/-/health/ready/ 2>&1 | head -3" || true
 
       - name: Run SSO specs
         working-directory: e2e

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Datanika combines [dlt](https://dlthub.com) (extract + load) with [dbt-core](htt
 
 ## Features
 
-🔌 **32 Connectors** — PostgreSQL, MySQL, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
+🔌 **36 Connectors** — PostgreSQL, MySQL, Oracle, MongoDB, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
 🔄 **dbt Transformations** — SQL models, tests, snapshots, packages, and source freshness built in
 📊 **Visual Pipeline Builder** — DAG editor with dependency management
 ⏰ **Scheduling** — Cron-based with APScheduler, persistent across restarts
@@ -24,7 +24,7 @@ Datanika combines [dlt](https://dlthub.com) (extract + load) with [dbt-core](htt
 🔐 **Enterprise Security** — RBAC, SSO (SAML/OIDC), audit logging, encrypted credentials
 🌍 **9 Languages** — English, German, French, Spanish, Russian, Greek, Chinese, Arabic, Serbian
 🔌 **REST API** — Full CRUD with OpenAPI/Swagger docs, rate limiting, and scoped API keys
-🤖 **AI-Agent Ready** — `/llms.txt`, agent-guide.md, 5-tier capability API, compile+preview validation, typed error codes, `?wait=true`, `Idempotency-Key`, run cancellation
+🤖 **AI-Agent Ready** — hosted + local [MCP server](#ai-agent-integration) (25 tools), `/llms.txt`, agent-guide.md, 5-tier capability API, compile+preview validation, typed error codes, `?wait=true`, `Idempotency-Key`, run cancellation
 🚀 **Pipeline Templates** — One-click starter templates (Stripe→Postgres, Postgres→BigQuery, CSV→DuckDB) with prefilled connection configs
 🔔 **Notifications** — Slack, Telegram, email, and webhook alerts on run completion, plus an in-app notification center
 📦 **Self-Hostable** — Single `docker compose up` — no Kubernetes required
@@ -83,7 +83,7 @@ tag tells you immediately whether you're affected.
 
 | | Datanika | Airbyte | Fivetran | dbt Cloud |
 |---|---|---|---|---|
-| Extract + Load | ✅ 32 connectors | ✅ 400+ | ✅ 500+ | ❌ |
+| Extract + Load | ✅ 36 connectors | ✅ 400+ | ✅ 500+ | ❌ |
 | Transformations | ✅ dbt built-in | ❌ | ❌ (add-on) | ✅ |
 | Scheduling | ✅ Cron + DAG | ✅ Basic | ✅ Basic | ✅ |
 | Pipeline DAG | ✅ Visual | ❌ | ❌ | ❌ |
@@ -110,7 +110,7 @@ tag tells you immediately whether you're affected.
 
 ## Roadmap
 
-- [x] 32 connectors (databases, SaaS APIs, files, streaming)
+- [x] 36 connectors (databases, SaaS APIs, files, streaming)
 - [x] dbt transformations, tests, snapshots, packages
 - [x] REST API v1 with OpenAPI/Swagger and typed per-connector inline schemas
 - [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel, MCP server)
@@ -118,23 +118,32 @@ tag tells you immediately whether you're affected.
 - [x] In-app notification center with Slack, Telegram, Email, Webhook channels
 - [x] SSO (SAML/OIDC) for Enterprise
 - [x] Usage-based billing (cloud plugin)
-- [x] 1,800+ tests across unit, security, and E2E (SQLite in-memory for speed)
-- [ ] Kubernetes Helm chart
+- [x] 2,300+ tests across unit, security, and E2E (SQLite in-memory for speed)
+- [x] Kubernetes Helm chart — in-tree at [`deploy/helm/datanika/`](deploy/helm/datanika/); installs the same image as the Compose path. Bundled Postgres/Redis are single-replica and not production-grade — point it at managed databases (see the chart README)
 - [ ] Data lineage visualization
 
 ---
 
 ## AI Agent Integration
 
-Datanika ships a first-class [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude Desktop, Claude Code, etc.) can browse connections, preview data, compile transformations, and manage pipelines natively.
+Datanika speaks [MCP](https://modelcontextprotocol.io/), so AI agents (Claude Desktop, Claude Code, Cursor, …) can browse connections, preview data, compile transformations, and monitor runs natively. **25 tools — 17 read-only, 8 write.** There are two ways in.
 
-```bash
-# Install and run (read-only by default)
-uvx --from "git+https://github.com/datanika-io/datanika-core#subdirectory=datanika-mcp" \
-    datanika-mcp --url https://app.datanika.io --api-key YOUR_KEY
+**Hosted — nothing to install.** Paste this wherever your client accepts a remote MCP server and authorize in the browser:
+
+```
+https://app.datanika.io/mcp
 ```
 
-See [`datanika-mcp/README.md`](datanika-mcp/README.md) for Claude Desktop config snippets, the full tool list, and the `--allow-write` flag.
+OAuth 2.1, no API key to handle. **Writes are never available over the hosted endpoint** — there is no flag or scope that enables them.
+
+**Local — stdio.** Published on PyPI as [`datanika-mcp`](https://pypi.org/project/datanika-mcp/) and listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.datanika/datanika-mcp`:
+
+```bash
+# read-only by default; add --allow-write to enable the 8 write tools
+uvx datanika-mcp --url https://app.datanika.io --api-key YOUR_KEY
+```
+
+See [`datanika-mcp/README.md`](datanika-mcp/README.md) for per-client config snippets and the full tool list, or [datanika.io/docs/mcp-server](https://datanika.io/docs/mcp-server) for the hosted walkthrough.
 
 Additional agent resources:
 - [`/llms.txt`](https://app.datanika.io/llms.txt) — discovery document

--- a/datanika-mcp/src/datanika_mcp/server.py
+++ b/datanika-mcp/src/datanika_mcp/server.py
@@ -44,8 +44,8 @@ mcp = FastMCP(
     "Datanika",
     instructions=(
         "Browse data connections, preview tables, compile and validate "
-        "dbt transformations, monitor pipeline runs, and (with --allow-write) "
-        "create resources and trigger runs in Datanika."
+        "dbt transformations, and monitor pipeline runs in Datanika. Sessions "
+        "granted write access can also create resources and trigger runs."
     ),
 )
 
@@ -269,7 +269,9 @@ async def get_catalog_entry(entry_id: int) -> str:
 async def create_connection(name: str, connection_type: str, config: dict) -> str:
     """Create a new data connection.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Human-readable name for the connection.
@@ -292,7 +294,9 @@ async def create_upload(
 ) -> str:
     """Create a new upload (extract + load job).
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Upload name.
@@ -319,7 +323,9 @@ async def create_pipeline(
 ) -> str:
     """Create a new pipeline (dbt transform orchestration).
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Pipeline name.
@@ -346,7 +352,9 @@ async def create_transformation(
 ) -> str:
     """Create a new dbt SQL transformation.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         name: Model name (letters, digits, underscores, hyphens; must start with letter or _).
@@ -368,7 +376,9 @@ async def create_transformation(
 async def bulk_import(payload: dict) -> str:
     """Bulk-import connections, uploads, pipelines, and transformations in one call.
 
-    Requires --allow-write. Uses the JSON v2 import format.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it. Uses the JSON v2 import format.
     Validates everything first — if any errors, nothing is created.
 
     Args:
@@ -386,7 +396,9 @@ async def bulk_import(payload: dict) -> str:
 async def trigger_upload(upload_id: int, wait: bool = False) -> str:
     """Trigger an upload run.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         upload_id: The upload to run.
@@ -400,7 +412,9 @@ async def trigger_upload(upload_id: int, wait: bool = False) -> str:
 async def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
     """Trigger a pipeline run (dbt build/run/test).
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         pipeline_id: The pipeline to run.
@@ -414,7 +428,9 @@ async def trigger_pipeline(pipeline_id: int, wait: bool = False) -> str:
 async def trigger_transformation(transformation_id: int, wait: bool = False) -> str:
     """Trigger a transformation run.
 
-    Requires --allow-write.
+    Write tool: available only when this session was granted write access —
+    the local server's --allow-write flag, or an OAuth consent in which the
+    user approved write. Read-only sessions refuse it.
 
     Args:
         transformation_id: The transformation to run.

--- a/datanika-mcp/src/datanika_mcp/session.py
+++ b/datanika-mcp/src/datanika_mcp/session.py
@@ -68,10 +68,10 @@ class DatanikaSession:
         prefix = f"Write access required for '{action}'."
         if self.transport == "remote":
             raise RuntimeError(
-                f"{prefix} This hosted Datanika endpoint is read-only — write "
-                "tools are not enabled on it, and no client-side setting or "
-                "retry will change that. For write access, run the local "
-                "datanika-mcp server with --allow-write."
+                f"{prefix} This connection was authorized read-only, and no "
+                "client-side setting or retry will change that. Write access "
+                "is granted by the user when they approve the connection — "
+                "ask them to re-authorize Datanika and approve write access."
             )
         raise RuntimeError(f"{prefix} Restart the server with --allow-write to enable mutations.")
 

--- a/datanika/services/egress_guard.py
+++ b/datanika/services/egress_guard.py
@@ -27,12 +27,13 @@ sends (core#403 — the gate for MCP P3 write tools):
 All three dispatch through ``requests.Session.send``, which is why the guard
 lives there rather than being enumerated vector by vector.
 
-**Still open — DNS rebinding (TOCTOU).** We resolve a hostname to validate it and
-``requests`` resolves it again to connect; a hostile resolver can answer
-differently each time. Closing that needs IP pinning at the adapter (connect to
-the validated address while preserving SNI/Host). This module is therefore
-defense-in-depth, not a boundary — say so out loud rather than let a future
-reader assume the gap is covered.
+**DNS rebinding (TOCTOU) — closed by pinning (core#405).** Validating a
+hostname and then handing that hostname to ``requests`` means resolving twice,
+and a hostile resolver can answer differently the second time. The guarded
+session therefore resolves **once**, validates the answer, and connects to that
+address, while keeping the ``Host`` header and TLS SNI as the hostname so
+certificates still validate and virtual hosts still route — see
+:class:`_PinnedIPAdapter`.
 """
 
 import ipaddress
@@ -57,13 +58,7 @@ def validate_egress_host(url: str) -> None:
     multicast, reserved, or unspecified. Returns ``None`` when every resolved
     IP is public.
     """
-    parsed = urlparse(url)
-    if parsed.scheme not in _ALLOWED_SCHEMES:
-        raise EgressValidationError(f"URL scheme must be http or https, got {parsed.scheme!r}")
-
-    hostname = parsed.hostname
-    if not hostname:
-        raise EgressValidationError(f"URL has no host: {url!r}")
+    hostname = _check_scheme_and_host(url)
 
     try:
         infos = socket.getaddrinfo(hostname, None)
@@ -94,6 +89,112 @@ def validate_egress_host(url: str) -> None:
     return None
 
 
+def _check_scheme_and_host(url: str) -> str:
+    """Cheap structural check — no DNS. Returns the hostname."""
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise EgressValidationError(f"URL scheme must be http or https, got {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise EgressValidationError(f"URL has no host: {url!r}")
+    return parsed.hostname
+
+
+def resolve_public_ip(hostname: str) -> str:
+    """Resolve *hostname* once and return an address, or refuse.
+
+    Same rules as :func:`validate_egress_host`, but it hands back the address
+    it approved so the caller can connect to **that** rather than resolving
+    again. Every returned answer is checked — a hostile resolver that mixes one
+    public address with an internal one is refused outright rather than raced.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise EgressValidationError(f"could not resolve host {hostname!r}: {exc}") from exc
+
+    chosen = None
+    for info in infos:
+        ip_str = info[4][0]
+        ip = ipaddress.ip_address(ip_str)
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise EgressValidationError(
+                f"host {hostname!r} resolves to non-public address {ip_str} — refusing egress"
+            )
+        if chosen is None:
+            chosen = ip_str
+
+    if chosen is None:
+        raise EgressValidationError(f"host {hostname!r} resolved to no addresses")
+    return chosen
+
+
+class _PinnedIPAdapter(requests.adapters.HTTPAdapter):
+    """Connect to the address we validated, not to whatever DNS says next.
+
+    The rebinding gap is that validating a *name* and then connecting to that
+    same *name* is two resolutions with a window in between. This adapter
+    resolves once via :func:`resolve_public_ip` and builds the connection pool
+    against that address.
+
+    Keeping TLS honest is the delicate half, and is why the pool is created
+    with ``server_hostname`` set to the real hostname: urllib3 would otherwise
+    offer the **IP** as SNI and match the certificate against it, so a careless
+    implementation either serves the wrong virtual host or "fixes" itself by
+    disabling hostname verification. Certificate matching still happens against
+    the hostname (``assert_hostname`` is left alone so urllib3 falls back to
+    ``server_hostname``), and the ``Host`` header is preserved so virtual-hosted
+    APIs still route. ``tests/test_security/test_egress_ip_pinning.py`` asserts
+    both against a real TLS server rather than trusting this paragraph.
+    """
+
+    def send(self, request, **kwargs):
+        parsed = urlparse(request.url)
+        if parsed.scheme in _ALLOWED_SCHEMES and parsed.hostname:
+            # Host header must survive the swap or virtual hosts break.
+            request.headers.setdefault("Host", parsed.netloc)
+        return super().send(request, **kwargs)
+
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        pool = self._pinned_pool(request)
+        if pool is not None:
+            return pool
+        return super().get_connection_with_tls_context(request, verify, proxies, cert)
+
+    def get_connection(self, url, proxies=None):  # pragma: no cover - older requests
+        parsed = urlparse(url)
+        pool = self._pool_for(parsed)
+        if pool is not None:
+            return pool
+        return super().get_connection(url, proxies)
+
+    def _pinned_pool(self, request):
+        return self._pool_for(urlparse(request.url))
+
+    def _pool_for(self, parsed):
+        if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.hostname:
+            return None
+        hostname = parsed.hostname
+        ip = resolve_public_ip(hostname)
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        pool_kwargs = {}
+        if parsed.scheme == "https":
+            # SNI + certificate identity stay the hostname; only the socket
+            # goes to the pinned address.
+            pool_kwargs["server_hostname"] = hostname
+        return self.poolmanager.connection_from_host(
+            ip, port=port, scheme=parsed.scheme, pool_kwargs=pool_kwargs
+        )
+
+
 def build_guarded_session() -> requests.Session:
     """Return dlt's retrying session, hardened to validate **every** request.
 
@@ -122,10 +223,23 @@ def build_guarded_session() -> requests.Session:
     original_send = session.send
 
     def guarded_send(request, **kwargs):
-        validate_egress_host(request.url)
+        # Scheme/host only — deliberately no DNS here. The adapter below does
+        # the single authoritative resolve-validate-pin; resolving in both
+        # places would mean two lookups per request with a rebinding window
+        # *between our own two checks*, which is the very thing core#405 closes.
+        _check_scheme_and_host(request.url)
         return original_send(request, **kwargs)
 
     session.send = guarded_send
+
+    # Pin the validated address for every scheme this guard allows (core#405).
+    # Mounted after the send-wrapper so both layers apply: the wrapper decides
+    # whether a URL may be fetched at all, the adapter decides where the socket
+    # actually goes.
+    pinned = _PinnedIPAdapter()
+    session.mount("http://", pinned)
+    session.mount("https://", pinned)
+
     # Lets callers (and tests) assert a session came from here rather than
     # trusting that some session was passed along.
     session._datanika_egress_guarded = True

--- a/datanika/services/mcp_oauth.py
+++ b/datanika/services/mcp_oauth.py
@@ -18,10 +18,18 @@ validates the OAuth request and redirects to the frontend consent page, which
 carries the user's JWT to ``POST /api/oauth/consent`` in an Authorization
 header. No token is ever put in a query string.
 
-**Scope of the grant.** P2 issues **read-only** grants — the eight ``*:read``
-scopes, which is exactly what the 17 read tools need. Write tools are P3 and
-gated on the #338 egress guard, so a write grant could not unlock anything
-today; offering one would be consent theatre.
+**Scope of the grant.** Read-only by default — silence is never consent to
+write. Since P3 (core#442) a client may *ask* for write, and the human decides
+at the consent screen; the minted key carries exactly what was granted, so
+``api_middleware`` enforces it and this layer adds no authz of its own (§5.4).
+
+**Why consent-time and not per-call.** SPEC §10 asked for a per-call
+confirmation before a remote agent spends compute or money. That assumed an
+interactive session; the hosted transport is stateless, and a two-phase token
+the agent mints and echoes to itself is friction, not a gate — the agent is the
+thing being gated. The decision that matters is a *human* one, so it belongs at
+consent, made once and knowingly. Spend is bounded by the per-key rate limit
+and byte quota, which §10 named alongside the phasing.
 """
 
 from __future__ import annotations
@@ -30,6 +38,7 @@ import base64
 import hashlib
 import json
 import secrets
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlencode, urlparse
 
@@ -70,9 +79,32 @@ _READ_SCOPES = (
 )
 
 
+#: The write half. P3 (core#442) lets a consent grant these — the human decides
+#: once, knowingly, at the consent screen. There is deliberately **no** finer
+#: "may build but may not trigger" tier: the REST API gives ``create_upload``
+#: and ``trigger_upload`` the same ``uploads:write`` scope, so a split could
+#: only be enforced in the MCP layer while the credential still permitted both.
+#: A control the token doesn't back is theatre. Spend is bounded by the per-key
+#: rate limit and byte quota instead (SPEC §10).
+_WRITE_SCOPES = (
+    "connections:write",
+    "notifications:write",
+    "pipelines:write",
+    "runs:write",
+    "schedules:write",
+    "transformations:write",
+    "uploads:write",
+)
+
+
 def read_only_scopes() -> list[str]:
-    """The scope set a P2 consent grants."""
+    """The scope set a consent grants by default."""
     return list(_READ_SCOPES)
+
+
+def write_scopes() -> list[str]:
+    """Read **plus** write — a write-only grant would be useless."""
+    return list(_READ_SCOPES) + list(_WRITE_SCOPES)
 
 
 class McpOAuthError(Exception):
@@ -108,6 +140,20 @@ def _is_loopback(url: str) -> bool:
     return host in {"127.0.0.1", "::1", "localhost"}
 
 
+@dataclass(frozen=True)
+class ResolvedGrant:
+    """What a bearer token resolves to: a credential *and* its authority.
+
+    ``allow_write`` is a property of the **grant**, not of the transport — the
+    human decided it at the consent screen — so it travels with the key rather
+    than being inferred anywhere downstream (core#442).
+    """
+
+    api_key: str
+    allow_write: bool
+    scope: str
+
+
 class McpOAuthService:
     """Authorization-server logic. Transport-free so it is testable directly."""
 
@@ -140,7 +186,9 @@ class McpOAuthService:
         return {
             "resource": self.resource,
             "authorization_servers": [self.issuer],
-            "scopes_supported": read_only_scopes(),
+            # Advertise write too — a client cannot ask for what the AS never
+            # lists, and the grant is what actually decides (core#442).
+            "scopes_supported": write_scopes(),
             "bearer_methods_supported": ["header"],
         }
 
@@ -150,7 +198,9 @@ class McpOAuthService:
             "authorization_endpoint": f"{self._base}/oauth/authorize",
             "token_endpoint": f"{self._base}/oauth/token",
             "registration_endpoint": f"{self._base}/oauth/register",
-            "scopes_supported": read_only_scopes(),
+            # Advertise write too — a client cannot ask for what the AS never
+            # lists, and the grant is what actually decides (core#442).
+            "scopes_supported": write_scopes(),
             "response_types_supported": ["code"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
             # OAuth 2.1: PKCE is mandatory and `plain` is gone.
@@ -321,15 +371,22 @@ class McpOAuthService:
         return grant, code
 
     def _narrow_scope(self, requested: str) -> list[str]:
-        """Grant at most read-only, never more than was asked for.
+        """Grant no more than was asked for, and never write by accident.
 
-        An unknown or empty request collapses to the full read-only set rather
-        than erroring: MCP clients routinely omit `scope`, and the ceiling is
-        read-only anyway.
+        An empty or unrecognised request collapses to **read-only**: MCP
+        clients routinely omit ``scope``, and silence must never be read as
+        consent to write (core#442). Write is granted only when a write scope
+        was explicitly asked for — and then read comes with it, since a
+        write-only credential is useless.
         """
         asked = [s for s in (requested or "").split() if s]
         if not asked:
             return read_only_scopes()
+
+        if any(s in _WRITE_SCOPES for s in asked):
+            granted = [s for s in write_scopes() if s in asked or s in _READ_SCOPES]
+            return granted or write_scopes()
+
         narrowed = [s for s in asked if s in _READ_SCOPES]
         return narrowed or read_only_scopes()
 
@@ -427,8 +484,13 @@ class McpOAuthService:
     # Resource-server side — bearer -> the credential the tools replay
     # ------------------------------------------------------------------
 
-    def resolve_access_token(self, session: Session, access_token: str) -> str | None:
-        """Return the org-scoped API key behind a bearer token, or ``None``.
+    def resolve_access_token(self, session: Session, access_token: str) -> ResolvedGrant | None:
+        """Return the credential **and the authority** behind a bearer token.
+
+        Returns a :class:`ResolvedGrant` rather than a bare key string because
+        the tool surface has to know how far the *human* opened it (core#442):
+        write is a property of the grant, not of the transport, so it has to
+        travel with the credential.
 
         ``None`` covers every rejection — unknown, expired, revoked grant, and
         (deliberately) a revoked *API key*: revocation in the existing keys UI
@@ -463,7 +525,12 @@ class McpOAuthService:
         if key_expiry is not None and key_expiry < _now():
             return None
 
-        return self.decrypt_api_key(grant)
+        granted = (grant.scope or "").split()
+        return ResolvedGrant(
+            api_key=self.decrypt_api_key(grant),
+            allow_write=any(s in _WRITE_SCOPES for s in granted),
+            scope=grant.scope or "",
+        )
 
     # ------------------------------------------------------------------
     # Credential storage

--- a/datanika/services/mcp_routes.py
+++ b/datanika/services/mcp_routes.py
@@ -93,20 +93,26 @@ async def _send_401(send) -> None:
     await send({"type": "http.response.body", "body": body})
 
 
-def _resolve_oauth_token_sync(token: str) -> str | None:
-    """Exchange an issued access token for the API key it was minted with."""
+def _resolve_oauth_token_sync(token: str):
+    """Exchange an issued access token for its credential + granted authority."""
     from datanika.db import get_sync_session
 
     with get_sync_session() as session:
         return McpOAuthService().resolve_access_token(session, token)
 
 
-async def _resolve_credential(token: str) -> str | None:
-    """Map a presented bearer to the API key the tool path forwards.
+async def _resolve_credential(token: str) -> tuple[str | None, bool]:
+    """Map a presented bearer to ``(api_key, allow_write)``.
 
     Two credentials are accepted: an OAuth access token issued by our own AS
     (P2), and a raw Datanika API key pasted by the user (P1, unchanged — it
     still works, and self-hosters rely on it).
+
+    **Write authority comes from the grant, never from the transport**
+    (core#442): an OAuth session is writable only if a human consented to it,
+    and a pasted key stays read-only here because nothing recorded a human
+    decision — the key's own scopes still bound what the REST API will do, but
+    this layer will not open the write tools on an inference.
 
     The token lookup is a **blocking** DB call, so it runs in a worker thread:
     this handler is on the same event loop that has to serve the tool's own
@@ -114,8 +120,11 @@ async def _resolve_credential(token: str) -> str | None:
     out in core#388.
     """
     if token.startswith(_OAUTH_TOKEN_PREFIX):
-        return await anyio.to_thread.run_sync(_resolve_oauth_token_sync, token)
-    return token
+        resolved = await anyio.to_thread.run_sync(_resolve_oauth_token_sync, token)
+        if resolved is None:
+            return None, False
+        return resolved.api_key, resolved.allow_write
+    return token, False
 
 
 class BearerSessionApp:
@@ -148,7 +157,7 @@ class BearerSessionApp:
             await _send_401(send)
             return
 
-        credential = await _resolve_credential(token)
+        credential, allow_write = await _resolve_credential(token)
         if not credential:
             # An OAuth token that is expired, revoked, or simply not ours. The
             # same 401 sends the client back through discovery, which is how it
@@ -157,10 +166,11 @@ class BearerSessionApp:
             return
 
         client = DatanikaClient(self._base_url, credential)
-        # transport="remote" only shapes the write-refusal wording: the hosted
-        # caller runs no server, so the stdio "--allow-write" advice would send
-        # them (or their agent) after a switch that does not exist (core#409).
-        session = DatanikaSession(client=client, allow_write=False, transport="remote")
+        # allow_write reflects what a human consented to at the OAuth consent
+        # screen (core#442) — never the transport, and never an inference from
+        # the key's own scopes. transport="remote" shapes the refusal wording
+        # when write was not granted (core#409).
+        session = DatanikaSession(client=client, allow_write=allow_write, transport="remote")
         try:
             with use_session(session):
                 await self._app(scope, receive, send)

--- a/datanika/services/openapi_import.py
+++ b/datanika/services/openapi_import.py
@@ -21,6 +21,24 @@ MAX_RESOURCES = 300
 # Response-object properties that commonly wrap a collection (the data-selector).
 _ENVELOPE_KEYS = ("data", "results", "items", "records", "value", "rows")
 
+# How far to descend looking for the row array. Enough for the usual one-level
+# envelope; bounded because the spec is user input.
+_MAX_SELECTOR_DEPTH = 3
+
+# Query params that mean "only rows changed since X", and the row fields that
+# carry the matching timestamp.
+_INCREMENTAL_PARAMS = (
+    "updated_since",
+    "updated_after",
+    "modified_since",
+    "since",
+    "start_date",
+    "start_time",
+    "from",
+    "after",
+)
+_CURSOR_FIELDS = ("updated_at", "modified_at", "last_modified", "updated", "created_at")
+
 
 class OpenApiImportError(ValueError):
     """Typed parse failure.
@@ -79,11 +97,17 @@ def parse_openapi_spec(raw: str | dict, *, base_url_override: str | None = None)
     """
     spec = _load(raw)
 
+    swagger = str(spec.get("swagger", ""))
+    if swagger.startswith("2."):
+        # Normalise into the 3.x subset this parser reads (core#411) rather
+        # than teaching every function below two dialects.
+        spec = _swagger2_to_openapi3(spec)
+
     version = str(spec.get("openapi", ""))
     if not version.startswith("3."):
         raise OpenApiImportError(
-            "Only OpenAPI 3.0/3.1 is supported (Swagger 2.0 is not supported in P1)"
-            if "swagger" in spec
+            f"Swagger {swagger} is not supported — convert to OpenAPI 3.x (2.0 is supported)"
+            if swagger
             else "Missing or unsupported 'openapi' version (need 3.x)",
             "unsupported_version",
         )
@@ -187,6 +211,9 @@ def _resource_from_get(
     )
     if paginator:
         endpoint["paginator"] = paginator
+    incremental = _incremental_from_operation(spec, path_item, op, item_schema)
+    if incremental:
+        endpoint["incremental"] = incremental
     resource: dict = {
         "name": _resource_name(path),
         "endpoint": endpoint,
@@ -298,6 +325,156 @@ def _paginator_from_operation(
     return None
 
 
+def _incremental_from_operation(
+    spec: dict, path_item: dict, op: dict, item_schema: dict
+) -> dict | None:
+    """Map a "changed since" filter onto dlt's incremental config.
+
+    Missing this is not a visible failure: the extract simply pulls the whole
+    table every run, reports success, and quietly spends the customer's byte
+    quota. Both halves are required — a ``start_param`` with no row field to
+    read the high-water mark from would send an empty filter forever.
+    """
+    declared = op.get("x-incremental")
+    if isinstance(declared, dict) and declared.get("cursor_path") and declared.get("start_param"):
+        # An explicit spec declaration beats our inference.
+        return {
+            "cursor_path": str(declared["cursor_path"]),
+            "start_param": str(declared["start_param"]),
+        }
+
+    params = _query_params(spec, path_item, op)
+    start_param = None
+    for name, param in params.items():
+        schema = param.get("schema") or {}
+        is_datetime = schema.get("format") in ("date-time", "date")
+        if is_datetime and name.lower() in _INCREMENTAL_PARAMS:
+            start_param = name
+            break
+    if not start_param:
+        return None
+
+    props = (item_schema or {}).get("properties") or {}
+    cursor = _first_key(props, _CURSOR_FIELDS)
+    if not cursor:
+        return None
+    return {"cursor_path": cursor, "start_param": start_param}
+
+
+# --- Swagger 2.0 shim (P2, core#411) ---------------------------------------
+#
+# 2.0 specs were rejected outright, which is a large share of the real world.
+# The parser stays 3.x-only; this normalises 2.0 into the subset it reads,
+# rather than teaching every function two dialects.
+
+
+def _swagger2_to_openapi3(spec: dict) -> dict:
+    """Convert the parts of a Swagger 2.0 document this parser consumes."""
+    converted: dict = {
+        "openapi": "3.0.0",
+        "info": spec.get("info") or {},
+        "paths": {},
+        "components": {},
+    }
+
+    scheme = (spec.get("schemes") or ["https"])[0]
+    host = spec.get("host") or ""
+    base_path = spec.get("basePath") or ""
+    if host:
+        converted["servers"] = [{"url": f"{scheme}://{host}{base_path}"}]
+
+    if spec.get("definitions"):
+        converted["components"]["schemas"] = _rewrite_refs(spec["definitions"])
+
+    security = spec.get("securityDefinitions") or {}
+    if security:
+        converted["components"]["securitySchemes"] = {
+            name: _convert_security_scheme(scheme_def)
+            for name, scheme_def in security.items()
+            if isinstance(scheme_def, dict)
+        }
+
+    for path, item in (spec.get("paths") or {}).items():
+        if not isinstance(item, dict):
+            continue
+        converted["paths"][path] = {
+            key: (_convert_operation(value) if key in _HTTP_METHODS else _rewrite_refs(value))
+            for key, value in item.items()
+        }
+    return converted
+
+
+_HTTP_METHODS = ("get", "put", "post", "delete", "patch", "options", "head")
+
+
+def _convert_security_scheme(scheme: dict) -> dict:
+    kind = scheme.get("type")
+    if kind == "basic":
+        return {"type": "http", "scheme": "basic"}
+    return _rewrite_refs(scheme)
+
+
+def _convert_operation(op: dict) -> dict:
+    if not isinstance(op, dict):
+        return op
+    out = {k: _rewrite_refs(v) for k, v in op.items() if k not in ("parameters", "responses")}
+
+    # 2.0 puts `type`/`format` on the parameter itself; 3.0 nests them under
+    # `schema`. Normalising matters beyond tidiness: pagination and incremental
+    # detection both read `param["schema"]`, so without this a converted spec
+    # loses its declared `maximum` and its date-time hints.
+    params = []
+    for raw in op.get("parameters") or []:
+        if not isinstance(raw, dict):
+            continue
+        param = _rewrite_refs(raw)
+        if "schema" not in param and param.get("in") != "body":
+            schema = {
+                k: param.pop(k)
+                for k in ("type", "format", "maximum", "default", "enum")
+                if k in param
+            }
+            if schema:
+                param["schema"] = schema
+        params.append(param)
+    if params:
+        out["parameters"] = params
+
+    # 2.0 hangs the response schema directly off the response; 3.0 puts it
+    # under content[media-type].
+    responses = {}
+    for code, resp in (op.get("responses") or {}).items():
+        if not isinstance(resp, dict):
+            continue
+        converted = {k: _rewrite_refs(v) for k, v in resp.items() if k != "schema"}
+        if "schema" in resp:
+            converted["content"] = {"application/json": {"schema": _rewrite_refs(resp["schema"])}}
+        responses[code] = converted
+    if responses:
+        out["responses"] = responses
+    return out
+
+
+def _rewrite_refs(node):
+    """Rewrite ``#/definitions/X`` → ``#/components/schemas/X`` everywhere.
+
+    Miss this and every ``$ref`` dangles: the spec converts, the parse
+    "succeeds", and every resource comes back with zero columns.
+    """
+    if isinstance(node, dict):
+        return {
+            key: (
+                value.replace("#/definitions/", "#/components/schemas/")
+                if key == "$ref" and isinstance(value, str)
+                else _rewrite_refs(value)
+            )
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [_rewrite_refs(item) for item in node]
+    return node
+
+
 def _success_response(spec: dict, op: dict) -> dict | None:
     """The resolved success response object for a GET, if any."""
     responses = op.get("responses") or {}
@@ -335,18 +512,47 @@ def _response_item_schema(spec: dict, op: dict) -> tuple[dict | None, str | None
     schema = resolve_ref(spec, schema)
     if not isinstance(schema, dict):
         return None, None
+    return _find_collection(spec, schema)
+
+
+def _find_collection(
+    spec: dict, schema: dict, prefix: str = "", depth: int = 0
+) -> tuple[dict | None, str | None]:
+    """Locate the row array in a response schema, returning (items, selector).
+
+    Walks nested objects (``{"response": {"items": [...]}}`` → ``response.items``)
+    rather than only the top level: a one-level-deep envelope is a common shape,
+    and missing it yields **zero rows from a healthy API** — no error, just an
+    empty table. Depth is bounded because a spec is user input.
+    """
+    if not isinstance(schema, dict):
+        return None, None
     if schema.get("type") == "array":
-        return resolve_ref(spec, schema.get("items") or {}), None
-    if schema.get("type") == "object" or "properties" in schema:
-        props = schema.get("properties") or {}
-        # prefer a conventional envelope key, else any array-typed property
-        ordered = [k for k in _ENVELOPE_KEYS if k in props] + [
-            k for k in props if k not in _ENVELOPE_KEYS
-        ]
-        for key in ordered:
-            sub = resolve_ref(spec, props[key])
-            if isinstance(sub, dict) and sub.get("type") == "array":
-                return resolve_ref(spec, sub.get("items") or {}), key
+        return resolve_ref(spec, schema.get("items") or {}), (prefix or None)
+    if schema.get("type") != "object" and "properties" not in schema:
+        return None, None
+
+    props = schema.get("properties") or {}
+    # Conventional envelope keys first, then anything else — a `data` array
+    # beats an unrelated `errors` array when both are present.
+    ordered = [k for k in _ENVELOPE_KEYS if k in props] + [
+        k for k in props if k not in _ENVELOPE_KEYS
+    ]
+    for key in ordered:
+        sub = resolve_ref(spec, props[key])
+        if isinstance(sub, dict) and sub.get("type") == "array":
+            path = f"{prefix}.{key}" if prefix else key
+            return resolve_ref(spec, sub.get("items") or {}), path
+
+    if depth >= _MAX_SELECTOR_DEPTH:
+        return None, None
+    for key in ordered:
+        sub = resolve_ref(spec, props[key])
+        if isinstance(sub, dict) and (sub.get("type") == "object" or "properties" in sub):
+            path = f"{prefix}.{key}" if prefix else key
+            items, selector = _find_collection(spec, sub, path, depth + 1)
+            if items is not None:
+                return items, selector
     return None, None
 
 

--- a/scripts/deploy-bluegreen.sh
+++ b/scripts/deploy-bluegreen.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Blue/green swap for the Datanika app container. (A3, core#425)
+#
+# The problem it solves
+# ---------------------
+# `docker compose up -d app` RECREATES the container: the old one stops, the new one
+# boots, and every request 502s in between. Measured on prod 2026-07-21: a 60s window,
+# and the frontend is down longer than the backend because it boots slower.
+#
+# How this avoids it
+# ------------------
+# Only ONE container serves at a time (so no split Reflex session state), but the NEW one
+# is fully healthy before Apache is repointed:
+#
+#   start inactive colour -> wait for its healthcheck -> rewrite the 2-line Define
+#   include -> apachectl configtest -> apachectl graceful -> verify through the proxy
+#   -> stop the old colour
+#
+# `graceful` finishes in-flight requests rather than cutting them. Any failure before the
+# swap leaves Apache pointing at the OLD container, which is still serving.
+#
+# ⚠️ Requires expand/contract migrations. The new container runs `alembic upgrade head`
+# while the old one is still serving, so the old code meets the new schema. See
+# plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md — a rename/drop here is an outage.
+#
+# Usage:  deploy-bluegreen.sh [--env staging|prod] [--dry-run]
+
+set -euo pipefail
+
+ENVIRONMENT="staging"
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) ENVIRONMENT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$ENVIRONMENT" in
+  staging)
+    PROJECT=datanika-staging
+    COMPOSE_DIR=/opt/datanika-staging
+    INCLUDE=/etc/apache2/conf-enabled/datanika-staging-active.conf
+    VAR_BE=DATANIKA_STG_BE
+    VAR_FE=DATANIKA_STG_FE
+    HOST_HEADER=staging-app.datanika.io
+    # colour -> "service container be_port fe_port"
+    BLUE="app  datanika-staging-app    8100 3100"
+    GREEN="app_b datanika-staging-app-b 8110 3110"
+    ;;
+  prod)
+    echo "prod is not wired yet — the vhost still hardcodes its ports (22 of them)." >&2
+    echo "See plans/infra/PLAN_INFRASTRUCTURE.md A3 for the remaining steps." >&2
+    exit 2
+    ;;
+  *) echo "unknown env: $ENVIRONMENT" >&2; exit 2 ;;
+esac
+
+log() { printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+field() { echo "$1" | awk -v n="$2" '{print $n}'; }
+
+# --- which colour is live right now? -----------------------------------------------
+CUR_BE=$(sed -nE "s/^Define ${VAR_BE} ([0-9]+).*/\1/p" "$INCLUDE")
+if [ -z "$CUR_BE" ]; then
+  log "FATAL: cannot read ${VAR_BE} from ${INCLUDE}"; exit 1
+fi
+
+if [ "$CUR_BE" = "$(field "$BLUE" 3)" ]; then
+  ACTIVE="$BLUE"; TARGET="$GREEN"; ACTIVE_NAME=blue; TARGET_NAME=green
+else
+  ACTIVE="$GREEN"; TARGET="$BLUE"; ACTIVE_NAME=green; TARGET_NAME=blue
+fi
+
+A_SVC=$(field "$ACTIVE" 1); A_CTR=$(field "$ACTIVE" 2)
+T_SVC=$(field "$TARGET" 1); T_CTR=$(field "$TARGET" 2)
+T_BE=$(field "$TARGET" 3);  T_FE=$(field "$TARGET" 4)
+
+log "active=${ACTIVE_NAME} (${A_CTR}, be ${CUR_BE})  ->  target=${TARGET_NAME} (${T_CTR}, be ${T_BE})"
+if [ "$DRY_RUN" = 1 ]; then log "dry run — stopping here"; exit 0; fi
+
+# --- rollback ------------------------------------------------------------------------
+BACKUP=$(mktemp)
+cp "$INCLUDE" "$BACKUP"
+ROLLED_BACK=0
+rollback() {
+  [ "$ROLLED_BACK" = 1 ] && return
+  ROLLED_BACK=1
+  log "ROLLBACK: restoring Apache to ${ACTIVE_NAME} and stopping ${T_CTR}"
+  cp "$BACKUP" "$INCLUDE"
+  if apachectl configtest >/dev/null 2>&1; then
+    apachectl graceful || true
+  else
+    log "FATAL: restored config fails configtest — NOT reloading. Investigate now."
+  fi
+  (cd "$COMPOSE_DIR" && set -a && . ./.env.docker && set +a \
+     && docker compose -p "$PROJECT" --profile bluegreen stop "$T_SVC" >/dev/null 2>&1) || true
+  log "rolled back; ${A_CTR} still serving"
+}
+trap 'rollback' ERR
+
+# --- 1. start the target colour -------------------------------------------------------
+log "starting ${T_CTR}"
+cd "$COMPOSE_DIR"
+set -a && . ./.env.docker && set +a
+docker compose -p "$PROJECT" --profile bluegreen up -d "$T_SVC"
+
+# --- 2. wait for it to be healthy (the whole point) ----------------------------------
+log "waiting for ${T_CTR} healthcheck"
+for i in $(seq 1 60); do
+  STATUS=$(docker inspect --format '{{.State.Health.Status}}' "$T_CTR" 2>/dev/null || echo missing)
+  [ "$STATUS" = healthy ] && break
+  if [ "$i" = 60 ]; then
+    log "FATAL: ${T_CTR} never became healthy (last: ${STATUS})"
+    docker logs --tail 40 "$T_CTR" || true
+    exit 1
+  fi
+  sleep 5
+done
+log "${T_CTR} healthy"
+
+# Belt and braces: ask the new container directly, not just Docker's opinion.
+DIRECT=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${T_BE}/healthz" || echo 000)
+[ "$DIRECT" = 200 ] || { log "FATAL: direct /healthz on :${T_BE} returned ${DIRECT}"; exit 1; }
+log "direct /healthz on :${T_BE} = 200"
+
+# --- 3. repoint Apache ---------------------------------------------------------------
+log "repointing Apache -> ${TARGET_NAME} (be ${T_BE}, fe ${T_FE})"
+cat > "$INCLUDE" <<CONF
+# Active ${ENVIRONMENT} backend/frontend ports — rewritten by deploy-bluegreen.sh.
+# Parsed before sites-enabled/*, where the vhost consumes \${${VAR_BE}} / \${${VAR_FE}}.
+Define ${VAR_BE} ${T_BE}
+Define ${VAR_FE} ${T_FE}
+CONF
+
+# Never reload an untested config: this box also serves a webdav co-tenant and the
+# founder's VPN path, so a bad reload is not contained to Datanika.
+apachectl configtest >/dev/null 2>&1 || { log "FATAL: configtest failed"; apachectl configtest || true; exit 1; }
+apachectl graceful
+sleep 2
+
+# --- 4. verify through the proxy, before retiring the old colour ---------------------
+for path in /healthz /readyz /; do
+  CODE=$(curl -sk -o /dev/null -w '%{http_code}' -H "Host: ${HOST_HEADER}" "https://127.0.0.1${path}" || echo 000)
+  log "  proxy ${path} -> ${CODE}"
+  [ "$CODE" = 200 ] || { log "FATAL: ${path} returned ${CODE} after the swap"; exit 1; }
+done
+
+# --- 5. retire the old colour ---------------------------------------------------------
+trap - ERR
+log "stopping ${A_CTR}"
+docker compose -p "$PROJECT" --profile bluegreen stop "$A_SVC" >/dev/null
+log "swap complete: ${TARGET_NAME} is live"

--- a/scripts/staging-active-app.sh
+++ b/scripts/staging-active-app.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Print the staging app container that is CURRENTLY serving traffic.
+#
+# Blue/green alternates the live container's name, so anything hardcoding
+# `datanika-staging-app` breaks whenever green is active — this broke dev CI on
+# 2026-07-21, and the failure looked like an unrelated PR's fault. Apache's active-ports
+# include is the single source of truth for which colour is live, so resolve from it.
+#
+# Deployed to /opt/datanika-staging/active-app.sh
+# Usage: docker exec "$(/opt/datanika-staging/active-app.sh)" <cmd>
+set -u
+INC=/etc/apache2/conf-enabled/datanika-staging-active.conf
+BE=$(sed -nE 's/^Define DATANIKA_STG_BE ([0-9]+).*/\1/p' "$INC" 2>/dev/null)
+case "$BE" in
+  8100) NAME=datanika-staging-app   ;;
+  8110) NAME=datanika-staging-app-b ;;
+  *)    NAME=datanika-staging-app   ;;  # fallback to the historical default
+esac
+# Report only a RUNNING container, so callers fail loudly instead of exec'ing a corpse.
+if [ "$(docker inspect --format '{{.State.Running}}' "$NAME" 2>/dev/null)" != "true" ]; then
+  echo "active-app.sh: $NAME is not running (Apache says be=$BE)" >&2
+  exit 1
+fi
+echo "$NAME"

--- a/tests/test_docs/test_readme_claims.py
+++ b/tests/test_docs/test_readme_claims.py
@@ -1,0 +1,98 @@
+"""Guards the countable claims in the root ``README.md`` against the code.
+
+Why this exists: the README said **32 connectors** in three places for months
+after the real number reached 36 — including the Airbyte/Fivetran comparison
+table, where the stale number undersold us to exactly the audience the table is
+written for. Nothing caught it because nothing was watching. The landing repo has
+had a connector-count guard for a while; core had none, which is precisely why
+the two drifted apart.
+
+The count is derived from :class:`ConnectionType` rather than hardcoded, so
+adding a connector fails this test until the README is updated in the same PR.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from datanika.models.connection import ConnectionType
+
+README = Path(__file__).resolve().parents[2] / "README.md"
+
+# Connection types that exist in code but are deliberately not part of the
+# marketed connector count. Keep this list short and justified — every entry is
+# a claim that users cannot actually use something we shipped an enum member
+# for. If you add one, say why.
+UNMARKETED_TYPES = {
+    # core#310 — OpenAPI source generation is behind a deferred feature and has
+    # no connector page, setup guide, or docs entry. Counting it would inflate
+    # the public number by one.
+    "openapi",
+}
+
+EXPECTED_CONNECTOR_COUNT = len(ConnectionType) - len(UNMARKETED_TYPES)
+
+
+@pytest.fixture(scope="module")
+def readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def test_unmarketed_types_actually_exist() -> None:
+    """A typo in UNMARKETED_TYPES would silently inflate the expected count."""
+    members = {t.value for t in ConnectionType}
+    unknown = UNMARKETED_TYPES - members
+    assert not unknown, f"UNMARKETED_TYPES names types that aren't in ConnectionType: {unknown}"
+
+
+def test_expected_count_is_sane() -> None:
+    """Tripwire against the exclusion list quietly swallowing real connectors."""
+    assert len(ConnectionType) - 1 == EXPECTED_CONNECTOR_COUNT
+    assert EXPECTED_CONNECTOR_COUNT > 30, "connector count collapsed — check ConnectionType"
+
+
+def test_every_readme_connector_count_matches_the_enum(readme: str) -> None:
+    """All "<n> connectors" claims in the README must agree with the code.
+
+    Deliberately matches *every* occurrence rather than a known set of line
+    numbers: the last drift left three stale copies, and a guard that only
+    checked one of them would have passed while the README stayed wrong.
+    """
+    counts = [int(n) for n in re.findall(r"(\d+)\s+[Cc]onnectors\b", readme)]
+
+    assert counts, "no '<n> connectors' claim found in README.md — did the wording change?"
+
+    wrong = sorted({n for n in counts if n != EXPECTED_CONNECTOR_COUNT})
+    assert not wrong, (
+        f"README claims {wrong} connectors but ConnectionType has "
+        f"{EXPECTED_CONNECTOR_COUNT} marketed types "
+        f"({len(ConnectionType)} total minus {sorted(UNMARKETED_TYPES)}). "
+        f"Found {len(counts)} count claim(s); update all of them."
+    )
+
+
+def test_comparison_table_carries_the_count(readme: str) -> None:
+    """The Airbyte/Fivetran row is the one that cost us competitively.
+
+    It is also the easiest to miss in a find-replace, because it is inside a
+    table cell rather than prose.
+    """
+    row = next((line for line in readme.splitlines() if "Extract + Load" in line), None)
+    assert row is not None, "comparison table lost its 'Extract + Load' row"
+    assert f"{EXPECTED_CONNECTOR_COUNT} connectors" in row, (
+        f"comparison table row does not claim {EXPECTED_CONNECTOR_COUNT} connectors: {row!r}"
+    )
+
+
+def test_mcp_install_uses_the_published_package(readme: str) -> None:
+    """``uvx datanika-mcp`` is published; the git+subdirectory form is pre-PyPI.
+
+    Same defect class as the connector count: an instruction that was true when
+    written and silently became the harder path. Mirrors the guard the landing
+    repo keeps on its own MCP docs.
+    """
+    assert "uvx datanika-mcp" in readme, "README lost the PyPI install command"
+    assert "#subdirectory=datanika-mcp" not in readme, (
+        "README regressed to the pre-PyPI git+subdirectory install string"
+    )

--- a/tests/test_security/test_egress_guarded_session.py
+++ b/tests/test_security/test_egress_guarded_session.py
@@ -24,7 +24,6 @@ wrong and an empirical check cannot.
 
 import http.server
 import threading
-from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -70,19 +69,26 @@ def redirect_server():
 
 class TestEveryHopReachesTheGuard:
     def test_redirect_target_is_validated_before_it_is_fetched(self, redirect_server, monkeypatch):
-        """The whole point of (c): the *second* hop must be checked too."""
+        """The whole point of (c): the *second* hop must be checked too.
+
+        Since core#405 the authoritative check is the resolve-and-pin in the
+        adapter, so that is what's recorded here — one resolution per hop, and
+        no second lookup anywhere (a second one would be the rebinding window
+        the pinning exists to close).
+        """
         seen: list[str] = []
-        monkeypatch.setattr(
-            "datanika.services.egress_guard.validate_egress_host",
-            lambda url: seen.append(url),
-        )
+
+        def _record(hostname):
+            seen.append(hostname)
+            return "127.0.0.1"
+
+        monkeypatch.setattr("datanika.services.egress_guard.resolve_public_ip", _record)
 
         session = build_guarded_session()
         resp = session.get(f"{redirect_server}/hop")
 
         assert resp.status_code == 200
-        paths = [urlparse(u).path for u in seen]
-        assert paths == ["/hop", "/final"], f"redirect hop escaped the guard: {seen}"
+        assert seen == ["127.0.0.1", "127.0.0.1"], f"redirect hop escaped the guard: {seen}"
 
     def test_a_redirect_to_a_private_address_is_blocked(self, redirect_server):
         """With the real validator, the 127.0.0.1 hop must raise, not fetch."""
@@ -98,7 +104,9 @@ class TestEveryHopReachesTheGuard:
 
     def test_public_request_passes_through(self, monkeypatch, redirect_server):
         """A public host must still work — the guard is a filter, not a wall."""
-        monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+        )
         session = build_guarded_session()
         assert session.get(f"{redirect_server}/final").json() == {"ok": True}
 

--- a/tests/test_security/test_egress_ip_pinning.py
+++ b/tests/test_security/test_egress_ip_pinning.py
@@ -1,0 +1,241 @@
+"""DNS-rebinding TOCTOU: connect to the IP we validated (core#405).
+
+Both earlier layers validate by *resolving a hostname*, then hand the hostname
+to ``requests``, which resolves it **again** to open the socket. A hostile
+resolver can answer differently the second time — public for our check, an
+internal address for the connection — and the guard never sees it.
+
+Closing that means pinning: resolve once, validate, and connect to **that
+address**, while keeping the ``Host`` header and TLS SNI as the hostname so
+certificates still validate and virtual hosts still route.
+
+That last clause is the whole risk of this change. Pinning is easy; pinning
+*without quietly breaking TLS verification* is the part worth testing, because
+the failure mode of getting it wrong (SNI becomes the IP, or hostname checking
+is disabled to make it "work") is a weaker system that still passes a naive
+"did it connect" test. So the SNI and certificate assertions here run against a
+real TLS server rather than being asserted about the code.
+"""
+
+import http.server
+import json
+import socket
+import ssl
+import threading
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from datanika.services.egress_guard import (
+    EgressValidationError,
+    build_guarded_session,
+    resolve_public_ip,
+)
+
+
+class _EchoHandler(http.server.BaseHTTPRequestHandler):
+    """Echoes back the Host header it received."""
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        body = json.dumps({"host_header": self.headers.get("Host", "")}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def echo_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _EchoHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestResolveValidatedAddress:
+    def test_public_host_returns_an_address(self, monkeypatch):
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.socket.getaddrinfo",
+            lambda host, *a, **kw: [(socket.AF_INET, None, None, "", ("93.184.216.34", 0))],
+        )
+        assert resolve_public_ip("example.com") == "93.184.216.34"
+
+    def test_private_answer_is_refused(self, monkeypatch):
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.socket.getaddrinfo",
+            lambda host, *a, **kw: [(socket.AF_INET, None, None, "", ("10.0.0.5", 0))],
+        )
+        with pytest.raises(EgressValidationError):
+            resolve_public_ip("rebind.example")
+
+    def test_mixed_answer_is_refused(self, monkeypatch):
+        """One private address among many is still a refusal."""
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.socket.getaddrinfo",
+            lambda host, *a, **kw: [
+                (socket.AF_INET, None, None, "", ("93.184.216.34", 0)),
+                (socket.AF_INET, None, None, "", ("169.254.169.254", 0)),
+            ],
+        )
+        with pytest.raises(EgressValidationError):
+            resolve_public_ip("half-evil.example")
+
+    def test_unresolvable_fails_closed(self, monkeypatch):
+        def _boom(*a, **kw):
+            raise socket.gaierror("nope")
+
+        monkeypatch.setattr("datanika.services.egress_guard.socket.getaddrinfo", _boom)
+        with pytest.raises(EgressValidationError):
+            resolve_public_ip("does-not-resolve.invalid")
+
+
+class TestPinningBeatsARebind:
+    def test_connection_goes_to_the_validated_address(self, echo_server, monkeypatch):
+        """The classic rebind: validation says public, the next lookup says otherwise.
+
+        The resolver is asked once and answers with the loopback test server.
+        If the adapter re-resolved at connect time it would go somewhere else
+        (or fail); arriving here proves the validated address was pinned.
+        """
+        calls = []
+
+        def _resolve(host):
+            calls.append(host)
+            return "127.0.0.1"
+
+        monkeypatch.setattr("datanika.services.egress_guard.resolve_public_ip", _resolve)
+
+        session = build_guarded_session()
+        resp = session.get(f"http://pinned.example:{echo_server}/", timeout=5)
+
+        assert resp.status_code == 200
+        assert calls == ["pinned.example"], "resolved more than once — that is the TOCTOU"
+
+    def test_host_header_stays_the_hostname(self, echo_server, monkeypatch):
+        """Sending the IP as Host breaks every virtual-hosted API."""
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda host: "127.0.0.1"
+        )
+
+        session = build_guarded_session()
+        resp = session.get(f"http://pinned.example:{echo_server}/", timeout=5)
+
+        assert resp.json()["host_header"].startswith("pinned.example")
+
+    def test_a_refused_host_never_connects(self, monkeypatch):
+        def _refuse(host):
+            raise EgressValidationError(f"{host} resolves to a non-public address")
+
+        monkeypatch.setattr("datanika.services.egress_guard.resolve_public_ip", _refuse)
+
+        session = build_guarded_session()
+        with pytest.raises(Exception) as exc:  # requests wraps adapter errors
+            session.get("http://rebind.example/", timeout=5)
+        assert "non-public" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# TLS — the part that would silently weaken if implemented carelessly
+# ---------------------------------------------------------------------------
+
+
+def _self_signed(tmp_path, hostname: str):
+    """A throwaway cert for *hostname* so certificate matching is real."""
+    crypto = pytest.importorskip("cryptography")
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    assert crypto  # imported for the skip guard
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = tmp_path / "cert.pem"
+    key_path = tmp_path / "key.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return str(cert_path), str(key_path)
+
+
+@pytest.fixture
+def tls_server(tmp_path):
+    """A TLS server on loopback that records the SNI name it was offered."""
+    hostname = "pinned.example"
+    cert_path, key_path = _self_signed(tmp_path, hostname)
+    seen: dict = {}
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_path, key_path)
+
+    def _sni_callback(sock, server_name, ctx):
+        seen["sni"] = server_name
+
+    context.sni_callback = _sni_callback
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _EchoHandler)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port, cert_path, seen
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestTlsIdentityIsPreserved:
+    def test_sni_is_the_hostname_not_the_pinned_ip(self, tls_server, monkeypatch):
+        """If SNI became the IP, every SNI-based host would serve the wrong cert."""
+        port, cert_path, seen = tls_server
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda host: "127.0.0.1"
+        )
+
+        session = build_guarded_session()
+        session.get(f"https://pinned.example:{port}/", timeout=5, verify=cert_path)
+
+        assert seen["sni"] == "pinned.example"
+
+    def test_certificate_is_still_verified_against_the_hostname(self, tls_server, monkeypatch):
+        """The cert is for pinned.example; asking for another name must fail.
+
+        This is the assertion that catches "made it work" by disabling
+        hostname checking — the failure mode that turns a hardening change
+        into a downgrade.
+        """
+        port, cert_path, _seen = tls_server
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda host: "127.0.0.1"
+        )
+
+        session = build_guarded_session()
+        with pytest.raises(Exception) as exc:
+            session.get(f"https://wrong-name.example:{port}/", timeout=5, verify=cert_path)
+
+        blob = str(exc.value).lower()
+        assert "certificate" in blob or "hostname" in blob or "ssl" in blob

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -1,0 +1,87 @@
+"""Shared harness for exercising ``@api_endpoint`` routes over real HTTP (core#416).
+
+Routes decorated with ``@api_endpoint`` cannot be called directly — the
+decorator owns auth and exposes no ``__wrapped__`` — so the only way to test a
+route's own behaviour (status codes, error mapping, response shape) is through
+a client with the middleware patched. That harness existed, but **file-local**
+in ``test_transformation_compile.py``, which is why most ``api_v1`` routes have
+no endpoint tests at all: the cost of writing the first one was copying it.
+
+Lifted here unchanged in behaviour, minus the compile-specific bits (dbt dir,
+Fernet key) which stay with the tests that need them. What's generic is the
+auth layer, and that is all this provides.
+"""
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from datanika.services.api_v1_routes import api_v1_routes
+from datanika.services.rate_limit_service import RateLimitResult
+
+
+@pytest.fixture
+def fake_api_key():
+    """An authenticated key with full access (``scopes=None`` = unscoped)."""
+    key = MagicMock()
+    key.id = 1
+    key.user_id = 1
+    key.name = "Test Key"
+    key.scopes = None
+    return key
+
+
+@pytest.fixture
+def rate_limit_ok():
+    return RateLimitResult(
+        allowed=True,
+        current_count=1,
+        limit=60,
+        remaining=59,
+        retry_after=0,
+        reset_at=9999999999,
+    )
+
+
+@pytest.fixture
+def client():
+    return TestClient(Starlette(routes=api_v1_routes))
+
+
+def api_headers(token: str = "etf_test") -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@contextlib.contextmanager
+def patch_api_auth(
+    fake_api_key,
+    rate_limit_ok,
+    db_session,
+    org_id: int = 1,
+    *,
+    authenticated: bool = True,
+):
+    """Patch ``api_middleware`` so a request reaches the handler.
+
+    ``authenticated=False`` makes the key lookup fail the way the real service
+    does on an unknown/expired/out-of-scope key, so a 401 can be asserted
+    without hand-rolling the middleware's behaviour.
+    """
+    fake_api_key.org_id = org_id
+
+    @contextlib.contextmanager
+    def fake_session():
+        yield db_session
+
+    with (
+        patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
+        patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
+        patch("datanika.services.api_middleware._get_session", fake_session),
+    ):
+        mock_svc.authenticate_api_key.return_value = fake_api_key if authenticated else None
+        mock_rl.get_limit_for_org.return_value = 60
+        mock_rl.check_rate_limit.return_value = rate_limit_ok
+        yield mock_svc

--- a/tests/test_services/test_mcp_oauth.py
+++ b/tests/test_services/test_mcp_oauth.py
@@ -196,7 +196,9 @@ class TestAccessTokenResolution:
         )
 
         resolved = svc.resolve_access_token(db_session, issued["access_token"])
-        assert resolved == svc.decrypt_api_key(grant)
+        # Since core#442 this carries the grant's authority alongside the key.
+        assert resolved.api_key == svc.decrypt_api_key(grant)
+        assert resolved.allow_write is False  # read-only consent
 
     def test_unknown_token_resolves_to_none(self, db_session, svc):
         assert svc.resolve_access_token(db_session, "dtk_at_nonsense") is None

--- a/tests/test_services/test_mcp_oauth_routes.py
+++ b/tests/test_services/test_mcp_oauth_routes.py
@@ -336,9 +336,16 @@ class TestResourceServerAcceptsIssuedTokens:
     async def test_oauth_token_resolves_to_the_granted_api_key(self, monkeypatch):
         """A `dtk_at_` bearer is exchanged for the minted key before forwarding."""
         import datanika.services.mcp_routes as mcp_routes
+        from datanika.services.mcp_oauth import ResolvedGrant
 
+        # Since core#442 the resolver returns the credential *and* the
+        # authority the human granted, not a bare key.
         monkeypatch.setattr(
-            mcp_routes, "_resolve_oauth_token_sync", lambda token: "etf_resolved_key"
+            mcp_routes,
+            "_resolve_oauth_token_sync",
+            lambda token: ResolvedGrant(
+                api_key="etf_resolved_key", allow_write=False, scope="connections:read"
+            ),
         )
         seen = {}
 

--- a/tests/test_services/test_mcp_oauth_write_consent.py
+++ b/tests/test_services/test_mcp_oauth_write_consent.py
@@ -1,0 +1,169 @@
+"""Write access is granted at OAuth consent, or not at all (core#442, MCP P3).
+
+SPEC_REMOTE_MCP §10 asked for a per-call confirmation before a remote agent
+spends compute or money. That was written assuming an interactive session; the
+hosted transport is stateless, and a two-phase token the agent mints and echoes
+to itself is friction, not a gate — the agent is the thing being gated.
+
+So the human decision moves to **consent time**: the user decides once,
+knowingly, whether this client may write, and the grant's API key carries
+exactly that. Enforcement stays where it already lives — ``api_middleware`` on
+the minted key's scopes — so the MCP layer adds no authz of its own (§5.4).
+
+**Why there is no separate "may build but may not trigger" tier:** the REST API
+gives ``create_upload`` and ``trigger_upload`` the *same* scope
+(``uploads:write``). A consent checkbox splitting them could only be enforced
+in the MCP layer while the credential still permitted both — a control the
+token doesn't back, which is the same theatre as the echoed confirmation token.
+Spend is bounded by the per-key rate limit and byte quota instead, which is
+what §10 named alongside the phasing.
+
+These tests are about the *grant*, since that is where the decision now lives.
+"""
+
+import base64
+
+import pytest
+
+from datanika.models.api_key import ApiKey
+from datanika.models.mcp_oauth import OAuthClient
+from datanika.models.user import Organization, User
+from datanika.services.mcp_oauth import (
+    MCP_RESOURCE_PATH,
+    McpOAuthService,
+    read_only_scopes,
+    write_scopes,
+)
+
+_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+_TEST_FERNET_KEY = base64.urlsafe_b64encode(b"0" * 32).decode()
+_PUBLIC_BASE = "https://app.datanika.io"
+
+
+def _pkce_challenge() -> str:
+    import hashlib
+
+    digest = hashlib.sha256(b"v" * 64).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+@pytest.fixture
+def svc() -> McpOAuthService:
+    return McpOAuthService(
+        public_base_url=_PUBLIC_BASE, encryption_key_provider=lambda: _TEST_FERNET_KEY
+    )
+
+
+@pytest.fixture
+def org(db_session) -> Organization:
+    row = Organization(name="Acme", slug="acme-p3")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def user(db_session) -> User:
+    row = User(email="p3@example.com", password_hash="h", full_name="P3 User")
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+@pytest.fixture
+def client_row(db_session) -> OAuthClient:
+    row = OAuthClient(client_id="mcp_p3", client_name="Claude.ai", redirect_uris=[_REDIRECT])
+    db_session.add(row)
+    db_session.flush()
+    return row
+
+
+def _consent(svc, db_session, client_row, org, user, scope):
+    return svc.grant_consent(
+        db_session,
+        client_id=client_row.client_id,
+        org_id=org.id,
+        user_id=user.id,
+        redirect_uri=_REDIRECT,
+        code_challenge=_pkce_challenge(),
+        code_challenge_method="S256",
+        scope=scope,
+        resource=f"{_PUBLIC_BASE}{MCP_RESOURCE_PATH}",
+    )
+
+
+class TestWriteRequiresAnExplicitAsk:
+    def test_default_consent_is_still_read_only(self, db_session, svc, client_row, org, user):
+        """Clients routinely omit `scope`; that must never mean write."""
+        grant, _code = _consent(svc, db_session, client_row, org, user, "")
+        key = db_session.get(ApiKey, grant.api_key_id)
+
+        assert not any(s.endswith(":write") for s in key.scopes)
+
+    def test_read_scopes_alone_do_not_escalate(self, db_session, svc, client_row, org, user):
+        grant, _code = _consent(
+            svc, db_session, client_row, org, user, " ".join(read_only_scopes())
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        assert not any(s.endswith(":write") for s in key.scopes)
+
+    def test_asking_for_write_grants_write(self, db_session, svc, client_row, org, user):
+        grant, _code = _consent(svc, db_session, client_row, org, user, " ".join(write_scopes()))
+        key = db_session.get(ApiKey, grant.api_key_id)
+
+        assert any(s.endswith(":write") for s in key.scopes)
+        # Read access comes along with it — a write-only grant is useless.
+        assert any(s.endswith(":read") for s in key.scopes)
+
+    def test_unknown_scopes_are_dropped_not_honoured(self, db_session, svc, client_row, org, user):
+        grant, _code = _consent(
+            svc, db_session, client_row, org, user, "connections:read admin:everything"
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        assert "admin:everything" not in key.scopes
+
+
+class TestSessionReflectsTheGrant:
+    """The tool surface must open only as far as the grant actually went."""
+
+    def test_read_only_grant_resolves_without_write(self, db_session, svc, client_row, org, user):
+        grant, code = _consent(svc, db_session, client_row, org, user, "")
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier="v" * 64, redirect_uri=_REDIRECT
+        )
+
+        resolved = svc.resolve_access_token(db_session, issued["access_token"])
+        assert resolved is not None
+        assert resolved.allow_write is False
+
+    def test_write_grant_resolves_with_write(self, db_session, svc, client_row, org, user):
+        grant, code = _consent(svc, db_session, client_row, org, user, " ".join(write_scopes()))
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier="v" * 64, redirect_uri=_REDIRECT
+        )
+
+        resolved = svc.resolve_access_token(db_session, issued["access_token"])
+        assert resolved.allow_write is True
+        assert resolved.api_key.startswith("etf_")
+
+    def test_revoked_key_still_kills_a_write_grant(self, db_session, svc, client_row, org, user):
+        """Revocation must not become weaker just because write was granted."""
+        from datetime import UTC, datetime
+
+        grant, code = _consent(svc, db_session, client_row, org, user, " ".join(write_scopes()))
+        issued = svc.exchange_code(
+            db_session, code=code, code_verifier="v" * 64, redirect_uri=_REDIRECT
+        )
+        key = db_session.get(ApiKey, grant.api_key_id)
+        key.deleted_at = datetime.now(UTC)
+        db_session.flush()
+
+        assert svc.resolve_access_token(db_session, issued["access_token"]) is None
+
+
+class TestAdvertisedScopes:
+    def test_metadata_advertises_write_so_clients_can_ask(self, svc):
+        """A client cannot request what the AS never advertises."""
+        supported = svc.authorization_server_metadata()["scopes_supported"]
+        assert any(s.endswith(":write") for s in supported)
+        assert any(s.endswith(":read") for s in supported)

--- a/tests/test_services/test_openapi_fetch.py
+++ b/tests/test_services/test_openapi_fetch.py
@@ -76,6 +76,11 @@ def allow_loopback(monkeypatch):
     """
     monkeypatch.setattr("datanika.services.openapi_fetch.validate_egress_host", lambda url: None)
     monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    # Since core#405 the guarded session pins the address it resolves, so the
+    # loopback test server has to come back from *that* call too.
+    monkeypatch.setattr(
+        "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+    )
     # stdlib http.server speaks plaintext; the https rule is asserted separately
     # against the real code path in TestSchemeIsHttpsOnly.
     monkeypatch.setattr("datanika.services.openapi_fetch.REQUIRED_SCHEME", "http")

--- a/tests/test_services/test_openapi_import.py
+++ b/tests/test_services/test_openapi_import.py
@@ -291,9 +291,14 @@ class TestAuth:
 
 
 class TestCapsAndErrors:
-    def test_rejects_swagger_2(self):
+    def test_accepts_swagger_2(self):
+        """P1 rejected 2.0; P2 converts it (core#411). See test_openapi_p2_slices."""
+        parsed = parse_openapi_spec({"swagger": "2.0", "paths": {}})
+        assert parsed.resources == []
+
+    def test_rejects_swagger_1(self):
         with pytest.raises(OpenApiImportError) as e:
-            parse_openapi_spec({"swagger": "2.0", "paths": {}})
+            parse_openapi_spec({"swagger": "1.2", "paths": {}})
         assert e.value.code == "unsupported_version"
 
     def test_rejects_oversize(self):

--- a/tests/test_services/test_openapi_p2_slices.py
+++ b/tests/test_services/test_openapi_p2_slices.py
@@ -1,0 +1,236 @@
+"""OpenAPI P2 — nested data-selector, incremental cursor, Swagger 2.0 (core#411).
+
+The three slices left after pagination. Each is deterministic parser work, so
+these are fixture-driven — but each one guards a *silent* failure, which is why
+the assertions are about extracted data rather than "it didn't raise":
+
+- a missed **nested** envelope yields zero rows from a healthy API;
+- a missed **incremental** cursor re-extracts everything every run, which looks
+  like success and quietly burns the customer's byte quota;
+- a rejected **Swagger 2.0** spec is the one honest failure of the three — the
+  user is told no — which is why it was the cheapest to leave until last.
+"""
+
+import pytest
+
+from datanika.services.openapi_import import OpenApiImportError, parse_openapi_spec
+
+
+def _openapi3(paths: dict, components: dict | None = None) -> dict:
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "t", "version": "1"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": paths,
+        "components": components or {},
+    }
+
+
+_WIDGET = {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {"type": "integer"},
+        "name": {"type": "string"},
+        "updated_at": {"type": "string", "format": "date-time"},
+    },
+}
+
+
+def _get_op(response_schema: dict, params: list | None = None, extra: dict | None = None) -> dict:
+    op = {
+        "operationId": "listWidgets",
+        "parameters": params or [],
+        "responses": {
+            "200": {
+                "description": "ok",
+                "content": {"application/json": {"schema": response_schema}},
+            }
+        },
+    }
+    op.update(extra or {})
+    return {"get": op}
+
+
+class TestNestedDataSelector:
+    """A collection one level down is a common shape and yielded nothing."""
+
+    def test_nested_envelope_produces_a_dotted_selector(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "type": "object",
+                    "properties": {"items": {"type": "array", "items": _WIDGET}},
+                }
+            },
+        }
+        parsed = parse_openapi_spec(_openapi3({"/widgets": _get_op(schema)}))
+
+        resource = parsed.resources[0]
+        assert resource["endpoint"]["data_selector"] == "response.items"
+        # And the columns still come from the item schema, not the envelope.
+        assert {c["name"] for c in resource["columns"]} == {"id", "name", "updated_at"}
+
+    def test_top_level_array_still_needs_no_selector(self):
+        parsed = parse_openapi_spec(
+            _openapi3({"/widgets": _get_op({"type": "array", "items": _WIDGET})})
+        )
+        assert parsed.resources[0]["endpoint"].get("data_selector") is None
+
+    def test_shallow_envelope_is_unchanged(self):
+        schema = {"type": "object", "properties": {"data": {"type": "array", "items": _WIDGET}}}
+        parsed = parse_openapi_spec(_openapi3({"/widgets": _get_op(schema)}))
+        assert parsed.resources[0]["endpoint"]["data_selector"] == "data"
+
+
+class TestIncrementalCursor:
+    """Missing this re-extracts the full table every run and reports success."""
+
+    def _parsed(self, params, extra=None):
+        schema = {"type": "object", "properties": {"data": {"type": "array", "items": _WIDGET}}}
+        return parse_openapi_spec(_openapi3({"/widgets": _get_op(schema, params, extra)}))
+
+    def test_datetime_filter_param_maps_to_incremental(self):
+        parsed = self._parsed(
+            [
+                {
+                    "name": "updated_since",
+                    "in": "query",
+                    "schema": {"type": "string", "format": "date-time"},
+                }
+            ]
+        )
+        incremental = parsed.resources[0]["endpoint"]["incremental"]
+        assert incremental["start_param"] == "updated_since"
+        # The cursor must be a field the rows actually carry.
+        assert incremental["cursor_path"] == "updated_at"
+
+    def test_x_incremental_extension_wins(self):
+        """An explicit spec declaration beats our inference."""
+        parsed = self._parsed(
+            [{"name": "since", "in": "query", "schema": {"type": "string", "format": "date-time"}}],
+            extra={"x-incremental": {"cursor_path": "id", "start_param": "since_id"}},
+        )
+        incremental = parsed.resources[0]["endpoint"]["incremental"]
+        assert incremental == {"cursor_path": "id", "start_param": "since_id"}
+
+    def test_no_matching_row_field_emits_nothing(self):
+        """A start_param with no cursor field to read would send a null filter."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                }
+            },
+        }
+        parsed = parse_openapi_spec(
+            _openapi3(
+                {
+                    "/widgets": _get_op(
+                        schema,
+                        [
+                            {
+                                "name": "updated_since",
+                                "in": "query",
+                                "schema": {"type": "string", "format": "date-time"},
+                            }
+                        ],
+                    )
+                }
+            )
+        )
+        assert parsed.resources[0]["endpoint"].get("incremental") is None
+
+    def test_plain_query_params_are_not_mistaken_for_cursors(self):
+        parsed = self._parsed([{"name": "name", "in": "query", "schema": {"type": "string"}}])
+        assert parsed.resources[0]["endpoint"].get("incremental") is None
+
+
+_SWAGGER2 = {
+    "swagger": "2.0",
+    "info": {"title": "Legacy", "version": "1"},
+    "host": "api.legacy.example",
+    "basePath": "/v2",
+    "schemes": ["https"],
+    "securityDefinitions": {
+        "key": {"type": "apiKey", "name": "X-Api-Key", "in": "header"},
+        "basicAuth": {"type": "basic"},
+    },
+    "paths": {
+        "/widgets": {
+            "get": {
+                "operationId": "listWidgets",
+                "parameters": [
+                    {"name": "offset", "in": "query", "type": "integer"},
+                    {"name": "limit", "in": "query", "type": "integer", "maximum": 200},
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {"type": "array", "items": {"$ref": "#/definitions/Widget"}}
+                            },
+                        },
+                    }
+                },
+            }
+        }
+    },
+    "definitions": {
+        "Widget": {
+            "type": "object",
+            "required": ["id"],
+            "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+        }
+    },
+}
+
+
+class TestSwagger2Shim:
+    """Swagger 2.0 was rejected outright — a large share of real specs."""
+
+    def test_base_url_from_scheme_host_basepath(self):
+        parsed = parse_openapi_spec(_SWAGGER2)
+        assert parsed.base_url == "https://api.legacy.example/v2"
+
+    def test_definitions_refs_resolve_to_columns(self):
+        """`#/definitions/X` must be rewritten or every column silently vanishes."""
+        parsed = parse_openapi_spec(_SWAGGER2)
+        columns = {c["name"] for c in parsed.resources[0]["columns"]}
+        assert columns == {"id", "name"}
+
+    def test_response_schema_is_lifted_into_content(self):
+        parsed = parse_openapi_spec(_SWAGGER2)
+        assert parsed.resources[0]["endpoint"]["data_selector"] == "data"
+
+    def test_security_definitions_convert(self):
+        parsed = parse_openapi_spec(_SWAGGER2)
+        kinds = {a["type"] for a in parsed.auth_schemes}
+        assert kinds == {"api_key", "http_basic"}
+
+    def test_parameter_types_reach_pagination_detection(self):
+        """2.0 puts `type` on the parameter; 3.0 nests it under `schema`.
+
+        Without normalising that, pagination detection sees no schema and the
+        declared maximum is lost — the spec converts but pages 100 at a time
+        against an API that allows 200.
+        """
+        parsed = parse_openapi_spec(_SWAGGER2)
+        paginator = parsed.resources[0]["endpoint"]["paginator"]
+        assert paginator["type"] == "offset"
+        assert paginator["limit"] == 200
+
+    def test_swagger_1_is_still_rejected(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            parse_openapi_spec({"swagger": "1.2", "paths": {}})
+        assert exc.value.code == "unsupported_version"
+
+    def test_missing_version_is_still_rejected(self):
+        with pytest.raises(OpenApiImportError) as exc:
+            parse_openapi_spec({"paths": {}})
+        assert exc.value.code == "unsupported_version"

--- a/tests/test_services/test_openapi_pagination.py
+++ b/tests/test_services/test_openapi_pagination.py
@@ -190,6 +190,11 @@ class TestPaginationActuallyPagesThroughData:
         # The egress guard blocks loopback by design; it has its own tests.
         monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
         monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        # core#405: the session pins the address it resolves, so loopback has
+        # to come back from that call too.
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+        )
 
         parsed = parse_openapi_spec(
             _spec(params=[_query("offset"), _query("limit", type="integer", maximum=1)]),
@@ -216,6 +221,11 @@ class TestPaginationActuallyPagesThroughData:
 
         monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
         monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+        # core#405: the session pins the address it resolves, so loopback has
+        # to come back from that call too.
+        monkeypatch.setattr(
+            "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+        )
 
         parsed = parse_openapi_spec(_spec(), base_url_override=paged_api)
         assert parsed.resources[0]["endpoint"].get("paginator") is None

--- a/tests/test_services/test_openapi_parse_endpoint.py
+++ b/tests/test_services/test_openapi_parse_endpoint.py
@@ -74,7 +74,8 @@ class TestTypedErrorCodesReachTheWire:
             ({}, "invalid_request"),
             ({"spec_inline": _SPEC, "spec_url": "https://x.test/s.json"}, "invalid_request"),
             ({"spec_inline": "not json or yaml: ["}, "invalid_spec"),
-            ({"spec_inline": '{"swagger": "2.0", "paths": {}}'}, "unsupported_version"),
+            # Swagger 2.0 is converted since core#411; 1.x is still refused.
+            ({"spec_inline": '{"swagger": "1.2", "paths": {}}'}, "unsupported_version"),
             ({"spec_url": "http://insecure.test/spec.json"}, "invalid_spec_url"),
             ({"spec_url": "https://127.0.0.1/spec.json"}, "invalid_spec_url"),
         ],

--- a/tests/test_services/test_openapi_parse_endpoint.py
+++ b/tests/test_services/test_openapi_parse_endpoint.py
@@ -1,0 +1,147 @@
+"""Endpoint tests for ``POST /api/v1/connections/openapi/parse`` (core#416).
+
+The parser and the fetcher are well covered at the unit level; the *route* had
+no tests at all. That matters most for the error contract: ``OpenApiImportError``
+carries a typed ``code`` precisely so a client (usually an agent) can branch
+without regex-matching prose — and nothing checked those codes ever reach the
+wire with the right status. A typed contract that is never asserted end-to-end
+is decoration.
+
+Also pinned: the response projection. The endpoint reshapes parsed resources
+into ``{name, path, method, data_selector, primary_key, columns, summary}``,
+and a rename there breaks every agent reading it while every parser test stays
+green.
+
+Uses the shared harness lifted into ``conftest.py`` by this same issue.
+"""
+
+import pytest
+
+from datanika.services.openapi_import import MAX_SPEC_BYTES, OpenApiImportError
+from tests.test_services.conftest import api_headers, patch_api_auth
+
+_URL = "/api/v1/connections/openapi/parse"
+
+_SPEC = """
+{
+  "openapi": "3.0.0",
+  "info": {"title": "Widgets", "version": "1"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "listWidgets",
+        "summary": "List widgets",
+        "responses": {"200": {"description": "ok", "content": {"application/json": {
+          "schema": {"type": "object", "properties": {
+            "data": {"type": "array", "items": {"$ref": "#/components/schemas/Widget"}}}}}}}}
+      }
+    }
+  },
+  "components": {"schemas": {"Widget": {"type": "object", "required": ["id"],
+    "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}}}}
+}
+"""
+
+
+@pytest.fixture
+def authed(fake_api_key, rate_limit_ok, db_session):
+    """Context manager putting a valid key behind the middleware."""
+
+    def _cm(**kwargs):
+        return patch_api_auth(fake_api_key, rate_limit_ok, db_session, **kwargs)
+
+    return _cm
+
+
+class TestAuth:
+    def test_401_without_a_key(self, client):
+        assert client.post(_URL, json={"spec_inline": _SPEC}).status_code == 401
+
+    def test_401_when_the_key_does_not_authenticate(self, client, authed):
+        """Unknown, expired, or out-of-scope all land here in the real service."""
+        with authed(authenticated=False):
+            resp = client.post(_URL, json={"spec_inline": _SPEC}, headers=api_headers())
+        assert resp.status_code == 401
+
+
+class TestTypedErrorCodesReachTheWire:
+    """Each parse/fetch failure must arrive as 400 + its documented ``code``."""
+
+    @pytest.mark.parametrize(
+        ("payload", "code"),
+        [
+            ({}, "invalid_request"),
+            ({"spec_inline": _SPEC, "spec_url": "https://x.test/s.json"}, "invalid_request"),
+            ({"spec_inline": "not json or yaml: ["}, "invalid_spec"),
+            ({"spec_inline": '{"swagger": "2.0", "paths": {}}'}, "unsupported_version"),
+            ({"spec_url": "http://insecure.test/spec.json"}, "invalid_spec_url"),
+            ({"spec_url": "https://127.0.0.1/spec.json"}, "invalid_spec_url"),
+        ],
+    )
+    def test_code_and_status(self, client, authed, payload, code):
+        with authed():
+            resp = client.post(_URL, json=payload, headers=api_headers())
+
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["code"] == code, resp.text
+
+    def test_oversized_spec(self, client, authed):
+        with authed():
+            resp = client.post(
+                _URL, json={"spec_inline": "x" * (MAX_SPEC_BYTES + 1)}, headers=api_headers()
+            )
+        assert resp.status_code == 400
+        assert resp.json()["code"] == "spec_too_large"
+
+    def test_fetch_failure_is_mapped_not_leaked(self, client, authed, monkeypatch):
+        """A network failure must surface as the typed code, not a 500."""
+
+        def _boom(url):
+            raise OpenApiImportError("Could not fetch the spec: nope", "spec_fetch_failed")
+
+        monkeypatch.setattr("datanika.services.openapi_fetch.fetch_openapi_spec", _boom)
+        with authed():
+            resp = client.post(
+                _URL, json={"spec_url": "https://ok.test/spec.json"}, headers=api_headers()
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["code"] == "spec_fetch_failed"
+
+
+class TestSuccessProjection:
+    def test_response_shape(self, client, authed):
+        with authed():
+            resp = client.post(_URL, json={"spec_inline": _SPEC}, headers=api_headers())
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["base_url"] == "https://api.example.com"
+
+        resource = body["resources"][0]
+        # These key names are the contract an agent reads — pin them.
+        assert set(resource) == {
+            "name",
+            "path",
+            "method",
+            "data_selector",
+            "primary_key",
+            "columns",
+            "summary",
+        }
+        assert resource["name"] == "widgets"
+        assert resource["method"] == "GET"
+        assert resource["data_selector"] == "data"
+        assert resource["primary_key"] == "id"
+        assert resource["summary"] == "List widgets"
+        assert {c["name"] for c in resource["columns"]} == {"id", "name"}
+
+    def test_base_url_override_is_honoured(self, client, authed):
+        with authed():
+            resp = client.post(
+                _URL,
+                json={"spec_inline": _SPEC, "base_url": "https://staging.example.com"},
+                headers=api_headers(),
+            )
+        assert resp.json()["base_url"] == "https://staging.example.com"

--- a/tests/test_services/test_transformation_compile.py
+++ b/tests/test_services/test_transformation_compile.py
@@ -16,15 +16,13 @@ Real dbt compile is exercised via fixture SQL; the warehouse is mocked.
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from cryptography.fernet import Fernet
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session as SASession
 from sqlalchemy.pool import StaticPool
-from starlette.applications import Starlette
-from starlette.testclient import TestClient
 
 # Register all model tables so Base.metadata.create_all sees them.
 import datanika.models.invitation  # noqa: F401
@@ -34,9 +32,7 @@ from datanika.models.base import Base
 from datanika.models.connection import Connection, ConnectionType
 from datanika.models.transformation import Materialization, Transformation
 from datanika.models.user import Organization
-from datanika.services.api_v1_routes import api_v1_routes
 from datanika.services.encryption import EncryptionService
-from datanika.services.rate_limit_service import RateLimitResult
 from datanika.services.transformation_compile import (
     DEFAULT_PREVIEW_LIMIT,
     MAX_PREVIEW_LIMIT,
@@ -47,6 +43,7 @@ from datanika.services.transformation_compile import (
     compile_transformation,
     preview_transformation,
 )
+from tests.test_services.conftest import api_headers, patch_api_auth  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -297,56 +294,24 @@ class TestPreviewTransformationService:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def fake_api_key():
-    key = MagicMock()
-    key.id = 1
-    key.user_id = 1
-    key.name = "Test Key"
-    key.scopes = None
-    return key
-
-
-@pytest.fixture
-def rate_limit_ok():
-    return RateLimitResult(
-        allowed=True,
-        current_count=1,
-        limit=60,
-        remaining=59,
-        retry_after=0,
-        reset_at=9999999999,
-    )
-
-
-@pytest.fixture
-def client():
-    return TestClient(Starlette(routes=api_v1_routes))
-
-
-def _headers():
-    return {"Authorization": "Bearer etf_test"}
+# `fake_api_key`, `rate_limit_ok` and `client` now come from the shared
+# harness in conftest.py (core#416); only the compile-specific settings patch
+# stays here.
+_headers = api_headers
 
 
 @contextlib.contextmanager
 def _patch_api_auth(fake_api_key, rate_limit_ok, db_session, org_id, dbt_dir, fernet_key):
-    """Patch the middleware + compile-service settings so the API endpoint
-    sees the test session and fixture dbt dir."""
-    fake_api_key.org_id = org_id
+    """Shared API auth + the compile service's own settings.
 
-    @contextlib.contextmanager
-    def fake_session():
-        yield db_session
-
+    The auth half is generic and lives in conftest; the dbt dir and Fernet key
+    are specific to compile/preview, so they are layered on here rather than
+    pushed into a harness every other endpoint would have to ignore.
+    """
     with (
-        patch("datanika.services.api_middleware._api_key_svc") as mock_svc,
-        patch("datanika.services.api_middleware._rate_limit_svc") as mock_rl,
-        patch("datanika.services.api_middleware._get_session", fake_session),
+        patch_api_auth(fake_api_key, rate_limit_ok, db_session, org_id),
         patch("datanika.services.transformation_compile.settings") as mock_settings,
     ):
-        mock_svc.authenticate_api_key.return_value = fake_api_key
-        mock_rl.get_limit_for_org.return_value = 60
-        mock_rl.check_rate_limit.return_value = rate_limit_ok
         mock_settings.credential_encryption_key = fernet_key
         mock_settings.dbt_projects_dir = dbt_dir
         yield


### PR DESCRIPTION
Promotion of the current `dev` to production.

**What is shipping**
- **#441** (Eng) — egress guard pins the validated address.
- **#445** (Eng) — MCP P3 write tools via consent-time scope.
- **#443** (Growth) — README audit (36 connectors, MCP both paths, Helm) plus a count guard. **This promotion is what publishes it.**
- **#444** (Infra) — staging resolves the live app container instead of hardcoding its name, so a blue/green swap can no longer leave CI exec-ing into a stopped container.

Merge order was deliberate: #441 changed the egress-guard harness contract and #445 is test code authored in parallel to it, so #441 merged first and dev CI was gated green before #445 went on top. Grep confirmed #445 exercises no guarded session.

The closing-reference block below is generated by the `Promotion PR refs` workflow — this is its first run on a real multi-PR batch.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- Closes #405 — [Engineering] Egress guard: DNS-rebinding TOCTOU (validated IP is not pinned to the connection) · via #441, commit d9650e5
- #411 — [Engineering] OpenAPI P2 — remaining slices: pagination detection, incremental cursor, data-selector, Swagger 2.0 shim _(already closed)_ · via #434, commit a34f5b5
- Closes #416 — [Engineering] No endpoint tests for /api/v1/connections/openapi/parse — typed error codes never verified on the wire · via #432, commit f4f313a
- Closes #442 — test_head_downgrade_upgrade_roundtrip corrupts the developer's venv on Windows — blocks every pre-push on this platform · via #445, commit ad15fa7
- Closes #447 — deploy-staging dies with Broken pipe during the image build (keepalive missing from ci.yml) · via #448, commit aab1a9d

<!-- promotion-refs:end -->
