### PR TITLE
[Infra] pre-push: set UV_NO_SYNC, and warn on branch/commit issue mismatch (closes #487)

### DIFF
--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -121,11 +121,23 @@ jobs:
       # unchanged, so `compose up -d` won't recreate, and Grafana only reads provisioning
       # at startup. Before this step, a deployed alerting change silently did nothing
       # while CI and CD both reported success (#426).
+      #
+      # --force-recreate is NOT belt-and-braces, it is load-bearing. Six mounts here are
+      # single FILES (prometheus.yml, blackbox.yml, four Grafana dashboards), and a
+      # single-file bind mount pins the INODE. `tar xzf` replaces the file rather than
+      # editing it, so the container keeps reading the old inode forever — and
+      # `POST /-/reload` then re-reads that stale file and reports success.
+      #
+      # Observed 2026-07-22: host prometheus.yml inode=1317518 (1898 bytes, with the
+      # app_b scrape job) while the container held inode=1317530 (1222 bytes, 15h old,
+      # without it). `prometheus_config_last_reload_successful` was 1 the whole time.
+      # Grafana's provisioning escaped only because it is a DIRECTORY mount.
+      # Recreating rebinds the current inode.
       - name: Reload monitoring config
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
             'cd /opt/datanika/datanika && set -a && . ./.env.docker && set +a && \
-             docker compose up -d prometheus grafana blackbox && \
+             docker compose up -d --force-recreate prometheus grafana blackbox && \
              for i in $(seq 1 20); do curl -fsS -X POST http://127.0.0.1:9090/-/reload >/dev/null 2>&1 && { echo "prometheus reloaded"; break; }; sleep 3; \
                [ "$i" = 20 ] && { echo "prometheus /-/reload never succeeded"; exit 1; }; done && \
              docker restart datanika-grafana >/dev/null && echo "grafana restarted"'
@@ -143,20 +155,57 @@ jobs:
               > /tmp/live-rules.json 2>/dev/null && break
             sleep 5
           done
+          curl -sf http://127.0.0.1:9090/api/v1/status/config -o /tmp/live-promcfg.json || true
           python3 - <<'PY'
-          import json, re, sys
-          expected = len(re.findall(r"^\s*-\s*uid:\s*\S+",
-              open("/opt/datanika/datanika/monitoring/grafana/provisioning/alerting/alerts.yml",
-                   encoding="utf-8").read(), re.M))
+          import json, re, sys, yaml
+
+          REPO = "/opt/datanika/datanika/monitoring"
+          failed = False
+
+          # --- alert rules: COUNT is not enough -------------------------------------
+          # A count check passes for any change that edits expressions without adding or
+          # removing rules — which is exactly what #480 did, so this step went green
+          # while Grafana still held the old expressions. Compare the expressions too.
+          src = open(f"{REPO}/grafana/provisioning/alerting/alerts.yml", encoding="utf-8").read()
+          defined = {}
+          for g in yaml.safe_load(src)["groups"]:
+              for r in g["rules"]:
+                  defined[r["title"]] = (r["data"][0]["model"].get("expr") or "").strip()
           try:
-              live = len(json.load(open("/tmp/live-rules.json")))
+              live_rules = json.load(open("/tmp/live-rules.json"))
           except Exception as e:
               print("could not read live rules from Grafana:", e); sys.exit(1)
-          print(f"alert rules: defined={expected} live={live}")
-          if live != expected:
-              print("MISMATCH - Grafana did not load the deployed rules (provisioning error?)")
-              sys.exit(1)
-          print("alert rules are in effect")
+          live = {r["title"]: (r["data"][0]["model"].get("expr") or "").strip() for r in live_rules}
+
+          print(f"alert rules: defined={len(defined)} live={len(live)}")
+          if len(defined) != len(live):
+              print("MISMATCH - rule count differs"); failed = True
+          drift = [t for t, e in defined.items() if live.get(t, "<missing>") != e]
+          if drift:
+              failed = True
+              print(f"MISMATCH - {len(drift)} rule(s) whose LIVE expression differs from the repo:")
+              for t in drift[:8]:
+                  print(f"  {t}\n    repo: {e_ := defined[t]}\n    live: {live.get(t, '<missing>')}")
+          else:
+              print("all rule expressions match the repo")
+
+          # --- prometheus scrape config --------------------------------------------
+          # Single-FILE bind mounts pin the inode, so a tar deploy can leave the container
+          # reading a file that no longer exists while /-/reload reports success. Compare
+          # the LOADED config against the repo rather than trusting the reload (#479).
+          want = {j["job_name"] for j in yaml.safe_load(open(f"{REPO}/prometheus.yml", encoding="utf-8"))["scrape_configs"]}
+          try:
+              got = {j["job_name"] for j in yaml.safe_load(json.load(open("/tmp/live-promcfg.json"))["data"]["yaml"])["scrape_configs"]}
+          except Exception as e:
+              print("could not read live prometheus config:", e); sys.exit(1)
+          if want != got:
+              failed = True
+              print(f"MISMATCH - prometheus scrape jobs differ.\n  repo-only: {sorted(want - got)}\n  live-only: {sorted(got - want)}")
+              print("  (classic cause: single-file bind mount pinned to a replaced inode — recreate the container)")
+          else:
+              print(f"prometheus scrape jobs match the repo ({len(got)} jobs)")
+
+          sys.exit(1 if failed else 0)
           PY
           VERIFY
       - name: Smoke through Cloudflare

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -25,6 +25,37 @@ if [[ "$BRANCH" != "dev" && "$BRANCH" != "master" && "$BRANCH" != "main" ]]; the
   fi
 fi
 
+# --- branch/commit consistency -------------------------------------------------------
+# Catches commits that landed on the wrong branch. Branches are `<issue>-<slug>`
+# (WORKFLOW_RULES §2), so if this branch names an issue, the commits being pushed should
+# close THAT issue — not a different one.
+#
+# Real case, 2026-07-22: a script ran `git commit --amend` without checking out its own
+# branch first, so it rewrote the message of whatever was HEAD. Branch
+# `486-inode-stale-config` ended up carrying "closes #477". The PR had the right content,
+# the wrong title, and would have closed the wrong issue and left misleading history.
+#
+# Warn-only by design: closing several issues at once is legitimate, and a branch may
+# predate its issue. The value is making the mismatch impossible to miss, not blocking.
+BRANCH_ISSUE=$(printf '%s' "$BRANCH" | sed -nE 's/^([0-9]+)-.*/\1/p')
+if [ -n "$BRANCH_ISSUE" ]; then
+  RANGE=$(git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1 && echo '@{upstream}..HEAD' || echo 'origin/dev..HEAD')
+  CLOSES=$(git log --format=%B "$RANGE" 2>/dev/null \
+           | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' \
+           | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')
+  if [ -n "$CLOSES" ] && ! printf '%s' "$CLOSES" | grep -qw "$BRANCH_ISSUE"; then
+    echo ""
+    echo "  pre-push WARNING: branch/commit mismatch"
+    echo "      branch '$BRANCH' refers to issue #$BRANCH_ISSUE"
+    echo "      commits close: $(printf '%s' "$CLOSES" | sed 's/\([0-9][0-9]*\)/#\1/g')"
+    echo ""
+    echo "      Usually means a commit landed on the wrong branch — e.g. 'git commit --amend'"
+    echo "      run without checking out its own branch first, which rewrites whatever is HEAD."
+    echo "      Check with: git log --oneline $RANGE"
+    echo ""
+  fi
+fi
+
 # Find venv
 if [ -x ".venv/Scripts/python.exe" ]; then
   PY=".venv/Scripts/python.exe"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -40,7 +40,18 @@ echo "pre-push: ruff check"
 echo "pre-push: ruff format --check"
 "$PY" -m ruff format --check datanika tests
 echo "pre-push: pytest"
-"$PY" -m pytest tests/ -x -q --tb=short
+# UV_NO_SYNC=1 is NOT optional on Windows. test_head_downgrade_upgrade_roundtrip shells
+# out to `uv run alembic`, which tries to replace native extensions (sqlalchemy's
+# cyextension, cryptography, ...) while this pytest process still holds the files open.
+# Windows refuses, the removal half-completes, and the venv is left gutted — presenting
+# as "my dependencies randomly vanished" and sending people hunting for a cause that
+# isn't there.
+#
+# WORKFLOW_RULES §3 has documented this as mandatory since it cost QA, and then Growth
+# four reinstalls — and the stated lesson was that a fix living only in prose gets
+# rediscovered the expensive way. It was still only in prose: the hook never set it.
+# Setting it here means nobody has to know.
+UV_NO_SYNC=1 "$PY" -m pytest tests/ -x -q --tb=short
 
 # Helm lint — only if chart files were modified in the push range
 if command -v helm >/dev/null 2>&1 && [ -d "$REPO_ROOT/deploy/helm" ]; then


### PR DESCRIPTION
`WORKFLOW_RULES` §3 documents `UV_NO_SYNC=1` as **not optional on Windows** — `test_head_downgrade_upgrade_roundtrip` shells out to `uv run alembic`, which replaces native extensions while pytest still holds them open, leaving a gutted venv that presents as *"my dependencies randomly vanished"*.

The rule records that it bit QA, then bit Growth for four reinstalls, and states the lesson:

> A fix recorded only in your dept's `current_state.md` will be rediscovered the expensive way by someone else.

**It was still only in prose.** The hook ran plain `pytest` with no `UV_NO_SYNC`, so the trap was avoidable only by having read §3 and remembering — which is the thing §3 says doesn't work.

I hit it twice tonight pushing an unrelated CI change, and **both times it presented as a Docker failure** (a `container.stop()` npipe timeout, then a ryuk pull failing at setup). I checked Docker health first and it was fine. That misdirection is the strongest argument for fixing it in the tooling: the symptom doesn't point at the cause.

One line in the hook. Documenting an environment trap tells people what to do; putting it in the tooling means nobody has to know.