### PR TITLE
[Infra] Guard: scope the closing-keyword scan to this branch's own commits (closes #507)

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -39,7 +39,10 @@ fi
 # predate its issue. The value is making the mismatch impossible to miss, not blocking.
 BRANCH_ISSUE=$(printf '%s' "$BRANCH" | sed -nE 's/^([0-9]+)-.*/\1/p')
 if [ -n "$BRANCH_ISSUE" ]; then
-  RANGE=$(git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1 && echo '@{upstream}..HEAD' || echo 'origin/dev..HEAD')
+  # origin/dev..HEAD, NOT @{upstream}..HEAD. The latter means "since this branch was last
+  # pushed", so after a rebase it includes every commit the rebase pulled from dev and
+  # attributes dev's closures to this branch. That fired on the first PR the guard met.
+  RANGE='origin/dev..HEAD'
   CLOSES=$(git log --format=%B "$RANGE" 2>/dev/null \
            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' \
            | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')


### PR DESCRIPTION
See #507. The guard shipped in #488 used `@{upstream}..HEAD`, which after a rebase includes the commits the rebase pulled from `dev` — so it blamed the branch for `dev`'s closures and false-positived on the very next PR (listing #449 and #487, both closed on `dev` that morning).

Since `dev` became `strict=true`, rebase-then-push is the standard flow, so this would fire on nearly every push. A warning that always fires is worse than none.

Proven against real git: quiet on its own issue after a rebase onto current `dev`, still catches a genuine mismatch.