### PR TITLE
[Infra] Promote dev -> master: blue/green cutover (colour-aware alerting + CD swaps colours)

### DIFF
--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -62,14 +62,59 @@ jobs:
           chmod 600 ~/.ssh/config
       - name: Transfer source (box .env.docker preserved)
         run: cat /tmp/src.tgz | ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" 'cd /opt/datanika && tar xzf -'
-      - name: Build image + recreate app/celery
+      - name: Build image + datastores
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
-            'cd /opt/datanika/datanika && set -a && . ./.env.docker && set +a && docker compose build app celery && docker compose up -d postgres redis app celery'
-      - name: Wait for health
+            'cd /opt/datanika/datanika && set -a && . ./.env.docker && set +a && docker compose build app celery app_b && docker compose up -d postgres redis'
+
+      # The app is deployed by SWAPPING colours, not by recreating one container.
+      #
+      # The old step ran `up -d app`, which stops the running container and starts the new
+      # one — a measured ~60s window where every request 502s (#425). deploy-bluegreen.sh
+      # instead starts the INACTIVE colour, waits for its healthcheck, repoints Apache with
+      # a graceful reload, verifies through Cloudflare, and only then stops the old colour.
+      # Measured on prod: 549 probed requests across two swaps, zero non-200s.
+      #
+      # It also fixes a subtler bug: with Apache pointed at green, `up -d app` would have
+      # rebuilt BLUE, passed its health gate, reported success, and changed nothing that
+      # serves. The script derives the target colour from Apache's active-ports include,
+      # so it always deploys the one that is not live.
+      #
+      # On any pre-swap failure it rolls back to the live colour and exits non-zero, so a
+      # failed deploy leaves production exactly as it was.
+      #
+      # ⚠️ Both colours run `alembic upgrade head`, so the previously-deployed code briefly
+      # runs against the new schema. Migrations must be expand/contract — #449.
+      - name: Deploy the app via blue/green swap
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
-            'for i in $(seq 1 40); do h=$(docker inspect --format "{{.State.Health.Status}}" datanika-app 2>/dev/null); [ "$h" = healthy ] && { echo healthy; exit 0; }; sleep 5; done; echo "NOT healthy"; docker logs --tail 40 datanika-app; exit 1'
+            'cd /opt/datanika/datanika && bash scripts/deploy-bluegreen.sh --env prod'
+
+      # Celery is NOT blue/green: it serves no HTTP traffic, so a brief restart costs
+      # nothing (tasks stay queued in Redis) and running two workers on one broker would
+      # double-consume. Recreate it after the swap so it picks up the same new image.
+      - name: Recreate celery worker
+        run: |
+          ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
+            'cd /opt/datanika/datanika && set -a && . ./.env.docker && set +a && docker compose up -d celery'
+
+      # Assert the colour that is actually SERVING is healthy — not a hardcoded container
+      # name, which is what made the old check meaningless once colours alternate.
+      - name: Verify the serving colour is healthy
+        run: |
+          ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" 'bash -s' <<'VERIFY'
+          set -e
+          BE=$(sed -nE 's/^Define DATANIKA_BE ([0-9]+).*/\1/p' /etc/apache2/conf-enabled/datanika-prod-active.conf)
+          case "$BE" in
+            8000) LIVE=datanika-app ;;
+            8010) LIVE=datanika-app-b ;;
+            *) echo "cannot determine serving colour (be=$BE)"; exit 1 ;;
+          esac
+          echo "serving colour: $LIVE (be=$BE)"
+          H=$(docker inspect --format '{{.State.Health.Status}}' "$LIVE" 2>/dev/null || echo missing)
+          [ "$H" = healthy ] || { echo "$LIVE is $H"; docker logs --tail 40 "$LIVE"; exit 1; }
+          echo "$LIVE healthy"
+          VERIFY
 
       # Monitoring config (prometheus.yml, grafana provisioning) is BIND-MOUNTED, so the
       # transfer updates it on disk but nothing re-reads it: the container spec is

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -19,7 +19,12 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'time() - container_last_seen{name=~"datanika-(app|celery|postgres|redis)"} > 60'
+              # Excludes the app pair on purpose — see "App Container Down" below.
+              # Under blue/green exactly ONE of datanika-app / datanika-app-b is running,
+              # so a per-container staleness check pages for the colour we deliberately
+              # retired. Confirmed live during the first prod swap: this rule fired for
+              # `datanika-app` while prod served correctly from `datanika-app-b`.
+              expr: 'time() - container_last_seen{name=~"datanika-(celery|postgres|redis)"} > 60'
               refId: A
           - refId: C
             relativeTimeRange:
