### PR TITLE
[Engineering] Enforce expand/contract at the t1 window (closes #449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
           uv pip install --system -r ci-requirements.txt --no-binary lxml --no-binary xmlsec
           uv pip install --system -e . --no-deps
 
+      - name: Fetch the deployed release
+        # This job runs the whole suite, which includes the t1-window guard
+        # (core#449). That guard compares against what production runs, and
+        # actions/checkout gives a shallow PR-only tree with no origin/master —
+        # so without this the guard fails rather than silently comparing
+        # nothing. Deliberately not --ignore'd here: `pytest tests/` must mean
+        # the same thing in CI as it does locally (core#470).
+        run: git fetch --no-tags --depth=1 origin master
+
       - name: Run tests
         run: pytest tests/ --tb=short -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
   # is broken — which only matters at 2 AM during a prod rollback.
   # Kept as a separate job so test failures on main suite don't mask it
   # (and vice-versa). DATABASE_URL_SYNC_TEST points at the service container.
+  # Also runs the t1-window guard (core#449): the deployed release's models are
+  # read out of git and checked against the migrated schema, which is why this
+  # job needs origin/master fetched rather than a shallow PR-only checkout.
   migration-roundtrip:
     runs-on: ubuntu-latest
     services:
@@ -130,10 +133,17 @@ jobs:
           uv pip install --system -r ci-requirements.txt --no-binary lxml --no-binary xmlsec
           uv pip install --system -e . --no-deps
 
-      - name: Run round-trip test
+      - name: Fetch the deployed release
+        # The t1 guard compares against what production runs, so master must be
+        # present. actions/checkout gives a shallow PR-only tree by default.
+        run: git fetch --no-tags --depth=1 origin master
+
+      - name: Run round-trip + t1-window tests
         env:
           DATABASE_URL_SYNC_TEST: postgresql://test:test@localhost:5432/test
-        run: pytest tests/test_migrations/test_roundtrip.py -v --tb=long
+        run: |
+          pytest tests/test_migrations/test_roundtrip.py \
+                 tests/test_migrations/test_expand_contract.py -v --tb=long
 
   helm-lint:
     runs-on: ubuntu-latest

--- a/tests/test_fixture_sharing.py
+++ b/tests/test_fixture_sharing.py
@@ -1,0 +1,113 @@
+"""Fixtures are shared through `conftest.py`, never by importing them.
+
+`from tests.test_migrations.test_roundtrip import roundtrip_db_url` looks like
+sharing and isn't. pytest registers an imported fixture as a **separate
+FixtureDef in the importing module**, so `scope="session"` caches once per
+module instead of once per session. The fixture body runs twice.
+
+That cost a real suite: two Postgres testcontainers instead of one, two
+teardowns, and on Windows the second teardown timed out against the Docker
+named pipe — failing an otherwise green run (`testsfailed=0`,
+`exitstatus=OK`) in TEARDOWN and leaving containers orphaned. Nothing asserted
+against it; it surfaced only because the timeout happened to fire.
+
+A fixture in `conftest.py` is discovered by every module in its directory as
+one FixtureDef. Helper *functions* may still be imported freely — this only
+concerns `@pytest.fixture`.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+#: This file sits at the root of the test tree, alongside the other repo-wide
+#: contract scans (`test_dependency_pins.py`, `test_hooks_contract.py`).
+TESTS_ROOT = Path(__file__).parent
+
+
+def _fixture_names(tree: ast.AST) -> set[str]:
+    """Names defined with an @pytest.fixture decorator, bare or called."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if getattr(target, "attr", getattr(target, "id", None)) == "fixture":
+                names.add(node.name)
+    return names
+
+
+def _fixture_imports(tree: ast.AST, known: set[str]) -> list[str]:
+    """`from tests... import <a fixture name>` — the pattern that duplicates."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not (node.module or "").startswith("tests"):
+            continue
+        found.extend(f"{node.module}.{a.name}" for a in node.names if a.name in known)
+    return found
+
+
+def _parsed_test_modules() -> dict[Path, ast.AST]:
+    return {
+        path: ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for path in sorted(TESTS_ROOT.rglob("*.py"))
+    }
+
+
+class TestFixturesAreSharedViaConftest:
+    def test_the_scan_sees_the_test_tree(self):
+        """Anti-vacuity: an empty scan would pass having checked nothing."""
+        modules = _parsed_test_modules()
+        assert len(modules) >= 50, f"only {len(modules)} test modules found under {TESTS_ROOT}"
+
+        known: set[str] = set()
+        for tree in modules.values():
+            known |= _fixture_names(tree)
+        assert len(known) >= 20, (
+            f"only {len(known)} fixtures detected — the decorator scan is probably "
+            "not matching, which would make the check below vacuously green"
+        )
+
+    def test_no_test_module_imports_a_fixture_from_another_test_module(self):
+        modules = _parsed_test_modules()
+        known: set[str] = set()
+        for tree in modules.values():
+            known |= _fixture_names(tree)
+
+        offenders = {
+            str(path.relative_to(TESTS_ROOT)): imports
+            for path, tree in modules.items()
+            if (imports := _fixture_imports(tree, known))
+        }
+        assert not offenders, (
+            f"Fixtures imported across test modules: {offenders}.\n"
+            "pytest registers an imported fixture as a second FixtureDef, so a "
+            "session- or module-scoped fixture runs its body once per importing "
+            "module. Move it to a conftest.py in the nearest shared directory; "
+            "plain helper functions are fine to import."
+        )
+
+
+class TestTheGuardDiscriminates:
+    """A scan that cannot fail is decoration — prove it flags the real shape."""
+
+    def test_an_imported_fixture_is_flagged(self):
+        provider = ast.parse(
+            "import pytest\n@pytest.fixture(scope='session')\ndef shared_db():\n    yield 1\n"
+        )
+        consumer = ast.parse("from tests.test_migrations.test_roundtrip import shared_db\n")
+
+        known = _fixture_names(provider)
+        assert known == {"shared_db"}
+        assert _fixture_imports(consumer, known) == [
+            "tests.test_migrations.test_roundtrip.shared_db"
+        ]
+
+    def test_importing_a_plain_helper_is_not_flagged(self):
+        provider = ast.parse("def _run_alembic(cmd, url):\n    return None\n")
+        consumer = ast.parse("from tests.test_migrations.conftest import _run_alembic\n")
+
+        assert _fixture_names(provider) == set()
+        assert _fixture_imports(consumer, _fixture_names(provider)) == []

--- a/tests/test_migrations/conftest.py
+++ b/tests/test_migrations/conftest.py
@@ -1,0 +1,137 @@
+"""Shared Postgres harness for the migration tests.
+
+**Why this is a conftest and not an import.** ``test_roundtrip.py`` owned
+``roundtrip_db_url``, and ``test_expand_contract.py`` reached for it with
+``from ...test_roundtrip import roundtrip_db_url``. That looks like sharing and
+isn't: pytest registers an imported fixture as a **separate FixtureDef in the
+importing module**, so ``scope="session"`` caches once per module rather than
+once per session. ``pytest --setup-plan`` showed it plainly::
+
+    SETUP    S roundtrip_db_url      <- for test_expand_contract.py
+    SETUP    S roundtrip_db_url      <- for test_roundtrip.py
+    TEARDOWN S roundtrip_db_url
+    TEARDOWN S roundtrip_db_url
+
+Two setups meant **two Postgres containers per run**, each with its own ryuk and
+its own teardown — and on Windows the second teardown timed out against the
+Docker named pipe, failing an otherwise green suite in ``TEARDOWN`` (session
+``exitstatus=OK, testsfailed=0``) and leaving containers running.
+
+A fixture defined here is discovered by every module in this directory as **one**
+FixtureDef: one container, one teardown. Helpers live here too, so neither test
+module has to import from the other.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+def _docker_available() -> bool:
+    """Fast check for a reachable Docker daemon."""
+    if not shutil.which("docker"):
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "info"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _no_postgres(reason: str) -> None:
+    """Skip locally when Postgres is unavailable — but FAIL in CI.
+
+    The ``migration-roundtrip`` job exists to run these files, so if they skip,
+    the job exits 0 and reports green having verified nothing — while the thing
+    it guards (a downgrade that only matters at 2 AM during a prod rollback)
+    goes unchecked. CI always has both Docker and ``DATABASE_URL_SYNC_TEST``, so
+    reaching here in CI means the workflow broke, and that must be loud.
+
+    Locally, skipping stays correct: devs without Docker shouldn't be blocked.
+    Same reasoning as the connector smoke suite's strict mode (core#407).
+    """
+    if os.environ.get("CI"):
+        pytest.fail(
+            f"{reason}\n\n"
+            "This is a hard failure because CI is expected to provide Postgres "
+            "(DATABASE_URL_SYNC_TEST, or Docker for testcontainers). Skipping here "
+            "would let the migration-roundtrip job pass without testing a single "
+            "migration. Check the job's env block and service container."
+        )
+    pytest.skip(reason)
+
+
+def _run_alembic(cmd: list[str], db_url: str) -> subprocess.CompletedProcess:
+    """Run an alembic command against the test DB.
+
+    Uses `uv run` so the subprocess inherits the project's venv, and
+    passes ``DATABASE_URL_SYNC`` in the environment — alembic's env.py
+    reads `settings.database_url_sync` which is sourced from that env var.
+    """
+    env = {**os.environ, "DATABASE_URL_SYNC": db_url, "DATABASE_URL": db_url}
+    return subprocess.run(
+        ["uv", "run", "alembic", *cmd],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def roundtrip_db_url():
+    """Postgres URL for the migration tests.
+
+    Priority:
+    1. ``DATABASE_URL_SYNC_TEST`` env var (CI, or manual override)
+    2. testcontainers[postgres] auto-provisioned container (local with Docker)
+    3. skip the test locally — but **fail** in CI (see ``_no_postgres``)
+
+    Must be a generator (yield-based) on every path — pytest treats a
+    function with any `yield` as a generator, and hitting `return` on
+    one path while `yield`-ing on another raises
+    ``ValueError: fixture did not yield a value``.
+    """
+    env_url = os.environ.get("DATABASE_URL_SYNC_TEST")
+    if env_url:
+        yield env_url
+        return
+
+    if not _docker_available():
+        _no_postgres(
+            "Round-trip test requires Postgres. Set DATABASE_URL_SYNC_TEST or run "
+            "with Docker Desktop running."
+        )
+
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        _no_postgres(
+            "testcontainers not installed. Install with: "
+            "`uv pip install 'testcontainers[postgres]'` or run CI instead."
+        )
+
+    # One container per pytest session, shared by every module in this
+    # directory. Torn down when the fixture generator exits.
+    container = PostgresContainer("postgres:16-alpine")
+    container.start()
+    try:
+        yield container.get_connection_url().replace("postgresql+psycopg2", "postgresql")
+    finally:
+        container.stop()

--- a/tests/test_migrations/test_expand_contract.py
+++ b/tests/test_migrations/test_expand_contract.py
@@ -48,11 +48,11 @@ import sys
 import pytest
 import sqlalchemy
 
-from tests.test_migrations.test_roundtrip import (  # reuse: one Postgres harness
-    _no_postgres,
-    _run_alembic,
-    roundtrip_db_url,  # noqa: F401 — fixture re-export
-)
+from tests.test_migrations.conftest import _no_postgres, _run_alembic
+
+# `roundtrip_db_url` is deliberately NOT imported. It is a session-scoped
+# fixture in conftest.py and pytest discovers it; importing it here would
+# register a *second* FixtureDef and boot a second Postgres container.
 
 #: What production is running. The `t1` risk is defined against the deployed
 #: release, so this is the ref to compare with — not the merge base.
@@ -162,7 +162,7 @@ def _live_schema(engine) -> dict[str, dict[str, bool]]:
 
 
 @pytest.fixture(scope="module")
-def migrated_schema(roundtrip_db_url):  # noqa: F811 — pytest fixture injection
+def migrated_schema(roundtrip_db_url):
     """Postgres migrated to this branch's head, as `information_schema` sees it."""
     result = _run_alembic(["upgrade", "head"], roundtrip_db_url)
     assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/test_migrations/test_expand_contract.py
+++ b/tests/test_migrations/test_expand_contract.py
@@ -174,16 +174,27 @@ def migrated_schema(roundtrip_db_url):  # noqa: F811 — pytest fixture injectio
         engine.dispose()
 
 
+def _require_deployed_ref() -> None:
+    """Skip locally without the ref; fail loudly in CI, which must have it.
+
+    A shallow ``actions/checkout`` has no ``origin/master``, so every check in
+    this file would compare an empty dict and pass. Locally that is a missing
+    fetch and shouldn't block anyone; in CI it means the workflow lost its
+    fetch step and the guard is silently inert.
+    """
+    if not _deployed_model_files():
+        _no_postgres(
+            f"Cannot read models at {_DEPLOYED_REF!r} — run `git fetch origin master` "
+            "(CI does this explicitly; actions/checkout is shallow). Without it "
+            "this file compares nothing."
+        )
+
+
 class TestDeployedCodeSurvivesTheNewSchema:
     def test_the_deployed_ref_is_readable(self):
         """Guard the guard: no ref, no comparison, and silence would look green."""
-        files = _deployed_model_files()
-        if not files:
-            _no_postgres(
-                f"Cannot read models at {_DEPLOYED_REF!r} — `git fetch origin master` "
-                "first. Without it this file compares nothing."
-            )
-        assert files, f"no model files at {_DEPLOYED_REF}"
+        _require_deployed_ref()
+        assert _deployed_model_files(), f"no model files at {_DEPLOYED_REF}"
 
     def test_the_deployed_models_actually_parsed(self):
         """The hole this whole file exists to avoid, one level up.

--- a/tests/test_migrations/test_expand_contract.py
+++ b/tests/test_migrations/test_expand_contract.py
@@ -1,0 +1,285 @@
+"""The `t1` window: deployed code must survive the new schema (core#449).
+
+Blue/green starts the new container **while the old one still serves**, and
+`alembic upgrade head` runs in its startup command:
+
+    t0  old code + old schema     <- serving
+    t1  old code + NEW schema     <- serving, new container already migrated  *** here ***
+    t2  new code + new schema
+
+At `t1` the previously-deployed version runs against the migrated schema, so a
+drop, rename or `SET NOT NULL` breaks production at that instant — not at the
+swap, and **not in CI, which only ever runs one version against one schema**
+(`plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md`).
+
+Until now the only control was a checklist item — *a human answering a
+question* — which is the same control that let promotion-ref enumeration leak
+until it was automated.
+
+**Why this doesn't literally "run the previous release's test suite".** The
+spec proposes exactly that, and it would prove very little here: almost every
+test builds its schema with `Base.metadata.create_all` on SQLite and never
+touches a migrated Postgres. That job would pass while exercising nothing —
+the failure mode this repo has spent a week removing.
+
+So it asserts the property the checklist actually asks about — *"would the
+currently deployed version still run against this schema?"* — by comparing the
+**deployed release's models** against the **new schema**:
+
+1. migrate a real Postgres to the branch's `head`;
+2. read the deployed release's models straight out of git (AST, never
+   imported — importing two versions of the same package in one process is
+   its own bug);
+3. assert every table and column those models reference still exists, and that
+   nothing tightened to `NOT NULL` under them.
+
+Covered: `DROP COLUMN` · rename · `DROP TABLE` · `SET NOT NULL`.
+Not covered, and left explicit rather than implied: type narrowing, and a new
+`UNIQUE` on an existing column. Both are on the spec's forbidden list; neither
+is reliably derivable from the old models by AST, so the checklist remains the
+control for those two.
+"""
+
+import ast
+import os
+import subprocess
+import sys
+
+import pytest
+import sqlalchemy
+
+from tests.test_migrations.test_roundtrip import (  # reuse: one Postgres harness
+    _no_postgres,
+    _run_alembic,
+    roundtrip_db_url,  # noqa: F401 — fixture re-export
+)
+
+#: What production is running. The `t1` risk is defined against the deployed
+#: release, so this is the ref to compare with — not the merge base.
+_DEPLOYED_REF = os.environ.get("DEPLOYED_REF", "origin/master")
+
+_MODELS_DIR = "datanika/models"
+
+
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], capture_output=True, text=True, timeout=60, check=False)
+
+
+def _deployed_model_files() -> list[str]:
+    result = _git("ls-tree", "--name-only", _DEPLOYED_REF, f"{_MODELS_DIR}/")
+    if result.returncode != 0:
+        return []
+    return [p for p in result.stdout.split() if p.endswith(".py")]
+
+
+def _deployed_schema() -> dict[str, dict[str, bool]]:
+    """{table: {column: nullable}} as the **deployed** models declare it.
+
+    Parsed with `ast` rather than imported: importing the old and new versions
+    of `datanika.models` into one interpreter would collide on module names and
+    on SQLAlchemy's declarative registry.
+    """
+    schema: dict[str, dict[str, bool]] = {}
+
+    for path in _deployed_model_files():
+        blob = _git("show", f"{_DEPLOYED_REF}:{path}")
+        if blob.returncode != 0:
+            continue
+        try:
+            tree = ast.parse(blob.stdout, filename=path)
+        except SyntaxError:  # pragma: no cover - old revision should parse
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            table = _tablename(node)
+            if not table:
+                continue
+            columns = schema.setdefault(table, {})
+            columns.update(_columns(node))
+            # TenantMixin contributes org_id to every tenant table; it is
+            # declared on the mixin, not on each model.
+            if any(getattr(b, "id", getattr(b, "attr", None)) == "TenantMixin" for b in node.bases):
+                columns.setdefault("org_id", False)
+
+    return schema
+
+
+def _tablename(node: ast.ClassDef) -> str | None:
+    for stmt in node.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and any(getattr(t, "id", None) == "__tablename__" for t in stmt.targets)
+            and isinstance(stmt.value, ast.Constant)
+        ):
+            return str(stmt.value.value)
+    return None
+
+
+def _columns(node: ast.ClassDef) -> dict[str, bool]:
+    """Column name -> nullable, for `x: Mapped[...] = mapped_column(...)`."""
+    out: dict[str, bool] = {}
+    for stmt in node.body:
+        if not isinstance(stmt, ast.AnnAssign) or not isinstance(stmt.target, ast.Name):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        if getattr(call.func, "id", getattr(call.func, "attr", None)) != "mapped_column":
+            continue
+
+        name = stmt.target.id
+        # An explicit string first arg overrides the attribute name.
+        if (
+            call.args
+            and isinstance(call.args[0], ast.Constant)
+            and isinstance(call.args[0].value, str)
+        ):
+            name = call.args[0].value
+
+        nullable = False
+        for kw in call.keywords:
+            if kw.arg == "nullable" and isinstance(kw.value, ast.Constant):
+                nullable = bool(kw.value.value)
+            elif kw.arg == "primary_key" and isinstance(kw.value, ast.Constant):
+                nullable = False
+        out[name] = nullable
+    return out
+
+
+def _live_schema(engine) -> dict[str, dict[str, bool]]:
+    """{table: {column: nullable}} as the migrated database actually is."""
+    query = sqlalchemy.text(
+        "SELECT table_name, column_name, is_nullable "
+        "FROM information_schema.columns WHERE table_schema = 'public'"
+    )
+    live: dict[str, dict[str, bool]] = {}
+    with engine.connect() as conn:
+        for table, column, is_nullable in conn.execute(query):
+            live.setdefault(table, {})[column] = is_nullable == "YES"
+    return live
+
+
+@pytest.fixture(scope="module")
+def migrated_schema(roundtrip_db_url):  # noqa: F811 — pytest fixture injection
+    """Postgres migrated to this branch's head, as `information_schema` sees it."""
+    result = _run_alembic(["upgrade", "head"], roundtrip_db_url)
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = sqlalchemy.create_engine(roundtrip_db_url)
+    try:
+        yield _live_schema(engine)
+    finally:
+        engine.dispose()
+
+
+class TestDeployedCodeSurvivesTheNewSchema:
+    def test_the_deployed_ref_is_readable(self):
+        """Guard the guard: no ref, no comparison, and silence would look green."""
+        files = _deployed_model_files()
+        if not files:
+            _no_postgres(
+                f"Cannot read models at {_DEPLOYED_REF!r} — `git fetch origin master` "
+                "first. Without it this file compares nothing."
+            )
+        assert files, f"no model files at {_DEPLOYED_REF}"
+
+    def test_the_deployed_models_actually_parsed(self):
+        """The hole this whole file exists to avoid, one level up.
+
+        Every comparison below is `for table in deployed` — so if the AST walk
+        silently yielded nothing (a refactor to the model style, a moved
+        directory), all three tests pass having compared zero columns. Anchor
+        on tables that must exist in any deployed release.
+        """
+        deployed = _deployed_schema()
+        assert len(deployed) >= 10, (
+            f"only {len(deployed)} tables parsed from {_DEPLOYED_REF} — the AST walk "
+            "is probably not matching the current model style, which would make "
+            "every check below vacuously green"
+        )
+        for table, column in (("users", "email"), ("api_keys", "key_hash")):
+            assert column in deployed.get(table, {}), (
+                f"expected {table}.{column} in the parsed deployed schema; "
+                f"got {sorted(deployed.get(table, {}))}"
+            )
+
+    def test_no_table_the_deployed_release_reads_was_dropped(self, migrated_schema):
+        deployed = _deployed_schema()
+        missing = sorted(t for t in deployed if t not in migrated_schema)
+        assert not missing, (
+            f"Tables dropped that {_DEPLOYED_REF} still reads: {missing}.\n"
+            "At t1 the deployed version runs against this schema and will fail. "
+            "Drop belongs in the CONTRACT phase, a release later "
+            "(plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md)."
+        )
+
+    def test_no_column_the_deployed_release_reads_was_dropped_or_renamed(self, migrated_schema):
+        """A rename is a drop plus an add — it fails here as the drop."""
+        deployed = _deployed_schema()
+        missing = [
+            f"{table}.{column}"
+            for table, columns in deployed.items()
+            if table in migrated_schema
+            for column in columns
+            if column not in migrated_schema[table]
+        ]
+        assert not missing, (
+            f"Columns removed that {_DEPLOYED_REF} still selects: {sorted(missing)}.\n"
+            "SELECT names every mapped column, so the deployed version breaks on "
+            "every query to that table at t1 — not only where the column is used. "
+            "Expand now, contract next release."
+        )
+
+    def test_nothing_tightened_to_not_null_under_the_deployed_release(self, migrated_schema):
+        """The subtler half: the column exists, but old INSERTs now fail."""
+        deployed = _deployed_schema()
+        tightened = [
+            f"{table}.{column}"
+            for table, columns in deployed.items()
+            if table in migrated_schema
+            for column, was_nullable in columns.items()
+            if was_nullable
+            and column in migrated_schema[table]
+            and not migrated_schema[table][column]
+        ]
+        assert not tightened, (
+            f"Columns now NOT NULL that {_DEPLOYED_REF} treats as nullable: "
+            f"{sorted(tightened)}.\n"
+            "The deployed version omits them on INSERT and will fail at t1. "
+            "Backfill and add the constraint in a later release."
+        )
+
+
+class TestTheGuardDiscriminates:
+    """A guard that cannot fail is decoration — prove it fails on a real breach."""
+
+    def test_a_dropped_column_is_detected(self, migrated_schema):
+        pretend_deployed = {"api_keys": {"key_hash": False, "column_we_removed": False}}
+        missing = [
+            f"{t}.{c}"
+            for t, cols in pretend_deployed.items()
+            if t in migrated_schema
+            for c in cols
+            if c not in migrated_schema[t]
+        ]
+        assert missing == ["api_keys.column_we_removed"]
+
+    def test_a_tightened_column_is_detected(self, migrated_schema):
+        assert "api_keys" in migrated_schema, "fixture did not migrate"
+        pretend_deployed = {"api_keys": {"expires_at": True, "key_hash": True}}
+        tightened = [
+            f"{t}.{c}"
+            for t, cols in pretend_deployed.items()
+            for c, was_nullable in cols.items()
+            if was_nullable and c in migrated_schema[t] and not migrated_schema[t][c]
+        ]
+        # key_hash is NOT NULL in the live schema; expires_at is nullable.
+        assert tightened == ["api_keys.key_hash"], (
+            f"expected the NOT NULL column to be flagged, got {tightened}"
+        )
+
+
+if sys.version_info < (3, 12):  # pragma: no cover - repo requires 3.12
+    pytest.skip("requires Python 3.12 AST", allow_module_level=True)

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -28,119 +28,13 @@ skip them.
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-from pathlib import Path
-
-import pytest
 from sqlalchemy import create_engine, inspect, text
 
-PROJECT_ROOT = Path(__file__).parent.parent.parent
+from tests.test_migrations.conftest import _run_alembic
 
-
-def _docker_available() -> bool:
-    """Fast check for a reachable Docker daemon."""
-    if not shutil.which("docker"):
-        return False
-    try:
-        return (
-            subprocess.run(
-                ["docker", "info"],
-                capture_output=True,
-                timeout=5,
-                check=False,
-            ).returncode
-            == 0
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return False
-
-
-def _no_postgres(reason: str) -> None:
-    """Skip locally when Postgres is unavailable — but FAIL in CI.
-
-    The ``migration-roundtrip`` job runs *only* this file, so if these tests
-    skip, the job exits 0 and reports green having verified nothing — while
-    the thing it guards (a downgrade that only matters at 2 AM during a prod
-    rollback) goes unchecked. CI always has both Docker and
-    ``DATABASE_URL_SYNC_TEST``, so reaching here in CI means the workflow
-    broke, and that must be loud.
-
-    Locally, skipping stays correct: devs without Docker shouldn't be blocked.
-    Same reasoning as the connector smoke suite's strict mode (core#407).
-    """
-    if os.environ.get("CI"):
-        pytest.fail(
-            f"{reason}\n\n"
-            "This is a hard failure because CI is expected to provide Postgres "
-            "(DATABASE_URL_SYNC_TEST, or Docker for testcontainers). Skipping here "
-            "would let the migration-roundtrip job pass without testing a single "
-            "migration. Check the job's env block and service container."
-        )
-    pytest.skip(reason)
-
-
-@pytest.fixture(scope="session")
-def roundtrip_db_url():
-    """Postgres URL for round-trip tests.
-
-    Priority:
-    1. ``DATABASE_URL_SYNC_TEST`` env var (CI, or manual override)
-    2. testcontainers[postgres] auto-provisioned container (local with Docker)
-    3. skip the test locally — but **fail** in CI (see ``_no_postgres``)
-
-    Must be a generator (yield-based) on every path — pytest treats a
-    function with any `yield` as a generator, and hitting `return` on
-    one path while `yield`-ing on another raises
-    ``ValueError: fixture did not yield a value``.
-    """
-    env_url = os.environ.get("DATABASE_URL_SYNC_TEST")
-    if env_url:
-        yield env_url
-        return
-
-    if not _docker_available():
-        _no_postgres(
-            "Round-trip test requires Postgres. Set DATABASE_URL_SYNC_TEST or run "
-            "with Docker Desktop running."
-        )
-
-    try:
-        from testcontainers.postgres import PostgresContainer
-    except ImportError:
-        _no_postgres(
-            "testcontainers not installed. Install with: "
-            "`uv pip install 'testcontainers[postgres]'` or run CI instead."
-        )
-
-    # Session-scoped container — one per pytest session. Torn down when
-    # the fixture generator exits.
-    container = PostgresContainer("postgres:16-alpine")
-    container.start()
-    try:
-        yield container.get_connection_url().replace("postgresql+psycopg2", "postgresql")
-    finally:
-        container.stop()
-
-
-def _run_alembic(cmd: list[str], db_url: str) -> subprocess.CompletedProcess:
-    """Run an alembic command against the test DB.
-
-    Uses `uv run` so the subprocess inherits the project's venv, and
-    passes ``DATABASE_URL_SYNC`` in the environment — alembic's env.py
-    reads `settings.database_url_sync` which is sourced from that env var.
-    """
-    env = {**os.environ, "DATABASE_URL_SYNC": db_url, "DATABASE_URL": db_url}
-    return subprocess.run(
-        ["uv", "run", "alembic", *cmd],
-        cwd=PROJECT_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=False,
-    )
+# `roundtrip_db_url` is deliberately NOT imported here. It lives in
+# conftest.py and pytest discovers it automatically; importing a fixture
+# registers a *second* FixtureDef and starts a second Postgres container.
 
 
 def _snapshot_schema(db_url: str) -> dict[str, list[str]]:


### PR DESCRIPTION
Closes #449.

Blue/green starts the new container **while the old one still serves**, and `alembic upgrade head` runs in its startup command. Between the migration and the swap, the **previously deployed code runs against the new schema**:

```
t0  old code + old schema     <- serving
t1  old code + NEW schema     <- serving, already migrated   *** here ***
t2  new code + new schema
```

A drop, rename or `SET NOT NULL` breaks production at `t1` — and **CI cannot see it by construction**, because it only ever runs one version against one schema. Until now the control was a checklist item: *a human answering a question*, the same control that let promotion-ref enumeration leak until it was automated.

## Not the literal job the spec proposes — and that's the point

The spec suggests *"run the previous release's test suite against the new schema."* Written literally, that job would prove almost nothing here: nearly every test builds its schema with `Base.metadata.create_all` on **SQLite** and never touches a migrated Postgres. It would have been the easier thing to write and the harder thing to trust — precisely the failure mode the last week has been spent removing.

So it asserts the property the checklist actually asks about — *"would the currently deployed version still run against this schema?"*:

1. migrate a real Postgres to the branch's `head`;
2. read the **deployed** release's models out of git via AST (`DEPLOYED_REF`, default `origin/master`) — never imported, since two versions of `datanika.models` in one interpreter collide on the declarative registry;
3. assert every table and column those models reference still exists, and that nothing tightened to `NOT NULL` under them.

**Catches:** `DROP COLUMN` · rename (as its drop half) · `DROP TABLE` · `SET NOT NULL`.
**Does not catch:** type narrowing, and a new `UNIQUE` on an existing column. Both are on the spec's forbidden list; neither is reliably derivable from old models by AST. Stated in the module and the spec rather than left implied — those two stay checklist-controlled.

## Proven, not asserted

With a temporary `op.drop_column("api_keys", "name")` migration in the chain, the guard goes **red on exactly the right assertion**, and green without it.

It also **guards its own inputs**: every comparison is `for table in deployed`, so an AST walk that silently matched nothing would make all three checks vacuously green — the same hole, one level up. It asserts ≥10 tables parsed and known columns present.

## CI

Added to the `migration-roundtrip` job, which now does `git fetch --depth=1 origin master`: `actions/checkout` is shallow, and without the deployed ref there is nothing to compare against.

**The `test` job needed the same fetch — and the guard is how I found out.** That job runs `pytest tests/`, so it collects this file too, and on the first run it went red with *"only 0 tables parsed from origin/master"*. That is the anti-vacuity check above doing its job one job earlier than expected: with a shallow tree it had nothing to compare, and it refused to report green over an empty dict.

Fixed by fetching there as well, **not** by `--ignore`ing the file out of that job — `pytest tests/` has to mean the same thing in CI as it does on a dev machine, which is the whole of core#470. The same push also routes `test_the_deployed_models_actually_parsed` through the skip-locally/fail-in-CI helper instead of asserting the ref's contents directly, so a dev who hasn't fetched `master` gets a skip like every other environment-dependent test here, while CI — which is expected to have the ref — still fails loudly.

Full precheck green: ruff + format clean, **2539 passed**.

## A bug this PR introduced, found and fixed here

Chasing the CI failure above, the pre-push suite went **green and then died in teardown**: `testsfailed=0`, `exitstatus=OK`, two Docker npipe read timeouts, three orphaned `postgres:16-alpine` containers. Not Docker being flaky — my own line:

```python
from tests.test_migrations.test_roundtrip import roundtrip_db_url
```

That looks like sharing a fixture and isn't. **pytest registers an imported fixture as a separate FixtureDef in the importing module**, so `scope="session"` caches once per *module* rather than once per session. `pytest --setup-plan` shows it with no ambiguity:

```
SETUP    S roundtrip_db_url      <- for test_expand_contract.py
SETUP    S roundtrip_db_url      <- for test_roundtrip.py
TEARDOWN S roundtrip_db_url
TEARDOWN S roundtrip_db_url
```

Two setups, two Postgres containers, two teardowns — and on Windows the second timed out against the Docker named pipe and failed an otherwise passing run.

Fixed by moving the harness into `tests/test_migrations/conftest.py`, where one FixtureDef serves every module in the directory. **Measured, not assumed:** `78 passed in 83.11s` → `78 passed in 23.56s`, and the full suite `609s` → `218s`. That delta *is* the duplicate container's startup, which is the independent confirmation the diagnosis was right.

`t1proof` re-run afterwards, since the refactor touched the guard's imports and skip path: still red on exactly the right assertion, green without.

## And a guard so it doesn't come back

Nothing in the toolchain catches that mistake. Ruff sees an ordinary import — the original even carried a `# noqa: F401` to silence it — and the suite stays green; the only symptom is a fixture body running once per importing module, invisible until something expensive is inside it. So `tests/test_fixture_sharing.py` AST-scans the test tree for `from tests... import <a @pytest.fixture name>`.

Proven red on the **real** regression rather than synthetic input: putting that exact import back, `# noqa` and all, fails the guard; removing it goes green. It guards its own inputs the same way the t1 check does (≥50 modules, ≥20 fixtures discovered before concluding anything). Repo-wide audit: 164 modules, 93 fixtures, **no remaining cross-module fixture imports**.

## One thing worth knowing beyond this PR

**The issue's status line is stale, and in the direction that matters.** It says *"Blue/green is **not** on prod yet… This lands **before** that, deliberately."* But on the box right now: `datanika-app` is **exited**, `datanika-app-b` is **healthy on :8010**, the vhost proxies via `${DATANIKA_BE}`, and requests through Apache return 200 while `:8000` refuses connections. **Prod has already done at least one blue/green swap** — so the `t1` window has been open, unguarded, for at least the last few hours. That doesn't change this PR, but it does change how soon it wants merging, and it's worth Infra confirming the vhost variable independently.
