### PR TITLE
[Growth] README: hosted MCP writes are consent-granted, not impossible (core#445)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Datanika speaks [MCP](https://modelcontextprotocol.io/), so AI agents (Claude De
 https://app.datanika.io/mcp
 ```
 
-OAuth 2.1, no API key to handle. **Writes are never available over the hosted endpoint** — there is no flag or scope that enables them.
+OAuth 2.1, no API key to handle. **Read-only unless you grant write at consent** — a client that asks for nothing gets read-only, and a pasted API key stays read-only here even if its own scopes allow writes.
 
 **Local — stdio.** Published on PyPI as [`datanika-mcp`](https://pypi.org/project/datanika-mcp/) and listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.datanika/datanika-mcp`:
 


### PR DESCRIPTION
Follow-up to #443, correcting a claim that #445 invalidated between that PR opening and merging.

The README said:

> **Writes are never available over the hosted endpoint** — there is no flag or scope that enables them.

That was true when written. #445 made write access grantable at OAuth consent time, and it is live — prod `/.well-known/oauth-authorization-server` advertises `connections:write`, `pipelines:write`, `runs:write`, `uploads:write` and the rest.

Now reads:

> **Read-only unless you grant write at consent** — a client that asks for nothing gets read-only, and a pasted API key stays read-only here even if its own scopes allow writes.

Both clauses are load-bearing and both come straight from #445's design: silence is never read as consent to write, and the hosted layer won't infer a human decision from a bearer key's scopes.

Landing is being corrected in the same pass ([landing#271](https://github.com/datanika-io/datanika-landing/pull/271)), which also documents the consent-time mechanism in full and discloses the open consent-screen gap ([#450](https://github.com/datanika-io/datanika-core/issues/450)).

Precheck: ruff clean, **2489 passed, 20 skipped** (run at push time via the hook, with `UV_NO_SYNC=1` per WORKFLOW_RULES §3).
