### PR TITLE
[QA] Wire the @slow specs into e2e-staging — no CI job set DATANIKA_E2E_SLOW (closes #484)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,10 +332,50 @@ jobs:
           DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
           DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
           DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
+          # Include @slow specs (core#484). Until 2026-07-22 NO job set this, so
+          # `playwright.config.ts`'s grepInvert silently dropped every @slow spec
+          # from every run: this job reported success having executed 5 of 62
+          # tests, both files about `?template=` handling. golden-path,
+          # tenant-jwt-boundary, tenant-isolation, rbac and viewer-role-ui had
+          # never gated a merge.
+          #
+          # Safe to switch on wholesale because the expensive-and-unavailable
+          # specs gate themselves independently, and therefore skip rather than
+          # fail: sso-* need DATANIKA_E2E_SSO_AUTHENTIK (its own job is
+          # `if: false` — the IdP was not rebuilt after the 2026-07-17 outage)
+          # and overage-charge-cycle needs DATANIKA_E2E_OVERAGE_CHARGE plus the
+          # Paddle sandbox secrets, which the nightly soak owns. Neither is set
+          # here, so this flag adds 5 real specs, not 57.
+          #
+          # This job is NOT a required check on `dev` (those are lint + test),
+          # so a red here is loud without blocking anyone's merge — which is the
+          # point: the signal was missing, not the tests.
+          DATANIKA_E2E_SLOW: "1"
           DATANIKA_E2E_SEED_CMD: >-
             ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
             'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
+
+      # A green tick above is not evidence that anything ran — that is exactly
+      # how core#484 hid for months. Print the collected count so the run log
+      # carries the number, and fail if it collapses back toward the fast subset.
+      - name: Assert the @slow specs were actually collected
+        if: always()
+        working-directory: e2e
+        env:
+          DATANIKA_E2E_SLOW: "1"
+          DATANIKA_E2E_SKIP_SEED: "1"
+          DATANIKA_E2E_USER_EMAIL: collected-count@datanika.test
+        run: |
+          # stderr is deliberately NOT suppressed: if --list itself breaks, the
+          # count is 0 and the reason needs to be readable, not swallowed.
+          LAST=$(npx playwright test --list | tail -1)
+          echo "playwright --list said: $LAST"
+          COUNT=$(printf '%s' "$LAST" | grep -oE '[0-9]+' | head -1)
+          if [ "${COUNT:-0}" -lt 40 ]; then
+            echo "::error::Only ${COUNT:-0} tests collected (expected 60+). The @slow specs are being filtered out again — see core#484."
+            exit 1
+          fi
 
       - name: Upload Playwright report
         if: always()

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,9 +23,15 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   globalSetup: require.resolve("./global-setup"),
-  // @slow tests run only when explicitly included via --grep.
-  // CI workflow for PRs to `master` sets DATANIKA_E2E_SLOW=1 to include them;
-  // PRs to `dev` run the fast subset. See plans/qa/PLAN_QA.md §P0 #1.
+  // @slow tests run only when DATANIKA_E2E_SLOW=1.
+  //
+  // The `e2e-staging` job sets it (core#484). Before 2026-07-22 **no job did**,
+  // and this comment claimed a "PRs to `master`" workflow that did not exist —
+  // so every @slow spec was dropped from every run and the job reported success
+  // having executed 5 of 62 tests. Local runs default to the fast subset.
+  //
+  // If you are tempted to unset it to speed CI up: that is the bug, not the fix.
+  // The job asserts the collected count precisely to stop it regressing.
   grepInvert: process.env.DATANIKA_E2E_SLOW === "1" ? undefined : /@slow/,
   reporter: [
     ["list"],


### PR DESCRIPTION
Closes #484. **Merge this before #485** — otherwise #485 lands green having never executed, which is the failure this PR exists to end.

## The defect

`playwright.config.ts` drops `@slow` unless `DATANIKA_E2E_SLOW=1`, and **no CI job set it.** The only two occurrences in `.github/workflows` were the overage nightly (its own spec) and the `e2e-sso` job — gated **`if: false`**. `e2e-staging` never set it and is itself gated to `push` on `dev`, so the "PRs to `master`" workflow the config comment described **does not exist.**

Measured two independent ways that agree exactly — the [CI run log for 29877770817](https://github.com/datanika-io/datanika-core/actions/runs/29877770817) and a local `playwright test --list`:

```
with    DATANIKA_E2E_SLOW=1 → Total: 62 tests in 11 files
without DATANIKA_E2E_SLOW   → Total:  5 tests in  2 files
```

**`e2e-staging: success` meant 3 passing assertions across two `?template=` specs.** `golden-path`, `tenant-jwt-boundary` (Q1a — the VC-memo P0), `tenant-isolation`, `rbac` and `viewer-role-ui` had never gated a merge. PLAN_QA records them as shipped *and wired into CI*. They were shipped.

## Why flipping it wholesale is safe

I expected this to switch on ~57 never-run specs and said so when I declined to do it in #485. Checking rather than assuming, it does not: **the unavailable specs gate themselves and therefore skip rather than fail.**

| Spec group | Self-gate | Effect here |
|---|---|---|
| `sso-*` (16) | `DATANIKA_E2E_SSO_AUTHENTIK` | skips — IdP not rebuilt since the 07-17 outage; its own job is `if: false` |
| `overage-charge-cycle` (3) | `DATANIKA_E2E_OVERAGE_CHARGE` + Paddle sandbox vars | skips — the nightly soak owns those, no interference with Gate 4 |
| `golden-path`, `tenant-jwt-boundary`, `tenant-isolation`, `rbac`, `viewer-role-ui` | none | **actually run** |

So this adds **5 real specs, not 57.**

And `e2e-staging` is **not a required check** on `dev` — `gh api .../branches/dev/protection` returns `["lint","test"]` — so a red here is loud without blocking anyone'\''s merge. The signal was what was missing, not the tests.

## Expect the first run to tell you something

Four security specs are about to execute in CI for the first time, alongside #485'\''s golden path, which has never run anywhere. **A red first run is a successful first run.** The alternative — leaving them filtered — is what we have been doing.

## The count assert

A green tick is not evidence anything ran; that is precisely how this hid. The new step prints what `--list` collected and fails below 40. Verified by breaking what it guards:

| Condition | Collected | Guard |
|---|---|---|
| flag set | 62 | passes |
| flag unset | 5 | **fails** |

stderr is deliberately not suppressed — if `--list` itself breaks, the count is 0 and the reason has to be readable.

## Note for #485

This PR also corrects the `playwright.config.ts` comment. #485 edits the same lines with the pre-fix wording, so **rebase #485 onto this and keep this version.**