### PR TITLE
[Infra] Container Down: collapse duplicate cadvisor series per name (refs #457)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -24,7 +24,7 @@ groups:
               # so a per-container staleness check pages for the colour we deliberately
               # retired. Confirmed live during the first prod swap: this rule fired for
               # `datanika-app` while prod served correctly from `datanika-app-b`.
-              expr: 'time() - container_last_seen{name=~"datanika-(celery|postgres|redis)"} > 60'
+              expr: 'time() - max by (name) (container_last_seen{name=~"datanika-(celery|postgres|redis)"}) > 60'
               refId: A
           - refId: C
             relativeTimeRange:


### PR DESCRIPTION
Found by inspecting prod immediately after the first CD-driven blue/green deploy: `Container Down` fired for `datanika-celery` while the worker was demonstrably healthy (`celery@… ready`, connected to Redis, `restarts=0`).

**Cause.** After any `compose up -d`, cadvisor briefly holds **two** series for one container name:

```
id=…a305fc20  176.3s since last seen   <- destroyed container
id=…3414498    11.3s since last seen   <- the live one
```

The rule matches by `name`, so the stale duplicate trips `> 60` and pages.

**Pre-existing, not a blue/green regression.** Every deploy that recreated a container has produced this, for as long as the rule has existed. It survived because an alert that fires and then resolves itself reads as a transient blip rather than a broken rule — the same shape as the `noDataState` finding earlier: noise that is actually a defect.

**Fix:** `max by (name)` takes the freshest sighting per container, so it fires only when *every* series for that name is stale — the container is genuinely gone. Absence (no series at all) stays covered by the `absent()` watchdogs, which is the complementary case.

**Validated on live prod while the duplicate was still present** — current expression fires, fixed expression quiet, worker healthy throughout. That window doesn't reproduce on demand.

Rebased onto current `dev` deliberately: the first attempt edited this file on a branch predating #460, and committing it would have silently reverted the colour-aware rules. The PR asserts `Container Down`, `App Container Down` and the app-pair watchdog all coexist.