### PR TITLE
[QA] Golden path: fold picker lookup into createUpload so it cannot run on the wrong page (closes #515)

### DIFF
--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -228,42 +228,23 @@ export async function createCsvConnection(
  * extract-load object is an Upload at `/uploads`. The connector guides describe
  * a UI that does not exist here (landing#272); the UI is the source of truth.
  */
-export async function createUpload(
-  page: Page,
-  name: string,
-  sourceOption: string,
-  destOption: string,
-): Promise<string> {
-  const saved = sanitizeName(name);
-  await gotoReady(page, "/uploads");
-
-  const nameField = page.getByPlaceholder("Upload name");
-  await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
-  await nameField.fill(name, { timeout: UI_TIMEOUT });
-
-  // These two default to "" in UploadState, so the placeholder IS what shows.
-  await selectSearchable(page, ["Source connection"], sourceOption);
-  await selectSearchable(page, ["Destination connection"], destOption);
-  await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
-
-  await expect(
-    page.getByRole("cell", { name: saved, exact: true }),
-    `Upload "${saved}" did not appear in the uploads table`,
-  ).toBeVisible({ timeout: UI_TIMEOUT });
-  return saved;
-}
+export type ConnectionRef = { name: string; kind: ConnectionKind };
 
 /**
- * The connection picker on /uploads labels options `"{id} — {name} ({type})"`
- * (upload_state.py). Callers know the name and type but not the id, so match on
- * the stable tail and read the full label back off the DOM.
+ * Pick a connection in one of the `/uploads` pickers.
+ *
+ * The options are labelled `"{id} — {name} ({type})"` (upload_state.py) and the
+ * caller knows the name and type but not the id, so match on the stable tail.
+ *
+ * **Assumes the page is already on `/uploads`** — which is why this is not
+ * exported: it is only ever reachable through `createUpload`, which navigates
+ * first. See the note there.
  */
-export async function uploadOptionFor(
+async function selectConnectionOption(
   page: Page,
   placeholder: string,
-  connectionName: string,
-  kind: ConnectionKind,
-): Promise<string> {
+  conn: ConnectionRef,
+): Promise<void> {
   const trigger = searchableTrigger(page, [placeholder]);
   await present(page, trigger, `searchable-select trigger "${placeholder}"`);
   await trigger.click({ timeout: UI_TIMEOUT });
@@ -273,17 +254,53 @@ export async function uploadOptionFor(
     timeout: UI_TIMEOUT,
   });
 
-  const suffix = `${connectionName} (${kind})`;
-  const option = popover.getByText(new RegExp(`\\d+ — ${suffix}$`));
+  const suffix = `${conn.name} (${conn.kind})`;
+  const option = popover.getByText(new RegExp(`\\d+ — ${escapeRegExp(suffix)}$`));
   await expect(
     option,
     `no ${placeholder} option ending "${suffix}" — is the connection the right type?`,
   ).toBeVisible({ timeout: UI_TIMEOUT });
-
-  const label = (await option.textContent())?.trim() ?? "";
-  await page.keyboard.press("Escape");
+  await option.click({ timeout: UI_TIMEOUT });
   await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
-  return label;
+}
+
+/**
+ * Create an upload (extract+load) wiring a source connection to a destination.
+ *
+ * Note there is no "pipeline builder" and no "Configure pipeline" button — the
+ * extract-load object is an Upload at `/uploads`. The connector guides describe
+ * a UI that does not exist here (landing#272); the UI is the source of truth.
+ *
+ * Takes the connections themselves rather than pre-resolved option labels. The
+ * earlier shape made the caller resolve labels first, which meant the picker
+ * was queried while the browser was still on `/connections` — and the failure
+ * read as "trigger 'Source connection' not found" on a page that legitimately
+ * has no such control (core#515). Navigation and lookup now live together, so
+ * that ordering hazard is not expressible.
+ */
+export async function createUpload(
+  page: Page,
+  name: string,
+  source: ConnectionRef,
+  destination: ConnectionRef,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/uploads");
+
+  const nameField = page.getByPlaceholder("Upload name");
+  await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
+  // Both default to "" in UploadState, so the placeholder IS what shows.
+  await selectConnectionOption(page, "Source connection", source);
+  await selectConnectionOption(page, "Destination connection", destination);
+  await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
+
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `Upload "${saved}" did not appear in the uploads table`,
+  ).toBeVisible({ timeout: UI_TIMEOUT });
+  return saved;
 }
 
 export type RunOutcome = { status: string; rows: number };

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -8,7 +8,6 @@ import {
   createDuckDbConnection,
   createUpload,
   runUploadAndAwait,
-  uploadOptionFor,
 } from "../fixtures/data";
 
 /**
@@ -96,11 +95,13 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
       return createCsvConnection(page, srcName, csvPath);
     });
 
-    const savedUpload = await test.step("4. wire them together as an Upload", async () => {
-      const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
-      const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
-      return createUpload(page, uploadName, sourceOption, destOption);
-    });
+    const savedUpload = await test.step("4. wire them together as an Upload", async () =>
+      createUpload(
+        page,
+        uploadName,
+        { name: savedSrc, kind: "csv" },
+        { name: savedDest, kind: "duckdb" },
+      ));
 
     const outcome = await test.step("5. run it and read the terminal status", async () =>
       runUploadAndAwait(page, savedUpload));


### PR DESCRIPTION
Closes #515. Third round on the golden path; steps 2–3 now pass.

## What broke

```
could not find searchable-select trigger "Source connection"
on https://staging-app.datanika.io/connections
```

Read the URL. There is no "Source connection" picker on `/connections` — that control lives on `/uploads`. `uploadOptionFor()` opened the picker but never navigated; `createUpload()` did the navigating and ran *after* it.

So the caller had to remember to be on the right page before calling a function that gave no hint it cared. **I wrote both halves and still got the order wrong on the first attempt** — which is the argument for the fix below rather than a comment saying "call this on /uploads".

## Fix

`createUpload` now takes the connections themselves (`{ name, kind }`) instead of pre-resolved labels, and does navigation **and** lookup together. `selectConnectionOption` is private, reachable only through it. **There is no longer an order for a caller to get wrong.**

Side benefit: it halves the interactions — the old shape opened each popover once to *read* a label and again to *select* it.

## ⚠️ Recorded, not fixed: a possible session-loss flake

The **retry** of the same test failed differently — on **`/login`**, session gone mid-test after a signup that had already succeeded once. That looks like **#472** (*"Connection Error" drops the session on roughly every other navigation*), not this spec.

Deliberately not papering over it with a retry bump: if #472 reaches the golden path, the right outcome is a flaky signal that argues for fixing #472 — not a spec tuned to tolerate a broken session layer.

## Still unproven

**Step 5 — the Celery run and the terminal-status assertion, the part that would actually have caught #456 — has still never executed.** Each round has moved the failure one step later; this is round three of an unknown number, and I would rather say that than imply the finish line is close.