### PR TITLE
[Engineering] A file source matching zero files fails the run (closes #493)

### DIFF
--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -1,5 +1,6 @@
 """Connection management service — CRUD with encrypted credentials."""
 
+import logging
 import re
 from datetime import UTC, datetime
 from functools import partial
@@ -12,6 +13,8 @@ from datanika.models.connection import Connection, ConnectionDirection, Connecti
 from datanika.services.egress_guard import validate_egress_host
 from datanika.services.encryption import EncryptionService
 from datanika.services.naming import validate_name
+
+logger = logging.getLogger(__name__)
 
 validate_connection_name = partial(validate_name, entity_label="Connection")
 
@@ -78,6 +81,16 @@ def infer_direction(connection_type: str | ConnectionType) -> ConnectionDirectio
         return ConnectionDirection.DESTINATION
     return ConnectionDirection.SOURCE
 
+
+# File-backed sources. Still non-SQL, but they *are* testable: the location can
+# be listed. Kept as a subset of _NON_DB_TYPES so query/list_tables behaviour is
+# unchanged — only `test_connection` treats them specially (core#493).
+_FILE_TYPES = {
+    ConnectionType.S3,
+    ConnectionType.CSV,
+    ConnectionType.JSON,
+    ConnectionType.PARQUET,
+}
 
 # Connection types that don't support SQL queries (SELECT 1 testing or execute_query)
 _NON_DB_TYPES = {
@@ -375,6 +388,54 @@ class ConnectionService:
             return False, "Connection failed — check your credentials and network settings"
 
     @staticmethod
+    def _test_file_source(config: dict, connection_type: ConnectionType) -> tuple[bool, str]:
+        """Actually test a file source, instead of declaring the test N/A.
+
+        These types previously fell into `_NON_DB_TYPES` and returned
+        `(True, "Test not applicable for this type")` unconditionally — so a
+        wrong path tested **exactly like a right one**, and the first signal
+        anything was wrong was a green run with zero rows (core#493). Our own
+        CSV guide warned *"a wrong path looks exactly like a right one here"*;
+        that was a description of a gap, not a fact of life.
+
+        Uses the same lister the loader uses, so a connection that tests green
+        and a run that finds files agree by construction.
+        """
+        from dlt.sources.filesystem import filesystem
+
+        from datanika.services.dlt_runner import (
+            AWS_CREDENTIAL_KEYS,
+            DEFAULT_FILE_GLOBS,
+            describe_empty_file_match,
+        )
+
+        location = config.get("bucket_url") or config.get("path") or ""
+        if not location:
+            return False, "Set the bucket URL or path first — there is nothing to test yet"
+
+        # The pipeline's own `file_glob` lives in per-upload config, not on the
+        # connection, so the type's default is the best available stand-in.
+        # Narrower globs can still match nothing; the run-time check covers that.
+        file_glob = DEFAULT_FILE_GLOBS.get(connection_type.value, "*")
+
+        kwargs = {"bucket_url": location, "file_glob": file_glob}
+        if connection_type == ConnectionType.S3:
+            credentials = {k: v for k, v in config.items() if k in AWS_CREDENTIAL_KEYS}
+            if credentials:
+                kwargs["credentials"] = credentials
+
+        try:
+            first = next(iter(filesystem(**kwargs)), None)
+        except Exception as exc:
+            logger.warning("File-source connection test failed for %s: %s", location, exc)
+            return False, f"Could not read {location} — check the path, permissions and credentials"
+
+        if first is None:
+            return False, describe_empty_file_match(location, file_glob)
+
+        return True, f"Connected — found files matching {file_glob}"
+
+    @staticmethod
     def test_connection(config: dict, connection_type: ConnectionType) -> tuple[bool, str]:
         """Test real database connectivity via SELECT 1. Returns (success, message)."""
         if not config:
@@ -382,6 +443,9 @@ class ConnectionService:
 
         if connection_type == ConnectionType.MONGODB:
             return ConnectionService._test_mongodb(config)
+
+        if connection_type in _FILE_TYPES:
+            return ConnectionService._test_file_source(config, connection_type)
 
         if connection_type in _NON_DB_TYPES:
             return True, "Test not applicable for this type"

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -313,6 +313,59 @@ def _build_format_reader(file_format: str, dlt_config: dict):
     return read_json()
 
 
+def describe_empty_file_match(bucket_url: str, file_glob: str) -> str:
+    """Explain *why* nothing matched, as specifically as the location allows.
+
+    The production case (core#493) was a `bucket_url` set to a full file path:
+    the glob is applied *under* that value, so `*.csv` under
+    `/docs_samples/customers.csv` matched nothing and the run went green with
+    0 rows. "No files matched" alone would leave the user re-checking a glob
+    that was never the problem, so the file-vs-directory case is called out by
+    name.
+
+    Local paths are diagnosed precisely; remote buckets get the general form,
+    because probing a URL for existence costs a second round trip and the
+    credentials to do it may be exactly what is wrong.
+    """
+    # Paths are quoted by hand rather than with !r: on Windows `repr` doubles
+    # every backslash, so the path we tell the user to try comes back looking
+    # like a typo of itself.
+    general = (
+        f"No files matched '{file_glob}' under '{bucket_url}'. "
+        "The run would have completed with zero rows."
+    )
+
+    if "://" in bucket_url:
+        return f"{general} Check the prefix and the file pattern."
+
+    if os.path.isfile(bucket_url):
+        return (
+            f"{general} '{bucket_url}' is a file, but this field must be the "
+            "directory that contains your files — the pattern is matched inside "
+            f"it. Try '{os.path.dirname(bucket_url)}' instead."
+        )
+
+    if not os.path.exists(bucket_url):
+        return f"{general} That path does not exist."
+
+    return f"{general} The directory exists but holds nothing matching that pattern."
+
+
+def _first_file_or_none(lister):
+    """Peek the lister dlt itself will use.
+
+    Deliberately not a second implementation with `fsspec_filesystem` +
+    `glob_files`: that path rejects our plain credentials dict (only
+    `filesystem()`'s config injection coerces it), and any separate matching
+    logic could drift from the loader's. Peeking the same resource means
+    detection and loading agree by construction.
+
+    Re-iterating afterwards still yields the files, so the peeked lister goes
+    on to the pipeline unchanged.
+    """
+    return next(iter(lister), None)
+
+
 def _file_table_name(connection_type: str, file_glob: str, dlt_config: dict) -> str:
     """Name the destination table for a file source.
 
@@ -534,7 +587,16 @@ class DltRunnerService:
         reader = _build_format_reader(file_format, dlt_config)
         table_name = _file_table_name(connection_type, file_glob, dlt_config)
 
-        return (filesystem(**kwargs) | reader).with_name(table_name)
+        lister = filesystem(**kwargs)
+
+        # Matching nothing is not a successful load of nothing (core#493). A
+        # typo'd path, a moved file, an export that didn't run and an emptied
+        # prefix all produced `success` / `Rows: 0`, which is byte-identical to
+        # a healthy run. Fail here, where the reason is still known.
+        if _first_file_or_none(lister) is None:
+            raise DltRunnerError(describe_empty_file_match(bucket_url, file_glob))
+
+        return (lister | reader).with_name(table_name)
 
     @staticmethod
     def _rest_api_from_parts(

--- a/tests/test_services/test_connection_service.py
+++ b/tests/test_services/test_connection_service.py
@@ -399,15 +399,22 @@ class TestTestConnection:
         assert ok is False
         assert "Driver not installed" in msg
 
-    def test_non_db_type_skipped_s3(self, svc):
-        ok, msg = svc.test_connection({"bucket_url": "s3://my-bucket"}, ConnectionType.S3)
-        assert ok is True
-        assert "not applicable" in msg.lower()
+    def test_file_types_are_no_longer_skipped_s3(self, svc):
+        """Contract change (core#493): file sources are testable, so they get tested.
 
-    def test_non_db_type_skipped_csv(self, svc):
+        These two used to assert `(True, "not applicable")` — which is exactly
+        how a wrong path came to test identically to a right one, and why a
+        typo'd `bucket_url` was first noticed as a green run with zero rows.
+        An unreachable bucket must not report success.
+        """
+        ok, msg = svc.test_connection({"bucket_url": "s3://no-such-bucket"}, ConnectionType.S3)
+        assert ok is False
+        assert "not applicable" not in msg.lower()
+
+    def test_file_types_are_no_longer_skipped_csv(self, svc):
         ok, msg = svc.test_connection({"bucket_url": "/data"}, ConnectionType.CSV)
-        assert ok is True
-        assert "not applicable" in msg.lower()
+        assert ok is False
+        assert "not applicable" not in msg.lower()
 
     def test_non_db_type_skipped_rest_api(self, svc):
         config = {"base_url": "https://api.example.com"}

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -314,7 +314,10 @@ def _fake_lister():
     """
     import dlt
 
-    return dlt.resource(lambda: iter([]), name="filesystem")
+    # Must yield at least one item: `_build_file_source` now peeks the lister
+    # and refuses to build a source that matches nothing (core#493), so an
+    # empty stand-in would fail every test here for the wrong reason.
+    return dlt.resource(lambda: iter([{"file_name": "customers.csv"}]), name="filesystem")
 
 
 class TestBuildFileSource:
@@ -392,7 +395,9 @@ class TestBuildFileSource:
         mock_pipeline.run.return_value = load_info
         mock_dlt.pipeline.return_value = mock_pipeline
         mock_dlt.destinations.postgres.return_value = "pg_dest"
-        mock_fs.return_value = MagicMock()
+        # A MagicMock iterates empty, which now reads as "matched no files"
+        # and refuses to build the source (core#493).
+        mock_fs.return_value = _fake_lister()
 
         result = svc.execute(
             pipeline_id=1,

--- a/tests/test_services/test_file_source_zero_match.py
+++ b/tests/test_services/test_file_source_zero_match.py
@@ -1,0 +1,173 @@
+"""A file source that matches nothing must not report success (core#493).
+
+Found on production alongside core#492: connection `customerscsv` had
+`bucket_url` set to a **full file path**, and the glob is applied *under* that
+value, so `*.csv` matched nothing. The run completed **`success`** in 3.7s with
+`Rows: 0`, created only dlt's bookkeeping tables, and left no signal anywhere
+that distinguished "loaded everything" from "found nothing".
+
+That is the same family as core#456 (run rows that lie) and the alert rules that
+could not tell healthy from dead: **a state that should be loud is byte-identical
+to the healthy one.** A typo'd path, a moved file, an export that didn't run and
+an emptied S3 prefix all landed here.
+
+`Test Connection` could not catch it either — every file type fell into
+`_NON_DB_TYPES` and returned `(True, "Test not applicable for this type")`
+unconditionally, so a wrong path tested exactly like a right one. Both halves
+are covered here, because fixing only the run would leave the user with no way
+to find out *before* running.
+"""
+
+import pytest
+
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import ConnectionService
+from datanika.services.dlt_runner import DltRunnerError, DltRunnerService
+
+
+@pytest.fixture
+def svc():
+    return DltRunnerService(pipelines_dir="/tmp/t493")
+
+
+def _write_csv(directory, name="customers.csv"):
+    path = directory / name
+    path.write_text("customer_id,full_name\n1001,Ada Lovelace\n", encoding="utf-8")
+    return path
+
+
+class TestTheRunRefusesToLoadNothing:
+    def test_a_glob_matching_nothing_raises(self, svc, tmp_path):
+        (tmp_path / "customers.txt").write_text("not a csv", encoding="utf-8")
+
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+
+        assert "*.csv" in str(exc.value)
+        assert "zero rows" in str(exc.value)
+
+    def test_bucket_url_pointing_at_a_file_says_so(self, svc, tmp_path):
+        """The production repro, and the message that would have solved it.
+
+        `bucket_url` was a full file path. "No files matched" alone sends the
+        user to re-check a glob that was never the problem, so the message has
+        to name the file-vs-directory mistake and the fix.
+        """
+        csv_path = _write_csv(tmp_path)
+
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("csv", {}, {"bucket_url": str(csv_path)})
+
+        message = str(exc.value)
+        assert "is a file" in message
+        assert str(tmp_path) in message, "the message should name the directory to use instead"
+
+    def test_a_missing_path_says_it_does_not_exist(self, svc, tmp_path):
+        with pytest.raises(DltRunnerError, match="does not exist"):
+            svc.build_source("csv", {}, {"bucket_url": str(tmp_path / "nope")})
+
+    def test_an_empty_directory_is_distinguished_from_a_bad_path(self, svc, tmp_path):
+        """Three causes, three messages — otherwise the error is a shrug."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("csv", {}, {"bucket_url": str(empty)})
+
+        assert "exists but holds nothing" in str(exc.value)
+
+    def test_a_matching_source_still_builds(self, svc, tmp_path):
+        """The guard must not refuse healthy sources.
+
+        Peeking consumes an item from the lister; if that broke re-iteration,
+        every real load would silently lose its first file.
+        """
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+        assert source is not None
+
+    def test_peeking_does_not_consume_the_first_file(self, svc, tmp_path):
+        """The specific way this guard could corrupt a working pipeline."""
+        duckdb = pytest.importorskip("duckdb")
+        import dlt
+
+        _write_csv(tmp_path)
+        _write_csv(tmp_path, name="customers_2.csv")
+
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "table_name": "customers"}
+        )
+        pipeline = dlt.pipeline(
+            pipeline_name="t493_peek",
+            destination=dlt.destinations.duckdb(str(tmp_path / "peek.duckdb")),
+            dataset_name="probe",
+            pipelines_dir=str(tmp_path / "state"),
+        )
+        pipeline.run(source)
+
+        con = duckdb.connect(str(tmp_path / "peek.duckdb"), read_only=True)
+        try:
+            rows = con.execute("SELECT count(*) FROM probe.customers").fetchone()[0]
+        finally:
+            con.close()
+        assert rows == 2, "a row per file — the peeked file must still be loaded"
+
+
+class TestConnectionTestActuallyTests:
+    def test_a_good_path_passes(self, tmp_path):
+        _write_csv(tmp_path)
+        ok, message = ConnectionService.test_connection(
+            {"bucket_url": str(tmp_path)}, ConnectionType.CSV
+        )
+        assert ok, message
+
+    def test_a_wrong_path_no_longer_looks_like_a_right_one(self, tmp_path):
+        """The whole point: this returned `(True, "not applicable")` before."""
+        ok, message = ConnectionService.test_connection(
+            {"bucket_url": str(tmp_path / "nope")}, ConnectionType.CSV
+        )
+        assert not ok
+        assert "does not exist" in message
+
+    def test_a_file_path_is_diagnosed_at_test_time(self, tmp_path):
+        """Catch the production mistake before the user ever runs."""
+        csv_path = _write_csv(tmp_path)
+        ok, message = ConnectionService.test_connection(
+            {"bucket_url": str(csv_path)}, ConnectionType.CSV
+        )
+        assert not ok
+        assert "is a file" in message
+
+    def test_the_legacy_path_key_is_accepted(self, tmp_path):
+        """`CONFIG_SCHEMAS` declares `path`; live connections carry `bucket_url`."""
+        _write_csv(tmp_path)
+        ok, message = ConnectionService.test_connection({"path": str(tmp_path)}, ConnectionType.CSV)
+        assert ok, message
+
+    def test_an_empty_config_is_rejected_before_listing(self):
+        ok, message = ConnectionService.test_connection({}, ConnectionType.CSV)
+        assert not ok
+
+    def test_a_config_without_a_location_is_rejected(self):
+        ok, message = ConnectionService.test_connection(
+            {"aws_access_key_id": "AKID"}, ConnectionType.S3
+        )
+        assert not ok
+        assert "bucket URL or path" in message
+
+    @pytest.mark.parametrize(
+        "connection_type",
+        [ConnectionType.CSV, ConnectionType.JSON, ConnectionType.PARQUET, ConnectionType.S3],
+    )
+    def test_no_file_type_still_answers_not_applicable(self, connection_type, tmp_path):
+        """All four, not just the one the bug was reported on."""
+        _, message = ConnectionService.test_connection(
+            {"bucket_url": str(tmp_path / "nope")}, connection_type
+        )
+        assert "not applicable" not in message
+
+    def test_non_file_types_are_untouched(self):
+        ok, message = ConnectionService.test_connection(
+            {"base_url": "https://api.example.com"}, ConnectionType.REST_API
+        )
+        assert ok and "not applicable" in message


### PR DESCRIPTION
Closes #493.

A file source that matched **zero** files completed as `success` with `Rows: 0`. On production, connection `customerscsv` had `bucket_url` set to a **full file path**, and the glob is applied *under* that value — so `*.csv` under `.../customers.csv` matched nothing, the run went green in 3.7s, and the destination got only dlt's bookkeeping tables.

A typo'd path, a moved file, an export that didn't run, an emptied S3 prefix — all produced a green run. This is the same family as #456 and the alert rules that could not tell healthy from dead: **a state that should be loud was byte-identical to the healthy one.**

## Two halves, because fixing one leaves the other

**Runtime** — `_build_file_source` now peeks the lister and raises when nothing matches, so no run can start that was always going to load nothing. It sits in `_build_file_source` rather than `execute()` deliberately: `build_source` is the shared entry point for **all three** run paths (ETL `execute`, `elt_runner`, `ir/builder`), so there is no route around it.

**Test Connection** — every file type fell into `_NON_DB_TYPES` and returned `(True, "Test not applicable for this type")` **unconditionally**, so a wrong path tested exactly like a right one. `csv`/`json`/`parquet`/`s3` now list the location and report what they find. Our own CSV guide warned *"a wrong path looks exactly like a right one here"* — that was a description of a gap, not a fact of life.

## Detection shares the loader's code path, by construction

Two designs were tried against real dlt and **both were wrong in ways that reading the docs would not have shown**:

1. **A counting transformer** piped between `filesystem()` and the reader. It fails twice: it breaks `FileItemDict` (`'str' object has no attribute 'open'`), and on the zero-match case **the run completed with no exception at all** — the post-loop raise never propagated. This is the design I would have shipped on reasoning alone.
2. **Re-globbing with `fsspec_filesystem` + `glob_files`.** Works for local paths, but it rejects our plain credentials dict — `AttributeError: 'dict' object has no attribute 'to_s3fs_credentials'`, for a dict *and* for `None`. Only `filesystem()`'s config injection coerces it, so this would have shipped `s3` support that could never list a bucket. There are no S3 credentials in CI, so nothing downstream would have caught it.

What ships instead: peek the **same lister the loader uses**, via `next(iter(lister), None)`. Credentials are handled by dlt's own injection, and detection cannot drift from loading because it *is* loading's first step. Verified that re-iterating after the peek still yields every file — `test_peeking_does_not_consume_the_first_file` loads two files and asserts two rows, because a guard that silently ate the first file of every load would be a worse bug than the one being fixed.

## The message is the fix

"No files matched" alone sends the user to re-check a glob that was never the problem. Three causes, three messages:

| Cause | Message |
|---|---|
| `bucket_url` is a file | *"'…/customers.csv' is a file, but this field must be the directory that contains your files… Try '…/\_docs_samples' instead."* |
| Path missing | *"That path does not exist."* |
| Directory empty | *"The directory exists but holds nothing matching that pattern."* |

Remote buckets get the general form: probing a URL costs a round trip, and the credentials needed to do it may be exactly what is wrong.

Paths are quoted by hand rather than with `!r`, because on Windows `repr` doubles every backslash and the path we tell the user to try comes back looking like a typo of itself.

## Contract change

`test_connection` **no longer returns `True` for `csv`/`json`/`parquet`/`s3`.** Two existing tests asserted the old behaviour and have been rewritten — they encoded the bug as the contract. Query/`list_tables` behaviour is unchanged; `_FILE_TYPES` is a subset of `_NON_DB_TYPES` and only `test_connection` treats it specially.

**Proven red on the pre-fix code: 11 of 17 fail** with both halves reverted. The 6 that stay green are the healthy-path tests, which describe behaviour that existed before.

Local precheck green.