@@ -40,6 +45,49 @@ groups:
         annotations:
           summary: "Container {{ $labels.name }} is down"
           description: "Container {{ $labels.name }} has not been seen for over 60 seconds."
+
+      # --- App container (blue/green aware) ---
+      # The app runs as one of a PAIR: datanika-app (blue) or datanika-app-b (green).
+      # Exactly one is up at a time, and a swap deliberately stops the other, so a
+      # per-container check is wrong by construction — it pages for the retired colour.
+      #
+      # `max()` over the pair collapses them: the value is the most recent sighting of
+      # EITHER colour, so this fires only when *neither* is alive, which is the actual
+      # outage. During the first prod swap the old per-container rule fired for
+      # `datanika-app` while prod served perfectly from `datanika-app-b`.
+      - uid: app-container-down
+        title: App Container Down
+        condition: C
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'time() - max(container_last_seen{name=~"datanika-app(-b)?"}) > 60'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No app container is running (neither blue nor green)"
+          description: "Neither datanika-app nor datanika-app-b has been seen for over 60 seconds. During a blue/green swap exactly one is expected to be down; this fires only when both are."
 
       # --- High CPU ---
       - uid: high-cpu
@@ -1333,6 +1381,46 @@ groups:
         annotations:
           summary: "node-exporter metrics have disappeared"
           description: "Host metrics are absent. High CPU/Memory and Disk Space Critical cannot fire while this is true."
+      # App Container Down uses `max(container_last_seen{...}) > 60`, which is a FILTERING
+      # expression: if BOTH colours are gone, cadvisor stops exporting the series
+      # entirely, the query returns nothing, and the rule sits silently at NoData -> OK.
+      # Verified: once datanika-app-b exited, its container_last_seen series disappeared
+      # rather than going stale. absent() covers precisely that hole — the same blindness
+      # this whole group exists to fix, which App Container Down would otherwise reproduce.
+      - uid: watchdog-app-pair
+        title: "Watchdog: no app container is being reported at all"
+        condition: C
+        noDataState: OK
+        execErrState: Alerting
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'absent(container_last_seen{name=~"datanika-app(-b)?"})'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Neither app colour is reporting to cadvisor"
+          description: "No container_last_seen series exists for datanika-app or datanika-app-b. Either both are gone, or cadvisor stopped seeing them — App Container Down cannot fire while this is true."
+
       - uid: watchdog-cadvisor
         title: "Watchdog: cadvisor metrics missing"
         condition: C


### PR DESCRIPTION
Promotion of the current `dev` to production. **This completes the A3 cutover (#457).**

- **#460** — container alerting is blue/green aware. `Container Down` no longer covers the app pair; `App Container Down` uses `max()` across both colours so it fires only when *neither* is alive; an `absent()` watchdog covers the case where cadvisor exports no series for either (verified: an exited container's series disappears rather than going stale).
- **#461** — CD deploys the app by *swapping colours* instead of recreating a container. Removes both the measured ~60s deploy gap and a silent no-op where `up -d app` would rebuild the non-serving colour and report success.

**This promotion is its own test:** the push to `master` triggers CD, which now runs the swap. A probe runs against prod throughout.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- Closes #457 — Blue/green cutover prerequisites: CD targets one colour, and monitoring pages on the other · via #461, commit 7005ac4

<!-- promotion-refs:end -->