### PR TITLE
[QA] Make golden-path failures diagnosable — bound actions, name steps, keep traces on cancel (closes #501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,13 @@ jobs:
       # Raw test-results fallback. The HTML report can fail to render when
       # the trace JSON is truncated (process killed mid-write, OOM, etc.) —
       # the raw traces + screenshots + videos survive that class of failure.
-      - name: Upload raw test-results (failure only)
-        if: failure()
+      # `always()`, not `failure()`: the concurrency group cancels this job
+      # whenever another push lands on dev mid-run, and a CANCELLED job is not a
+      # FAILED one — so the traces and screenshots from the run that just failed
+      # were never uploaded. That happened on golden-path's first execution and
+      # cost the entire diagnosis (core#501).
+      - name: Upload raw test-results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results

--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -18,7 +18,21 @@ import { gotoReady } from "./auth";
  *     did complete — only the recorded status was wrong.
  *
  * So: click what a user clicks, and assert the status a user sees.
+ *
+ * ── Every interaction is explicitly bounded (core#501) ───────────────────────
+ * `playwright.config.ts` sets a test timeout and an *expect* timeout but no
+ * `actionTimeout`, so Playwright actions default to **unbounded** — they are
+ * capped only by the enclosing test. The first run of this spec proved what
+ * that costs: a locator never resolved, `.fill()` sat on it for the full
+ * 6-minute test budget, and the report said nothing except "timed out". A
+ * six-minute silence is not a test result.
+ *
+ * Hence `UI_TIMEOUT` on every action. A wrong selector now fails in ~15s and
+ * names itself, which is the difference between a diagnosis and another run.
  */
+
+/** Bound for a single UI interaction. Long enough for Reflex's WS round trip. */
+const UI_TIMEOUT = 15_000;
 
 /** A connection type as the picker lists it (see connections.py PICKER_TYPES). */
 export type ConnectionKind = "duckdb" | "csv";
@@ -35,6 +49,17 @@ export function sanitizeName(value: string): string {
 }
 
 /**
+ * Assert a locator is present before acting on it, with a message naming what
+ * was expected. Without this, a bad selector surfaces as a bare timeout on
+ * whatever action came next.
+ */
+async function present(page: Page, locator: ReturnType<Page["locator"]>, what: string) {
+  await expect(locator.first(), `could not find ${what} on ${page.url()}`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
+}
+
+/**
  * Pick a value from a `searchable_select` (components/searchable_select.py).
  *
  * It is a Radix popover, not a `<select>`: the trigger is a button whose
@@ -48,19 +73,27 @@ export async function selectSearchable(
   placeholder: string,
   optionText: string,
 ): Promise<void> {
-  await page.getByRole("button", { name: placeholder, exact: true }).click();
+  const trigger = page.getByRole("button", { name: placeholder, exact: true });
+  await present(page, trigger, `searchable-select trigger "${placeholder}"`);
+  await trigger.click({ timeout: UI_TIMEOUT });
 
   // Radix portals popover content into a positioned wrapper at the body root.
   const popover = page.locator("[data-radix-popper-content-wrapper]").last();
-  await expect(popover).toBeVisible();
+  await expect(popover, `popover for "${placeholder}" did not open`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
 
   // The filter input is pure frontend JS (rx.script), so typing narrows the
   // list without a round trip. Filtering first keeps the click unambiguous
   // when one option's text is a prefix of another's.
-  await popover.getByPlaceholder("Search...").fill(optionText);
+  await popover.getByPlaceholder("Search...").fill(optionText, { timeout: UI_TIMEOUT });
 
-  await popover.getByText(optionText, { exact: true }).click();
-  await expect(popover).toBeHidden();
+  const option = popover.getByText(optionText, { exact: true });
+  await expect(option, `option "${optionText}" not offered by "${placeholder}"`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
+  await option.click({ timeout: UI_TIMEOUT });
+  await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
 }
 
 /**
@@ -79,15 +112,22 @@ export async function createDuckDbConnection(
   const saved = sanitizeName(name);
   await gotoReady(page, "/connections");
 
-  await page.getByPlaceholder("Connection name").fill(name);
+  const nameField = page.getByPlaceholder("Connection name");
+  await present(page, nameField, 'the connection-name field (placeholder "Connection name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
   await selectSearchable(page, "Connection type", "duckdb");
-  await page.getByPlaceholder("/data/warehouse.duckdb").fill(dbPath);
-  await page.getByRole("button", { name: "Create Connection" }).click();
+
+  const pathField = page.getByPlaceholder("/data/warehouse.duckdb");
+  await present(page, pathField, "the DuckDB path field — did the type picker actually apply?");
+  await pathField.fill(dbPath, { timeout: UI_TIMEOUT });
+
+  await page.getByRole("button", { name: "Create Connection" }).click({ timeout: UI_TIMEOUT });
 
   await expect(
     page.getByRole("cell", { name: saved, exact: true }),
     `DuckDB connection "${saved}" did not appear in the connections table`,
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
   return saved;
 }
 
@@ -108,10 +148,18 @@ export async function createCsvConnection(
   const saved = sanitizeName(name);
   await gotoReady(page, "/connections");
 
-  await page.getByPlaceholder("Connection name").fill(name);
+  const nameField = page.getByPlaceholder("Connection name");
+  await present(page, nameField, 'the connection-name field (placeholder "Connection name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
   await selectSearchable(page, "Connection type", "csv");
 
-  await page.locator('input[type="file"]').setInputFiles(csvPath);
+  const fileInput = page.locator('input[type="file"]');
+  await expect(
+    fileInput.first(),
+    "no <input type=file> — rx.upload did not render for the csv type",
+  ).toBeAttached({ timeout: UI_TIMEOUT });
+  await fileInput.setInputFiles(csvPath, { timeout: UI_TIMEOUT });
 
   // connections.file_uploaded — proves the upload handler returned 2xx. A bare
   // "connection saved" assertion passes even when the drop zone 500s, because
@@ -119,13 +167,13 @@ export async function createCsvConnection(
   await expect(
     page.getByText("File uploaded"),
     "CSV upload did not confirm — the connections upload handler may be failing (see #452)",
-  ).toBeVisible({ timeout: 20_000 });
+  ).toBeVisible({ timeout: 30_000 });
 
-  await page.getByRole("button", { name: "Create Connection" }).click();
+  await page.getByRole("button", { name: "Create Connection" }).click({ timeout: UI_TIMEOUT });
   await expect(
     page.getByRole("cell", { name: saved, exact: true }),
     `CSV connection "${saved}" did not appear in the connections table`,
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
   return saved;
 }
 
@@ -145,15 +193,18 @@ export async function createUpload(
   const saved = sanitizeName(name);
   await gotoReady(page, "/uploads");
 
-  await page.getByPlaceholder("Upload name").fill(name);
+  const nameField = page.getByPlaceholder("Upload name");
+  await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
   await selectSearchable(page, "Source connection", sourceOption);
   await selectSearchable(page, "Destination connection", destOption);
-  await page.getByRole("button", { name: "Create Upload" }).click();
+  await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
 
   await expect(
     page.getByRole("cell", { name: saved, exact: true }),
     `Upload "${saved}" did not appear in the uploads table`,
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
   return saved;
 }
 
@@ -168,20 +219,25 @@ export async function uploadOptionFor(
   connectionName: string,
   kind: ConnectionKind,
 ): Promise<string> {
-  await page.getByRole("button", { name: placeholder, exact: true }).click();
+  const trigger = page.getByRole("button", { name: placeholder, exact: true });
+  await present(page, trigger, `searchable-select trigger "${placeholder}"`);
+  await trigger.click({ timeout: UI_TIMEOUT });
+
   const popover = page.locator("[data-radix-popper-content-wrapper]").last();
-  await expect(popover).toBeVisible();
+  await expect(popover, `popover for "${placeholder}" did not open`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
 
   const suffix = `${connectionName} (${kind})`;
   const option = popover.getByText(new RegExp(`\\d+ — ${suffix}$`));
   await expect(
     option,
     `no ${placeholder} option ending "${suffix}" — is the connection the right type?`,
-  ).toBeVisible({ timeout: 10_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
 
   const label = (await option.textContent())?.trim() ?? "";
   await page.keyboard.press("Escape");
-  await expect(popover).toBeHidden();
+  await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
   return label;
 }
 
@@ -198,12 +254,12 @@ export type RunOutcome = { status: string; rows: number };
 export async function runUploadAndAwait(
   page: Page,
   uploadName: string,
-  timeoutMs = 180_000,
+  timeoutMs = 150_000,
 ): Promise<RunOutcome> {
   await gotoReady(page, "/uploads");
   const row = page.getByRole("row").filter({ hasText: uploadName });
-  await expect(row, `upload "${uploadName}" is not listed`).toBeVisible();
-  await row.getByRole("button", { name: "Run", exact: true }).click();
+  await expect(row, `upload "${uploadName}" is not listed`).toBeVisible({ timeout: UI_TIMEOUT });
+  await row.getByRole("button", { name: "Run", exact: true }).click({ timeout: UI_TIMEOUT });
 
   const deadline = Date.now() + timeoutMs;
   let last: RunOutcome = { status: "(no run row appeared)", rows: 0 };
@@ -212,7 +268,7 @@ export async function runUploadAndAwait(
     await gotoReady(page, "/runs");
     const runRow = page.getByRole("row").filter({ hasText: uploadName }).first();
 
-    if (await runRow.isVisible().catch(() => false)) {
+    if (await runRow.isVisible({ timeout: 5_000 }).catch(() => false)) {
       const cells = runRow.getByRole("cell");
       // runs.py column order: ID | Target | Status | Started | Finished | Rows | Error | Logs
       const status = ((await cells.nth(2).textContent()) ?? "").trim();

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -59,8 +59,10 @@ const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
 
 test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
   // Signup, two connections, an upload and a Celery round trip. The default
-  // 60s budget covers none of that; runUploadAndAwait alone allows 180s.
-  test.setTimeout(360_000);
+  // 60s covers none of that. Deliberately NOT larger: every interaction is
+  // individually bounded in fixtures/data.ts, so this cap should never be what
+  // fails — if it is, something is hanging that no per-action timeout covers.
+  test.setTimeout(300_000);
 
   test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
     const stamp = `${Date.now()}`;
@@ -70,34 +72,38 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
     const srcName = `qa golden src ${stamp}`;
     const uploadName = `qa golden upload ${stamp}`;
 
-    // 1. Signup. signUp() fills the form (incl. the required Full Name) and
-    //    handles the Reflex hydration race — it retries if the click falls back
-    //    to a native GET submit before on_submit is wired (core#295).
-    await signUp(page);
-    await expect(page).toHaveURL(/\/(dashboard|connections|onboarding)?$/);
-    await expect(page.getByRole("link", { name: "Connections" }).first()).toBeVisible({
-      timeout: 10_000,
+    // Each phase is a named step so a failure reports WHICH phase broke. The
+    // first CI run of this spec died as an unqualified 6-minute timeout and the
+    // report could not say where — a result that costs a full run to learn
+    // nothing (core#501).
+    await test.step("1. sign up and reach the app", async () => {
+      // signUp() fills the form (incl. the required Full Name) and handles the
+      // Reflex hydration race — it retries if the click falls back to a native
+      // GET submit before on_submit is wired (core#295).
+      await signUp(page);
+      await expect(page).toHaveURL(/\/(dashboard|connections|onboarding)?$/);
+      await expect(page.getByRole("link", { name: "Connections" }).first()).toBeVisible({
+        timeout: 10_000,
+      });
     });
 
-    // 2. Destination: a DuckDB file on the shared volume.
-    const savedDest = await createDuckDbConnection(
-      page,
-      destName,
-      `${SHARED_DIR}/qa_golden_${stamp}.duckdb`,
-    );
+    const savedDest = await test.step("2. create the DuckDB destination", async () =>
+      createDuckDbConnection(page, destName, `${SHARED_DIR}/qa_golden_${stamp}.duckdb`));
 
-    // 3. Source: a CSV uploaded through the drop zone — #452's path.
-    const csvPath = join(mkdtempSync(join(tmpdir(), "qa-golden-")), "orders.csv");
-    writeFileSync(csvPath, CSV_CONTENT, "utf8");
-    const savedSrc = await createCsvConnection(page, srcName, csvPath);
+    const savedSrc = await test.step("3. create the CSV source via the drop zone", async () => {
+      const csvPath = join(mkdtempSync(join(tmpdir(), "qa-golden-")), "orders.csv");
+      writeFileSync(csvPath, CSV_CONTENT, "utf8");
+      return createCsvConnection(page, srcName, csvPath);
+    });
 
-    // 4. Wire them together as an Upload (there is no "pipeline builder" UI).
-    const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
-    const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
-    const savedUpload = await createUpload(page, uploadName, sourceOption, destOption);
+    const savedUpload = await test.step("4. wire them together as an Upload", async () => {
+      const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
+      const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
+      return createUpload(page, uploadName, sourceOption, destOption);
+    });
 
-    // 5. Run it, and assert the status a user would see.
-    const outcome = await runUploadAndAwait(page, savedUpload);
+    const outcome = await test.step("5. run it and read the terminal status", async () =>
+      runUploadAndAwait(page, savedUpload));
 
     expect(
       outcome.status,


### PR DESCRIPTION
Closes #501.

## What this is for

The golden path ([#485]) ran for the first time anywhere and failed as an **unqualified 6.0-minute timeout** with no recoverable evidence ([run 29903907117](https://github.com/datanika-io/datanika-core/actions/runs/29903907117)). A full CI cycle spent to learn nothing.

**This PR does not fix the selector. It makes the next failure say which selector.** I cannot fix what I cannot see, and the first run was configured so that I could not see it.

## Two defects, one mine

**1. Actions are unbounded.** `playwright.config.ts` sets `timeout` (test) and `expect.timeout` but no `actionTimeout`, which Playwright defaults to **0 — no limit**. So `.fill()`/`.click()` on a locator that never resolves waits until the enclosing *test* dies. In #485 I raised `test.setTimeout` to cover a genuinely long flow without bounding the steps inside it, which converted "wrong selector" into "mystery hang". That one is on me.

**2. A cancelled job uploads no evidence.** `Upload raw test-results` was gated `if: failure()`. The concurrency group (`cancel-in-progress: true`) cancelled the job when the next push hit `dev` — and **cancelled is not failed**, so traces, screenshots and videos were discarded. The `playwright-report` artifact did upload, but only `index.html`: the report shell without its `data/` payload, i.e. no failure detail either.

That second one is general, not golden-path-specific: **any** spec that fails and is then superseded loses its diagnosis, and `dev` is busy enough that this will recur.

## Changes

| Change | Effect |
|---|---|
| `UI_TIMEOUT` (15s) on every interaction, each with a message naming what was expected | a bad selector fails in ~15s and identifies itself, instead of eating 5 minutes |
| `test.step` per phase (signup / destination / CSV upload / wiring / run) | the report names **which** phase broke |
| `present()` helper asserts visibility before acting | "could not find the DuckDB path field — did the type picker actually apply?" beats a bare timeout |
| raw test-results upload → `if: always()` | a cancelled job still yields traces |
| `test.setTimeout` 360s → 300s | with every action bounded, the test cap should never be what fails; if it is, something is hanging that no per-action timeout covers |

## Verified

Spec still collects (`golden-path.spec.ts:67`), `ci.yml` parses with `if: always()` on the results upload, full core suite green via the pre-push hook.

## Expected next

The next `e2e-staging` run should fail **fast** and name a step. That output is the actual fix input.