### PR TITLE
[QA] Golden path: implement steps 2-5 — connection, CSV upload, run, assert rows (closes #482)

### DIFF
--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -1,0 +1,230 @@
+import { expect, type Page } from "@playwright/test";
+import { gotoReady } from "./auth";
+
+/**
+ * Builders for the golden path: connections, uploads, runs.
+ *
+ * These drive the **real UI**, not the API. That distinction is the whole point
+ * of core#482: the backend create/run path already had API-level coverage (the
+ * nightly connector-smoke matrix, the 2026-07-17 restore check) and both P0s of
+ * 2026-07-22 still reached production through it —
+ *
+ *   - #452 the connections upload handler was annotated bare `list` instead of
+ *     `list[rx.UploadFile]`, so the drop zone returned HTTP 500. Reflex locates
+ *     the upload param by scanning for a generic alias; no API test touches that.
+ *   - #456 `run.*_completed` was emitted with kwargs the registered notification
+ *     handlers could not accept, so `emit()` raised *after* the run finished and
+ *     the surrounding `except` overwrote it with `fail_run(...)`. The run really
+ *     did complete — only the recorded status was wrong.
+ *
+ * So: click what a user clicks, and assert the status a user sees.
+ */
+
+/** A connection type as the picker lists it (see connections.py PICKER_TYPES). */
+export type ConnectionKind = "duckdb" | "csv";
+
+/**
+ * `ConnectionState.set_form_name` runs `re.sub(r"[^a-zA-Z0-9 ]", "", value)` on
+ * every keystroke, so a name with a dash or underscore is silently NOT the name
+ * you typed. Mirror that here rather than asserting on the typed string — a test
+ * that types `qa-golden-1` and looks for `qa-golden-1` fails for a reason that
+ * has nothing to do with the behaviour under test.
+ */
+export function sanitizeName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9 ]/g, "");
+}
+
+/**
+ * Pick a value from a `searchable_select` (components/searchable_select.py).
+ *
+ * It is a Radix popover, not a `<select>`: the trigger is a button whose
+ * accessible name is the placeholder until something is chosen, and the options
+ * are `rx.box`es inside the popover content. We scope option lookup to the
+ * popover — the same text ("duckdb") also appears in the connections table, so
+ * an unscoped `getByText` matches the row behind the overlay and clicks nothing.
+ */
+export async function selectSearchable(
+  page: Page,
+  placeholder: string,
+  optionText: string,
+): Promise<void> {
+  await page.getByRole("button", { name: placeholder, exact: true }).click();
+
+  // Radix portals popover content into a positioned wrapper at the body root.
+  const popover = page.locator("[data-radix-popper-content-wrapper]").last();
+  await expect(popover).toBeVisible();
+
+  // The filter input is pure frontend JS (rx.script), so typing narrows the
+  // list without a round trip. Filtering first keeps the click unambiguous
+  // when one option's text is a prefix of another's.
+  await popover.getByPlaceholder("Search...").fill(optionText);
+
+  await popover.getByText(optionText, { exact: true }).click();
+  await expect(popover).toBeHidden();
+}
+
+/**
+ * Create a DuckDB destination connection and return the name as saved.
+ *
+ * `dbPath` must be reachable from BOTH the web container and the Celery worker:
+ * the load runs in the worker, so a web-only path fails at run time rather than
+ * at save time — the slower, more confusing failure (#471, same reasoning as the
+ * `uploaded_files` volume).
+ */
+export async function createDuckDbConnection(
+  page: Page,
+  name: string,
+  dbPath: string,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/connections");
+
+  await page.getByPlaceholder("Connection name").fill(name);
+  await selectSearchable(page, "Connection type", "duckdb");
+  await page.getByPlaceholder("/data/warehouse.duckdb").fill(dbPath);
+  await page.getByRole("button", { name: "Create Connection" }).click();
+
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `DuckDB connection "${saved}" did not appear in the connections table`,
+  ).toBeVisible({ timeout: 15_000 });
+  return saved;
+}
+
+/**
+ * Create a CSV source connection by uploading a file through the drop zone.
+ *
+ * **This is #452's exact path.** `rx.upload(id="file_upload", no_drag=True)`
+ * renders a react-dropzone with a hidden `<input type="file">`; setting files on
+ * it fires the same `on_drop` → `handle_file_upload` the button does. The bug
+ * returned HTTP 500 on that handler, so asserting the "File uploaded" confirmation
+ * is the assertion that matters — not merely that the connection saved.
+ */
+export async function createCsvConnection(
+  page: Page,
+  name: string,
+  csvPath: string,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/connections");
+
+  await page.getByPlaceholder("Connection name").fill(name);
+  await selectSearchable(page, "Connection type", "csv");
+
+  await page.locator('input[type="file"]').setInputFiles(csvPath);
+
+  // connections.file_uploaded — proves the upload handler returned 2xx. A bare
+  // "connection saved" assertion passes even when the drop zone 500s, because
+  // the file path field is optional.
+  await expect(
+    page.getByText("File uploaded"),
+    "CSV upload did not confirm — the connections upload handler may be failing (see #452)",
+  ).toBeVisible({ timeout: 20_000 });
+
+  await page.getByRole("button", { name: "Create Connection" }).click();
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `CSV connection "${saved}" did not appear in the connections table`,
+  ).toBeVisible({ timeout: 15_000 });
+  return saved;
+}
+
+/**
+ * Create an upload (extract+load) wiring a source connection to a destination.
+ *
+ * Note there is no "pipeline builder" and no "Configure pipeline" button — the
+ * extract-load object is an Upload at `/uploads`. The connector guides describe
+ * a UI that does not exist here (landing#272); the UI is the source of truth.
+ */
+export async function createUpload(
+  page: Page,
+  name: string,
+  sourceOption: string,
+  destOption: string,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/uploads");
+
+  await page.getByPlaceholder("Upload name").fill(name);
+  await selectSearchable(page, "Source connection", sourceOption);
+  await selectSearchable(page, "Destination connection", destOption);
+  await page.getByRole("button", { name: "Create Upload" }).click();
+
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `Upload "${saved}" did not appear in the uploads table`,
+  ).toBeVisible({ timeout: 15_000 });
+  return saved;
+}
+
+/**
+ * The connection picker on /uploads labels options `"{id} — {name} ({type})"`
+ * (upload_state.py). Callers know the name and type but not the id, so match on
+ * the stable tail and read the full label back off the DOM.
+ */
+export async function uploadOptionFor(
+  page: Page,
+  placeholder: string,
+  connectionName: string,
+  kind: ConnectionKind,
+): Promise<string> {
+  await page.getByRole("button", { name: placeholder, exact: true }).click();
+  const popover = page.locator("[data-radix-popper-content-wrapper]").last();
+  await expect(popover).toBeVisible();
+
+  const suffix = `${connectionName} (${kind})`;
+  const option = popover.getByText(new RegExp(`\\d+ — ${suffix}$`));
+  await expect(
+    option,
+    `no ${placeholder} option ending "${suffix}" — is the connection the right type?`,
+  ).toBeVisible({ timeout: 10_000 });
+
+  const label = (await option.textContent())?.trim() ?? "";
+  await page.keyboard.press("Escape");
+  await expect(popover).toBeHidden();
+  return label;
+}
+
+export type RunOutcome = { status: string; rows: number };
+
+/**
+ * Trigger an upload run and wait for it to reach a terminal state.
+ *
+ * Returns whatever terminal state it reached — deliberately does NOT assert
+ * success. The caller asserts, so a failure reads `expected "success", got
+ * "failed"` rather than a timeout, and so #465 (nothing announces
+ * `status="failed"`) cannot be mistaken for a hung run.
+ */
+export async function runUploadAndAwait(
+  page: Page,
+  uploadName: string,
+  timeoutMs = 180_000,
+): Promise<RunOutcome> {
+  await gotoReady(page, "/uploads");
+  const row = page.getByRole("row").filter({ hasText: uploadName });
+  await expect(row, `upload "${uploadName}" is not listed`).toBeVisible();
+  await row.getByRole("button", { name: "Run", exact: true }).click();
+
+  const deadline = Date.now() + timeoutMs;
+  let last: RunOutcome = { status: "(no run row appeared)", rows: 0 };
+
+  while (Date.now() < deadline) {
+    await gotoReady(page, "/runs");
+    const runRow = page.getByRole("row").filter({ hasText: uploadName }).first();
+
+    if (await runRow.isVisible().catch(() => false)) {
+      const cells = runRow.getByRole("cell");
+      // runs.py column order: ID | Target | Status | Started | Finished | Rows | Error | Logs
+      const status = ((await cells.nth(2).textContent()) ?? "").trim();
+      const rows = Number(((await cells.nth(5).textContent()) ?? "0").trim() || 0);
+      last = { status, rows };
+      if (status === "success" || status === "failed") return last;
+    }
+    await page.waitForTimeout(3_000);
+  }
+  throw new Error(
+    `run for "${uploadName}" did not reach a terminal state within ${timeoutMs}ms ` +
+      `(last seen: status="${last.status}", rows=${last.rows}). ` +
+      "Is the Celery worker running?",
+  );
+}

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -1,4 +1,15 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { test, expect, signUp } from "../fixtures/auth";
+import {
+  createCsvConnection,
+  createDuckDbConnection,
+  createUpload,
+  runUploadAndAwait,
+  uploadOptionFor,
+} from "../fixtures/data";
 
 /**
  * Golden path: a new user signs up, creates a connection, uploads a CSV,
@@ -8,14 +19,57 @@ import { test, expect, signUp } from "../fixtures/auth";
  * the critical revenue-producing flow works end to end. If this is red,
  * no other E2E result matters.
  *
- * Unblocked by core#109 (e2e-seed lands in dev). Still tagged @slow because
- * the full stack exercise remains expensive on the GHA runner.
+ * ── Why steps 2–5 are code now (core#482) ────────────────────────────────────
+ * They used to be a comment. The deferral said the backend create/run path was
+ * "covered by the nightly connector-smoke matrix and re-verified via API in the
+ * 2026-07-17 restore check" — both API-level. On 2026-07-22 two P0s reached
+ * production straight through the gap between that coverage and a browser:
+ *
+ *   #452  the connections upload handler returned HTTP 500 (Reflex could not
+ *         find the upload param behind a bare `list` annotation)
+ *   #456  every successful run was recorded FAILED — `emit()` raised on the
+ *         completion hooks and the surrounding `except` called `fail_run(...)`
+ *
+ * Both were found by a person clicking through prod, while `e2e-staging`
+ * reported success on every push. Hence the shape of this spec: drive the UI a
+ * user drives, and assert the terminal run status a user sees.
+ *
+ * #456 is why `expect(status).toBe("success")` is the assertion and "a run row
+ * appeared" is not: the run *did* complete — only its recorded status was
+ * wrong. A test that waited for a run to exist would have passed throughout.
+ *
+ * ── Cost ─────────────────────────────────────────────────────────────────────
+ * Tagged @slow: signup + two connections + an upload + a real Celery run.
+ * @slow specs are excluded unless DATANIKA_E2E_SLOW=1 — which for a long time
+ * no CI job set, so nothing here ran at all (core#484). If you are reading this
+ * because the job is slow, the fix is a smaller fixture — not dropping the tag,
+ * and not un-setting the flag.
  */
