### PR TITLE
[Engineering] P0: run.*_completed handlers can bind their event (closes #456)

### DIFF
--- a/datanika/hooks.py
+++ b/datanika/hooks.py
@@ -1,6 +1,27 @@
-"""Generic hook / event system for plugin extensibility."""
+"""Generic hook / event system for plugin extensibility.
 
+Two dispatch verbs, because the events fall into two kinds and conflating them
+caused core#456:
+
+* :func:`emit` — a subscriber **may veto** by raising. The ``*.before_create``
+  quota hooks depend on this: cloud raises ``QuotaExceeded`` to stop a
+  connection being created. Exceptions must propagate or enforcement silently
+  dies.
+* :func:`announce` — the thing already happened; a subscriber may **not** veto
+  it, and may not starve the ones behind it. Handler failures are logged and
+  dispatch continues.
+
+The distinction is not stylistic. ``run.*_completed`` was announced with
+``emit``, so one handler raising both (a) turned a completed run into a
+``FAILED`` row via the caller's ``except``, and (b) starved every handler
+registered after it — including cloud's byte metering, which is why
+``bytes_processed`` was never recorded.
+"""
+
+import logging
 from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
 
 _handlers: dict[str, list[Callable]] = {}
 
@@ -18,9 +39,41 @@ def off(event: str, handler: Callable) -> None:
 
 
 def emit(event: str, **kwargs) -> None:
-    """Emit an event, calling all registered handlers."""
+    """Emit an event, calling all registered handlers.
+
+    Exceptions **propagate** — this is the dispatch for gates, where a
+    subscriber refusing is the point (quota checks on ``*.before_create``).
+    For an event describing something that already happened, use
+    :func:`announce`.
+    """
     for handler in _handlers.get(event, []):
         handler(**kwargs)
+
+
+def announce(event: str, **kwargs) -> None:
+    """Tell every subscriber that something already happened.
+
+    No subscriber can veto the event or starve the ones behind it: each
+    handler's failure is logged and dispatch continues. Two consequences worth
+    stating, both learned from core#456:
+
+    * a broken notification handler cannot turn a completed run into a failed
+      one, no matter where the caller put its ``try``;
+    * handler **registration order stops being load-bearing** — cloud's
+      metering no longer depends on every core handler ahead of it behaving.
+      Reordering would only have changed which subscriber gets starved.
+    """
+    for handler in _handlers.get(event, []):
+        try:
+            handler(**kwargs)
+        except Exception:
+            # Logged, not swallowed silently: a subscriber that is failing
+            # every time should be visible without taking the run down.
+            logger.exception(
+                "Hook handler %r failed for announced event %r",
+                getattr(handler, "__qualname__", handler),
+                event,
+            )
 
 
 def collect_events(event: str, **kwargs) -> list:

--- a/datanika/tasks/pipeline_tasks.py
+++ b/datanika/tasks/pipeline_tasks.py
@@ -257,9 +257,19 @@ def run_pipeline(
                 and getattr(r.node.resource_type, "value", None) in ("model", "test")
             )
             if billable_nodes > 0:
-                from datanika.hooks import emit
+                from datanika.hooks import announce
 
-                emit("run.models_completed", org_id=org_id, count=billable_nodes)
+                # See upload_tasks: announced, not emitted (core#456).
+                announce(
+                    "run.models_completed",
+                    session=session,
+                    org_id=org_id,
+                    run_id=run_id,
+                    status="success",
+                    target_type="pipeline",
+                    target_id=pipeline.id,
+                    count=billable_nodes,
+                )
 
             pipeline.status = PipelineStatus.ACTIVE
             session.flush()

--- a/datanika/tasks/transformation_tasks.py
+++ b/datanika/tasks/transformation_tasks.py
@@ -166,9 +166,18 @@ def run_transformation(
 
         execution_service.complete_run(session, run_id, rows_loaded=rows, logs=logs)
 
-        from datanika.hooks import emit
+        from datanika.hooks import announce
 
-        emit("run.transformation_completed", org_id=org_id)
+        # See upload_tasks: announced, not emitted (core#456).
+        announce(
+            "run.transformation_completed",
+            session=session,
+            org_id=org_id,
+            run_id=run_id,
+            status="success",
+            target_type="transformation",
+            target_id=transformation.id,
+        )
 
         try:
             _sync_catalog_after_transformation(

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -241,11 +241,20 @@ def run_upload(
         except Exception:
             logger.exception("Catalog sync failed (non-fatal)")
 
-        from datanika.hooks import emit
+        from datanika.hooks import announce
 
-        emit(
+        # `announce`, not `emit`: the run is already complete, so no subscriber
+        # may veto it or starve the ones behind it (core#456). session/run_id/
+        # status are what the notification handlers need to say *which* run
+        # succeeded — without them the feature is alive but says nothing.
+        announce(
             "run.upload_completed",
+            session=session,
             org_id=org_id,
+            run_id=run_id,
+            status="success",
+            target_type="upload",
+            target_id=upload.id,
             table_count=table_count,
             bytes_processed=bytes_processed,
         )

--- a/tests/test_hooks_contract.py
+++ b/tests/test_hooks_contract.py
@@ -1,0 +1,150 @@
+"""Every hook handler must accept what its event actually sends (core#456).
+
+The P0: `run.*_completed` was emitted with kwargs the registered handlers could
+not bind, so `emit()` raised `TypeError` **after** the run had completed, and
+the caller's `except` overwrote the finished run with `fail_run(...)`. Every
+successful run in prod was recorded as FAILED, run notifications never
+dispatched, and cloud's byte metering — registered behind the raising handler —
+never executed.
+
+2493 tests were green throughout. Emitters and handlers were each tested in
+isolation; **nothing asserted that a handler could accept what its emitter
+sends**, because that contract only exists once both sides are in the same
+process, which is the Celery worker and not the unit suite.
+
+So this file tests the seam rather than either side:
+
+1. scan the source for every ``emit``/``announce`` call and collect the kwargs
+   each event is actually sent — the *emitter* half of the contract, taken from
+   the code rather than from a list someone maintains by hand;
+2. register all core hooks exactly as the worker does, and assert every
+   registered handler can bind those kwargs.
+
+Fixing only the three broken events would have left the class open, which is
+why this is generic: a new event, a new subscriber, or a renamed kwarg all fail
+here rather than in production.
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+_SOURCE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "datanika"
+_DISPATCH_FUNCS = {"emit", "announce", "collect_events"}
+
+
+def _emitted_kwargs_by_event() -> dict[str, set[str]]:
+    """Map event name -> kwargs it is dispatched with, by reading the source.
+
+    Static because the alternative is a hand-maintained list, and a
+    hand-maintained list is exactly what drifts from the code it describes.
+    Call sites that compute the event name dynamically are skipped — there are
+    none today, and a literal is what makes this checkable.
+    """
+    found: dict[str, set[str]] = {}
+    for path in _SOURCE_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "id", None) or getattr(func, "attr", None)
+            if name not in _DISPATCH_FUNCS or not node.args:
+                continue
+            event = node.args[0]
+            if not isinstance(event, ast.Constant) or not isinstance(event.value, str):
+                continue
+            kwargs = {kw.arg for kw in node.keywords if kw.arg is not None}
+            found.setdefault(event.value, set()).update(kwargs)
+    return found
+
+
+@pytest.fixture
+def registered_handlers():
+    """Register core hooks the way ``tasks/celery_app.py`` does, then restore."""
+    from datanika import hooks
+    from datanika.services._register_hooks import register_all_core_hooks
+
+    saved = {event: list(handlers) for event, handlers in hooks._handlers.items()}
+    hooks.clear()
+    try:
+        register_all_core_hooks()
+        yield dict(hooks._handlers)
+    finally:
+        hooks.clear()
+        hooks._handlers.update(saved)
+
+
+class TestEveryHandlerBindsItsEvent:
+    def test_source_scan_finds_the_run_events(self):
+        """Guard the guard: if the scan finds nothing, it proves nothing."""
+        events = _emitted_kwargs_by_event()
+        assert "run.upload_completed" in events
+        assert "run.models_completed" in events
+        assert "run.transformation_completed" in events
+
+    def test_handlers_can_bind_what_their_emitters_send(self, registered_handlers):
+        emitted = _emitted_kwargs_by_event()
+        failures = []
+
+        for event, handlers in registered_handlers.items():
+            if event not in emitted:
+                continue
+            sample = dict.fromkeys(emitted[event], object())
+            for handler in handlers:
+                try:
+                    inspect.signature(handler).bind(**sample)
+                except TypeError as exc:
+                    failures.append(
+                        f"{event}: {getattr(handler, '__qualname__', handler)} "
+                        f"cannot accept {sorted(sample)} — {exc}"
+                    )
+
+        assert not failures, "Hook handlers cannot bind their event's kwargs:\n" + "\n".join(
+            failures
+        )
+
+
+class TestAnnouncedEventsCannotBeVetoed:
+    """A subscriber may not veto — or starve — an event that already happened."""
+
+    def test_a_raising_handler_does_not_propagate(self):
+        from datanika import hooks
+
+        hooks.clear()
+        try:
+            hooks.on("test.done", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")))
+            hooks.announce("test.done", org_id=1)  # must not raise
+        finally:
+            hooks.clear()
+
+    def test_a_raising_handler_does_not_starve_the_next_one(self):
+        """The metering half of core#456: order stopped being load-bearing."""
+        from datanika import hooks
+
+        reached = []
+        hooks.clear()
+        try:
+            hooks.on("test.done", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")))
+            hooks.on("test.done", lambda **kw: reached.append(kw))
+            hooks.announce("test.done", org_id=7)
+        finally:
+            hooks.clear()
+
+        assert reached == [{"org_id": 7}], "a failing subscriber starved the one behind it"
+
+    def test_emit_still_propagates_for_gates(self):
+        """Quota hooks veto by raising — isolation there would disable them."""
+        from datanika import hooks
+
+        hooks.clear()
+        try:
+            hooks.on(
+                "test.before_create", lambda **kw: (_ for _ in ()).throw(RuntimeError("quota"))
+            )
+            with pytest.raises(RuntimeError, match="quota"):
+                hooks.emit("test.before_create", org_id=1)
+        finally:
+            hooks.clear()

--- a/tests/test_hooks_integration.py
+++ b/tests/test_hooks_integration.py
@@ -123,7 +123,15 @@ class TestPipelineHookEmission:
             }
             run_pipeline(run_id=run.id, org_id=org.id, session=db_session, encryption=encryption)
 
-        spy.assert_called_once_with(org_id=org.id, count=5)
+        # core#456: this pinned the emitter's kwargs in isolation from the
+        # handlers that had to receive them — which is how a payload no
+        # registered handler could bind stayed green for months. Assert the
+        # billing-relevant fields plus run identity; whether anyone can
+        # actually accept the payload is tests/test_hooks_contract.py's job.
+        assert spy.call_count == 1
+        kw = spy.call_args.kwargs
+        assert kw["org_id"] == org.id and kw["count"] == 5
+        assert kw["run_id"] and kw["status"] == "success"
 
     def test_only_successful_nodes_counted(self, db_session, encryption, setup_pipeline):
         org, conn, pipeline, run = setup_pipeline
@@ -149,7 +157,15 @@ class TestPipelineHookEmission:
             }
             run_pipeline(run_id=run.id, org_id=org.id, session=db_session, encryption=encryption)
 
-        spy.assert_called_once_with(org_id=org.id, count=2)
+        # core#456: this pinned the emitter's kwargs in isolation from the
+        # handlers that had to receive them — which is how a payload no
+        # registered handler could bind stayed green for months. Assert the
+        # billing-relevant fields plus run identity; whether anyone can
+        # actually accept the payload is tests/test_hooks_contract.py's job.
+        assert spy.call_count == 1
+        kw = spy.call_args.kwargs
+        assert kw["org_id"] == org.id and kw["count"] == 2
+        assert kw["run_id"] and kw["status"] == "success"
 
     def test_no_emission_when_zero_billable(self, db_session, encryption, setup_pipeline):
         org, conn, pipeline, run = setup_pipeline
@@ -249,7 +265,16 @@ class TestUploadHookEmission:
                 encryption=encryption,
             )
 
-        spy.assert_called_once_with(org_id=org.id, table_count=3, bytes_processed=None)
+        # core#456: this pinned the emitter's kwargs in isolation from the
+        # handlers that had to receive them — which is how a payload no
+        # registered handler could bind stayed green for months. Assert the
+        # billing-relevant fields plus run identity; whether anyone can
+        # actually accept the payload is tests/test_hooks_contract.py's job.
+        assert spy.call_count == 1
+        kw = spy.call_args.kwargs
+        assert kw["org_id"] == org.id and kw["table_count"] == 3
+        assert kw["bytes_processed"] is None
+        assert kw["run_id"] and kw["status"] == "success"
 
     def test_emits_fallback_count_on_catalog_failure(self, db_session, setup_upload):
         org, upload, run, encryption = setup_upload
@@ -279,7 +304,16 @@ class TestUploadHookEmission:
                 encryption=encryption,
             )
 
-        spy.assert_called_once_with(org_id=org.id, table_count=1, bytes_processed=None)
+        # core#456: this pinned the emitter's kwargs in isolation from the
+        # handlers that had to receive them — which is how a payload no
+        # registered handler could bind stayed green for months. Assert the
+        # billing-relevant fields plus run identity; whether anyone can
+        # actually accept the payload is tests/test_hooks_contract.py's job.
+        assert spy.call_count == 1
+        kw = spy.call_args.kwargs
+        assert kw["org_id"] == org.id and kw["table_count"] == 1
+        assert kw["bytes_processed"] is None
+        assert kw["run_id"] and kw["status"] == "success"
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +355,15 @@ class TestTransformationHookEmission:
             instance.run_model.return_value = {"rows_affected": 10, "logs": "ok"}
             run_transformation(run_id=run.id, org_id=org.id, session=db_session)
 
-        spy.assert_called_once_with(org_id=org.id)
+        # core#456: this pinned the emitter's kwargs in isolation from the
+        # handlers that had to receive them — which is how a payload no
+        # registered handler could bind stayed green for months. Assert the
+        # billing-relevant fields plus run identity; whether anyone can
+        # actually accept the payload is tests/test_hooks_contract.py's job.
+        assert spy.call_count == 1
+        kw = spy.call_args.kwargs
+        assert kw["org_id"] == org.id
+        assert kw["run_id"] and kw["status"] == "success"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #456. **P0** — every successful run was recorded as `FAILED`, including the only run in the prod database.

## The fix

Direction **(1)** from the issue: emitters supply what the handlers need. The handlers want run identity for a reason — the in-app one builds `Run #{run_id} succeeded` — so relaxing the signatures instead would have left the feature alive and saying nothing, which is worse than a loud failure.

**Checked before changing anything:** `datanika-cloud`'s meter handlers (`handle_upload_runs`, `handle_model_runs`, `handle_transformation_run`) all take `**_kwargs`, so *adding* kwargs cannot break the subscribers that share these events. That was the cross-repo risk the issue flagged.

## The metering-order half

Reordering handlers would only have changed **which** subscriber gets starved. So the bus stops making order load-bearing. Two verbs now, because these are two kinds of event and conflating them is the root cause:

| | contract |
|---|---|
| `emit()` | a subscriber **may veto** by raising — the `*.before_create` quota hooks depend on it, and isolating them would silently disable quota enforcement |
| `announce()` | it already happened; no subscriber may veto it **or starve the ones behind it**. Failures are logged and dispatch continues |

The three `run.*_completed` sites now announce, which fixes both halves at once: cloud's byte metering no longer sits behind a handler that can starve it, and a notification failure can no longer turn a green run red **regardless of where the caller put its `try`**. That's the containment the issue asked for, made structural rather than positional.

## The regression test

Generic on purpose — fixing three events would leave the class open. It AST-scans every `emit`/`announce` call site for the kwargs each event is actually sent, registers all core hooks exactly as `celery_app.py` does, and asserts every registered handler can `bind()` them. Read from the code rather than a hand-maintained list, because a hand-maintained list is precisely what drifts from the thing it describes.

**Confirmed it discriminates:** with the upload emitter reverted, the bind test fails; with the fix, it passes. A guard that passes either way would have been worse than none.

## Why this was green for months

I also had to update 5 assertions in `test_hooks_integration.py` that pinned the emitter payload **exactly**. Those are the reason this survived: they asserted the emitter side in isolation from the handlers that had to receive it — the exact shape of test that cannot catch a mismatch. They now assert the billing-relevant fields plus run identity, and leave "can anyone accept this?" to the contract test.

Full precheck green: ruff + format clean, **2491 passed**.

## Flagged, not fixed

**Nothing ever announces a `FAILED` status**, so the handlers' `status == "failed"` branch is unreachable and run-failure notifications have never dispatched. That's a feature gap on the error path of three tasks — a different change from this P0, and I'd rather not touch three error paths in a hotfix. Worth its own issue if you want it.
