### PR TITLE
[QA] Quarantine golden-path from the promotion gate, keeping it running (closes #520)

### DIFF
--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -56,6 +56,18 @@ const CSV_CONTENT = ["id,name,amount", "1,alpha,100", "2,beta,200", "3,gamma,300
  */
 const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
 
+// Artifacts unconditionally while quarantined (core#520). The global config uses
+// `retain-on-failure`, and a `test.fail()` test that fails is classified
+// `expected` rather than `failed` — so the diagnostics every round has depended
+// on could be dropped exactly when the verdict stops being reported. A
+// quarantined test that stops producing evidence is just a disabled one.
+//
+// Must be file top-level, NOT inside the describe: `use({ trace })` forces a new
+// worker, and Playwright refuses it in a describe group — which fails collection
+// of the WHOLE suite, not just this spec. Caught by running `--list`; it would
+// have taken all 62 tests down, far worse than the thing being quarantined.
+test.use({ trace: "on", screenshot: "on", video: "retain-on-failure" });
+
 test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
   // Signup, two connections, an upload and a Celery round trip. The default
   // 60s covers none of that. Deliberately NOT larger: every interaction is
@@ -64,6 +76,32 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
   test.setTimeout(300_000);
 
   test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
+    // ── QUARANTINED FROM THE PROMOTION GATE — core#520 ───────────────────────
+    // This spec has NEVER passed. It was written 2026-07-22 (#482/#485) and each
+    // round moves the failure one step later; step 5 has still never executed.
+    // It was therefore not protecting production — it was work in progress that
+    // happened to live in the gating job, holding back #500 (a P0), #505, #510,
+    // #516, #518, Growth's announcement and landing#281.
+    //
+    // The distinction that makes this safe, and the line not to cross:
+    //   • quarantining a test that USED TO PASS hides a regression — never.
+    //   • quarantining a test that has NEVER PASSED removes a non-gate from the
+    //     gate. Same call as the Kafka smoke quarantine (#399), which was
+    //     un-quarantined once it could pass.
+    //
+    // `test.fail()` rather than `test.skip()` is the whole point: the test still
+    // RUNS, still exercises staging, still uploads artifacts — only its verdict
+    // is quarantined. And Playwright reports an *unexpectedly passing*
+    // `test.fail()` as a failure, so the first green turns the job red and
+    // forces this marker out. Re-arming is enforced by the tool, not by someone
+    // remembering. When that happens: delete this line and close core#520.
+    test.fail(
+      true,
+      "core#520: golden-path has never passed; quarantined from the promotion " +
+        "gate. It still runs. Playwright fails the job if it starts passing — " +
+        "when it does, remove this and close core#520.",
+    );
+
     const stamp = `${Date.now()}`;
     // set_form_name strips everything outside [a-zA-Z0-9 ], so keep names in
     // that alphabet — otherwise the saved name is not the one typed.


### PR DESCRIPTION
Closes #520. Releases the promotion: #500 (P0), #505, #510, #516, #518, Growth'\''s announcement and landing#281.

## The mechanism: `test.fail()`, not `test.skip()`

This is the whole point of the issue'\''s "quarantine the verdict, not the execution". The spec still **runs**, still exercises staging, still uploads artifacts — only its verdict stops gating.

And **re-arming is enforced by the tool, not by anyone remembering**: Playwright reports an *unexpectedly passing* `test.fail()` as a failure, so the first green turns the job red and forces the marker out.

**Verified both directions with real exit codes** (not from the docs — the job'\''s verdict *is* that exit code, and my first attempt at measuring it accidentally captured `tail`'\''s):

```
marked-fail + fails   -> playwright exit 0   job stays green, quarantine holds
marked-fail + passes  -> playwright exit 1   job goes red, re-arm forced
```

## The line, restated in the code

The marker comment carries the distinction so the next reader inherits it: quarantining a test that **used to pass** hides a regression and is never acceptable; quarantining one that has **never passed** removes a non-gate from the gate. Same call as the Kafka smoke quarantine (#399), which was un-quarantined once it could pass.

## Artifacts pinned on

`test.use({ trace: "on", screenshot: "on" })` for this spec. The global config is `retain-on-failure`, and an expected failure is classified `expected` — so the diagnostics every round has depended on could have been dropped **exactly when the verdict stopped being reported**. A quarantined test that stops producing evidence is just a disabled one.

## ⚠️ A near-miss worth recording

My first version put that `test.use` **inside the describe block**. Playwright refuses it there (*"forces a new worker"*) and **fails collection of the entire file** — `--list` returned 0 tests instead of 62. Had it merged, it would have taken **all 62 specs** down: far worse than the single test being quarantined, and in a PR whose stated purpose is unblocking the promotion.

Caught by running `--list` rather than trusting the edit. Fixed by moving it to file top-level; the comment there now says why it cannot move back.

## Evidence preserved, not discarded

Per the issue, the #472 evidence is attached to **#472**, not buried here. Nothing has been papered over with a retry bump.

## Unrelated, found while pushing

The pre-push hook failed on `test_catalog_duckdb.py::TestTheDuckDBDialectIsInstalled` — **a stale worktree venv, not a break**: `duckdb-engine` is in `uv.lock` (added recently) but was not installed locally. `uv sync --extra dev` fixed it. Flagging because anyone whose worktree predates that lock change will hit the same wall and may read it as a real failure.