### PR TITLE
[Infra] CI: cache uv builds, keyed on the lockfile (closes #477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:
@@ -55,6 +61,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:
@@ -120,6 +132,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:
@@ -241,6 +259,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
**Measured before fixing, and the issue's premise does not hold — the slowdown is real but not persistent.**

| run | sha | lint | test | migration-roundtrip |
|---|---|---|---|---|
| before #475 | `561c975` | 17s | 137s | 39s |
| **#475 lands** | `30bd41b` | **188s** | **299s** | **218s** |
| next run, same config | `2f63cd8` | **38s** | **149s** | **47s** |

No cache existed between the last two runs, so the ~3 min/job figure in the issue was a **cold run**, not the steady state.

**The cache is still worth having** — the cold case is ~4× slower and every `uv.lock` change pays it — but it is worth roughly **2 min on a cold run**, not 3 min on every job. Better that the record is accurate than that someone later tunes CI against a number that was never real.

Applied to **all four** `setup-uv` steps rather than just the slowest — the same class of miss that left the SSH keepalive in `deploy-pointer.yml` but not `ci.yml` earlier today, which then broke a promotion.

**This cannot be validated by its own run**: the run that populates a cache always pays full price, so green CI here proves nothing about the benefit. I will post before/after from a rerun after merge. If the cache underdelivers, the fallback from the issue (build the SAML pair once in a setup job, share via artifact) is next — reverting the source builds is not, since that silently restores #470.