### PR TITLE
[Infra] Promote dev -> master: stop the blue/green alert noise (#479)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -319,7 +319,12 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'up{job="datanika-app"} == 0'
+              # Blue/green: two scrape jobs, exactly ONE of which is expected to be up.
+              # `up{job="datanika-app"} == 0` fired continuously whenever GREEN served,
+              # because the compose name `app` did not resolve — re-notifying hourly
+              # while the site was fine (#479). max() collapses the pair, so this fires
+              # only when NEITHER colour is scrapeable, which is the real outage.
+              expr: 'max(up{job=~"datanika-app(-b)?"}) == 0'
               refId: A
           - refId: C
             relativeTimeRange:
@@ -502,7 +507,13 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'probe_success{instance="https://plausible.datanika.io/login"}'
+              # ⚠️ INVERTED until 2026-07-22: this was missing `== 0`. Every rule's
+              # condition is `A > 0`, so with the raw gauge (1 = healthy) it fired
+              # whenever Plausible was UP — and re-notified every 4h, matching the
+              # warning `repeat_interval`. #479 spotted it as "fires with zero failed
+              # samples", which is exactly what an inverted probe check looks like.
+              # Every other probe rule already used `== 0`; this one was the outlier.
+              expr: 'probe_success{instance="https://plausible.datanika.io/login"} == 0'
               refId: A
           - refId: C
             relativeTimeRange:
@@ -1327,7 +1338,9 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'absent(up{job="datanika-app"})'
+              # Both colours: App Unhealthy uses max() over the pair, which returns no
+              # series if BOTH jobs vanish — NoData -> OK -> silence. This covers that.
+              expr: 'absent(up{job=~"datanika-app(-b)?"})'
               refId: A
           - refId: C
             relativeTimeRange:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -14,10 +14,23 @@ scrape_configs:
     static_configs:
       - targets: ["cadvisor:8080"]
 
+  # Blue/green: the app runs as one of a PAIR and the compose service name of the live
+  # one alternates. Scraping only "app" meant that whenever GREEN was serving, this
+  # target failed DNS resolution ("lookup app on 127.0.0.11:53: server misbehaving") and
+  # App Unhealthy fired continuously, re-notifying hourly, while the site was perfectly
+  # fine — observed overnight 23:40-06:20 UTC (#479).
+  #
+  # Both are scraped; exactly one is expected to be down at any moment, so the alert
+  # collapses them with max() rather than checking either individually.
   - job_name: "datanika-app"
     metrics_path: /metrics
     static_configs:
       - targets: ["app:8000"]
+
+  - job_name: "datanika-app-b"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["app_b:8000"]
 
   - job_name: "postgres-exporter"
     static_configs:


### PR DESCRIPTION
Promotion of the current `dev` to production.

**#480** (closes #479) — two defects behind ~20 overnight Telegram alerts while the site was fine:

- `App Unhealthy` scraped the app by compose DNS name `app:8000`, which does not resolve when **green** serves. It fired continuously for the whole 23:40–06:20 window and re-notified hourly, and could never self-resolve. **Mine** — I made `Container Down` colour-aware during the cutover and never swept the scrape config for the same assumption. Now scrapes both colours and collapses with `max()`.
- `Plausible Down` was **inverted**: missing `== 0`, so with every rule's `A > 0` condition the raw gauge (1 = healthy) fired whenever Plausible was up. Verified live — old expression fires, corrected one is quiet.

Swept the class afterwards: **0 of 24** remaining rules lack a comparison, `absent()`, or a time delta.

Not included: the genuine intermittent 502s. The evidence splits them into deploy-correlated bursts and isolated single-sample blips that continued overnight with no deploys, so the "flip window" story is incomplete and I am not shipping a guess.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- Closes #479 — [Infra] Overnight Telegram alert storm: one stale scrape target + real intermittent 502s at blue/green cutover · via #480, commit b1f4c83

<!-- promotion-refs:end -->