### PR TITLE
[Infra] Stop the blue/green alert noise: scrape both colours, fix inverted probe (closes #479)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -319,7 +319,12 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'up{job="datanika-app"} == 0'
+              # Blue/green: two scrape jobs, exactly ONE of which is expected to be up.
+              # `up{job="datanika-app"} == 0` fired continuously whenever GREEN served,
+              # because the compose name `app` did not resolve — re-notifying hourly
+              # while the site was fine (#479). max() collapses the pair, so this fires
+              # only when NEITHER colour is scrapeable, which is the real outage.
+              expr: 'max(up{job=~"datanika-app(-b)?"}) == 0'
               refId: A
           - refId: C
             relativeTimeRange:
@@ -502,7 +507,13 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'probe_success{instance="https://plausible.datanika.io/login"}'
+              # ⚠️ INVERTED until 2026-07-22: this was missing `== 0`. Every rule's
+              # condition is `A > 0`, so with the raw gauge (1 = healthy) it fired
+              # whenever Plausible was UP — and re-notified every 4h, matching the
+              # warning `repeat_interval`. #479 spotted it as "fires with zero failed
+              # samples", which is exactly what an inverted probe check looks like.
+              # Every other probe rule already used `== 0`; this one was the outlier.
+              expr: 'probe_success{instance="https://plausible.datanika.io/login"} == 0'
               refId: A
           - refId: C
             relativeTimeRange:
@@ -1327,7 +1338,9 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'absent(up{job="datanika-app"})'
+              # Both colours: App Unhealthy uses max() over the pair, which returns no
+              # series if BOTH jobs vanish — NoData -> OK -> silence. This covers that.
+              expr: 'absent(up{job=~"datanika-app(-b)?"})'
               refId: A
           - refId: C
             relativeTimeRange:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -14,10 +14,23 @@ scrape_configs:
     static_configs:
       - targets: ["cadvisor:8080"]
 
+  # Blue/green: the app runs as one of a PAIR and the compose service name of the live
+  # one alternates. Scraping only "app" meant that whenever GREEN was serving, this
+  # target failed DNS resolution ("lookup app on 127.0.0.11:53: server misbehaving") and
+  # App Unhealthy fired continuously, re-notifying hourly, while the site was perfectly
+  # fine — observed overnight 23:40-06:20 UTC (#479).
+  #
+  # Both are scraped; exactly one is expected to be down at any moment, so the alert
+  # collapses them with max() rather than checking either individually.
   - job_name: "datanika-app"
     metrics_path: /metrics
     static_configs:
       - targets: ["app:8000"]
+
+  - job_name: "datanika-app-b"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["app_b:8000"]
 
   - job_name: "postgres-exporter"
     static_configs:


### PR DESCRIPTION
~20 overnight Telegram alerts, site fine. Two separate defects, **one of them mine**.

### 1. `App Unhealthy` — my regression from the cutover

Prometheus scraped the app by compose DNS name `app:8000`. That name does not resolve when **green** is serving, so the target was down for the entire `23:40–06:20` window and the alert re-notified hourly. It could never self-resolve.

I made `Container Down` colour-aware during the cutover and **never swept the scrape config for the same assumption** — the identical defect, one file over.

Fix: scrape **both** colours and collapse with `max(...) == 0`, so it fires only when neither is scrapeable. The `absent()` watchdog now covers the pair as well, because `max()` over two missing jobs returns no series at all — NoData → OK → silence, which is the blindness this watchdog group exists to prevent.

### 2. `Plausible Down` — inverted, pre-existing

It was missing `== 0`. Every rule's condition is `A > 0`, so the raw gauge (**1 = healthy**) satisfied it: the alert fired whenever Plausible was **up**, re-notifying every 4h — matching the warning `repeat_interval`, and exactly matching the reporter's observation of "fires with zero failed samples".

Verified live: the old expression **FIRES**, the corrected one is **quiet**.

**Swept for the class rather than the instance:** after this fix, **0 of 24** rules lack a comparison, `absent()`, or a time delta.

### 3. The real 502s — deliberately NOT fixed here

The evidence splits them into two populations:

- **75–90s bursts** (5–6 consecutive samples), clustered in the deploy-heavy 16:00–23:00 window
- **isolated single 15s blips**, continuing overnight at ~1/hour **while green ran untouched from 23:40 to 06:20 with no deploys**

The second population cannot be a swap artefact. So "the flip window causes it" is incomplete at best, and my own swap probes recorded 549 + 415 requests with **zero** failures. I am not shipping a fix for a cause I have not established — that is how I published a wrong verdict earlier in this work.

The remaining question is what produces a single failed probe roughly hourly on an idle box; that needs its own investigation.