### PR TITLE
[Product] Fix connections file upload 500 — annotate handler list[rx.UploadFile] (closes #452)

### DIFF
--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -3,6 +3,7 @@
 import json
 import re
 
+import reflex as rx
 from pydantic import BaseModel
 
 from datanika.config import settings
@@ -408,8 +409,13 @@ class ConnectionState(BaseState):
     def set_form_service_account_json(self, value: str):
         self.form_service_account_json = value
 
-    async def handle_file_upload(self, files: list):
-        """Receive uploaded file, call FileUploadService.save_file, store ID."""
+    async def handle_file_upload(self, files: list[rx.UploadFile]):
+        """Receive uploaded file, call FileUploadService.save_file, store ID.
+
+        The annotation is load-bearing: ``POST /_upload`` finds this handler by
+        scanning type hints for a ``list[rx.UploadFile]``, and 500s before
+        calling it if there isn't one (#452).
+        """
         from datanika.services.file_upload_service import FileUploadService
 
         if not files:

--- a/tests/test_ui/test_upload_handlers.py
+++ b/tests/test_ui/test_upload_handlers.py
@@ -5,7 +5,7 @@ handler up by scanning its type hints for a parameter annotated as a *generic
 alias* whose first argument is ``UploadFile`` (``reflex/app.py::upload()``)::
 
     for k, v in get_type_hints(func).items():
-        if types.is_generic_alias(v) and types._issubclass(get_args(v)[0], UploadFile):
+        if is_generic_alias(v) and issubclass(get_args(v)[0], UploadFile):
             handler_upload_param = (k, v)
             break
     if not handler_upload_param:
@@ -28,12 +28,11 @@ import ast
 import functools
 import importlib
 from pathlib import Path
-from typing import get_args, get_type_hints
+from typing import get_args, get_origin, get_type_hints
 
 import pytest
 from reflex.components.core.upload import UploadFile
 from reflex.event import EventHandler
-from reflex.utils import types
 
 import datanika.ui
 
@@ -97,14 +96,30 @@ UPLOAD_SITES = _discover_upload_sites()
 
 
 def _reflex_upload_param(func) -> tuple[str, object] | None:
-    """Reflex's own scan, verbatim, so this tracks the rule and not our copy."""
+    """Reflex's rule, re-expressed with stdlib typing rather than its internals.
+
+    The first version of this called ``reflex.utils.types.is_generic_alias`` and
+    ``types._issubclass`` so it would track the rule verbatim. That is the more
+    faithful test and it does not survive an upgrade: those are private, and CI
+    resolves a Reflex where ``_issubclass`` has become ``safe_issubclass`` — so
+    the guard failed on the *correct* handlers for a reason that had nothing to
+    do with the contract it exists to check.
+
+    ``get_origin`` / ``get_args`` express the same condition ("a generic alias
+    whose first argument is an ``UploadFile`` subclass") out of the standard
+    library, which is stable. ``UploadFile`` is still imported from Reflex —
+    that part is public, and it is the thing being matched.
+    """
     if isinstance(func, EventHandler):
         func = func.fn
     if isinstance(func, functools.partial):
         func = func.func
 
     for name, hint in get_type_hints(func).items():
-        if types.is_generic_alias(hint) and types._issubclass(get_args(hint)[0], UploadFile):
+        args = get_args(hint)
+        if get_origin(hint) is None or not args:
+            continue
+        if isinstance(args[0], type) and issubclass(args[0], UploadFile):
             return name, hint
     return None
 

--- a/tests/test_ui/test_upload_handlers.py
+++ b/tests/test_ui/test_upload_handlers.py
@@ -1,0 +1,156 @@
+"""Every ``rx.upload`` handler must satisfy Reflex's own discovery rule.
+
+``POST /_upload`` does not call the handler we name in ``on_drop``. It looks the
+handler up by scanning its type hints for a parameter annotated as a *generic
+alias* whose first argument is ``UploadFile`` (``reflex/app.py::upload()``)::
+
+    for k, v in get_type_hints(func).items():
+        if types.is_generic_alias(v) and types._issubclass(get_args(v)[0], UploadFile):
+            handler_upload_param = (k, v)
+            break
+    if not handler_upload_param:
+        raise UploadValueError(...)
+
+A bare ``list`` is not a generic alias, so the scan finds nothing and the
+endpoint 500s before the handler body ever runs. That shipped: connection file
+upload was dead in production for CSV/JSON/Parquet — the zero-credentials
+onboarding path — while ``handle_file_upload`` itself was perfectly correct
+(#452).
+
+Unit tests could not catch it, and passing ones existed. They called the
+handler directly with a list of fakes, which exercises the body and skips the
+part that was broken: how Reflex *finds* the body. So this guard asserts the
+contract at the boundary that actually enforces it, for every upload surface in
+the app rather than the one that happened to break.
+"""
+
+import ast
+import functools
+import importlib
+from pathlib import Path
+from typing import get_args, get_type_hints
+
+import pytest
+from reflex.components.core.upload import UploadFile
+from reflex.event import EventHandler
+from reflex.utils import types
+
+import datanika.ui
+
+UI_ROOT = Path(datanika.ui.__file__).parent
+
+# Every ``rx.upload`` site we know about. A scan that silently finds nothing
+# would pass this file without asserting anything, so the count is pinned: add
+# an upload surface and this number moves with it, deliberately.
+EXPECTED_UPLOAD_SITES = 3
+
+
+def _module_name(path: Path) -> str:
+    rel = path.relative_to(UI_ROOT).with_suffix("")
+    return "datanika.ui." + ".".join(rel.parts)
+
+
+def _handler_ref(node: ast.AST) -> tuple[str, str] | None:
+    """``State.handler(...)`` or a bare ``State.handler`` -> ("State", "handler")."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        return node.value.id, node.attr
+    return None
+
+
+def _discover_upload_sites() -> list[tuple[str, str, str, int]]:
+    """(module, state class, handler, lineno) for every ``rx.upload(on_drop=...)``."""
+    sites: list[tuple[str, str, str, int]] = []
+
+    for path in sorted(UI_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_upload = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "upload"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "rx"
+            )
+            if not is_upload:
+                continue
+
+            for keyword in node.keywords:
+                if keyword.arg != "on_drop":
+                    continue
+                ref = _handler_ref(keyword.value)
+                assert ref is not None, (
+                    f"{path}:{keyword.value.lineno} has an on_drop this guard "
+                    "cannot resolve to a State.handler pair — teach it the new "
+                    "shape rather than leaving the site unchecked."
+                )
+                sites.append((_module_name(path), *ref, node.lineno))
+
+    return sites
+
+
+UPLOAD_SITES = _discover_upload_sites()
+
+
+def _reflex_upload_param(func) -> tuple[str, object] | None:
+    """Reflex's own scan, verbatim, so this tracks the rule and not our copy."""
+    if isinstance(func, EventHandler):
+        func = func.fn
+    if isinstance(func, functools.partial):
+        func = func.func
+
+    for name, hint in get_type_hints(func).items():
+        if types.is_generic_alias(hint) and types._issubclass(get_args(hint)[0], UploadFile):
+            return name, hint
+    return None
+
+
+class TestEveryUploadHandlerIsDiscoverable:
+    def test_the_scan_found_every_upload_site(self):
+        """Otherwise a refactor silently empties the parametrisation below."""
+        assert len(UPLOAD_SITES) == EXPECTED_UPLOAD_SITES, (
+            f"Found {len(UPLOAD_SITES)} rx.upload sites, expected "
+            f"{EXPECTED_UPLOAD_SITES}: {UPLOAD_SITES}"
+        )
+
+    @pytest.mark.parametrize(
+        ("module_name", "state_name", "handler_name", "lineno"),
+        UPLOAD_SITES,
+        ids=[f"{s[1]}.{s[2]}" for s in UPLOAD_SITES],
+    )
+    def test_handler_has_an_uploadfile_annotated_parameter(
+        self, module_name, state_name, handler_name, lineno
+    ):
+        module = importlib.import_module(module_name)
+        state_cls = getattr(module, state_name)
+        handler = getattr(state_cls, handler_name)
+
+        assert _reflex_upload_param(handler) is not None, (
+            f"{state_name}.{handler_name} (used by rx.upload at "
+            f"{module_name}:{lineno}) has no parameter annotated "
+            "list[rx.UploadFile]. Reflex cannot find the upload parameter and "
+            "POST /_upload raises UploadValueError -> HTTP 500 before the "
+            "handler runs. A bare `list` is not enough — it is not a generic "
+            "alias. See #452."
+        )
+
+    @pytest.mark.parametrize(
+        ("module_name", "state_name", "handler_name", "lineno"),
+        UPLOAD_SITES,
+        ids=[f"{s[1]}.{s[2]}" for s in UPLOAD_SITES],
+    )
+    def test_handler_is_not_a_background_task(self, module_name, state_name, handler_name, lineno):
+        """The same endpoint rejects these too, with the same 500."""
+        module = importlib.import_module(module_name)
+        handler = getattr(getattr(module, state_name), handler_name)
+
+        if isinstance(handler, EventHandler):
+            assert not handler.is_background, (
+                f"{state_name}.{handler_name} is @rx.event(background=True); "
+                "reflex/app.py::upload() raises UploadTypeError for background "
+                f"upload handlers ({module_name}:{lineno})."
+            )


### PR DESCRIPTION
Closes #452.

Uploading a CSV/JSON/Parquet on the Connections form returned **HTTP 500 in production**, so the zero-credentials onboarding path — the CSV → DuckDB template that `/docs/connectors/csv` calls *"the first pipeline you ever run on Datanika"* and `/templates/csv-to-duckdb` is the public landing page for — was dead on a new user's **first action**. Found while capturing connector-guide walkthrough screenshots against prod.

## The bug

`POST /_upload` does not call the handler named in `on_drop`. It *finds* it, by scanning type hints for a generic alias whose first arg is `UploadFile`, and raises `UploadValueError` when there isn't one (`reflex/app.py::upload()`, 0.8.26):

```python
for k, v in get_type_hints(func).items():
    if types.is_generic_alias(v) and types._issubclass(get_args(v)[0], UploadFile):
        handler_upload_param = (k, v)
        break
if not handler_upload_param:
    raise UploadValueError(...)
```

`files: list` is not a generic alias, so the lookup failed and the endpoint 500'd **before the handler ran**. The handler body was correct the whole time — which is why this reads as a storage or permissions bug and isn't one (`file_uploads_dir` exists and is writable on prod; nothing is logged, because the failure is in Reflex's dispatch, not ours).

The other two `rx.upload` sites were already annotated `list[rx.UploadFile]`, which is why SQL-file upload and backup restore work. Connections was the only outlier.

## Evidence — replayed against the shipped prod container

```
ConnectionState.handle_file_upload:
    files annotation = <class 'list'>
    upload param     = NONE -> UploadValueError -> HTTP 500
TransformationState.handle_sql_file_upload:
    files annotation = list[reflex.app.UploadFile]
    upload param     = ('files', list[reflex.app.UploadFile])
BackupState.handle_restore_upload:
    files annotation = list[reflex.app.UploadFile]
    upload param     = ('files', list[reflex.app.UploadFile])
```

Prod Apache access log, reproduced 3/3:

```
"POST /_upload HTTP/1.1" 500 499  "https://app.datanika.io/connections"
"POST /_upload HTTP/1.1" 500 2854 "https://app.datanika.io/connections"
```

## The fix

```diff
-    async def handle_file_upload(self, files: list):
+    async def handle_file_upload(self, files: list[rx.UploadFile]):
```

Plus `import reflex as rx` (the module didn't have it) and a docstring noting the annotation is load-bearing, since it looks like a cosmetic type hint and is not.

## Why the guard is shaped this way

Tests for this handler existed and passed. They call it **directly** with a list of fakes — which exercises the body and skips the part that was broken: how Reflex *finds* the body. Green tests, dead feature; same class as #417, where every assertion checked the destination and none checked the delivery.

So `tests/test_ui/test_upload_handlers.py` asserts the contract at the boundary that actually enforces it, and for **every** `rx.upload` site rather than the one that happened to break — AST-scanning `datanika/ui/` for `rx.upload(on_drop=…)`, resolving each to its state handler, and running Reflex's own detection against it. A fourth upload surface added later is covered automatically.

Two details that matter:

- **The site count is pinned** (`EXPECTED_UPLOAD_SITES = 3`). A scan that silently finds nothing would parametrise zero cases and pass green — the exact failure mode this file exists to prevent.
- **The scan refuses to skip what it can't parse.** An `on_drop` shape it can't resolve to a `State.handler` pair fails loudly rather than dropping the site from coverage.

Also guards the sibling rule from the same endpoint (background upload handlers raise `UploadTypeError`).

**Verified red before green**: on the old annotation, `1 failed, 6 passed` — the failure is `ConnectionState.handle_file_upload`, while the site count and the two correct handlers pass. After the fix, 7 passed.

## Checks

- Pre-push hook: ruff check + ruff format clean, **2493 passed / 23 skipped**.

## Not in this PR

`settings.file_uploads_dir` resolves to `./uploaded_files` inside `/app`, which is **not a mounted volume** on prod (`docker inspect datanika-app` shows only `datanika_dbt_projects → /app/dbt_projects`). Archives are lost on every container rebuild while their `UploadedFile` rows survive, leaving dangling `archive_path`s. Noted in #452; deserves its own issue and an Infra decision on the volume, not a drive-by fix here.
