### PR TITLE
[Engineering] File sources load contents, not a file listing (closes #492)

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -3,9 +3,11 @@
 import logging
 import os
 import shutil
+from pathlib import PurePosixPath
 
 import dlt
-from dlt.sources.filesystem import filesystem
+from dlt.common import json as dlt_json
+from dlt.sources.filesystem import filesystem, read_csv, read_parquet
 from dlt.sources.rest_api import rest_api_source
 from dlt.sources.sql_database import sql_database, sql_table
 
@@ -18,6 +20,28 @@ DEFAULT_BATCH_SIZE = 10_000
 SUPPORTED_FILE_TYPES = {"s3", "csv", "json", "parquet"}
 
 DEFAULT_FILE_GLOBS = {"csv": "*.csv", "json": "*.json", "parquet": "*.parquet", "s3": "*"}
+
+# dlt's `filesystem()` is a *lister*: it yields one FileItem per matched file
+# (name, size, mtime, mime type). Reading contents requires piping it through a
+# transformer. Without one the destination gets a table of filenames and the run
+# reports success — core#492, found on prod on the advertised onboarding path.
+FILE_FORMAT_BY_TYPE = {"csv": "csv", "json": "json", "parquet": "parquet"}
+
+# `s3` (and any glob-driven source) carries no format in its type, so it is
+# inferred from the pattern's extension. Deliberately not defaulted: guessing
+# wrong here reproduces exactly the failure this fixes, just one layer along.
+FILE_FORMAT_BY_EXTENSION = {
+    ".csv": "csv",
+    ".tsv": "csv",
+    ".txt": "csv",
+    ".json": "json",
+    ".jsonl": "json",
+    ".ndjson": "json",
+    ".parquet": "parquet",
+    ".pq": "parquet",
+}
+
+_GLOB_WILDCARDS = "*?["
 
 AWS_CREDENTIAL_KEYS = {"aws_access_key_id", "aws_secret_access_key", "region_name", "endpoint_url"}
 
@@ -62,6 +86,10 @@ INTERNAL_CONFIG_KEYS = {
     "filters",
     "bucket_url",
     "file_glob",
+    "file_format",
+    "table_name",
+    "delimiter",
+    "encoding",
     "resources",
     "resource_names",
     "paginator",
@@ -169,6 +197,141 @@ def _normalize_oracle_identifier(name: str | None) -> str | None:
     from sqlalchemy.dialects.oracle.base import OracleDialect
 
     return OracleDialect().normalize_name(name) or name
+
+
+def _json_chunks(file_obj, chunksize: int):
+    """Yield lists of records from one JSON file, whatever shape it is.
+
+    dlt ships `read_jsonl`, which is **JSON Lines only**, but our default glob
+    for the `json` connection type is `*.json` — the array/object case. Feeding
+    an array to `read_jsonl` does not fail: the whole file parses as one value,
+    so dlt writes a parent row with no business columns plus a `__value` child
+    table. Another green run with the data in the wrong shape (core#492).
+
+    So the shape is detected rather than assumed:
+      - `[...]`        -> the array's elements are the records
+      - one JSON value -> a single record (a dict) or its elements (a list)
+      - otherwise      -> JSON Lines, streamed a line at a time
+    """
+    head = file_obj.read(1024)
+    file_obj.seek(0)
+    first = head.lstrip()[:1]
+
+    if first == b"[":
+        records = dlt_json.loadb(file_obj.read())
+        for start in range(0, len(records), chunksize):
+            yield records[start : start + chunksize]
+        return
+
+    chunk = []
+    for line in file_obj:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            chunk.append(dlt_json.loadb(line))
+        except Exception:
+            # Not line-delimited after all — most likely one pretty-printed
+            # object spanning many lines. Re-read it as a whole.
+            file_obj.seek(0)
+            value = dlt_json.loadb(file_obj.read())
+            yield value if isinstance(value, list) else [value]
+            return
+        if len(chunk) >= chunksize:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+@dlt.transformer(name="json_records")
+def read_json(items, chunksize: int = 1000):
+    """Read JSON files whose shape is not known ahead of time.
+
+    Companion to dlt's `read_csv` / `read_parquet` / `read_jsonl`, covering the
+    gap that `read_jsonl` leaves: arrays and single objects.
+    """
+    for file_obj in items:
+        with file_obj.open() as f:
+            yield from _json_chunks(f, chunksize)
+
+
+def _resolve_file_format(connection_type: str, file_glob: str, dlt_config: dict) -> str:
+    """Decide which reader a file source needs — or refuse to guess.
+
+    Order: an explicit `file_format` wins; then the connection type, which
+    names the format for `csv`/`json`/`parquet`; then the glob's extension,
+    which is all `s3` has to go on.
+
+    A bare `s3` glob (`*`) reaches none of those, and **that raises**. Loading
+    the file listing instead is what core#492 was, and picking a format at
+    random would be the same bug with a different payload.
+    """
+    explicit = dlt_config.get("file_format")
+    if explicit:
+        normalized = str(explicit).lower().lstrip(".")
+        if normalized in {"jsonl", "ndjson"}:
+            return "json"
+        if normalized not in {"csv", "json", "parquet"}:
+            raise DltRunnerError(
+                f"Unsupported file_format {explicit!r}. Supported: csv, json, parquet."
+            )
+        return normalized
+
+    by_type = FILE_FORMAT_BY_TYPE.get(connection_type)
+    if by_type:
+        return by_type
+
+    suffix = PurePosixPath(file_glob).suffix.lower()
+    by_extension = FILE_FORMAT_BY_EXTENSION.get(suffix)
+    if by_extension:
+        return by_extension
+
+    raise DltRunnerError(
+        f"Cannot tell what format {file_glob!r} matches, so there is no way to read it. "
+        "Set 'file_format' (csv, json or parquet) in the pipeline config, or narrow "
+        "the file pattern to one extension (e.g. '*.csv')."
+    )
+
+
+def _build_format_reader(file_format: str, dlt_config: dict):
+    """Build the transformer for a resolved format, with its format options."""
+    if file_format == "csv":
+        # `read_csv` forwards **pandas_kwargs, so the CSV knobs are pandas'.
+        # Only forwarded when set — pandas already infers the header row and
+        # column types, and an unrequested override is a silent wrong answer.
+        pandas_kwargs = {}
+        if dlt_config.get("delimiter"):
+            pandas_kwargs["sep"] = dlt_config["delimiter"]
+        if dlt_config.get("encoding"):
+            pandas_kwargs["encoding"] = dlt_config["encoding"]
+        return read_csv(**pandas_kwargs)
+
+    if file_format == "parquet":
+        return read_parquet()
+
+    return read_json()
+
+
+def _file_table_name(connection_type: str, file_glob: str, dlt_config: dict) -> str:
+    """Name the destination table for a file source.
+
+    Required, not cosmetic: a piped transformer takes the transformer's name,
+    so the unrenamed result lands in a table called **`_read_csv`** — which
+    reads as a dlt internal. Order: an explicit `table_name`; then the glob's
+    stem when it names one file (`customers.csv` -> `customers`); then the
+    connection type, which is at least stable and predictable.
+    """
+    explicit = dlt_config.get("table_name")
+    if explicit:
+        return str(explicit)
+
+    if not any(char in file_glob for char in _GLOB_WILDCARDS):
+        stem = PurePosixPath(file_glob).stem
+        if stem:
+            return stem
+
+    return connection_type
 
 
 class DltRunnerService:
@@ -348,7 +511,12 @@ class DltRunnerService:
             return sql_database(**kwargs)
 
     def _build_file_source(self, connection_type: str, config: dict, dlt_config: dict):
-        """Build a dlt filesystem source for file-based connections."""
+        """Build a dlt filesystem source that loads file **contents**.
+
+        `filesystem()` alone lists files; piping it through a format reader is
+        what produces rows. See `_resolve_file_format` for how the reader is
+        chosen and `_file_table_name` for why the result is always renamed.
+        """
         bucket_url = dlt_config.get("bucket_url") or config.get("bucket_url", "")
         if not bucket_url:
             raise DltRunnerError("File sources require 'bucket_url' in config or dlt_config")
@@ -362,7 +530,11 @@ class DltRunnerService:
             if credentials:
                 kwargs["credentials"] = credentials
 
-        return filesystem(**kwargs)
+        file_format = _resolve_file_format(connection_type, file_glob, dlt_config)
+        reader = _build_format_reader(file_format, dlt_config)
+        table_name = _file_table_name(connection_type, file_glob, dlt_config)
+
+        return (filesystem(**kwargs) | reader).with_name(table_name)
 
     @staticmethod
     def _rest_api_from_parts(

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -3,6 +3,7 @@
 import logging
 import traceback
 from collections import defaultdict
+from pathlib import PurePosixPath
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -202,6 +203,15 @@ def run_upload(
                 if uploaded_file:
                     extracted_dir = file_svc.extract_for_dlt(uploaded_file)
                     dlt_config["bucket_url"] = extracted_dir
+                    # Name the table after the file the user uploaded. This is
+                    # the only layer that knows the original name — the runner
+                    # sees a hash-named extract dir and a `*.csv` glob, so
+                    # without this the advertised onboarding run lands in a
+                    # table called `csv` (core#492).
+                    if not dlt_config.get("table_name"):
+                        stem = PurePosixPath(uploaded_file.original_name).stem
+                        if stem:
+                            dlt_config["table_name"] = stem
 
             try:
                 from datanika.config import settings as app_cfg

--- a/tests/test_services/test_dlt_file_sources.py
+++ b/tests/test_services/test_dlt_file_sources.py
@@ -1,0 +1,255 @@
+"""File sources must load file **contents** (core#492).
+
+`dlt`'s `filesystem()` is a *lister*: it yields one record per matched file
+(name, size, mtime, mime type). Reading contents requires piping it through a
+format transformer. Without one, prod loaded a **table of filenames**, reported
+`success`, and showed `Rows: 1` — that 1 being the file, not the data. On the
+zero-credentials onboarding path we advertise hardest.
+
+**Why 2,500 green tests said nothing about it.** Every existing test in
+`TestBuildFileSource` patches `datanika.services.dlt_runner.filesystem` and
+asserts the kwargs we passed, with the mock returning the string `"csv_src"`.
+What dlt *yields* was unobservable to all of them, so the entire defect lived
+in the gap between "we called it correctly" and "it returns rows".
+
+So this file mocks nothing. It writes real files, runs a real dlt pipeline into
+a real DuckDB, and asserts the rows and columns that actually land. Every test
+here fails on the pre-fix code — that is the point of it existing.
+"""
+
+import json
+
+import pytest
+
+from datanika.services.dlt_runner import DltRunnerError, DltRunnerService
+
+duckdb = pytest.importorskip("duckdb", reason="file-source loads assert against a real DuckDB")
+
+CUSTOMERS = [
+    {"customer_id": 1001, "full_name": "Ada Lovelace", "lifetime_value_usd": 1840.00},
+    {"customer_id": 1002, "full_name": "Grace Hopper", "lifetime_value_usd": 7325.50},
+]
+
+#: The columns `filesystem()` yields when nobody pipes it through a reader.
+#: Their presence in a destination table *is* the bug.
+FILE_LISTING_COLUMNS = {"file_name", "relative_path", "file_url", "mime_type", "size_in_bytes"}
+
+
+def _write_csv(directory, name="customers.csv", delimiter=","):
+    header = delimiter.join(["customer_id", "full_name", "lifetime_value_usd"])
+    lines = [
+        delimiter.join([str(r["customer_id"]), r["full_name"], str(r["lifetime_value_usd"])])
+        for r in CUSTOMERS
+    ]
+    path = directory / name
+    path.write_text("\n".join([header, *lines]) + "\n", encoding="utf-8")
+    return path
+
+
+def _load(source, tmp_path, label="probe"):
+    """Run a real dlt pipeline into DuckDB; return {table: (columns, rows)}."""
+    import dlt
+
+    db_path = tmp_path / f"{label}.duckdb"
+    pipeline = dlt.pipeline(
+        pipeline_name=f"t492_{label}",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="probe",
+        pipelines_dir=str(tmp_path / f"state_{label}"),
+    )
+    pipeline.run(source)
+
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        tables = con.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'probe' AND table_name NOT LIKE '\\_dlt%' ESCAPE '\\'"
+        ).fetchall()
+        out = {}
+        for (table,) in tables:
+            columns = [
+                c[0]
+                for c in con.execute(f'DESCRIBE probe."{table}"').fetchall()
+                if not c[0].startswith("_dlt")
+            ]
+            rows = con.execute(f'SELECT count(*) FROM probe."{table}"').fetchone()[0]
+            out[table] = (columns, rows)
+        return out
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def svc():
+    return DltRunnerService(pipelines_dir="/tmp/t492")
+
+
+class TestFileContentsActuallyLand:
+    def test_csv_loads_rows_not_a_file_listing(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "csv")
+
+        assert len(tables) == 1, f"expected one table, got {sorted(tables)}"
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS), f"expected {len(CUSTOMERS)} data rows, got {rows}"
+        assert "customer_id" in columns and "full_name" in columns
+        assert not FILE_LISTING_COLUMNS & set(columns), (
+            f"the file *listing* landed instead of the data: {columns}"
+        )
+
+    def test_csv_values_survive_the_round_trip(self, svc, tmp_path):
+        """Row count alone would pass on a table of two filenames."""
+        _write_csv(tmp_path)
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "table_name": "customers"}
+        )
+        _load(source, tmp_path, "csvvals")
+
+        con = duckdb.connect(str(tmp_path / "csvvals.duckdb"), read_only=True)
+        try:
+            names = {r[0] for r in con.execute("SELECT full_name FROM probe.customers").fetchall()}
+        finally:
+            con.close()
+        assert names == {"Ada Lovelace", "Grace Hopper"}
+
+    def test_json_array_loads_flat_not_as_a_nested_child_table(self, svc, tmp_path):
+        """The shape dlt's own `read_jsonl` gets wrong.
+
+        Fed an array, `read_jsonl` parses the whole file as one value: dlt then
+        writes a parent row with no business columns plus a `__value` child
+        table. Green run, data in the wrong shape — the same class of failure as
+        the file listing.
+        """
+        (tmp_path / "customers.json").write_text(json.dumps(CUSTOMERS), encoding="utf-8")
+        source = svc.build_source("json", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "jsonarray")
+
+        assert len(tables) == 1, f"expected one flat table, got {sorted(tables)}"
+        table, (columns, rows) = next(iter(tables.items()))
+        assert not table.endswith("__value"), f"data landed in a child table: {table}"
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns
+
+    def test_json_lines_load(self, svc, tmp_path):
+        (tmp_path / "customers.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in CUSTOMERS), encoding="utf-8"
+        )
+        source = svc.build_source("json", {}, {"bucket_url": str(tmp_path), "file_glob": "*.jsonl"})
+
+        tables = _load(source, tmp_path, "jsonl")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns
+
+    def test_a_single_pretty_printed_object_loads_as_one_row(self, svc, tmp_path):
+        """Not line-delimited and not an array — the third real shape."""
+        (tmp_path / "customer.json").write_text(json.dumps(CUSTOMERS[0], indent=2), "utf-8")
+        source = svc.build_source("json", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "jsonobj")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == 1
+        assert "customer_id" in columns
+
+    def test_parquet_loads_rows(self, svc, tmp_path):
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        pd.DataFrame(CUSTOMERS).to_parquet(tmp_path / "customers.parquet", index=False)
+
+        source = svc.build_source("parquet", {}, {"bucket_url": str(tmp_path)})
+        tables = _load(source, tmp_path, "parquet")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS)
+        assert not FILE_LISTING_COLUMNS & set(columns)
+
+    def test_custom_delimiter_is_honoured(self, svc, tmp_path):
+        """A semicolon export read as comma-delimited yields one fused column."""
+        _write_csv(tmp_path, delimiter=";")
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path), "delimiter": ";"})
+
+        tables = _load(source, tmp_path, "semicolon")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns and "full_name" in columns
+
+
+class TestTableNaming:
+    def test_the_table_is_not_named_after_the_transformer(self, svc, tmp_path):
+        """Unrenamed, a piped transformer lands in `_read_csv`.
+
+        That reads as a dlt internal table, and `_dlt`-prefixed names are how
+        dlt marks its own bookkeeping — so the naive fix trades a wrong payload
+        for a table users would reasonably ignore.
+        """
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "naming")
+
+        for table in tables:
+            assert not table.startswith("_"), f"table {table!r} looks like a dlt internal"
+
+    def test_explicit_table_name_wins(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "table_name": "customers_daily"}
+        )
+        assert "customers_daily" in _load(source, tmp_path, "explicitname")
+
+    def test_a_single_named_file_names_the_table(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "file_glob": "customers.csv"}
+        )
+        assert "customers" in _load(source, tmp_path, "stemname")
+
+    def test_a_wildcard_glob_falls_back_to_the_connection_type(self, svc, tmp_path):
+        """Documents the fallback rather than leaving it to be discovered.
+
+        A wildcard matches many files, so no filename can name the table. The
+        connection type is at least stable and predictable. The *advertised*
+        upload path doesn't rely on this — `upload_tasks` sets `table_name`
+        from the uploaded file's original name, which is the only layer that
+        knows it (the runner sees a hash-named extract dir).
+        """
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+        assert "csv" in _load(source, tmp_path, "wildcardname")
+
+
+class TestUnreadableFormatsRefuseInsteadOfGuessing:
+    def test_bare_s3_glob_raises_rather_than_loading_a_listing(self, svc):
+        """`s3` + `*` carries no format. Guessing reproduces core#492."""
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("s3", {"bucket_url": "s3://bucket"}, {})
+
+        message = str(exc.value)
+        assert "file_format" in message, f"error should name the fix, got: {message}"
+
+    def test_s3_infers_the_format_from_the_pattern(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source("s3", {}, {"bucket_url": str(tmp_path), "file_glob": "*.csv"})
+        (columns, rows) = next(iter(_load(source, tmp_path, "s3csv").values()))
+        assert rows == len(CUSTOMERS)
+
+    def test_explicit_file_format_overrides_an_ambiguous_pattern(self, svc, tmp_path):
+        _write_csv(tmp_path, name="customers.data")
+        source = svc.build_source(
+            "s3",
+            {},
+            {"bucket_url": str(tmp_path), "file_glob": "*.data", "file_format": "csv"},
+        )
+        (columns, rows) = next(iter(_load(source, tmp_path, "explicitfmt").values()))
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns
+
+    def test_an_unknown_file_format_is_rejected(self, svc):
+        with pytest.raises(DltRunnerError, match="Unsupported file_format"):
+            svc.build_source("s3", {}, {"bucket_url": "s3://b", "file_format": "avro"})

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -302,49 +302,66 @@ class TestBuildSource:
 # ---------------------------------------------------------------------------
 # build_source — file types (Step 25)
 # ---------------------------------------------------------------------------
+def _fake_lister():
+    """A real (empty) dlt resource standing in for `filesystem()`.
+
+    These tests assert *the kwargs we hand dlt*, which is still worth pinning —
+    but the mock can no longer return a bare string, because `build_source` now
+    pipes the lister into a format reader (core#492). A string isn't pipeable,
+    and `result == "csv_src"` was never evidence of anything anyway: it asserted
+    the mock's own return value. Contents are covered for real, against real
+    files and a real DuckDB, in `test_dlt_file_sources.py`.
+    """
+    import dlt
+
+    return dlt.resource(lambda: iter([]), name="filesystem")
+
+
 class TestBuildFileSource:
     @patch("datanika.services.dlt_runner.filesystem")
     def test_csv_source_uses_filesystem(self, mock_fs, svc):
-        mock_fs.return_value = "csv_src"
-        result = svc.build_source("csv", {}, {"bucket_url": "/data"})
+        mock_fs.return_value = _fake_lister()
+        svc.build_source("csv", {}, {"bucket_url": "/data"})
         mock_fs.assert_called_once()
-        assert result == "csv_src"
         kwargs = mock_fs.call_args[1]
         assert kwargs["bucket_url"] == "/data"
         assert kwargs["file_glob"] == "*.csv"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_json_source_default_glob(self, mock_fs, svc):
-        mock_fs.return_value = "json_src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("json", {}, {"bucket_url": "/data"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["file_glob"] == "*.json"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_parquet_source_default_glob(self, mock_fs, svc):
-        mock_fs.return_value = "pq_src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("parquet", {}, {"bucket_url": "/data"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["file_glob"] == "*.parquet"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_s3_source_passes_credentials(self, mock_fs, svc):
-        mock_fs.return_value = "s3_src"
+        mock_fs.return_value = _fake_lister()
         config = {
             "aws_access_key_id": "AKID",
             "aws_secret_access_key": "secret",
             "region_name": "us-east-1",
             "bucket_url": "s3://my-bucket",
         }
-        svc.build_source("s3", config, {})
+        # A format is required now: `s3` + the default `*` glob names no format,
+        # and guessing one is how core#492 happened. See
+        # TestUnreadableFormatsRefuseInsteadOfGuessing.
+        svc.build_source("s3", config, {"file_glob": "*.csv"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["bucket_url"] == "s3://my-bucket"
-        assert kwargs["file_glob"] == "*"
+        assert kwargs["file_glob"] == "*.csv"
         assert kwargs["credentials"]["aws_access_key_id"] == "AKID"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_custom_file_glob_overrides_default(self, mock_fs, svc):
-        mock_fs.return_value = "src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("csv", {}, {"bucket_url": "/data", "file_glob": "reports_*.csv"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["file_glob"] == "reports_*.csv"
@@ -361,7 +378,7 @@ class TestBuildFileSource:
     @patch("datanika.services.dlt_runner.filesystem")
     def test_bucket_url_from_config(self, mock_fs, svc):
         """bucket_url can come from connection config instead of dlt_config."""
-        mock_fs.return_value = "src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("csv", {"bucket_url": "/from/config"}, {})
         kwargs = mock_fs.call_args[1]
         assert kwargs["bucket_url"] == "/from/config"


### PR DESCRIPTION
Closes #492.

`dlt`'s `filesystem()` is a **file lister** — it yields one record per matched file (name, size, mtime, mime type). Reading contents requires piping it through a format transformer. [`dlt_runner.py`](datanika/services/dlt_runner.py) returned the lister raw, so every `csv` / `json` / `parquet` / `s3` source loaded **a table of filenames**, reported `success`, and displayed `Rows: 1` — that 1 being the file, not the data. On the zero-credentials onboarding path we advertise hardest.

## Verified against real dlt before writing anything

The bug exists because nobody ever observed what `filesystem()` yields, so I didn't start from the API docs either. Reproduced it and tested the candidate fix against real dlt + real DuckDB first:

```
=== today: the lister, raw (this is prod) ===
bare-filesystem   table='filesystem'   rows=1  cols=['file_name','relative_path','file_url','mime_type','modification_date','size_in_bytes']

=== candidate fix ===
csv               table='_read_csv'    rows=2  cols=['customer_id','full_name','email','lifetime_value_usd']
json-array        table='_read_jsonl'          rows=1  cols=[]
json-array        table='_read_jsonl__value'   rows=2  cols=['customer_id','full_name']
```

That run settled three design questions that reading the docs would not have.

## Four decisions, and why

**1. The table must be renamed — it isn't cosmetic.** A piped transformer inherits *the transformer's* name, so the naive fix lands the advertised onboarding table in **`_read_csv`**. A leading underscore is exactly how dlt marks its own bookkeeping tables (`_dlt_loads`, `_dlt_version`), so the naive fix trades a wrong payload for a table users would reasonably scroll past. Naming order: explicit `table_name` → the glob's stem when it names one file (`customers.csv` → `customers`) → the connection type.

`upload_tasks` supplies `table_name` from the uploaded file's `original_name`, because **that is the only layer that knows it** — the runner sees a hash-named extract directory and a `*.csv` glob. Without it the advertised run lands in a table called `csv`.

**2. JSON needed a reader dlt doesn't ship.** `read_jsonl` is JSON **Lines** only, but our default glob for the `json` type is `*.json` — the array/object case. Fed an array it *doesn't fail*: the whole file parses as one value, so dlt writes a parent row with no business columns plus a `__value` child table (see the probe above). That is the same class of failure as the file listing — green run, data in the wrong shape — so fixing one and leaving the other would have been half a fix. `read_json` detects the three real shapes: array, single object (including pretty-printed across lines), and JSON Lines.

**3. An unresolvable format raises instead of guessing.** `s3` carries no format in its type and defaults to the glob `*`. Format resolution is: explicit `file_format` → connection type → the glob's extension → **`DltRunnerError` naming the fix**. Picking a default here would be core#492 again with a different payload. This is a **behaviour change**: an `s3` connection with a bare `*` glob now errors where it previously "succeeded". It was loading a file listing, so the error is strictly more truthful — but it is user-visible and worth knowing before promotion.

**4. CSV knobs are explicit, not sniffed.** pandas already infers the header row and column types, which is the "best-effort detection" half worth having. `delimiter` and `encoding` are forwarded **only when set**: a mis-sniffed delimiter yields one fused column or shifted data — a green run with wrong contents, which is the precise failure this PR exists to remove. Guessing is what got us here.

## Tests that would have caught it

The issue's diagnosis of why 2,500 green tests said nothing is exact, and worth restating because it generalises: every test in `TestBuildFileSource` patched `filesystem` and asserted **the kwargs we passed**, with the mock returning the string `"csv_src"`. `assert result == "csv_src"` asserted the mock's own return value. What dlt *yields* was unobservable to all of them, so the defect lived entirely in the gap between "we called it correctly" and "it returns rows".

`tests/test_services/test_dlt_file_sources.py` mocks nothing: real files → real dlt pipeline → real DuckDB → assert the columns, the row counts, and the values.

**Proven red on the pre-fix code — 14 of 15 fail** when `_build_file_source` is reverted to `return filesystem(**kwargs)`. The one that stays green is `test_the_table_is_not_named_after_the_transformer`, correctly: pre-fix the table is `filesystem`, which isn't underscore-prefixed. It guards the *naive fix*, not the original bug.

The old mocked tests are repaired rather than deleted — the kwargs contract (glob defaults, credential mapping) is still worth pinning cheaply, now that something real covers contents.

## Not fixed here

- **#493** (a glob matching nothing completes as `success`) is now *more* visible, not less: with real row counts, an empty match reads as `Rows: 0` on a green run. Still its own issue.
- **#494** (DuckDB loads never reach the Catalog) untouched.
- **UI + docs follow-up: #499.** `delimiter` / `encoding` / `file_format` are settable in pipeline config but have **no connection-schema fields**, so they can't be reached from the UI. That bites hardest on decision 3: an `s3` user now gets an error telling them to set `file_format`, and there is nowhere to set it. #499 also covers correcting the CSV guide, which promises delimiter/encoding "best-effort detection" that decision 4 deliberately does not do. Filed rather than left as a paragraph here — a residual documented only in a PR body is not tracked work.