-// @slow — full stack exercise (signup + run + destination query). Expensive on
-// the GHA runner (docker-compose + Celery + dbt), so gated to PRs targeting
-// master via DATANIKA_E2E_SLOW=1. See plans/qa/PLAN_QA.md §P0 #1.
+
+const CSV_ROWS = 3;
+const CSV_CONTENT = ["id,name,amount", "1,alpha,100", "2,beta,200", "3,gamma,300", ""].join("\n");
+
+/**
+ * A path both the web container and the Celery worker can reach.
+ * `/app/uploaded_files` is a named volume mounted rw by app, app_b and celery
+ * (docker-compose.yml, #471); anything web-only fails at run time rather than
+ * at save time — the slower, more confusing failure.
+ */
+const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
+
 test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
-  test("new user signs up and reaches the app", async ({ page }) => {
+  // Signup, two connections, an upload and a Celery round trip. The default
+  // 60s budget covers none of that; runUploadAndAwait alone allows 180s.
+  test.setTimeout(360_000);
+
+  test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
+    const stamp = `${Date.now()}`;
+    // set_form_name strips everything outside [a-zA-Z0-9 ], so keep names in
+    // that alphabet — otherwise the saved name is not the one typed.
+    const destName = `qa golden dest ${stamp}`;
+    const srcName = `qa golden src ${stamp}`;
+    const uploadName = `qa golden upload ${stamp}`;
+
     // 1. Signup. signUp() fills the form (incl. the required Full Name) and
     //    handles the Reflex hydration race — it retries if the click falls back
     //    to a native GET submit before on_submit is wired (core#295).
@@ -25,12 +79,37 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
       timeout: 10_000,
     });
 
