### PR TITLE
[Engineering] DuckDB loads reach the Catalog, and a failed sync says so (closes #494)

### DIFF
--- a/datanika/services/catalog_service.py
+++ b/datanika/services/catalog_service.py
@@ -1,12 +1,24 @@
 """Catalog service — introspect tables, manage catalog entries."""
 
+import logging
 from datetime import UTC, datetime
 
-from sqlalchemy import create_engine, inspect, select
+from sqlalchemy import create_engine, inspect, select, text
 from sqlalchemy.orm import Session
 
 from datanika.models.catalog_entry import CatalogEntry, CatalogEntryType
 from datanika.models.dependency import NodeType
+
+logger = logging.getLogger(__name__)
+
+#: Portable column metadata. Every destination we support implements
+#: `information_schema.columns`; not every SQLAlchemy dialect implements
+#: `get_columns` against it (core#494).
+_INFORMATION_SCHEMA_COLUMNS = text(
+    "SELECT column_name, data_type FROM information_schema.columns "
+    "WHERE table_schema = :schema AND table_name = :table "
+    "ORDER BY ordinal_position"
+)
 
 
 class CatalogService:
@@ -31,19 +43,57 @@ class CatalogService:
             for tbl in table_names:
                 if tbl.startswith("_dlt_"):
                     continue
-                try:
-                    cols = insp.get_columns(tbl, schema=schema_name)
-                except Exception:
+                columns = CatalogService._columns_for(engine, insp, tbl, schema_name)
+                if columns is None:
                     continue
-                results.append(
-                    {
-                        "table_name": tbl,
-                        "columns": [{"name": c["name"], "data_type": str(c["type"])} for c in cols],
-                    }
-                )
+                results.append({"table_name": tbl, "columns": columns})
             return results
         finally:
             engine.dispose()
+
+    @staticmethod
+    def _columns_for(engine, insp, table: str, schema: str) -> list[dict] | None:
+        """Column metadata for one table, with a portable fallback.
+
+        `get_columns` used to be wrapped in a bare `except: continue`, so a
+        dialect that could not answer produced an **empty catalog** rather than
+        an error — and the user was told to verify their first run by browsing
+        Catalog. That is exactly what happened on DuckDB (core#494):
+        `duckdb_engine` derives from the PostgreSQL dialect and its
+        `get_columns` queries `pg_collation`, which DuckDB does not provide::
+
+            ProgrammingError: Catalog Error: Table with name pg_collation does not exist!
+
+        Installing the dialect alone did **not** fix it — that only got as far
+        as `get_table_names`. So a failure here now falls back to
+        `information_schema`, which every destination we support implements,
+        and anything still unreadable is logged instead of vanishing.
+        """
+        try:
+            cols = insp.get_columns(table, schema=schema)
+            return [{"name": c["name"], "data_type": str(c["type"])} for c in cols]
+        except Exception as exc:
+            logger.warning(
+                "get_columns failed for %s.%s (%s) — falling back to information_schema",
+                schema,
+                table,
+                exc.__class__.__name__,
+            )
+
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    _INFORMATION_SCHEMA_COLUMNS, {"schema": schema, "table": table}
+                ).fetchall()
+        except Exception:
+            logger.exception("information_schema fallback failed for %s.%s", schema, table)
+            return None
+
+        if not rows:
+            logger.warning("No column metadata found for %s.%s — skipping", schema, table)
+            return None
+
+        return [{"name": name, "data_type": str(data_type)} for name, data_type in rows]
 
     @staticmethod
     def upsert_entry(

--- a/datanika/services/execution_service.py
+++ b/datanika/services/execution_service.py
@@ -70,6 +70,23 @@ class ExecutionService:
         session.flush()
         return run
 
+    def append_logs(self, session: Session, run_id: int, text: str) -> Run | None:
+        """Add a line to a finished run's logs.
+
+        For things that happen *after* the load completes and must not change
+        its status — catalog sync is the case that motivated it (core#494).
+        Swallowing that failure into the worker log alone kept a permanently
+        broken feature invisible for as long as DuckDB had been a destination:
+        the run row said success, Catalog stayed empty, and only SSH could
+        connect the two.
+        """
+        run = session.get(Run, run_id)
+        if run is None:
+            return None
+        run.logs = f"{run.logs}\n{text}" if run.logs else text
+        session.flush()
+        return run
+
     def cancel_run(self, session: Session, run_id: int) -> Run | None:
         run = session.get(Run, run_id)
         if run is None:

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -248,8 +248,19 @@ def run_upload(
                 dst_config,
                 dataset_name,
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Catalog sync failed (non-fatal)")
+            # Non-fatal to the run, but not invisible: the load succeeded and
+            # the data is there, while Models/Catalog will not show it. Saying
+            # so on the run is the difference between a user filing a bug and
+            # a user concluding the product does not work (core#494).
+            execution_service.append_logs(
+                session,
+                run_id,
+                "WARNING: the data loaded successfully, but the catalog sync failed, "
+                "so these tables will not appear under Models/Catalog: "
+                f"{exc.__class__.__name__}: {exc}",
+            )
 
         from datanika.hooks import announce
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ dependencies = [
     "pymongo>=4.0,<5",
     "clickhouse-connect>=0.11,<0.12",
     "duckdb>=1.0,<2",
+    # The SQLAlchemy dialect for DuckDB. dlt writes through its own driver, so
+    # loads worked without this — but catalog introspection goes through
+    # SQLAlchemy and raised NoSuchModuleError, leaving Models/Catalog
+    # permanently empty for every DuckDB user (core#494). Every other
+    # destination here already pairs a driver with its dialect; duckdb was the
+    # one that did not.
+    "duckdb-engine>=0.17,<0.18",
     "snowflake-sqlalchemy>=1.7,<2",
     "sqlalchemy-bigquery>=1.11,<2",
     "oracledb>=4.0,<5",

--- a/tests/test_services/test_catalog_duckdb.py
+++ b/tests/test_services/test_catalog_duckdb.py
@@ -1,0 +1,140 @@
+"""DuckDB loads must reach the Data Catalog (core#494).
+
+After a successful upload into a DuckDB destination, Models / Catalog stayed
+empty: *"No models found. Run an upload or transformation to populate the
+catalog."* The load itself worked — dlt writes to DuckDB through its own driver
+— but the catalog sync goes through **SQLAlchemy**, and the dialect was missing:
+
+    sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
+
+`duckdb` was installed; `duckdb_engine`, the SQLAlchemy dialect, was not.
+
+**Installing the dialect was necessary and not sufficient**, which these tests
+found and the issue's diagnosis did not. With `duckdb_engine` present,
+`create_engine` and `get_table_names` both work — but `get_columns` still
+raises, because the dialect derives from PostgreSQL's and queries
+`pg_collation`, which DuckDB does not have::
+
+    ProgrammingError: Catalog Error: Table with name pg_collation does not exist!
+
+`introspect_tables` wrapped that in a bare `except Exception: continue`, so
+every table was dropped silently and the catalog came back **empty even after
+the dependency fix**. A test asserting only `import duckdb_engine` would have
+gone green over a still-broken feature.
+
+DuckDB is the destination in the zero-credentials onboarding template, and both
+`/docs/connectors/duckdb` and `/docs/connectors/csv` tell the user to verify
+their first run by browsing Catalog. **For every DuckDB user that instruction
+had never once worked.** Data Preview (#260) was unreachable for the same
+reason — it needs a catalog entry.
+
+Both failures were swallowed — the per-table one here, and the whole sync in
+`upload_tasks` — so nothing outside the worker log knew. Both are covered.
+"""
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from datanika.services.catalog_service import CatalogService
+
+pytest.importorskip("duckdb", reason="core#494 is specifically about the DuckDB path")
+
+
+class TestTheDuckDBDialectIsInstalled:
+    def test_sqlalchemy_can_build_a_duckdb_engine(self):
+        """The exact failure from the production traceback.
+
+        `create_engine` is where it raised — before any query, so no amount of
+        retrying or different SQL would have helped.
+        """
+        engine = create_engine("duckdb:///:memory:")
+        engine.dispose()
+
+    def test_duckdb_engine_is_importable(self):
+        """Names the missing package, so a failure here reads as its own fix."""
+        import duckdb_engine  # noqa: F401
+
+
+class TestCatalogIntrospectionWorksOnDuckDB:
+    def test_introspect_tables_finds_a_real_table(self, tmp_path):
+        """Drive the real consumer, not just the import.
+
+        `import duckdb_engine` passing proves the package exists; it does not
+        prove `CatalogService` can read a DuckDB file. This is the call that
+        raised in production.
+        """
+        db_path = tmp_path / "warehouse.duckdb"
+        engine = create_engine(f"duckdb:///{db_path}")
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE SCHEMA customersdailyload"))
+                conn.execute(
+                    text(
+                        "CREATE TABLE customersdailyload.customers "
+                        "(customer_id BIGINT, full_name VARCHAR)"
+                    )
+                )
+                conn.execute(
+                    text("INSERT INTO customersdailyload.customers VALUES (1001, 'Ada Lovelace')")
+                )
+        finally:
+            engine.dispose()
+
+        tables = CatalogService.introspect_tables(
+            f"duckdb:///{db_path}", schema_name="customersdailyload"
+        )
+
+        assert [t["table_name"] for t in tables] == ["customers"]
+        assert {c["name"] for c in tables[0]["columns"]} == {"customer_id", "full_name"}
+
+    def test_a_dialect_that_cannot_answer_falls_back_instead_of_vanishing(self, tmp_path):
+        """The defect that installing the dependency did *not* fix.
+
+        `duckdb_engine` derives from the PostgreSQL dialect, so `get_columns`
+        queries `pg_collation` — which DuckDB does not have. The old bare
+        `except Exception: continue` turned that into an **empty catalog**, so
+        the dependency fix alone still left Models/Catalog blank.
+
+        Forced here rather than relying on the live dialect: whether upstream
+        fixes `get_columns` should not decide whether we notice a regression.
+        """
+        from unittest.mock import patch
+
+        db_path = tmp_path / "warehouse.duckdb"
+        engine = create_engine(f"duckdb:///{db_path}")
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE SCHEMA probe"))
+                conn.execute(text("CREATE TABLE probe.customers (customer_id BIGINT)"))
+        finally:
+            engine.dispose()
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("Catalog Error: Table with name pg_collation does not exist!")
+
+        with patch("sqlalchemy.engine.reflection.Inspector.get_columns", _boom):
+            tables = CatalogService.introspect_tables(f"duckdb:///{db_path}", schema_name="probe")
+
+        assert [t["table_name"] for t in tables] == ["customers"]
+        assert [c["name"] for c in tables[0]["columns"]] == ["customer_id"]
+
+    def test_dlt_bookkeeping_tables_are_filtered_out(self, tmp_path):
+        """The catalog should show the user's tables, not dlt's.
+
+        Production had *only* `_dlt_loads` / `_dlt_pipeline_state` /
+        `_dlt_version` in the destination, so this is also the shape a
+        zero-row run leaves behind (core#493).
+        """
+        db_path = tmp_path / "warehouse.duckdb"
+        engine = create_engine(f"duckdb:///{db_path}")
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE SCHEMA probe"))
+                conn.execute(text("CREATE TABLE probe._dlt_loads (load_id VARCHAR)"))
+                conn.execute(text("CREATE TABLE probe.customers (customer_id BIGINT)"))
+        finally:
+            engine.dispose()
+
+        tables = CatalogService.introspect_tables(f"duckdb:///{db_path}", schema_name="probe")
+
+        assert [t["table_name"] for t in tables] == ["customers"]

--- a/uv.lock
+++ b/uv.lock
@@ -942,6 +942,7 @@ dependencies = [
     { name = "dbt-sqlserver" },
     { name = "dlt", extra = ["bigquery", "clickhouse", "databricks", "duckdb", "mssql", "postgres", "snowflake", "synapse"] },
     { name = "duckdb" },
+    { name = "duckdb-engine" },
     { name = "google-auth" },
     { name = "gspread" },
     { name = "oracledb" },
@@ -992,6 +993,7 @@ requires-dist = [
     { name = "dbt-sqlserver", specifier = ">=1.7,<1.8" },
     { name = "dlt", extras = ["postgres", "snowflake", "bigquery", "mssql", "clickhouse", "duckdb", "databricks", "synapse"], specifier = ">=1.21,<2" },
     { name = "duckdb", specifier = ">=1.0,<2" },
+    { name = "duckdb-engine", specifier = ">=0.17,<0.18" },
     { name = "google-auth", specifier = ">=2.0,<3" },
     { name = "gspread", specifier = ">=6.0,<7" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28,<0.29" },
@@ -1376,6 +1378,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/4c/47e838393aa90d3d78549c8c04cb09452efeb14aaae0ee24dc0bd61c3a41/duckdb-1.5.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8843bd9594e1387f1e601439e19ad73abdf57356104fd1e53a708255bb95a13d", size = 21387569, upload-time = "2026-03-23T12:12:05.693Z" },
     { url = "https://files.pythonhosted.org/packages/f4/9b/ce65743e0e85f5c984d2f7e8a81bc908d0bac345d6d8b6316436b29430e7/duckdb-1.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:d68c5a01a283cb13b79eafe016fe5869aa11bff8c46e7141c70aa0aac808010f", size = 13603876, upload-time = "2026-03-23T12:12:09.344Z" },
     { url = "https://files.pythonhosted.org/packages/e6/ac/f9e4e731635192571f86f52d86234f537c7f8ca4f6917c56b29051c077ef/duckdb-1.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:a3be2072315982e232bfe49c9d3db0a59ba67b2240a537ef42656cc772a887c7", size = 14370790, upload-time = "2026-03-23T12:12:12.497Z" },
+]
+
+[[package]]
+name = "duckdb-engine"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "duckdb" },
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d5/c0d8d0a4ca3ffea92266f33d92a375e2794820ad89f9be97cf0c9a9697d0/duckdb_engine-0.17.0.tar.gz", hash = "sha256:396b23869754e536aa80881a92622b8b488015cf711c5a40032d05d2cf08f3cf", size = 48054, upload-time = "2025-03-29T09:49:17.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a2/e90242f53f7ae41554419b1695b4820b364df87c8350aa420b60b20cab92/duckdb_engine-0.17.0-py3-none-any.whl", hash = "sha256:3aa72085e536b43faab635f487baf77ddc5750069c16a2f8d9c6c3cb6083e979", size = 49676, upload-time = "2025-03-29T09:49:15.564Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #494.

After a successful upload into a DuckDB destination, Models / Catalog stayed empty. The load worked — dlt writes to DuckDB through its own driver — but catalog sync goes through **SQLAlchemy**, and the dialect was missing:

```
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
```

DuckDB is the destination in the zero-credentials onboarding template, and both `/docs/connectors/duckdb` and `/docs/connectors/csv` tell the user to verify their first run by browsing Catalog. **For every DuckDB user that instruction had never once worked.**

## Installing the dialect was necessary and not sufficient

This is the part the issue's diagnosis didn't reach, and it only surfaced because the test drives `CatalogService` against a real DuckDB file rather than asserting the import. With `duckdb_engine` installed, `create_engine` and `get_table_names` both work — so the fix *looks* complete — but `get_columns` still raises:

```
ProgrammingError: (_duckdb.CatalogException) Catalog Error: Table with name pg_collation does not exist!
```

`duckdb_engine` derives from the PostgreSQL dialect and queries `pg_collation`, which DuckDB does not have. `introspect_tables` wrapped that in a bare `except Exception: continue`, so **every table was dropped silently and the catalog came back empty even after the dependency fix.**

A test asserting only `import duckdb_engine` would have gone green over a still-broken feature, merged, and left Models/Catalog blank in production. **The missing dialect was the trigger; the silent swallow was the bug.**

## Three parts

**1. The dependency.** `duckdb-engine>=0.17,<0.18` — bound from the locked version per #470's rule (next minor for 0.x). `uv.lock` regenerated: `duckdb-engine 0.17.0` added, **zero other resolved versions moved**. Worth noting the shape of the gap — every other destination already pairs a driver with its SQLAlchemy dialect (`snowflake-sqlalchemy`, `sqlalchemy-bigquery`); `duckdb` was the one that didn't.

**2. Introspection stops vanishing.** `_columns_for` falls back to `information_schema.columns` — which every destination we support implements — and logs anything still unreadable instead of dropping it. Verified against a real DuckDB file, not mocked.

**3. A failed sync says so.** `ExecutionService.append_logs` puts it on the run row:

> WARNING: the data loaded successfully, but the catalog sync failed, so these tables will not appear under Models/Catalog: …

The run stays **successful** — the data really is there — but "non-fatal" no longer means "invisible". The issue was right that this deserved a second look: swallowing it kept a permanently broken feature hidden for as long as DuckDB has been a destination, with the run row saying success and only SSH able to connect the two.

Chosen over reordering `complete_run` to after the sync, which would delay marking a finished run successful for the sake of a cosmetic step.

## Test notes

The fallback test **forces** the dialect failure rather than relying on the live one — whether upstream fixes `get_columns` should not decide whether we notice a regression.

Precheck green: **2616 passed**.
