### PR TITLE
[Infra] Retire A4's for: 2m stopgap now the deploy gap is zero (closes #425)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -552,7 +552,7 @@ groups:
                     type: gt
                     params: [0]
               refId: C
-        for: 2m
+        for: 1m
         labels:
           severity: critical
         annotations:
@@ -590,7 +590,7 @@ groups:
                     type: gt
                     params: [0]
               refId: C
-        for: 2m
+        for: 1m
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
The last step of A3. **A4's `for: 2m` existed only to absorb a deploy gap that no longer exists.**

**Why it was 2m.** The old CD recreated the app container, so every request 502'd while it booted — measured at **60s**. The original `for: 5m` hid that, but would also have slept through the real 3-minute outage that started this whole thread. A4 set 2m as a deliberate stopgap: above our own deploy noise, below a real outage, with the number derived from measurement rather than taste.

**Why it can go now.** CD deploys by swapping colours, and the gap measures **zero**:

| | requests | non-200 |
|---|---|---|
| first CD-driven blue/green deploy | 415 | **0** |
| two manual prod swaps | 549 | **0** |

All verified locally **and** through Cloudflare.

**New value: 1m** — a real outage pages a minute sooner. Deliberately not lower: blackbox scrapes every 15s, so 1m is 4 consecutive failures, and this box hits 80-85% CPU during image builds; one slow response shouldn't page.

**Unchanged at 2m:** `Container Down` and `App Container Down`. Those watch container liveness, where a swap legitimately leaves one colour down — tightening them would buy noise, not sensitivity.

Closes #425. A3 is complete: policy → prod wiring → measured prod swap → cutover → stopgap retired.