-    // 2-5. Add a DuckDB connection → upload a CSV → run the pipeline → assert
-    // rows landed. Deferred from this spec: the connection-builder + upload UI
-    // selectors need verification against the live app, and the upload/run steps
-    // need a fixture CSV + an apiClient (fixtures/data.ts) that aren't in the
-    // harness yet. The backend create/run path is covered by the nightly
-    // connector-smoke matrix and was re-verified via API in the 2026-07-17
-    // restore check (run: pending → running → success). Tracked as follow-up.
+    // 2. Destination: a DuckDB file on the shared volume.
+    const savedDest = await createDuckDbConnection(
+      page,
+      destName,
+      `${SHARED_DIR}/qa_golden_${stamp}.duckdb`,
+    );
+
+    // 3. Source: a CSV uploaded through the drop zone — #452's path.
+    const csvPath = join(mkdtempSync(join(tmpdir(), "qa-golden-")), "orders.csv");
+    writeFileSync(csvPath, CSV_CONTENT, "utf8");
+    const savedSrc = await createCsvConnection(page, srcName, csvPath);
+
+    // 4. Wire them together as an Upload (there is no "pipeline builder" UI).
+    const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
+    const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
+    const savedUpload = await createUpload(page, uploadName, sourceOption, destOption);
+
+    // 5. Run it, and assert the status a user would see.
+    const outcome = await runUploadAndAwait(page, savedUpload);
+
+    expect(
+      outcome.status,
+      "the run did not end in `success` — a completed-but-FAILED run is #456's " +
+        "signature: check whether emit() raised on the completion hooks after " +
+        "the run had already finished",
+    ).toBe("success");
+
+    expect(
+      outcome.rows,
+      `expected the ${CSV_ROWS} CSV rows to land in DuckDB, got ${outcome.rows}. ` +
+        "A `success` run that moved zero rows is a load that silently did nothing.",
+    ).toBeGreaterThanOrEqual(CSV_ROWS);
   });
 });


