### PR TITLE
[QA] e2e-staging: seed API keys + point SSO specs at staging — the 40 failures are harness, not security (closes #496)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,9 +351,21 @@ jobs:
           # so a red here is loud without blocking anyone's merge — which is the
           # point: the signal was missing, not the tests.
           DATANIKA_E2E_SLOW: "1"
+          # sso-edge-cases hits the backend directly via fixtures/sso.ts, which
+          # defaults to http://localhost:8000 — on a CI runner that is nothing,
+          # and 5 specs died with `connect ECONNREFUSED ::1:8000` (core#496).
+          # The e2e-sso job has always set this; this job never did.
+          DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
+          # E2E_SEED_INCLUDE_API_KEYS=1 is required by rbac / tenant-isolation /
+          # tenant-jwt-boundary: without it the payload carries no keys and the
+          # fixtures throw at setup (`DATANIKA_E2E_API_KEY_READONLY not set`),
+          # which reads in the log as ~35 tenant-isolation FAILURES rather than
+          # as a missing flag (core#496). global-setup.ts already maps all three
+          # keys and every org-B field; only the flag was missing. Org B itself
+          # is seeded unconditionally — there is no second-tenant gate.
           DATANIKA_E2E_SEED_CMD: >-
             ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
-            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
+            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 -e E2E_SEED_INCLUDE_API_KEYS=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
 
       # A green tick above is not evidence that anything ran — that is exactly


### PR DESCRIPTION
Closes #496. Follow-up to #484 — the gate is on, and the first real run showed the specs could not have passed anyway.

## The run that prompted this

[29901632458](https://github.com/datanika-io/datanika-core/actions/runs/29901632458) — **40 failed / 16 skipped / 6 passed**, 62 collected.

**None of the 40 are security failures.** The log reads `Tenant isolation: org A cannot read org B — FAILED` twenty times, which is exactly what a catastrophic multi-tenancy breach would look like. The tell that it is not: **7ms, 19ms, 40ms**. Nothing reaches staging and back in 7ms — those specs threw before issuing a request.

## Two causes, both in this job'\''s own config

| # | Symptom | Cause | Specs |
|---|---|---|---|
| 1 | `DATANIKA_E2E_API_KEY_READONLY not set` | seed exec omits `E2E_SEED_INCLUDE_API_KEYS=1` | ~35 — `rbac`, `tenant-isolation`, `tenant-jwt-boundary` |
| 2 | `connect ECONNREFUSED ::1:8000` | `fixtures/sso.ts` defaults `DATANIKA_E2E_BACKEND_URL` to localhost; `e2e-sso` sets it (ci.yml:604), this job never did | 5 — `sso-edge-cases` |

`global-setup.ts` **already maps all three API keys and every org-B field** (lines 174–186). Nothing was missing but the flag. Org B is seeded unconditionally — there is no second-tenant gate, despite what PLAN_QA Q1a still implies.

## Why this is worse than #484 alone

**The four security specs could not have passed in CI even on the day someone flipped the flag.** The gap was two layers deep: not wired, *and* not runnable. Enabling the gate was necessary but not sufficient, and only running it could have revealed that.

It is also urgent in a way #484 was not. A gate that is red for harness reasons trains people to ignore it — the same disease as a green that proves nothing, wearing the opposite colour. Every hour it stays red costs credibility it will need later.

## Correcting myself

In #491 I asserted the SSO specs would **skip** because they gate on `DATANIKA_E2E_SSO_AUTHENTIK`. Five of `sso-edge-cases` do not — they exercise error paths needing no IdP — so they ran and failed. I derived that table from reading the specs rather than running them, which is the mistake this whole thread is about. The run is the correction.

## After this lands

The next `e2e-staging` run is the **first honest read** on the tenant/RBAC boundary. Expect it to be genuinely informative in either direction — and note it still will not cover the golden path, which lands separately in #485.