### PR TITLE
[Infra] Promote dev -> master: wire prod for blue/green swaps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,50 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  # --- Blue/green partner for zero-downtime deploys (A3, #425) ---
+  # Identical to `app` but on alternate host ports and a different container name.
+  # Behind a compose PROFILE, so an ordinary `up -d` never starts it: the second
+  # container exists only for the duration of a swap, leaving steady-state memory
+  # unchanged (~1.2 GiB per app instance on an 8 GB box that also runs staging +
+  # monitoring). scripts/deploy-bluegreen.sh brings it up, waits for its healthcheck,
+  # repoints Apache via the Define include, then stops the other colour.
+  #
+  # ⚠️ Both colours run `alembic upgrade head` at startup, so during a swap the OLD
+  # code briefly runs against the NEW schema. Migrations must therefore be
+  # expand/contract — see plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md (#449).
+  app_b:
+    profiles: ["bluegreen"]
+    image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}
+    build:
+      context: ..
+      dockerfile: datanika/Dockerfile
+    container_name: datanika-app-b
+    ports:
+      - "127.0.0.1:3010:3000"
+      - "127.0.0.1:8010:8000"
+    env_file:
+      - .env.docker
+    environment:
+      GRANIAN_WORKERS: "4"
+      REFLEX_MOUNT_FRONTEND_COMPILED_APP: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - dbt_projects:/app/dbt_projects
+    command: >
+      sh -c "uv run alembic upgrade head &&
+             uv run reflex run --env prod --backend-host 0.0.0.0"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
   celery:
     # Uses the same image as `app` — single Dockerfile, different CMD.
     image: ghcr.io/datanika-io/datanika-core:${DATANIKA_IMAGE_TAG:-latest}

--- a/scripts/deploy-bluegreen.sh
+++ b/scripts/deploy-bluegreen.sh
@@ -51,9 +51,14 @@ case "$ENVIRONMENT" in
     GREEN="app_b datanika-staging-app-b 8110 3110"
     ;;
   prod)
-    echo "prod is not wired yet — the vhost still hardcodes its ports (22 of them)." >&2
-    echo "See plans/infra/PLAN_INFRASTRUCTURE.md A3 for the remaining steps." >&2
-    exit 2
+    PROJECT=datanika
+    COMPOSE_DIR=/opt/datanika/datanika
+    INCLUDE=/etc/apache2/conf-enabled/datanika-prod-active.conf
+    VAR_BE=DATANIKA_BE
+    VAR_FE=DATANIKA_FE
+    HOST_HEADER=app.datanika.io
+    BLUE="app  datanika-app    8000 3000"
+    GREEN="app_b datanika-app-b 8010 3010"
     ;;
   *) echo "unknown env: $ENVIRONMENT" >&2; exit 2 ;;
 esac
@@ -147,6 +152,27 @@ for path in /healthz /readyz /; do
   log "  proxy ${path} -> ${CODE}"
   [ "$CODE" = 200 ] || { log "FATAL: ${path} returned ${CODE} after the swap"; exit 1; }
 done
+
+# Prod is reached by real users through Cloudflare, so a local Host-header check proves
+# Apache routing, not what users receive. Also assert the backend-routed endpoints that
+# live outside /api/ and have silently fallen through to the SPA before — a swap is
+# exactly when that would recur unnoticed.
+if [ "$ENVIRONMENT" = prod ]; then
+  for path in /healthz /; do
+    CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://${HOST_HEADER}${path}" || echo 000)
+    log "  public ${path} -> ${CODE}"
+    [ "$CODE" = 200 ] || { log "FATAL: public ${path} returned ${CODE}"; exit 1; }
+  done
+  MCP=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -X POST "https://${HOST_HEADER}/mcp" \
+        -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"swap","version":"1"}}}' || echo 000)
+  log "  public /mcp unauth -> ${MCP} (expect 401; 200 means it fell through to the SPA)"
+  [ "$MCP" = 401 ] || { log "FATAL: /mcp returned ${MCP}"; exit 1; }
+  OAUTH=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+          "https://${HOST_HEADER}/.well-known/oauth-authorization-server" || echo 000)
+  log "  public OAuth discovery -> ${OAUTH} (expect 200)"
+  [ "$OAUTH" = 200 ] || { log "FATAL: OAuth discovery returned ${OAUTH}"; exit 1; }
+fi
 
 # --- 5. retire the old colour ---------------------------------------------------------
 trap - ERR


### PR DESCRIPTION
Promotion of the current `dev` to production.

**core#451** — wires prod for blue/green: the profile-gated `app_b` service (`3010/8010`) and the prod path in `scripts/deploy-bluegreen.sh`, which verifies through Cloudflare and asserts `/mcp` still 401s and OAuth discovery still 200s.

The vhost half is already applied to the box and probe-verified (26 references indirected, 14/14 clean across the graceful reload).

**This deploy does not swap prod.** It only puts the service definition and the script on the box. The first prod swap is run manually, under a continuous probe, immediately after.