### PR TITLE
[Infra] Put uploaded files on a shared volume (closes #471)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,9 @@ services:
     environment:
       GRANIAN_WORKERS: "4"
       REFLEX_MOUNT_FRONTEND_COMPILED_APP: "true"
+      # Pinned absolute: the default `./uploaded_files` (config.py) resolves against the
+      # working directory, so app and celery could silently diverge. See #471.
+      FILE_UPLOADS_DIR: /app/uploaded_files
     depends_on:
       postgres:
         condition: service_healthy
@@ -85,6 +88,9 @@ services:
         condition: service_healthy
     volumes:
       - dbt_projects:/app/dbt_projects
+      # Uploads lived inside the image: every rebuild destroyed the archives while their
+      # UploadedFile rows survived, leaving dangling archive_paths (#471).
+      - uploaded_files:/app/uploaded_files
     command: >
       sh -c "uv run alembic upgrade head &&
              uv run reflex run --env prod --backend-host 0.0.0.0"
@@ -122,6 +128,10 @@ services:
     environment:
       GRANIAN_WORKERS: "4"
       REFLEX_MOUNT_FRONTEND_COMPILED_APP: "true"
+      # Pinned absolute on purpose. The default is `./uploaded_files` (config.py), which
+      # resolves against the working directory — so app and celery writing from different
+      # CWDs would silently use different directories. See #471.
+      FILE_UPLOADS_DIR: /app/uploaded_files
     depends_on:
       postgres:
         condition: service_healthy
@@ -129,6 +139,12 @@ services:
         condition: service_healthy
     volumes:
       - dbt_projects:/app/dbt_projects
+      # Uploaded archives lived inside the image, so every rebuild destroyed them while
+      # their UploadedFile rows survived, leaving dangling archive_paths (#471). Must be
+      # mounted rw by BOTH app and celery: the load runs in the worker, so a web-only
+      # path fails at run time rather than upload time — the slower, more confusing
+      # failure. app_b carries it too, or a blue/green swap would lose them.
+      - uploaded_files:/app/uploaded_files
     command: >
       sh -c "uv run alembic upgrade head &&
              uv run reflex run --env prod --backend-host 0.0.0.0"
@@ -149,6 +165,10 @@ services:
     container_name: datanika-celery
     env_file:
       - .env.docker
+    environment:
+      # Must match app/app_b exactly — the LOAD runs here, so if the worker resolves a
+      # different directory the failure surfaces at run time, not at upload time (#471).
+      FILE_UPLOADS_DIR: /app/uploaded_files
     depends_on:
       postgres:
         condition: service_healthy
@@ -156,6 +176,7 @@ services:
         condition: service_healthy
     volumes:
       - dbt_projects:/app/dbt_projects
+      - uploaded_files:/app/uploaded_files
     command: uv run celery -A datanika.tasks.celery_app:celery_app worker -l info
     restart: unless-stopped
 
@@ -256,6 +277,9 @@ volumes:
   pgdata:
   redisdata:
   dbt_projects:
+  # Shared rw by app, app_b and celery — see #471. The load runs in the worker, so a
+  # web-only path would fail at run time rather than upload time.
+  uploaded_files:
   pg_backups:
   prometheus_data:
   grafana_data:


### PR DESCRIPTION
Sequenced **with** #455, not behind it: while uploads 500'd this was latent, but #455 has now promoted, so uploads succeed and every subsequent deploy would silently orphan real user files.

**Two bugs, not one.**

1. **No volume.** `./uploaded_files` resolved inside `/app`; only `dbt_projects` was mounted, so rebuilds destroyed archives while their `UploadedFile` rows survived.
2. **The path is relative.** `config.py` defaults `file_uploads_dir` to `./uploaded_files`, resolved against the **working directory**. Mounting a volume alone still lets `app` and `celery` diverge if either CWD changes — and since the **load runs in the worker**, that surfaces at *run* time, not upload time: the slower, more confusing failure the issue explicitly warns about.

**Fix**
- Named volume `uploaded_files` mounted **rw on `app`, `app_b` and `celery`**. `app_b` matters — without it a blue/green swap loses uploads.
- `FILE_UPLOADS_DIR=/app/uploaded_files` pinned absolutely on all three, so CWD cannot matter. Infra-only: Pydantic maps the field straight to the env var, no app-code change.
- A check asserts `app` and `celery` resolve the *same* directory, since that mismatch is the run-time failure mode.

**Pre-flight on prod before mounting** — a fresh volume would have *masked* anything already there, turning fragile files into invisible ones:

```
datanika-app    /app/uploaded_files : 0 files
datanika-app-b  /app/uploaded_files : 0 files
uploaded_files rows in DB           : 0
```

So nothing is masked, and the issue's third criterion (**reconcile or explicitly accept dangling rows**) is answered by measurement: there are none, because uploads have been failing since #452.