### PR DESCRIPTION
Closes #482. Related: #484 (deliberately **not** fixed here — see "What this does not do").

## Why

`golden-path.spec.ts` described itself as *"the single most important test in the suite"* and then deferred steps 2–5 to a comment. It asserted signup, and that a "Connections" link was visible.

Both P0s of 2026-07-22 live inside the steps that were missing — **#452** (connections upload → HTTP 500) and **#456** (every successful run recorded FAILED) — and both were found by a person clicking through prod while `e2e-staging` reported success on every push.

The deferral note claimed the gap was *"covered by the nightly connector-smoke matrix and re-verified via API in the 2026-07-17 restore check"*. Both are **API-level**; #452 was a Reflex upload-param annotation and #456 was the completion-hook path, so **neither named check could have caught either bug.** The stated coverage did not cover the thing that broke.

## What it does

New `e2e/fixtures/data.ts` (connection / upload / run builders) + steps 2–5 wired into the spec, driving the **real** UI rather than the docs'\'' UI (landing#272):

- there is no pipeline builder — extract-load is an **Upload** at `/uploads`
- `set_form_name` runs `re.sub(r"[^a-zA-Z0-9 ]", "", value)` on every keystroke, so the saved name is not the typed one; `sanitizeName` mirrors it
- the type picker is a Radix popover, not a `<select>`; option lookup is scoped to the popover because "duckdb" also appears in the table behind the overlay
- the DuckDB path goes on `/app/uploaded_files` — the volume mounted rw by app **and** celery (#471). The load runs in the worker, so a web-only path fails at *run* time, not save time

Selectors are **derived from the UI source**, not guessed. The pre-existing `walkthrough-connectors.mjs` uses four-deep fallback chains, which is what unverified selectors look like.

### The two assertions that matter

```ts
expect(outcome.status).toBe("success");            // not "a run appeared"
expect(outcome.rows).toBeGreaterThanOrEqual(3);     // not "status is success"
```

**#456 is why the first is a status assertion and not an existence check** — the run genuinely completed and was *then* overwritten as failed, so a test waiting for a run to exist would have passed throughout the outage. The second exists because a `success` run that moved zero rows is a load that silently did nothing.

`runUploadAndAwait` returns the terminal state rather than asserting it, so a regression reads `expected "success", got "failed"` instead of a timeout.

## Verified

| Check | Result |
|---|---|
| Playwright collects the spec | ✅ appears with `DATANIKA_E2E_SLOW=1` |
| `@slow` gating behaves as documented | ✅ 5 tests / 2 files without it → 62 / 11 with it |
| TypeScript (strict) | ✅ no errors attributable to this code |
| Full core suite (pre-push hook) | ✅ **2568 passed, 20 skipped** |

## ⚠️ Not verified — read before merging

**This spec has not been run against a live application.** I could not get a trustworthy environment:

- no CF Access service token on this box, so staging is unreachable locally
- the local images are 3–5 months old, and the main checkout is at `75ae404` (**before** #452'\''s fix) **and** carries another agent'\''s uncommitted work — building from it would have validated the wrong code and disturbed a colleague, so I stopped the build rather than produce a false confirmation

So: it parses, it type-checks, and its selectors are source-derived — but **it has not been forced red, and it has not been seen green.** Treating it as proven would be exactly the mistake this PR exists to correct.

**Suggested merge path:** land it (it cannot make anything worse — nothing runs `@slow` today), then run it once by hand against staging with `DATANIKA_E2E_SLOW=1`, fix whatever the real DOM disagrees with, and only then wire it into a gate.

## What this does not do

**It does not turn on `DATANIKA_E2E_SLOW` in `e2e-staging`.** That is #484 — no CI job sets the flag, so *every* `@slow` spec (this one, tenant-JWT-boundary, tenant-isolation, RBAC, viewer-role, all 16 SSO specs) is filtered out of every run. Fixing #482 without #484 ships a better test that still never executes.

I left the gate alone deliberately: switching on ~57 specs that have **never** run in CI, in the same change that adds an unverified one, converts one unknown into a blocking gate made of unknowns. The flag should be flipped once, deliberately, with the run log read spec-by-spec.

`playwright.config.ts`'\''s comment is corrected here, since it actively documented a master-PR workflow that does not exist.

Also noted, not fixed: `@types/node` is absent from `e2e/package.json`, so the harness has never been typecheckable (`global-setup.ts` and `auth.ts` already import node builtins). Left out to keep this focused.