### PR TITLE
[Infra] Promote dev → master: alert rules that actually evaluate, CI verdict fix, pre-push guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,10 +332,50 @@ jobs:
           DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
           DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
           DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
+          # Include @slow specs (core#484). Until 2026-07-22 NO job set this, so
+          # `playwright.config.ts`'s grepInvert silently dropped every @slow spec
+          # from every run: this job reported success having executed 5 of 62
+          # tests, both files about `?template=` handling. golden-path,
+          # tenant-jwt-boundary, tenant-isolation, rbac and viewer-role-ui had
+          # never gated a merge.
+          #
+          # Safe to switch on wholesale because the expensive-and-unavailable
+          # specs gate themselves independently, and therefore skip rather than
+          # fail: sso-* need DATANIKA_E2E_SSO_AUTHENTIK (its own job is
+          # `if: false` — the IdP was not rebuilt after the 2026-07-17 outage)
+          # and overage-charge-cycle needs DATANIKA_E2E_OVERAGE_CHARGE plus the
+          # Paddle sandbox secrets, which the nightly soak owns. Neither is set
+          # here, so this flag adds 5 real specs, not 57.
+          #
+          # This job is NOT a required check on `dev` (those are lint + test),
+          # so a red here is loud without blocking anyone's merge — which is the
+          # point: the signal was missing, not the tests.
+          DATANIKA_E2E_SLOW: "1"
           DATANIKA_E2E_SEED_CMD: >-
             ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
             'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
+
+      # A green tick above is not evidence that anything ran — that is exactly
+      # how core#484 hid for months. Print the collected count so the run log
+      # carries the number, and fail if it collapses back toward the fast subset.
+      - name: Assert the @slow specs were actually collected
+        if: always()
+        working-directory: e2e
+        env:
+          DATANIKA_E2E_SLOW: "1"
+          DATANIKA_E2E_SKIP_SEED: "1"
+          DATANIKA_E2E_USER_EMAIL: collected-count@datanika.test
+        run: |
+          # stderr is deliberately NOT suppressed: if --list itself breaks, the
+          # count is 0 and the reason needs to be readable, not swallowed.
+          LAST=$(npx playwright test --list | tail -1)
+          echo "playwright --list said: $LAST"
+          COUNT=$(printf '%s' "$LAST" | grep -oE '[0-9]+' | head -1)
+          if [ "${COUNT:-0}" -lt 40 ]; then
+            echo "::error::Only ${COUNT:-0} tests collected (expected 60+). The @slow specs are being filtered out again — see core#484."
+            exit 1
+          fi
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,9 +351,21 @@ jobs:
           # so a red here is loud without blocking anyone's merge — which is the
           # point: the signal was missing, not the tests.
           DATANIKA_E2E_SLOW: "1"
+          # sso-edge-cases hits the backend directly via fixtures/sso.ts, which
+          # defaults to http://localhost:8000 — on a CI runner that is nothing,
+          # and 5 specs died with `connect ECONNREFUSED ::1:8000` (core#496).
+          # The e2e-sso job has always set this; this job never did.
+          DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
+          # E2E_SEED_INCLUDE_API_KEYS=1 is required by rbac / tenant-isolation /
+          # tenant-jwt-boundary: without it the payload carries no keys and the
+          # fixtures throw at setup (`DATANIKA_E2E_API_KEY_READONLY not set`),
+          # which reads in the log as ~35 tenant-isolation FAILURES rather than
+          # as a missing flag (core#496). global-setup.ts already maps all three
+          # keys and every org-B field; only the flag was missing. Org B itself
+          # is seeded unconditionally — there is no second-tenant gate.
           DATANIKA_E2E_SEED_CMD: >-
             ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
-            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
+            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 -e E2E_SEED_INCLUDE_API_KEYS=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
         run: npx playwright test
 
       # A green tick above is not evidence that anything ran — that is exactly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,13 @@ jobs:
       # Raw test-results fallback. The HTML report can fail to render when
       # the trace JSON is truncated (process killed mid-write, OOM, etc.) —
       # the raw traces + screenshots + videos survive that class of failure.
-      - name: Upload raw test-results (failure only)
-        if: failure()
+      # `always()`, not `failure()`: the concurrency group cancels this job
+      # whenever another push lands on dev mid-run, and a CANCELLED job is not a
+      # FAILED one — so the traces and screenshots from the run that just failed
+      # were never uploaded. That happened on golden-path's first execution and
+      # cost the entire diagnosis (core#501).
+      - name: Upload raw test-results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,22 @@ on:
     branches: [master, dev]
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Per-SHA for pushes, per-ref for PRs.
+  #
+  # A push to dev used to cancel the previous push's run, because the group was the ref. That
+  # was harmless when Infra was the only writer to dev. Since 2026-07-22 all five departments
+  # merge into dev themselves and merges arrive faster than CI finishes -- three commits landed
+  # inside 90 seconds on the first morning, and three of the last six dev runs were cancelled.
+  #
+  # The promotion pre-flight needs a green run for dev's EXACT head; a green run from three
+  # commits ago says nothing about what you are about to ship. When the head's run is cancelled
+  # that condition can never be satisfied. A cancelled run is not a failure -- it is the absence
+  # of evidence, and the fix is to stop discarding it.
+  #
+  # PRs keep cancellation: superseding a PR run is exactly what you want, and no promotion
+  # decision rests on it.
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
           uv pip install --system -r ci-requirements.txt --no-binary lxml --no-binary xmlsec
           uv pip install --system -e . --no-deps
 
+      - name: Fetch the deployed release
+        # This job runs the whole suite, which includes the t1-window guard
+        # (core#449). That guard compares against what production runs, and
+        # actions/checkout gives a shallow PR-only tree with no origin/master —
+        # so without this the guard fails rather than silently comparing
+        # nothing. Deliberately not --ignore'd here: `pytest tests/` must mean
+        # the same thing in CI as it does locally (core#470).
+        run: git fetch --no-tags --depth=1 origin master
+
       - name: Run tests
         run: pytest tests/ --tb=short -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
   # is broken — which only matters at 2 AM during a prod rollback.
   # Kept as a separate job so test failures on main suite don't mask it
   # (and vice-versa). DATABASE_URL_SYNC_TEST points at the service container.
+  # Also runs the t1-window guard (core#449): the deployed release's models are
+  # read out of git and checked against the migrated schema, which is why this
+  # job needs origin/master fetched rather than a shallow PR-only checkout.
   migration-roundtrip:
     runs-on: ubuntu-latest
     services:
@@ -130,10 +133,17 @@ jobs:
           uv pip install --system -r ci-requirements.txt --no-binary lxml --no-binary xmlsec
           uv pip install --system -e . --no-deps
 
-      - name: Run round-trip test
+      - name: Fetch the deployed release
+        # The t1 guard compares against what production runs, so master must be
+        # present. actions/checkout gives a shallow PR-only tree by default.
+        run: git fetch --no-tags --depth=1 origin master
+
+      - name: Run round-trip + t1-window tests
         env:
           DATABASE_URL_SYNC_TEST: postgresql://test:test@localhost:5432/test
-        run: pytest tests/test_migrations/test_roundtrip.py -v --tb=long
+        run: |
+          pytest tests/test_migrations/test_roundtrip.py \
+                 tests/test_migrations/test_expand_contract.py -v --tb=long
 
   helm-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:
@@ -55,6 +61,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:
@@ -120,6 +132,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:
@@ -241,6 +259,12 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           version: "latest"
+          # #475 made CI build lxml/xmlsec from source so it tests what ships, at a cost
+          # of ~3 min per job. Cache uv keyed on the lockfile so those builds happen once
+          # per lock change instead of once per job per run (#477). The faithfulness is
+          # the point -- reclaiming the time by reverting it would restore #470 silently.
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -121,11 +121,23 @@ jobs:
       # unchanged, so `compose up -d` won't recreate, and Grafana only reads provisioning
       # at startup. Before this step, a deployed alerting change silently did nothing
       # while CI and CD both reported success (#426).
+      #
+      # --force-recreate is NOT belt-and-braces, it is load-bearing. Six mounts here are
+      # single FILES (prometheus.yml, blackbox.yml, four Grafana dashboards), and a
+      # single-file bind mount pins the INODE. `tar xzf` replaces the file rather than
+      # editing it, so the container keeps reading the old inode forever — and
+      # `POST /-/reload` then re-reads that stale file and reports success.
+      #
+      # Observed 2026-07-22: host prometheus.yml inode=1317518 (1898 bytes, with the
+      # app_b scrape job) while the container held inode=1317530 (1222 bytes, 15h old,
+      # without it). `prometheus_config_last_reload_successful` was 1 the whole time.
+      # Grafana's provisioning escaped only because it is a DIRECTORY mount.
+      # Recreating rebinds the current inode.
       - name: Reload monitoring config
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
             'cd /opt/datanika/datanika && set -a && . ./.env.docker && set +a && \
-             docker compose up -d prometheus grafana blackbox && \
+             docker compose up -d --force-recreate prometheus grafana blackbox && \
              for i in $(seq 1 20); do curl -fsS -X POST http://127.0.0.1:9090/-/reload >/dev/null 2>&1 && { echo "prometheus reloaded"; break; }; sleep 3; \
                [ "$i" = 20 ] && { echo "prometheus /-/reload never succeeded"; exit 1; }; done && \
              docker restart datanika-grafana >/dev/null && echo "grafana restarted"'
@@ -143,20 +155,57 @@ jobs:
               > /tmp/live-rules.json 2>/dev/null && break
             sleep 5
           done
+          curl -sf http://127.0.0.1:9090/api/v1/status/config -o /tmp/live-promcfg.json || true
           python3 - <<'PY'
-          import json, re, sys
-          expected = len(re.findall(r"^\s*-\s*uid:\s*\S+",
-              open("/opt/datanika/datanika/monitoring/grafana/provisioning/alerting/alerts.yml",
-                   encoding="utf-8").read(), re.M))
+          import json, re, sys, yaml
+
+          REPO = "/opt/datanika/datanika/monitoring"
+          failed = False
+
+          # --- alert rules: COUNT is not enough -------------------------------------
+          # A count check passes for any change that edits expressions without adding or
+          # removing rules — which is exactly what #480 did, so this step went green
+          # while Grafana still held the old expressions. Compare the expressions too.
+          src = open(f"{REPO}/grafana/provisioning/alerting/alerts.yml", encoding="utf-8").read()
+          defined = {}
+          for g in yaml.safe_load(src)["groups"]:
+              for r in g["rules"]:
+                  defined[r["title"]] = (r["data"][0]["model"].get("expr") or "").strip()
           try:
-              live = len(json.load(open("/tmp/live-rules.json")))
+              live_rules = json.load(open("/tmp/live-rules.json"))
           except Exception as e:
               print("could not read live rules from Grafana:", e); sys.exit(1)
-          print(f"alert rules: defined={expected} live={live}")
-          if live != expected:
-              print("MISMATCH - Grafana did not load the deployed rules (provisioning error?)")
-              sys.exit(1)
-          print("alert rules are in effect")
+          live = {r["title"]: (r["data"][0]["model"].get("expr") or "").strip() for r in live_rules}
+
+          print(f"alert rules: defined={len(defined)} live={len(live)}")
+          if len(defined) != len(live):
+              print("MISMATCH - rule count differs"); failed = True
+          drift = [t for t, e in defined.items() if live.get(t, "<missing>") != e]
+          if drift:
+              failed = True
+              print(f"MISMATCH - {len(drift)} rule(s) whose LIVE expression differs from the repo:")
+              for t in drift[:8]:
+                  print(f"  {t}\n    repo: {e_ := defined[t]}\n    live: {live.get(t, '<missing>')}")
+          else:
+              print("all rule expressions match the repo")
+
+          # --- prometheus scrape config --------------------------------------------
+          # Single-FILE bind mounts pin the inode, so a tar deploy can leave the container
+          # reading a file that no longer exists while /-/reload reports success. Compare
+          # the LOADED config against the repo rather than trusting the reload (#479).
+          want = {j["job_name"] for j in yaml.safe_load(open(f"{REPO}/prometheus.yml", encoding="utf-8"))["scrape_configs"]}
+          try:
+              got = {j["job_name"] for j in yaml.safe_load(json.load(open("/tmp/live-promcfg.json"))["data"]["yaml"])["scrape_configs"]}
+          except Exception as e:
+              print("could not read live prometheus config:", e); sys.exit(1)
+          if want != got:
+              failed = True
+              print(f"MISMATCH - prometheus scrape jobs differ.\n  repo-only: {sorted(want - got)}\n  live-only: {sorted(got - want)}")
+              print("  (classic cause: single-file bind mount pinned to a replaced inode — recreate the container)")
+          else:
+              print(f"prometheus scrape jobs match the repo ({len(got)} jobs)")
+
+          sys.exit(1 if failed else 0)
           PY
           VERIFY
       - name: Smoke through Cloudflare

--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -156,6 +156,37 @@ jobs:
             sleep 5
           done
           curl -sf http://127.0.0.1:9090/api/v1/status/config -o /tmp/live-promcfg.json || true
+          # --- rule health: can Grafana actually EVALUATE what we shipped? ---
+          # Comparing expressions proves the right text reached Grafana. It does NOT
+          # prove the rule works. Every probe rule sat at "invalid format of evaluation
+          # results ... only reduced data can be alerted on" -- a threshold applied to an
+          # unreduced series -- so none of them ever evaluated their condition, and they
+          # paged only via execErrState. Expression comparison stayed green throughout.
+          docker exec datanika-grafana sh -c \
+            'curl -sf -u "admin:$GF_SECURITY_ADMIN_PASSWORD" \
+             http://127.0.0.1:3000/api/prometheus/grafana/api/v1/rules' \
+            > /tmp/live-health.json 2>/dev/null || true
+          python3 - <<'HEALTH'
+          import json, sys
+          try:
+              d = json.load(open('/tmp/live-health.json'))
+          except Exception as e:
+              print('could not read rule health from Grafana:', e); sys.exit(1)
+          bad = []
+          for g in d.get('data', {}).get('groups', []):
+              for r in g.get('rules', []):
+                  err = (r.get('lastError') or '').strip()
+                  for a in (r.get('alerts') or []):
+                      err = err or (a.get('annotations', {}) or {}).get('Error', '')
+                  if err:
+                      bad.append(r.get('name', '?') + ': ' + err[:110])
+          if bad:
+              print('ALERT RULES CANNOT EVALUATE:')
+              for b in bad: print('  -', b)
+              sys.exit(1)
+          print('rule health: all rules evaluate cleanly')
+          HEALTH
+          
           python3 - <<'PY'
           import json, re, sys, yaml
 

--- a/datanika/services/catalog_service.py
+++ b/datanika/services/catalog_service.py
@@ -1,12 +1,24 @@
 """Catalog service — introspect tables, manage catalog entries."""
 
+import logging
 from datetime import UTC, datetime
 
-from sqlalchemy import create_engine, inspect, select
+from sqlalchemy import create_engine, inspect, select, text
 from sqlalchemy.orm import Session
 
 from datanika.models.catalog_entry import CatalogEntry, CatalogEntryType
 from datanika.models.dependency import NodeType
+
+logger = logging.getLogger(__name__)
+
+#: Portable column metadata. Every destination we support implements
+#: `information_schema.columns`; not every SQLAlchemy dialect implements
+#: `get_columns` against it (core#494).
+_INFORMATION_SCHEMA_COLUMNS = text(
+    "SELECT column_name, data_type FROM information_schema.columns "
+    "WHERE table_schema = :schema AND table_name = :table "
+    "ORDER BY ordinal_position"
+)
 
 
 class CatalogService:
@@ -31,19 +43,57 @@ class CatalogService:
             for tbl in table_names:
                 if tbl.startswith("_dlt_"):
                     continue
-                try:
-                    cols = insp.get_columns(tbl, schema=schema_name)
-                except Exception:
+                columns = CatalogService._columns_for(engine, insp, tbl, schema_name)
+                if columns is None:
                     continue
-                results.append(
-                    {
-                        "table_name": tbl,
-                        "columns": [{"name": c["name"], "data_type": str(c["type"])} for c in cols],
-                    }
-                )
+                results.append({"table_name": tbl, "columns": columns})
             return results
         finally:
             engine.dispose()
+
+    @staticmethod
+    def _columns_for(engine, insp, table: str, schema: str) -> list[dict] | None:
+        """Column metadata for one table, with a portable fallback.
+
+        `get_columns` used to be wrapped in a bare `except: continue`, so a
+        dialect that could not answer produced an **empty catalog** rather than
+        an error — and the user was told to verify their first run by browsing
+        Catalog. That is exactly what happened on DuckDB (core#494):
+        `duckdb_engine` derives from the PostgreSQL dialect and its
+        `get_columns` queries `pg_collation`, which DuckDB does not provide::
+
+            ProgrammingError: Catalog Error: Table with name pg_collation does not exist!
+
+        Installing the dialect alone did **not** fix it — that only got as far
+        as `get_table_names`. So a failure here now falls back to
+        `information_schema`, which every destination we support implements,
+        and anything still unreadable is logged instead of vanishing.
+        """
+        try:
+            cols = insp.get_columns(table, schema=schema)
+            return [{"name": c["name"], "data_type": str(c["type"])} for c in cols]
+        except Exception as exc:
+            logger.warning(
+                "get_columns failed for %s.%s (%s) — falling back to information_schema",
+                schema,
+                table,
+                exc.__class__.__name__,
+            )
+
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    _INFORMATION_SCHEMA_COLUMNS, {"schema": schema, "table": table}
+                ).fetchall()
+        except Exception:
+            logger.exception("information_schema fallback failed for %s.%s", schema, table)
+            return None
+
+        if not rows:
+            logger.warning("No column metadata found for %s.%s — skipping", schema, table)
+            return None
+
+        return [{"name": name, "data_type": str(data_type)} for name, data_type in rows]
 
     @staticmethod
     def upsert_entry(

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -1,5 +1,6 @@
 """Connection management service — CRUD with encrypted credentials."""
 
+import logging
 import re
 from datetime import UTC, datetime
 from functools import partial
@@ -12,6 +13,8 @@ from datanika.models.connection import Connection, ConnectionDirection, Connecti
 from datanika.services.egress_guard import validate_egress_host
 from datanika.services.encryption import EncryptionService
 from datanika.services.naming import validate_name
+
+logger = logging.getLogger(__name__)
 
 validate_connection_name = partial(validate_name, entity_label="Connection")
 
@@ -78,6 +81,16 @@ def infer_direction(connection_type: str | ConnectionType) -> ConnectionDirectio
         return ConnectionDirection.DESTINATION
     return ConnectionDirection.SOURCE
 
+
+# File-backed sources. Still non-SQL, but they *are* testable: the location can
+# be listed. Kept as a subset of _NON_DB_TYPES so query/list_tables behaviour is
+# unchanged — only `test_connection` treats them specially (core#493).
+_FILE_TYPES = {
+    ConnectionType.S3,
+    ConnectionType.CSV,
+    ConnectionType.JSON,
+    ConnectionType.PARQUET,
+}
 
 # Connection types that don't support SQL queries (SELECT 1 testing or execute_query)
 _NON_DB_TYPES = {
@@ -375,6 +388,54 @@ class ConnectionService:
             return False, "Connection failed — check your credentials and network settings"
 
     @staticmethod
+    def _test_file_source(config: dict, connection_type: ConnectionType) -> tuple[bool, str]:
+        """Actually test a file source, instead of declaring the test N/A.
+
+        These types previously fell into `_NON_DB_TYPES` and returned
+        `(True, "Test not applicable for this type")` unconditionally — so a
+        wrong path tested **exactly like a right one**, and the first signal
+        anything was wrong was a green run with zero rows (core#493). Our own
+        CSV guide warned *"a wrong path looks exactly like a right one here"*;
+        that was a description of a gap, not a fact of life.
+
+        Uses the same lister the loader uses, so a connection that tests green
+        and a run that finds files agree by construction.
+        """
+        from dlt.sources.filesystem import filesystem
+
+        from datanika.services.dlt_runner import (
+            AWS_CREDENTIAL_KEYS,
+            DEFAULT_FILE_GLOBS,
+            describe_empty_file_match,
+        )
+
+        location = config.get("bucket_url") or config.get("path") or ""
+        if not location:
+            return False, "Set the bucket URL or path first — there is nothing to test yet"
+
+        # The pipeline's own `file_glob` lives in per-upload config, not on the
+        # connection, so the type's default is the best available stand-in.
+        # Narrower globs can still match nothing; the run-time check covers that.
+        file_glob = DEFAULT_FILE_GLOBS.get(connection_type.value, "*")
+
+        kwargs = {"bucket_url": location, "file_glob": file_glob}
+        if connection_type == ConnectionType.S3:
+            credentials = {k: v for k, v in config.items() if k in AWS_CREDENTIAL_KEYS}
+            if credentials:
+                kwargs["credentials"] = credentials
+
+        try:
+            first = next(iter(filesystem(**kwargs)), None)
+        except Exception as exc:
+            logger.warning("File-source connection test failed for %s: %s", location, exc)
+            return False, f"Could not read {location} — check the path, permissions and credentials"
+
+        if first is None:
+            return False, describe_empty_file_match(location, file_glob)
+
+        return True, f"Connected — found files matching {file_glob}"
+
+    @staticmethod
     def test_connection(config: dict, connection_type: ConnectionType) -> tuple[bool, str]:
         """Test real database connectivity via SELECT 1. Returns (success, message)."""
         if not config:
@@ -382,6 +443,9 @@ class ConnectionService:
 
         if connection_type == ConnectionType.MONGODB:
             return ConnectionService._test_mongodb(config)
+
+        if connection_type in _FILE_TYPES:
+            return ConnectionService._test_file_source(config, connection_type)
 
         if connection_type in _NON_DB_TYPES:
             return True, "Test not applicable for this type"

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -313,6 +313,59 @@ def _build_format_reader(file_format: str, dlt_config: dict):
     return read_json()
 
 
+def describe_empty_file_match(bucket_url: str, file_glob: str) -> str:
+    """Explain *why* nothing matched, as specifically as the location allows.
+
+    The production case (core#493) was a `bucket_url` set to a full file path:
+    the glob is applied *under* that value, so `*.csv` under
+    `/docs_samples/customers.csv` matched nothing and the run went green with
+    0 rows. "No files matched" alone would leave the user re-checking a glob
+    that was never the problem, so the file-vs-directory case is called out by
+    name.
+
+    Local paths are diagnosed precisely; remote buckets get the general form,
+    because probing a URL for existence costs a second round trip and the
+    credentials to do it may be exactly what is wrong.
+    """
+    # Paths are quoted by hand rather than with !r: on Windows `repr` doubles
+    # every backslash, so the path we tell the user to try comes back looking
+    # like a typo of itself.
+    general = (
+        f"No files matched '{file_glob}' under '{bucket_url}'. "
+        "The run would have completed with zero rows."
+    )
+
+    if "://" in bucket_url:
+        return f"{general} Check the prefix and the file pattern."
+
+    if os.path.isfile(bucket_url):
+        return (
+            f"{general} '{bucket_url}' is a file, but this field must be the "
+            "directory that contains your files — the pattern is matched inside "
+            f"it. Try '{os.path.dirname(bucket_url)}' instead."
+        )
+
+    if not os.path.exists(bucket_url):
+        return f"{general} That path does not exist."
+
+    return f"{general} The directory exists but holds nothing matching that pattern."
+
+
+def _first_file_or_none(lister):
+    """Peek the lister dlt itself will use.
+
+    Deliberately not a second implementation with `fsspec_filesystem` +
+    `glob_files`: that path rejects our plain credentials dict (only
+    `filesystem()`'s config injection coerces it), and any separate matching
+    logic could drift from the loader's. Peeking the same resource means
+    detection and loading agree by construction.
+
+    Re-iterating afterwards still yields the files, so the peeked lister goes
+    on to the pipeline unchanged.
+    """
+    return next(iter(lister), None)
+
+
 def _file_table_name(connection_type: str, file_glob: str, dlt_config: dict) -> str:
     """Name the destination table for a file source.
 
@@ -534,7 +587,16 @@ class DltRunnerService:
         reader = _build_format_reader(file_format, dlt_config)
         table_name = _file_table_name(connection_type, file_glob, dlt_config)
 
-        return (filesystem(**kwargs) | reader).with_name(table_name)
+        lister = filesystem(**kwargs)
+
+        # Matching nothing is not a successful load of nothing (core#493). A
+        # typo'd path, a moved file, an export that didn't run and an emptied
+        # prefix all produced `success` / `Rows: 0`, which is byte-identical to
+        # a healthy run. Fail here, where the reason is still known.
+        if _first_file_or_none(lister) is None:
+            raise DltRunnerError(describe_empty_file_match(bucket_url, file_glob))
+
+        return (lister | reader).with_name(table_name)
 
     @staticmethod
     def _rest_api_from_parts(

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -3,9 +3,11 @@
 import logging
 import os
 import shutil
+from pathlib import PurePosixPath
 
 import dlt
-from dlt.sources.filesystem import filesystem
+from dlt.common import json as dlt_json
+from dlt.sources.filesystem import filesystem, read_csv, read_parquet
 from dlt.sources.rest_api import rest_api_source
 from dlt.sources.sql_database import sql_database, sql_table
 
@@ -18,6 +20,28 @@ DEFAULT_BATCH_SIZE = 10_000
 SUPPORTED_FILE_TYPES = {"s3", "csv", "json", "parquet"}
 
 DEFAULT_FILE_GLOBS = {"csv": "*.csv", "json": "*.json", "parquet": "*.parquet", "s3": "*"}
+
+# dlt's `filesystem()` is a *lister*: it yields one FileItem per matched file
+# (name, size, mtime, mime type). Reading contents requires piping it through a
+# transformer. Without one the destination gets a table of filenames and the run
+# reports success — core#492, found on prod on the advertised onboarding path.
+FILE_FORMAT_BY_TYPE = {"csv": "csv", "json": "json", "parquet": "parquet"}
+
+# `s3` (and any glob-driven source) carries no format in its type, so it is
+# inferred from the pattern's extension. Deliberately not defaulted: guessing
+# wrong here reproduces exactly the failure this fixes, just one layer along.
+FILE_FORMAT_BY_EXTENSION = {
+    ".csv": "csv",
+    ".tsv": "csv",
+    ".txt": "csv",
+    ".json": "json",
+    ".jsonl": "json",
+    ".ndjson": "json",
+    ".parquet": "parquet",
+    ".pq": "parquet",
+}
+
+_GLOB_WILDCARDS = "*?["
 
 AWS_CREDENTIAL_KEYS = {"aws_access_key_id", "aws_secret_access_key", "region_name", "endpoint_url"}
 
@@ -62,6 +86,10 @@ INTERNAL_CONFIG_KEYS = {
     "filters",
     "bucket_url",
     "file_glob",
+    "file_format",
+    "table_name",
+    "delimiter",
+    "encoding",
     "resources",
     "resource_names",
     "paginator",
@@ -169,6 +197,141 @@ def _normalize_oracle_identifier(name: str | None) -> str | None:
     from sqlalchemy.dialects.oracle.base import OracleDialect
 
     return OracleDialect().normalize_name(name) or name
+
+
+def _json_chunks(file_obj, chunksize: int):
+    """Yield lists of records from one JSON file, whatever shape it is.
+
+    dlt ships `read_jsonl`, which is **JSON Lines only**, but our default glob
+    for the `json` connection type is `*.json` — the array/object case. Feeding
+    an array to `read_jsonl` does not fail: the whole file parses as one value,
+    so dlt writes a parent row with no business columns plus a `__value` child
+    table. Another green run with the data in the wrong shape (core#492).
+
+    So the shape is detected rather than assumed:
+      - `[...]`        -> the array's elements are the records
+      - one JSON value -> a single record (a dict) or its elements (a list)
+      - otherwise      -> JSON Lines, streamed a line at a time
+    """
+    head = file_obj.read(1024)
+    file_obj.seek(0)
+    first = head.lstrip()[:1]
+
+    if first == b"[":
+        records = dlt_json.loadb(file_obj.read())
+        for start in range(0, len(records), chunksize):
+            yield records[start : start + chunksize]
+        return
+
+    chunk = []
+    for line in file_obj:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            chunk.append(dlt_json.loadb(line))
+        except Exception:
+            # Not line-delimited after all — most likely one pretty-printed
+            # object spanning many lines. Re-read it as a whole.
+            file_obj.seek(0)
+            value = dlt_json.loadb(file_obj.read())
+            yield value if isinstance(value, list) else [value]
+            return
+        if len(chunk) >= chunksize:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+@dlt.transformer(name="json_records")
+def read_json(items, chunksize: int = 1000):
+    """Read JSON files whose shape is not known ahead of time.
+
+    Companion to dlt's `read_csv` / `read_parquet` / `read_jsonl`, covering the
+    gap that `read_jsonl` leaves: arrays and single objects.
+    """
+    for file_obj in items:
+        with file_obj.open() as f:
+            yield from _json_chunks(f, chunksize)
+
+
+def _resolve_file_format(connection_type: str, file_glob: str, dlt_config: dict) -> str:
+    """Decide which reader a file source needs — or refuse to guess.
+
+    Order: an explicit `file_format` wins; then the connection type, which
+    names the format for `csv`/`json`/`parquet`; then the glob's extension,
+    which is all `s3` has to go on.
+
+    A bare `s3` glob (`*`) reaches none of those, and **that raises**. Loading
+    the file listing instead is what core#492 was, and picking a format at
+    random would be the same bug with a different payload.
+    """
+    explicit = dlt_config.get("file_format")
+    if explicit:
+        normalized = str(explicit).lower().lstrip(".")
+        if normalized in {"jsonl", "ndjson"}:
+            return "json"
+        if normalized not in {"csv", "json", "parquet"}:
+            raise DltRunnerError(
+                f"Unsupported file_format {explicit!r}. Supported: csv, json, parquet."
+            )
+        return normalized
+
+    by_type = FILE_FORMAT_BY_TYPE.get(connection_type)
+    if by_type:
+        return by_type
+
+    suffix = PurePosixPath(file_glob).suffix.lower()
+    by_extension = FILE_FORMAT_BY_EXTENSION.get(suffix)
+    if by_extension:
+        return by_extension
+
+    raise DltRunnerError(
+        f"Cannot tell what format {file_glob!r} matches, so there is no way to read it. "
+        "Set 'file_format' (csv, json or parquet) in the pipeline config, or narrow "
+        "the file pattern to one extension (e.g. '*.csv')."
+    )
+
+
+def _build_format_reader(file_format: str, dlt_config: dict):
+    """Build the transformer for a resolved format, with its format options."""
+    if file_format == "csv":
+        # `read_csv` forwards **pandas_kwargs, so the CSV knobs are pandas'.
+        # Only forwarded when set — pandas already infers the header row and
+        # column types, and an unrequested override is a silent wrong answer.
+        pandas_kwargs = {}
+        if dlt_config.get("delimiter"):
+            pandas_kwargs["sep"] = dlt_config["delimiter"]
+        if dlt_config.get("encoding"):
+            pandas_kwargs["encoding"] = dlt_config["encoding"]
+        return read_csv(**pandas_kwargs)
+
+    if file_format == "parquet":
+        return read_parquet()
+
+    return read_json()
+
+
+def _file_table_name(connection_type: str, file_glob: str, dlt_config: dict) -> str:
+    """Name the destination table for a file source.
+
+    Required, not cosmetic: a piped transformer takes the transformer's name,
+    so the unrenamed result lands in a table called **`_read_csv`** — which
+    reads as a dlt internal. Order: an explicit `table_name`; then the glob's
+    stem when it names one file (`customers.csv` -> `customers`); then the
+    connection type, which is at least stable and predictable.
+    """
+    explicit = dlt_config.get("table_name")
+    if explicit:
+        return str(explicit)
+
+    if not any(char in file_glob for char in _GLOB_WILDCARDS):
+        stem = PurePosixPath(file_glob).stem
+        if stem:
+            return stem
+
+    return connection_type
 
 
 class DltRunnerService:
@@ -348,7 +511,12 @@ class DltRunnerService:
             return sql_database(**kwargs)
 
     def _build_file_source(self, connection_type: str, config: dict, dlt_config: dict):
-        """Build a dlt filesystem source for file-based connections."""
+        """Build a dlt filesystem source that loads file **contents**.
+
+        `filesystem()` alone lists files; piping it through a format reader is
+        what produces rows. See `_resolve_file_format` for how the reader is
+        chosen and `_file_table_name` for why the result is always renamed.
+        """
         bucket_url = dlt_config.get("bucket_url") or config.get("bucket_url", "")
         if not bucket_url:
             raise DltRunnerError("File sources require 'bucket_url' in config or dlt_config")
@@ -362,7 +530,11 @@ class DltRunnerService:
             if credentials:
                 kwargs["credentials"] = credentials
 
-        return filesystem(**kwargs)
+        file_format = _resolve_file_format(connection_type, file_glob, dlt_config)
+        reader = _build_format_reader(file_format, dlt_config)
+        table_name = _file_table_name(connection_type, file_glob, dlt_config)
+
+        return (filesystem(**kwargs) | reader).with_name(table_name)
 
     @staticmethod
     def _rest_api_from_parts(

--- a/datanika/services/execution_service.py
+++ b/datanika/services/execution_service.py
@@ -70,6 +70,23 @@ class ExecutionService:
         session.flush()
         return run
 
+    def append_logs(self, session: Session, run_id: int, text: str) -> Run | None:
+        """Add a line to a finished run's logs.
+
+        For things that happen *after* the load completes and must not change
+        its status — catalog sync is the case that motivated it (core#494).
+        Swallowing that failure into the worker log alone kept a permanently
+        broken feature invisible for as long as DuckDB had been a destination:
+        the run row said success, Catalog stayed empty, and only SSH could
+        connect the two.
+        """
+        run = session.get(Run, run_id)
+        if run is None:
+            return None
+        run.logs = f"{run.logs}\n{text}" if run.logs else text
+        session.flush()
+        return run
+
     def cancel_run(self, session: Session, run_id: int) -> Run | None:
         run = session.get(Run, run_id)
         if run is None:

--- a/datanika/services/execution_service.py
+++ b/datanika/services/execution_service.py
@@ -68,6 +68,34 @@ class ExecutionService:
         run.error_message = error_message
         run.logs = logs
         session.flush()
+
+        # A failed run has never produced a notification — Slack, email or
+        # in-app. Both handlers already branch on `status == "failed"`, but
+        # nothing ever sent that status, so the branch was unreachable
+        # (core#465).
+        #
+        # Announced from here rather than from each task's failure path
+        # because this is the one place every failure passes through: five
+        # call sites today, two of which are not `except` blocks at all (a dbt
+        # command failing, and upstream dependencies never being satisfied).
+        # Adding calls to those paths is what the issue warned against; this
+        # leaves them untouched and cannot be forgotten by a sixth caller.
+        #
+        # `announce`, not `emit`: no subscriber may veto a failure that has
+        # already happened, and a broken notifier must not mask the real error
+        # (core#456).
+        from datanika.hooks import announce
+
+        announce(
+            "run.failed",
+            session=session,
+            org_id=run.org_id,
+            run_id=run.id,
+            status=RunStatus.FAILED.value,
+            error_message=error_message,
+            target_type=getattr(run.target_type, "value", run.target_type),
+            target_id=run.target_id,
+        )
         return run
 
     def append_logs(self, session: Session, run_id: int, text: str) -> Run | None:

--- a/datanika/services/in_app_notification_hooks.py
+++ b/datanika/services/in_app_notification_hooks.py
@@ -54,3 +54,6 @@ def register_in_app_notification_hooks() -> None:
     hooks.on("run.upload_completed", _on_run_completed)
     hooks.on("run.models_completed", _on_run_completed)
     hooks.on("run.transformation_completed", _on_run_completed)
+    # See notification_service.register_hooks: failures get their own event so
+    # cloud's unconditional metering handlers never see them (core#465).
+    hooks.on("run.failed", _on_run_completed)

--- a/datanika/services/notification_service.py
+++ b/datanika/services/notification_service.py
@@ -313,3 +313,10 @@ def register_hooks(service):
     hooks.on("run.upload_completed", _on_run_completed)
     hooks.on("run.models_completed", _on_run_completed)
     hooks.on("run.transformation_completed", _on_run_completed)
+    # Failures arrive on their own event, not on `run.*_completed` with
+    # status="failed" (core#465). datanika-cloud's four metering handlers
+    # subscribe to those three and call `record_usage` unconditionally —
+    # none of them check `status` — so reusing them would bill the user for
+    # a run that failed. The separation is structural rather than a status
+    # check we would be trusting another repo's handlers to keep.
+    hooks.on("run.failed", _on_run_completed)

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -248,8 +248,19 @@ def run_upload(
                 dst_config,
                 dataset_name,
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Catalog sync failed (non-fatal)")
+            # Non-fatal to the run, but not invisible: the load succeeded and
+            # the data is there, while Models/Catalog will not show it. Saying
+            # so on the run is the difference between a user filing a bug and
+            # a user concluding the product does not work (core#494).
+            execution_service.append_logs(
+                session,
+                run_id,
+                "WARNING: the data loaded successfully, but the catalog sync failed, "
+                "so these tables will not appear under Models/Catalog: "
+                f"{exc.__class__.__name__}: {exc}",
+            )
 
         from datanika.hooks import announce
 

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -3,6 +3,7 @@
 import logging
 import traceback
 from collections import defaultdict
+from pathlib import PurePosixPath
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -202,6 +203,15 @@ def run_upload(
                 if uploaded_file:
                     extracted_dir = file_svc.extract_for_dlt(uploaded_file)
                     dlt_config["bucket_url"] = extracted_dir
+                    # Name the table after the file the user uploaded. This is
+                    # the only layer that knows the original name — the runner
+                    # sees a hash-named extract dir and a `*.csv` glob, so
+                    # without this the advertised onboarding run lands in a
+                    # table called `csv` (core#492).
+                    if not dlt_config.get("table_name"):
+                        stem = PurePosixPath(uploaded_file.original_name).stem
+                        if stem:
+                            dlt_config["table_name"] = stem
 
             try:
                 from datanika.config import settings as app_cfg

--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -1,0 +1,230 @@
+import { expect, type Page } from "@playwright/test";
+import { gotoReady } from "./auth";
+
+/**
+ * Builders for the golden path: connections, uploads, runs.
+ *
+ * These drive the **real UI**, not the API. That distinction is the whole point
+ * of core#482: the backend create/run path already had API-level coverage (the
+ * nightly connector-smoke matrix, the 2026-07-17 restore check) and both P0s of
+ * 2026-07-22 still reached production through it —
+ *
+ *   - #452 the connections upload handler was annotated bare `list` instead of
+ *     `list[rx.UploadFile]`, so the drop zone returned HTTP 500. Reflex locates
+ *     the upload param by scanning for a generic alias; no API test touches that.
+ *   - #456 `run.*_completed` was emitted with kwargs the registered notification
+ *     handlers could not accept, so `emit()` raised *after* the run finished and
+ *     the surrounding `except` overwrote it with `fail_run(...)`. The run really
+ *     did complete — only the recorded status was wrong.
+ *
+ * So: click what a user clicks, and assert the status a user sees.
+ */
+
+/** A connection type as the picker lists it (see connections.py PICKER_TYPES). */
+export type ConnectionKind = "duckdb" | "csv";
+
+/**
+ * `ConnectionState.set_form_name` runs `re.sub(r"[^a-zA-Z0-9 ]", "", value)` on
+ * every keystroke, so a name with a dash or underscore is silently NOT the name
+ * you typed. Mirror that here rather than asserting on the typed string — a test
+ * that types `qa-golden-1` and looks for `qa-golden-1` fails for a reason that
+ * has nothing to do with the behaviour under test.
+ */
+export function sanitizeName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9 ]/g, "");
+}
+
+/**
+ * Pick a value from a `searchable_select` (components/searchable_select.py).
+ *
+ * It is a Radix popover, not a `<select>`: the trigger is a button whose
+ * accessible name is the placeholder until something is chosen, and the options
+ * are `rx.box`es inside the popover content. We scope option lookup to the
+ * popover — the same text ("duckdb") also appears in the connections table, so
+ * an unscoped `getByText` matches the row behind the overlay and clicks nothing.
+ */
+export async function selectSearchable(
+  page: Page,
+  placeholder: string,
+  optionText: string,
+): Promise<void> {
+  await page.getByRole("button", { name: placeholder, exact: true }).click();
+
+  // Radix portals popover content into a positioned wrapper at the body root.
+  const popover = page.locator("[data-radix-popper-content-wrapper]").last();
+  await expect(popover).toBeVisible();
+
+  // The filter input is pure frontend JS (rx.script), so typing narrows the
+  // list without a round trip. Filtering first keeps the click unambiguous
+  // when one option's text is a prefix of another's.
+  await popover.getByPlaceholder("Search...").fill(optionText);
+
+  await popover.getByText(optionText, { exact: true }).click();
+  await expect(popover).toBeHidden();
+}
+
+/**
+ * Create a DuckDB destination connection and return the name as saved.
+ *
+ * `dbPath` must be reachable from BOTH the web container and the Celery worker:
+ * the load runs in the worker, so a web-only path fails at run time rather than
+ * at save time — the slower, more confusing failure (#471, same reasoning as the
+ * `uploaded_files` volume).
+ */
+export async function createDuckDbConnection(
+  page: Page,
+  name: string,
+  dbPath: string,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/connections");
+
+  await page.getByPlaceholder("Connection name").fill(name);
+  await selectSearchable(page, "Connection type", "duckdb");
+  await page.getByPlaceholder("/data/warehouse.duckdb").fill(dbPath);
+  await page.getByRole("button", { name: "Create Connection" }).click();
+
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `DuckDB connection "${saved}" did not appear in the connections table`,
+  ).toBeVisible({ timeout: 15_000 });
+  return saved;
+}
+
+/**
+ * Create a CSV source connection by uploading a file through the drop zone.
+ *
+ * **This is #452's exact path.** `rx.upload(id="file_upload", no_drag=True)`
+ * renders a react-dropzone with a hidden `<input type="file">`; setting files on
+ * it fires the same `on_drop` → `handle_file_upload` the button does. The bug
+ * returned HTTP 500 on that handler, so asserting the "File uploaded" confirmation
+ * is the assertion that matters — not merely that the connection saved.
+ */
+export async function createCsvConnection(
+  page: Page,
+  name: string,
+  csvPath: string,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/connections");
+
+  await page.getByPlaceholder("Connection name").fill(name);
+  await selectSearchable(page, "Connection type", "csv");
+
+  await page.locator('input[type="file"]').setInputFiles(csvPath);
+
+  // connections.file_uploaded — proves the upload handler returned 2xx. A bare
+  // "connection saved" assertion passes even when the drop zone 500s, because
+  // the file path field is optional.
+  await expect(
+    page.getByText("File uploaded"),
+    "CSV upload did not confirm — the connections upload handler may be failing (see #452)",
+  ).toBeVisible({ timeout: 20_000 });
+
+  await page.getByRole("button", { name: "Create Connection" }).click();
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `CSV connection "${saved}" did not appear in the connections table`,
+  ).toBeVisible({ timeout: 15_000 });
+  return saved;
+}
+
+/**
+ * Create an upload (extract+load) wiring a source connection to a destination.
+ *
+ * Note there is no "pipeline builder" and no "Configure pipeline" button — the
+ * extract-load object is an Upload at `/uploads`. The connector guides describe
+ * a UI that does not exist here (landing#272); the UI is the source of truth.
+ */
+export async function createUpload(
+  page: Page,
+  name: string,
+  sourceOption: string,
+  destOption: string,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/uploads");
+
+  await page.getByPlaceholder("Upload name").fill(name);
+  await selectSearchable(page, "Source connection", sourceOption);
+  await selectSearchable(page, "Destination connection", destOption);
+  await page.getByRole("button", { name: "Create Upload" }).click();
+
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `Upload "${saved}" did not appear in the uploads table`,
+  ).toBeVisible({ timeout: 15_000 });
+  return saved;
+}
+
+/**
+ * The connection picker on /uploads labels options `"{id} — {name} ({type})"`
+ * (upload_state.py). Callers know the name and type but not the id, so match on
+ * the stable tail and read the full label back off the DOM.
+ */
+export async function uploadOptionFor(
+  page: Page,
+  placeholder: string,
+  connectionName: string,
+  kind: ConnectionKind,
+): Promise<string> {
+  await page.getByRole("button", { name: placeholder, exact: true }).click();
+  const popover = page.locator("[data-radix-popper-content-wrapper]").last();
+  await expect(popover).toBeVisible();
+
+  const suffix = `${connectionName} (${kind})`;
+  const option = popover.getByText(new RegExp(`\\d+ — ${suffix}$`));
+  await expect(
+    option,
+    `no ${placeholder} option ending "${suffix}" — is the connection the right type?`,
+  ).toBeVisible({ timeout: 10_000 });
+
+  const label = (await option.textContent())?.trim() ?? "";
+  await page.keyboard.press("Escape");
+  await expect(popover).toBeHidden();
+  return label;
+}
+
+export type RunOutcome = { status: string; rows: number };
+
+/**
+ * Trigger an upload run and wait for it to reach a terminal state.
+ *
+ * Returns whatever terminal state it reached — deliberately does NOT assert
+ * success. The caller asserts, so a failure reads `expected "success", got
+ * "failed"` rather than a timeout, and so #465 (nothing announces
+ * `status="failed"`) cannot be mistaken for a hung run.
+ */
+export async function runUploadAndAwait(
+  page: Page,
+  uploadName: string,
+  timeoutMs = 180_000,
+): Promise<RunOutcome> {
+  await gotoReady(page, "/uploads");
+  const row = page.getByRole("row").filter({ hasText: uploadName });
+  await expect(row, `upload "${uploadName}" is not listed`).toBeVisible();
+  await row.getByRole("button", { name: "Run", exact: true }).click();
+
+  const deadline = Date.now() + timeoutMs;
+  let last: RunOutcome = { status: "(no run row appeared)", rows: 0 };
+
+  while (Date.now() < deadline) {
+    await gotoReady(page, "/runs");
+    const runRow = page.getByRole("row").filter({ hasText: uploadName }).first();
+
+    if (await runRow.isVisible().catch(() => false)) {
+      const cells = runRow.getByRole("cell");
+      // runs.py column order: ID | Target | Status | Started | Finished | Rows | Error | Logs
+      const status = ((await cells.nth(2).textContent()) ?? "").trim();
+      const rows = Number(((await cells.nth(5).textContent()) ?? "0").trim() || 0);
+      last = { status, rows };
+      if (status === "success" || status === "failed") return last;
+    }
+    await page.waitForTimeout(3_000);
+  }
+  throw new Error(
+    `run for "${uploadName}" did not reach a terminal state within ${timeoutMs}ms ` +
+      `(last seen: status="${last.status}", rows=${last.rows}). ` +
+      "Is the Celery worker running?",
+  );
+}

--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -228,42 +228,23 @@ export async function createCsvConnection(
  * extract-load object is an Upload at `/uploads`. The connector guides describe
  * a UI that does not exist here (landing#272); the UI is the source of truth.
  */
-export async function createUpload(
-  page: Page,
-  name: string,
-  sourceOption: string,
-  destOption: string,
-): Promise<string> {
-  const saved = sanitizeName(name);
-  await gotoReady(page, "/uploads");
-
-  const nameField = page.getByPlaceholder("Upload name");
-  await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
-  await nameField.fill(name, { timeout: UI_TIMEOUT });
-
-  // These two default to "" in UploadState, so the placeholder IS what shows.
-  await selectSearchable(page, ["Source connection"], sourceOption);
-  await selectSearchable(page, ["Destination connection"], destOption);
-  await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
-
-  await expect(
-    page.getByRole("cell", { name: saved, exact: true }),
-    `Upload "${saved}" did not appear in the uploads table`,
-  ).toBeVisible({ timeout: UI_TIMEOUT });
-  return saved;
-}
+export type ConnectionRef = { name: string; kind: ConnectionKind };
 
 /**
- * The connection picker on /uploads labels options `"{id} — {name} ({type})"`
- * (upload_state.py). Callers know the name and type but not the id, so match on
- * the stable tail and read the full label back off the DOM.
+ * Pick a connection in one of the `/uploads` pickers.
+ *
+ * The options are labelled `"{id} — {name} ({type})"` (upload_state.py) and the
+ * caller knows the name and type but not the id, so match on the stable tail.
+ *
+ * **Assumes the page is already on `/uploads`** — which is why this is not
+ * exported: it is only ever reachable through `createUpload`, which navigates
+ * first. See the note there.
  */
-export async function uploadOptionFor(
+async function selectConnectionOption(
   page: Page,
   placeholder: string,
-  connectionName: string,
-  kind: ConnectionKind,
-): Promise<string> {
+  conn: ConnectionRef,
+): Promise<void> {
   const trigger = searchableTrigger(page, [placeholder]);
   await present(page, trigger, `searchable-select trigger "${placeholder}"`);
   await trigger.click({ timeout: UI_TIMEOUT });
@@ -273,17 +254,53 @@ export async function uploadOptionFor(
     timeout: UI_TIMEOUT,
   });
 
-  const suffix = `${connectionName} (${kind})`;
-  const option = popover.getByText(new RegExp(`\\d+ — ${suffix}$`));
+  const suffix = `${conn.name} (${conn.kind})`;
+  const option = popover.getByText(new RegExp(`\\d+ — ${escapeRegExp(suffix)}$`));
   await expect(
     option,
     `no ${placeholder} option ending "${suffix}" — is the connection the right type?`,
   ).toBeVisible({ timeout: UI_TIMEOUT });
-
-  const label = (await option.textContent())?.trim() ?? "";
-  await page.keyboard.press("Escape");
+  await option.click({ timeout: UI_TIMEOUT });
   await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
-  return label;
+}
+
+/**
+ * Create an upload (extract+load) wiring a source connection to a destination.
+ *
+ * Note there is no "pipeline builder" and no "Configure pipeline" button — the
+ * extract-load object is an Upload at `/uploads`. The connector guides describe
+ * a UI that does not exist here (landing#272); the UI is the source of truth.
+ *
+ * Takes the connections themselves rather than pre-resolved option labels. The
+ * earlier shape made the caller resolve labels first, which meant the picker
+ * was queried while the browser was still on `/connections` — and the failure
+ * read as "trigger 'Source connection' not found" on a page that legitimately
+ * has no such control (core#515). Navigation and lookup now live together, so
+ * that ordering hazard is not expressible.
+ */
+export async function createUpload(
+  page: Page,
+  name: string,
+  source: ConnectionRef,
+  destination: ConnectionRef,
+): Promise<string> {
+  const saved = sanitizeName(name);
+  await gotoReady(page, "/uploads");
+
+  const nameField = page.getByPlaceholder("Upload name");
+  await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
+  // Both default to "" in UploadState, so the placeholder IS what shows.
+  await selectConnectionOption(page, "Source connection", source);
+  await selectConnectionOption(page, "Destination connection", destination);
+  await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
+
+  await expect(
+    page.getByRole("cell", { name: saved, exact: true }),
+    `Upload "${saved}" did not appear in the uploads table`,
+  ).toBeVisible({ timeout: UI_TIMEOUT });
+  return saved;
 }
 
 export type RunOutcome = { status: string; rows: number };

--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -59,22 +59,56 @@ async function present(page: Page, locator: ReturnType<Page["locator"]>, what: s
   });
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Locate a `searchable_select` trigger by the label it is *currently* showing.
+ *
+ * The trigger renders `rx.cond(value != "", value, placeholder)` — the selected
+ * value when there is one, the placeholder only when there is not. So there is
+ * no single stable string to match on, and which one applies depends on the
+ * state's default:
+ *
+ *   - `ConnectionState.form_type` defaults to **`"postgres"`**, so the connection
+ *     type picker never shows "Connection type" at all.
+ *   - `UploadState.form_source_id` / `form_dest_id` default to `""`, so those two
+ *     do show their placeholders.
+ *
+ * Passing the full set of labels the trigger may be showing is modelling that
+ * contract, not guessing at it. The first CI run of this spec failed precisely
+ * here: it looked for "Connection type" on a control that was displaying
+ * "postgres" (core#501).
+ */
+function searchableTrigger(page: Page, labels: string[]) {
+  const pattern = new RegExp(`^(${labels.map(escapeRegExp).join("|")})$`);
+  return page.getByRole("button", { name: pattern });
+}
+
 /**
  * Pick a value from a `searchable_select` (components/searchable_select.py).
  *
- * It is a Radix popover, not a `<select>`: the trigger is a button whose
- * accessible name is the placeholder until something is chosen, and the options
- * are `rx.box`es inside the popover content. We scope option lookup to the
- * popover — the same text ("duckdb") also appears in the connections table, so
- * an unscoped `getByText` matches the row behind the overlay and clicks nothing.
+ * It is a Radix popover, not a `<select>`: the options are `rx.box`es inside the
+ * popover content. We scope option lookup to the popover — the same text
+ * ("duckdb") also appears in the connections table, so an unscoped `getByText`
+ * matches the row behind the overlay and clicks nothing.
+ *
+ * `labels` is every string the trigger might currently display — see
+ * `searchableTrigger`.
  */
 export async function selectSearchable(
   page: Page,
-  placeholder: string,
+  labels: string[],
   optionText: string,
 ): Promise<void> {
-  const trigger = page.getByRole("button", { name: placeholder, exact: true });
-  await present(page, trigger, `searchable-select trigger "${placeholder}"`);
+  const placeholder = labels[0];
+  const trigger = searchableTrigger(page, labels);
+  await present(
+    page,
+    trigger,
+    `searchable-select trigger (showing one of: ${labels.join(" | ")})`,
+  );
   await trigger.click({ timeout: UI_TIMEOUT });
 
   // Radix portals popover content into a positioned wrapper at the body root.
@@ -94,6 +128,14 @@ export async function selectSearchable(
   });
   await option.click({ timeout: UI_TIMEOUT });
   await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
+
+  // The trigger now displays the selected value. Assert it, so "the click
+  // landed on the overlay instead of the option" fails here rather than three
+  // steps later as a confusing absence of the type-specific fields.
+  await expect(
+    searchableTrigger(page, [optionText]),
+    `selected "${optionText}" but the trigger does not show it — did the click miss?`,
+  ).toBeVisible({ timeout: UI_TIMEOUT });
 }
 
 /**
@@ -116,7 +158,9 @@ export async function createDuckDbConnection(
   await present(page, nameField, 'the connection-name field (placeholder "Connection name")');
   await nameField.fill(name, { timeout: UI_TIMEOUT });
 
-  await selectSearchable(page, "Connection type", "duckdb");
+  // "postgres" is ConnectionState.form_type's default, so that — not the
+  // placeholder — is what the trigger actually reads on a fresh form.
+  await selectSearchable(page, ["Connection type", "postgres"], "duckdb");
 
   const pathField = page.getByPlaceholder("/data/warehouse.duckdb");
   await present(page, pathField, "the DuckDB path field — did the type picker actually apply?");
@@ -152,7 +196,7 @@ export async function createCsvConnection(
   await present(page, nameField, 'the connection-name field (placeholder "Connection name")');
   await nameField.fill(name, { timeout: UI_TIMEOUT });
 
-  await selectSearchable(page, "Connection type", "csv");
+  await selectSearchable(page, ["Connection type", "postgres"], "csv");
 
   const fileInput = page.locator('input[type="file"]');
   await expect(
@@ -197,8 +241,9 @@ export async function createUpload(
   await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
   await nameField.fill(name, { timeout: UI_TIMEOUT });
 
-  await selectSearchable(page, "Source connection", sourceOption);
-  await selectSearchable(page, "Destination connection", destOption);
+  // These two default to "" in UploadState, so the placeholder IS what shows.
+  await selectSearchable(page, ["Source connection"], sourceOption);
+  await selectSearchable(page, ["Destination connection"], destOption);
   await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
 
   await expect(
@@ -219,7 +264,7 @@ export async function uploadOptionFor(
   connectionName: string,
   kind: ConnectionKind,
 ): Promise<string> {
-  const trigger = page.getByRole("button", { name: placeholder, exact: true });
+  const trigger = searchableTrigger(page, [placeholder]);
   await present(page, trigger, `searchable-select trigger "${placeholder}"`);
   await trigger.click({ timeout: UI_TIMEOUT });
 

--- a/e2e/fixtures/data.ts
+++ b/e2e/fixtures/data.ts
@@ -18,7 +18,21 @@ import { gotoReady } from "./auth";
  *     did complete — only the recorded status was wrong.
  *
  * So: click what a user clicks, and assert the status a user sees.
+ *
+ * ── Every interaction is explicitly bounded (core#501) ───────────────────────
+ * `playwright.config.ts` sets a test timeout and an *expect* timeout but no
+ * `actionTimeout`, so Playwright actions default to **unbounded** — they are
+ * capped only by the enclosing test. The first run of this spec proved what
+ * that costs: a locator never resolved, `.fill()` sat on it for the full
+ * 6-minute test budget, and the report said nothing except "timed out". A
+ * six-minute silence is not a test result.
+ *
+ * Hence `UI_TIMEOUT` on every action. A wrong selector now fails in ~15s and
+ * names itself, which is the difference between a diagnosis and another run.
  */
+
+/** Bound for a single UI interaction. Long enough for Reflex's WS round trip. */
+const UI_TIMEOUT = 15_000;
 
 /** A connection type as the picker lists it (see connections.py PICKER_TYPES). */
 export type ConnectionKind = "duckdb" | "csv";
@@ -35,6 +49,17 @@ export function sanitizeName(value: string): string {
 }
 
 /**
+ * Assert a locator is present before acting on it, with a message naming what
+ * was expected. Without this, a bad selector surfaces as a bare timeout on
+ * whatever action came next.
+ */
+async function present(page: Page, locator: ReturnType<Page["locator"]>, what: string) {
+  await expect(locator.first(), `could not find ${what} on ${page.url()}`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
+}
+
+/**
  * Pick a value from a `searchable_select` (components/searchable_select.py).
  *
  * It is a Radix popover, not a `<select>`: the trigger is a button whose
@@ -48,19 +73,27 @@ export async function selectSearchable(
   placeholder: string,
   optionText: string,
 ): Promise<void> {
-  await page.getByRole("button", { name: placeholder, exact: true }).click();
+  const trigger = page.getByRole("button", { name: placeholder, exact: true });
+  await present(page, trigger, `searchable-select trigger "${placeholder}"`);
+  await trigger.click({ timeout: UI_TIMEOUT });
 
   // Radix portals popover content into a positioned wrapper at the body root.
   const popover = page.locator("[data-radix-popper-content-wrapper]").last();
-  await expect(popover).toBeVisible();
+  await expect(popover, `popover for "${placeholder}" did not open`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
 
   // The filter input is pure frontend JS (rx.script), so typing narrows the
   // list without a round trip. Filtering first keeps the click unambiguous
   // when one option's text is a prefix of another's.
-  await popover.getByPlaceholder("Search...").fill(optionText);
+  await popover.getByPlaceholder("Search...").fill(optionText, { timeout: UI_TIMEOUT });
 
-  await popover.getByText(optionText, { exact: true }).click();
-  await expect(popover).toBeHidden();
+  const option = popover.getByText(optionText, { exact: true });
+  await expect(option, `option "${optionText}" not offered by "${placeholder}"`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
+  await option.click({ timeout: UI_TIMEOUT });
+  await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
 }
 
 /**
@@ -79,15 +112,22 @@ export async function createDuckDbConnection(
   const saved = sanitizeName(name);
   await gotoReady(page, "/connections");
 
-  await page.getByPlaceholder("Connection name").fill(name);
+  const nameField = page.getByPlaceholder("Connection name");
+  await present(page, nameField, 'the connection-name field (placeholder "Connection name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
   await selectSearchable(page, "Connection type", "duckdb");
-  await page.getByPlaceholder("/data/warehouse.duckdb").fill(dbPath);
-  await page.getByRole("button", { name: "Create Connection" }).click();
+
+  const pathField = page.getByPlaceholder("/data/warehouse.duckdb");
+  await present(page, pathField, "the DuckDB path field — did the type picker actually apply?");
+  await pathField.fill(dbPath, { timeout: UI_TIMEOUT });
+
+  await page.getByRole("button", { name: "Create Connection" }).click({ timeout: UI_TIMEOUT });
 
   await expect(
     page.getByRole("cell", { name: saved, exact: true }),
     `DuckDB connection "${saved}" did not appear in the connections table`,
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
   return saved;
 }
 
@@ -108,10 +148,18 @@ export async function createCsvConnection(
   const saved = sanitizeName(name);
   await gotoReady(page, "/connections");
 
-  await page.getByPlaceholder("Connection name").fill(name);
+  const nameField = page.getByPlaceholder("Connection name");
+  await present(page, nameField, 'the connection-name field (placeholder "Connection name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
   await selectSearchable(page, "Connection type", "csv");
 
-  await page.locator('input[type="file"]').setInputFiles(csvPath);
+  const fileInput = page.locator('input[type="file"]');
+  await expect(
+    fileInput.first(),
+    "no <input type=file> — rx.upload did not render for the csv type",
+  ).toBeAttached({ timeout: UI_TIMEOUT });
+  await fileInput.setInputFiles(csvPath, { timeout: UI_TIMEOUT });
 
   // connections.file_uploaded — proves the upload handler returned 2xx. A bare
   // "connection saved" assertion passes even when the drop zone 500s, because
@@ -119,13 +167,13 @@ export async function createCsvConnection(
   await expect(
     page.getByText("File uploaded"),
     "CSV upload did not confirm — the connections upload handler may be failing (see #452)",
-  ).toBeVisible({ timeout: 20_000 });
+  ).toBeVisible({ timeout: 30_000 });
 
-  await page.getByRole("button", { name: "Create Connection" }).click();
+  await page.getByRole("button", { name: "Create Connection" }).click({ timeout: UI_TIMEOUT });
   await expect(
     page.getByRole("cell", { name: saved, exact: true }),
     `CSV connection "${saved}" did not appear in the connections table`,
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
   return saved;
 }
 
@@ -145,15 +193,18 @@ export async function createUpload(
   const saved = sanitizeName(name);
   await gotoReady(page, "/uploads");
 
-  await page.getByPlaceholder("Upload name").fill(name);
+  const nameField = page.getByPlaceholder("Upload name");
+  await present(page, nameField, 'the upload-name field (placeholder "Upload name")');
+  await nameField.fill(name, { timeout: UI_TIMEOUT });
+
   await selectSearchable(page, "Source connection", sourceOption);
   await selectSearchable(page, "Destination connection", destOption);
-  await page.getByRole("button", { name: "Create Upload" }).click();
+  await page.getByRole("button", { name: "Create Upload" }).click({ timeout: UI_TIMEOUT });
 
   await expect(
     page.getByRole("cell", { name: saved, exact: true }),
     `Upload "${saved}" did not appear in the uploads table`,
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
   return saved;
 }
 
@@ -168,20 +219,25 @@ export async function uploadOptionFor(
   connectionName: string,
   kind: ConnectionKind,
 ): Promise<string> {
-  await page.getByRole("button", { name: placeholder, exact: true }).click();
+  const trigger = page.getByRole("button", { name: placeholder, exact: true });
+  await present(page, trigger, `searchable-select trigger "${placeholder}"`);
+  await trigger.click({ timeout: UI_TIMEOUT });
+
   const popover = page.locator("[data-radix-popper-content-wrapper]").last();
-  await expect(popover).toBeVisible();
+  await expect(popover, `popover for "${placeholder}" did not open`).toBeVisible({
+    timeout: UI_TIMEOUT,
+  });
 
   const suffix = `${connectionName} (${kind})`;
   const option = popover.getByText(new RegExp(`\\d+ — ${suffix}$`));
   await expect(
     option,
     `no ${placeholder} option ending "${suffix}" — is the connection the right type?`,
-  ).toBeVisible({ timeout: 10_000 });
+  ).toBeVisible({ timeout: UI_TIMEOUT });
 
   const label = (await option.textContent())?.trim() ?? "";
   await page.keyboard.press("Escape");
-  await expect(popover).toBeHidden();
+  await expect(popover).toBeHidden({ timeout: UI_TIMEOUT });
   return label;
 }
 
@@ -198,12 +254,12 @@ export type RunOutcome = { status: string; rows: number };
 export async function runUploadAndAwait(
   page: Page,
   uploadName: string,
-  timeoutMs = 180_000,
+  timeoutMs = 150_000,
 ): Promise<RunOutcome> {
   await gotoReady(page, "/uploads");
   const row = page.getByRole("row").filter({ hasText: uploadName });
-  await expect(row, `upload "${uploadName}" is not listed`).toBeVisible();
-  await row.getByRole("button", { name: "Run", exact: true }).click();
+  await expect(row, `upload "${uploadName}" is not listed`).toBeVisible({ timeout: UI_TIMEOUT });
+  await row.getByRole("button", { name: "Run", exact: true }).click({ timeout: UI_TIMEOUT });
 
   const deadline = Date.now() + timeoutMs;
   let last: RunOutcome = { status: "(no run row appeared)", rows: 0 };
@@ -212,7 +268,7 @@ export async function runUploadAndAwait(
     await gotoReady(page, "/runs");
     const runRow = page.getByRole("row").filter({ hasText: uploadName }).first();
 
-    if (await runRow.isVisible().catch(() => false)) {
+    if (await runRow.isVisible({ timeout: 5_000 }).catch(() => false)) {
       const cells = runRow.getByRole("cell");
       // runs.py column order: ID | Target | Status | Started | Finished | Rows | Error | Logs
       const status = ((await cells.nth(2).textContent()) ?? "").trim();

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,9 +23,15 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   globalSetup: require.resolve("./global-setup"),
-  // @slow tests run only when explicitly included via --grep.
-  // CI workflow for PRs to `master` sets DATANIKA_E2E_SLOW=1 to include them;
-  // PRs to `dev` run the fast subset. See plans/qa/PLAN_QA.md §P0 #1.
+  // @slow tests run only when DATANIKA_E2E_SLOW=1.
+  //
+  // The `e2e-staging` job sets it (core#484). Before 2026-07-22 **no job did**,
+  // and this comment claimed a "PRs to `master`" workflow that did not exist —
+  // so every @slow spec was dropped from every run and the job reported success
+  // having executed 5 of 62 tests. Local runs default to the fast subset.
+  //
+  // If you are tempted to unset it to speed CI up: that is the bug, not the fix.
+  // The job asserts the collected count precisely to stop it regressing.
   grepInvert: process.env.DATANIKA_E2E_SLOW === "1" ? undefined : /@slow/,
   reporter: [
     ["list"],

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -59,8 +59,10 @@ const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
 
 test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
   // Signup, two connections, an upload and a Celery round trip. The default
-  // 60s budget covers none of that; runUploadAndAwait alone allows 180s.
-  test.setTimeout(360_000);
+  // 60s covers none of that. Deliberately NOT larger: every interaction is
+  // individually bounded in fixtures/data.ts, so this cap should never be what
+  // fails — if it is, something is hanging that no per-action timeout covers.
+  test.setTimeout(300_000);
 
   test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
     const stamp = `${Date.now()}`;
@@ -70,34 +72,38 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
     const srcName = `qa golden src ${stamp}`;
     const uploadName = `qa golden upload ${stamp}`;
 
-    // 1. Signup. signUp() fills the form (incl. the required Full Name) and
-    //    handles the Reflex hydration race — it retries if the click falls back
-    //    to a native GET submit before on_submit is wired (core#295).
-    await signUp(page);
-    await expect(page).toHaveURL(/\/(dashboard|connections|onboarding)?$/);
-    await expect(page.getByRole("link", { name: "Connections" }).first()).toBeVisible({
-      timeout: 10_000,
+    // Each phase is a named step so a failure reports WHICH phase broke. The
+    // first CI run of this spec died as an unqualified 6-minute timeout and the
+    // report could not say where — a result that costs a full run to learn
+    // nothing (core#501).
+    await test.step("1. sign up and reach the app", async () => {
+      // signUp() fills the form (incl. the required Full Name) and handles the
+      // Reflex hydration race — it retries if the click falls back to a native
+      // GET submit before on_submit is wired (core#295).
+      await signUp(page);
+      await expect(page).toHaveURL(/\/(dashboard|connections|onboarding)?$/);
+      await expect(page.getByRole("link", { name: "Connections" }).first()).toBeVisible({
+        timeout: 10_000,
+      });
     });
 
-    // 2. Destination: a DuckDB file on the shared volume.
-    const savedDest = await createDuckDbConnection(
-      page,
-      destName,
-      `${SHARED_DIR}/qa_golden_${stamp}.duckdb`,
-    );
+    const savedDest = await test.step("2. create the DuckDB destination", async () =>
+      createDuckDbConnection(page, destName, `${SHARED_DIR}/qa_golden_${stamp}.duckdb`));
 
-    // 3. Source: a CSV uploaded through the drop zone — #452's path.
-    const csvPath = join(mkdtempSync(join(tmpdir(), "qa-golden-")), "orders.csv");
-    writeFileSync(csvPath, CSV_CONTENT, "utf8");
-    const savedSrc = await createCsvConnection(page, srcName, csvPath);
+    const savedSrc = await test.step("3. create the CSV source via the drop zone", async () => {
+      const csvPath = join(mkdtempSync(join(tmpdir(), "qa-golden-")), "orders.csv");
+      writeFileSync(csvPath, CSV_CONTENT, "utf8");
+      return createCsvConnection(page, srcName, csvPath);
+    });
 
-    // 4. Wire them together as an Upload (there is no "pipeline builder" UI).
-    const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
-    const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
-    const savedUpload = await createUpload(page, uploadName, sourceOption, destOption);
+    const savedUpload = await test.step("4. wire them together as an Upload", async () => {
+      const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
+      const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
+      return createUpload(page, uploadName, sourceOption, destOption);
+    });
 
-    // 5. Run it, and assert the status a user would see.
-    const outcome = await runUploadAndAwait(page, savedUpload);
+    const outcome = await test.step("5. run it and read the terminal status", async () =>
+      runUploadAndAwait(page, savedUpload));
 
     expect(
       outcome.status,

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -1,4 +1,15 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { test, expect, signUp } from "../fixtures/auth";
+import {
+  createCsvConnection,
+  createDuckDbConnection,
+  createUpload,
+  runUploadAndAwait,
+  uploadOptionFor,
+} from "../fixtures/data";
 
 /**
  * Golden path: a new user signs up, creates a connection, uploads a CSV,
@@ -8,14 +19,57 @@ import { test, expect, signUp } from "../fixtures/auth";
  * the critical revenue-producing flow works end to end. If this is red,
  * no other E2E result matters.
  *
- * Unblocked by core#109 (e2e-seed lands in dev). Still tagged @slow because
- * the full stack exercise remains expensive on the GHA runner.
+ * ── Why steps 2–5 are code now (core#482) ────────────────────────────────────
+ * They used to be a comment. The deferral said the backend create/run path was
+ * "covered by the nightly connector-smoke matrix and re-verified via API in the
+ * 2026-07-17 restore check" — both API-level. On 2026-07-22 two P0s reached
+ * production straight through the gap between that coverage and a browser:
+ *
+ *   #452  the connections upload handler returned HTTP 500 (Reflex could not
+ *         find the upload param behind a bare `list` annotation)
+ *   #456  every successful run was recorded FAILED — `emit()` raised on the
+ *         completion hooks and the surrounding `except` called `fail_run(...)`
+ *
+ * Both were found by a person clicking through prod, while `e2e-staging`
+ * reported success on every push. Hence the shape of this spec: drive the UI a
+ * user drives, and assert the terminal run status a user sees.
+ *
+ * #456 is why `expect(status).toBe("success")` is the assertion and "a run row
+ * appeared" is not: the run *did* complete — only its recorded status was
+ * wrong. A test that waited for a run to exist would have passed throughout.
+ *
+ * ── Cost ─────────────────────────────────────────────────────────────────────
+ * Tagged @slow: signup + two connections + an upload + a real Celery run.
+ * @slow specs are excluded unless DATANIKA_E2E_SLOW=1 — which for a long time
+ * no CI job set, so nothing here ran at all (core#484). If you are reading this
+ * because the job is slow, the fix is a smaller fixture — not dropping the tag,
+ * and not un-setting the flag.
  */
-// @slow — full stack exercise (signup + run + destination query). Expensive on
-// the GHA runner (docker-compose + Celery + dbt), so gated to PRs targeting
-// master via DATANIKA_E2E_SLOW=1. See plans/qa/PLAN_QA.md §P0 #1.
+
+const CSV_ROWS = 3;
+const CSV_CONTENT = ["id,name,amount", "1,alpha,100", "2,beta,200", "3,gamma,300", ""].join("\n");
+
+/**
+ * A path both the web container and the Celery worker can reach.
+ * `/app/uploaded_files` is a named volume mounted rw by app, app_b and celery
+ * (docker-compose.yml, #471); anything web-only fails at run time rather than
+ * at save time — the slower, more confusing failure.
+ */
+const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
+
 test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
-  test("new user signs up and reaches the app", async ({ page }) => {
+  // Signup, two connections, an upload and a Celery round trip. The default
+  // 60s budget covers none of that; runUploadAndAwait alone allows 180s.
+  test.setTimeout(360_000);
+
+  test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
+    const stamp = `${Date.now()}`;
+    // set_form_name strips everything outside [a-zA-Z0-9 ], so keep names in
+    // that alphabet — otherwise the saved name is not the one typed.
+    const destName = `qa golden dest ${stamp}`;
+    const srcName = `qa golden src ${stamp}`;
+    const uploadName = `qa golden upload ${stamp}`;
+
     // 1. Signup. signUp() fills the form (incl. the required Full Name) and
     //    handles the Reflex hydration race — it retries if the click falls back
     //    to a native GET submit before on_submit is wired (core#295).
@@ -25,12 +79,37 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
       timeout: 10_000,
     });
 
-    // 2-5. Add a DuckDB connection → upload a CSV → run the pipeline → assert
-    // rows landed. Deferred from this spec: the connection-builder + upload UI
-    // selectors need verification against the live app, and the upload/run steps
-    // need a fixture CSV + an apiClient (fixtures/data.ts) that aren't in the
-    // harness yet. The backend create/run path is covered by the nightly
-    // connector-smoke matrix and was re-verified via API in the 2026-07-17
-    // restore check (run: pending → running → success). Tracked as follow-up.
+    // 2. Destination: a DuckDB file on the shared volume.
+    const savedDest = await createDuckDbConnection(
+      page,
+      destName,
+      `${SHARED_DIR}/qa_golden_${stamp}.duckdb`,
+    );
+
+    // 3. Source: a CSV uploaded through the drop zone — #452's path.
+    const csvPath = join(mkdtempSync(join(tmpdir(), "qa-golden-")), "orders.csv");
+    writeFileSync(csvPath, CSV_CONTENT, "utf8");
+    const savedSrc = await createCsvConnection(page, srcName, csvPath);
+
+    // 4. Wire them together as an Upload (there is no "pipeline builder" UI).
+    const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
+    const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
+    const savedUpload = await createUpload(page, uploadName, sourceOption, destOption);
+
+    // 5. Run it, and assert the status a user would see.
+    const outcome = await runUploadAndAwait(page, savedUpload);
+
+    expect(
+      outcome.status,
+      "the run did not end in `success` — a completed-but-FAILED run is #456's " +
+        "signature: check whether emit() raised on the completion hooks after " +
+        "the run had already finished",
+    ).toBe("success");
+
+    expect(
+      outcome.rows,
+      `expected the ${CSV_ROWS} CSV rows to land in DuckDB, got ${outcome.rows}. ` +
+        "A `success` run that moved zero rows is a load that silently did nothing.",
+    ).toBeGreaterThanOrEqual(CSV_ROWS);
   });
 });

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -56,6 +56,18 @@ const CSV_CONTENT = ["id,name,amount", "1,alpha,100", "2,beta,200", "3,gamma,300
  */
 const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
 
+// Artifacts unconditionally while quarantined (core#520). The global config uses
+// `retain-on-failure`, and a `test.fail()` test that fails is classified
+// `expected` rather than `failed` — so the diagnostics every round has depended
+// on could be dropped exactly when the verdict stops being reported. A
+// quarantined test that stops producing evidence is just a disabled one.
+//
+// Must be file top-level, NOT inside the describe: `use({ trace })` forces a new
+// worker, and Playwright refuses it in a describe group — which fails collection
+// of the WHOLE suite, not just this spec. Caught by running `--list`; it would
+// have taken all 62 tests down, far worse than the thing being quarantined.
+test.use({ trace: "on", screenshot: "on", video: "retain-on-failure" });
+
 test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
   // Signup, two connections, an upload and a Celery round trip. The default
   // 60s covers none of that. Deliberately NOT larger: every interaction is
@@ -64,6 +76,32 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
   test.setTimeout(300_000);
 
   test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
+    // ── QUARANTINED FROM THE PROMOTION GATE — core#520 ───────────────────────
+    // This spec has NEVER passed. It was written 2026-07-22 (#482/#485) and each
+    // round moves the failure one step later; step 5 has still never executed.
+    // It was therefore not protecting production — it was work in progress that
+    // happened to live in the gating job, holding back #500 (a P0), #505, #510,
+    // #516, #518, Growth's announcement and landing#281.
+    //
+    // The distinction that makes this safe, and the line not to cross:
+    //   • quarantining a test that USED TO PASS hides a regression — never.
+    //   • quarantining a test that has NEVER PASSED removes a non-gate from the
+    //     gate. Same call as the Kafka smoke quarantine (#399), which was
+    //     un-quarantined once it could pass.
+    //
+    // `test.fail()` rather than `test.skip()` is the whole point: the test still
+    // RUNS, still exercises staging, still uploads artifacts — only its verdict
+    // is quarantined. And Playwright reports an *unexpectedly passing*
+    // `test.fail()` as a failure, so the first green turns the job red and
+    // forces this marker out. Re-arming is enforced by the tool, not by someone
+    // remembering. When that happens: delete this line and close core#520.
+    test.fail(
+      true,
+      "core#520: golden-path has never passed; quarantined from the promotion " +
+        "gate. It still runs. Playwright fails the job if it starts passing — " +
+        "when it does, remove this and close core#520.",
+    );
+
     const stamp = `${Date.now()}`;
     // set_form_name strips everything outside [a-zA-Z0-9 ], so keep names in
     // that alphabet — otherwise the saved name is not the one typed.

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -8,7 +8,6 @@ import {
   createDuckDbConnection,
   createUpload,
   runUploadAndAwait,
-  uploadOptionFor,
 } from "../fixtures/data";
 
 /**
@@ -96,11 +95,13 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
       return createCsvConnection(page, srcName, csvPath);
     });
 
-    const savedUpload = await test.step("4. wire them together as an Upload", async () => {
-      const sourceOption = await uploadOptionFor(page, "Source connection", savedSrc, "csv");
-      const destOption = await uploadOptionFor(page, "Destination connection", savedDest, "duckdb");
-      return createUpload(page, uploadName, sourceOption, destOption);
-    });
+    const savedUpload = await test.step("4. wire them together as an Upload", async () =>
+      createUpload(
+        page,
+        uploadName,
+        { name: savedSrc, kind: "csv" },
+        { name: savedDest, kind: "duckdb" },
+      ));
 
     const outcome = await test.step("5. run it and read the terminal status", async () =>
       runUploadAndAwait(page, savedUpload));

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -26,6 +26,16 @@ groups:
               # `datanika-app` while prod served correctly from `datanika-app-b`.
               expr: 'time() - max by (name) (container_last_seen{name=~"datanika-(celery|postgres|redis)"}) > 60'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 300
@@ -33,7 +43,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -69,6 +79,16 @@ groups:
             model:
               expr: 'time() - max(container_last_seen{name=~"datanika-app(-b)?"}) > 60'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 300
@@ -76,7 +96,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -104,6 +124,16 @@ groups:
             model:
               expr: '100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -111,7 +141,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -139,6 +169,16 @@ groups:
             model:
               expr: '(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 > 90'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -146,7 +186,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -174,6 +214,16 @@ groups:
             model:
               expr: '(1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100 > 80'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -181,7 +231,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -211,6 +261,16 @@ groups:
             model:
               expr: 'time() - datanika_backup_last_success_timestamp_seconds > 93600'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -218,7 +278,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -246,6 +306,16 @@ groups:
             model:
               expr: 'increase(container_start_time_seconds{name=~"datanika-.*"}[1h]) > 3'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 3600
@@ -253,7 +323,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -281,6 +351,16 @@ groups:
             model:
               expr: 'container_memory_usage_bytes{name=~"datanika-(app|celery)"} > 1.5e+9'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -288,7 +368,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -315,7 +395,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -326,18 +406,28 @@ groups:
               # only when NEITHER colour is scrapeable, which is the real outage.
               expr: 'max(up{job=~"datanika-app(-b)?"}) == 0'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
-                    type: gt
-                    params: [0]
+                    type: lt
+                    params: [1]
               refId: C
         for: 2m
         labels:
@@ -361,6 +451,16 @@ groups:
             model:
               expr: 'rate(celery_tasks_total{state="FAILURE"}[15m]) > 0.1'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 900
@@ -368,7 +468,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -396,6 +496,16 @@ groups:
             model:
               expr: 'celery_queue_length > 50'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -403,7 +513,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -430,24 +540,34 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
               expr: 'probe_success{instance="https://datanika.io/sitemap-index.xml"} == 0'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
-                    type: gt
-                    params: [0]
+                    type: lt
+                    params: [1]
               refId: C
         for: 15m
         labels:
@@ -465,24 +585,34 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
               expr: 'probe_success{instance="https://datanika.io/"} == 0'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
-                    type: gt
-                    params: [0]
+                    type: lt
+                    params: [1]
               refId: C
         for: 5m
         labels:
@@ -503,7 +633,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -515,14 +645,24 @@ groups:
               # Every other probe rule already used `== 0`; this one was the outlier.
               expr: 'probe_success{instance="https://plausible.datanika.io/login"} == 0'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: lt
@@ -544,31 +684,41 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
               expr: 'probe_success{instance="https://app.datanika.io/healthz"} == 0'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
-                    type: gt
-                    params: [0]
+                    type: lt
+                    params: [1]
               refId: C
-        for: 1m
+        for: 2m
         labels:
           severity: critical
         annotations:
           summary: "app.datanika.io /healthz not reachable externally"
-          description: "External blackbox probe to https://app.datanika.io/healthz has failed for 5 minutes. Distinct from the internal container healthcheck — this catches Nginx/Cloudflare/DNS problems."
+          description: "External blackbox probe to https://app.datanika.io/healthz has failed continuously for 2 minutes. Distinct from the internal container healthcheck — this catches Nginx/Cloudflare/DNS problems."
 
       # --- App frontend (what users actually load) ---
       # The /healthz probe only covers the backend :8000. Users hit /, served by the
@@ -582,26 +732,36 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
               expr: 'probe_success{instance="https://app.datanika.io/"} == 0'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
-                    type: gt
-                    params: [0]
+                    type: lt
+                    params: [1]
               refId: C
-        for: 1m
+        for: 2m
         labels:
           severity: critical
         annotations:
@@ -628,6 +788,16 @@ groups:
             model:
               expr: 'rate(pg_stat_statements_seconds_total{datname="datanika"}[5m]) > 0.5'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 900
@@ -635,7 +805,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1241,6 +1411,16 @@ groups:
             model:
               expr: 'absent(probe_success{instance="https://app.datanika.io/healthz"})'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1248,7 +1428,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1274,6 +1454,16 @@ groups:
             model:
               expr: 'absent(probe_success{instance="https://app.datanika.io/"})'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1281,7 +1471,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1307,6 +1497,16 @@ groups:
             model:
               expr: 'absent(probe_success{instance="https://datanika.io/"})'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1314,7 +1514,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1342,6 +1542,16 @@ groups:
               # series if BOTH jobs vanish — NoData -> OK -> silence. This covers that.
               expr: 'absent(up{job=~"datanika-app(-b)?"})'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1349,7 +1559,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1375,6 +1585,16 @@ groups:
             model:
               expr: 'absent(node_memory_MemTotal_bytes)'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1382,7 +1602,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1414,6 +1634,16 @@ groups:
             model:
               expr: 'absent(container_last_seen{name=~"datanika-app(-b)?"})'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1421,7 +1651,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1448,6 +1678,16 @@ groups:
             model:
               expr: 'absent(container_last_seen)'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1455,7 +1695,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt
@@ -1481,6 +1721,16 @@ groups:
             model:
               expr: 'absent(datanika_backup_last_success_timestamp_seconds)'
               refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
           - refId: C
             relativeTimeRange:
               from: 600
@@ -1488,7 +1738,7 @@ groups:
             datasourceUid: __expr__
             model:
               type: threshold
-              expression: A
+              expression: B
               conditions:
                 - evaluator:
                     type: gt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ dependencies = [
     "pymongo>=4.0,<5",
     "clickhouse-connect>=0.11,<0.12",
     "duckdb>=1.0,<2",
+    # The SQLAlchemy dialect for DuckDB. dlt writes through its own driver, so
+    # loads worked without this — but catalog introspection goes through
+    # SQLAlchemy and raised NoSuchModuleError, leaving Models/Catalog
+    # permanently empty for every DuckDB user (core#494). Every other
+    # destination here already pairs a driver with its dialect; duckdb was the
+    # one that did not.
+    "duckdb-engine>=0.17,<0.18",
     "snowflake-sqlalchemy>=1.7,<2",
     "sqlalchemy-bigquery>=1.11,<2",
     "oracledb>=4.0,<5",

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -39,7 +39,10 @@ fi
 # predate its issue. The value is making the mismatch impossible to miss, not blocking.
 BRANCH_ISSUE=$(printf '%s' "$BRANCH" | sed -nE 's/^([0-9]+)-.*/\1/p')
 if [ -n "$BRANCH_ISSUE" ]; then
-  RANGE=$(git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1 && echo '@{upstream}..HEAD' || echo 'origin/dev..HEAD')
+  # origin/dev..HEAD, NOT @{upstream}..HEAD. The latter means "since this branch was last
+  # pushed", so after a rebase it includes every commit the rebase pulled from dev and
+  # attributes dev's closures to this branch. That fired on the first PR the guard met.
+  RANGE='origin/dev..HEAD'
   CLOSES=$(git log --format=%B "$RANGE" 2>/dev/null \
            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' \
            | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -25,6 +25,37 @@ if [[ "$BRANCH" != "dev" && "$BRANCH" != "master" && "$BRANCH" != "main" ]]; the
   fi
 fi
 
+# --- branch/commit consistency -------------------------------------------------------
+# Catches commits that landed on the wrong branch. Branches are `<issue>-<slug>`
+# (WORKFLOW_RULES §2), so if this branch names an issue, the commits being pushed should
+# close THAT issue — not a different one.
+#
+# Real case, 2026-07-22: a script ran `git commit --amend` without checking out its own
+# branch first, so it rewrote the message of whatever was HEAD. Branch
+# `486-inode-stale-config` ended up carrying "closes #477". The PR had the right content,
+# the wrong title, and would have closed the wrong issue and left misleading history.
+#
+# Warn-only by design: closing several issues at once is legitimate, and a branch may
+# predate its issue. The value is making the mismatch impossible to miss, not blocking.
+BRANCH_ISSUE=$(printf '%s' "$BRANCH" | sed -nE 's/^([0-9]+)-.*/\1/p')
+if [ -n "$BRANCH_ISSUE" ]; then
+  RANGE=$(git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1 && echo '@{upstream}..HEAD' || echo 'origin/dev..HEAD')
+  CLOSES=$(git log --format=%B "$RANGE" 2>/dev/null \
+           | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' \
+           | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')
+  if [ -n "$CLOSES" ] && ! printf '%s' "$CLOSES" | grep -qw "$BRANCH_ISSUE"; then
+    echo ""
+    echo "  pre-push WARNING: branch/commit mismatch"
+    echo "      branch '$BRANCH' refers to issue #$BRANCH_ISSUE"
+    echo "      commits close: $(printf '%s' "$CLOSES" | sed 's/\([0-9][0-9]*\)/#\1/g')"
+    echo ""
+    echo "      Usually means a commit landed on the wrong branch — e.g. 'git commit --amend'"
+    echo "      run without checking out its own branch first, which rewrites whatever is HEAD."
+    echo "      Check with: git log --oneline $RANGE"
+    echo ""
+  fi
+fi
+
 # Find venv
 if [ -x ".venv/Scripts/python.exe" ]; then
   PY=".venv/Scripts/python.exe"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -40,7 +40,18 @@ echo "pre-push: ruff check"
 echo "pre-push: ruff format --check"
 "$PY" -m ruff format --check datanika tests
 echo "pre-push: pytest"
-"$PY" -m pytest tests/ -x -q --tb=short
+# UV_NO_SYNC=1 is NOT optional on Windows. test_head_downgrade_upgrade_roundtrip shells
+# out to `uv run alembic`, which tries to replace native extensions (sqlalchemy's
+# cyextension, cryptography, ...) while this pytest process still holds the files open.
+# Windows refuses, the removal half-completes, and the venv is left gutted — presenting
+# as "my dependencies randomly vanished" and sending people hunting for a cause that
+# isn't there.
+#
+# WORKFLOW_RULES §3 has documented this as mandatory since it cost QA, and then Growth
+# four reinstalls — and the stated lesson was that a fix living only in prose gets
+# rediscovered the expensive way. It was still only in prose: the hook never set it.
+# Setting it here means nobody has to know.
+UV_NO_SYNC=1 "$PY" -m pytest tests/ -x -q --tb=short
 
 # Helm lint — only if chart files were modified in the push range
 if command -v helm >/dev/null 2>&1 && [ -d "$REPO_ROOT/deploy/helm" ]; then

--- a/tests/test_fixture_sharing.py
+++ b/tests/test_fixture_sharing.py
@@ -1,0 +1,113 @@
+"""Fixtures are shared through `conftest.py`, never by importing them.
+
+`from tests.test_migrations.test_roundtrip import roundtrip_db_url` looks like
+sharing and isn't. pytest registers an imported fixture as a **separate
+FixtureDef in the importing module**, so `scope="session"` caches once per
+module instead of once per session. The fixture body runs twice.
+
+That cost a real suite: two Postgres testcontainers instead of one, two
+teardowns, and on Windows the second teardown timed out against the Docker
+named pipe — failing an otherwise green run (`testsfailed=0`,
+`exitstatus=OK`) in TEARDOWN and leaving containers orphaned. Nothing asserted
+against it; it surfaced only because the timeout happened to fire.
+
+A fixture in `conftest.py` is discovered by every module in its directory as
+one FixtureDef. Helper *functions* may still be imported freely — this only
+concerns `@pytest.fixture`.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+#: This file sits at the root of the test tree, alongside the other repo-wide
+#: contract scans (`test_dependency_pins.py`, `test_hooks_contract.py`).
+TESTS_ROOT = Path(__file__).parent
+
+
+def _fixture_names(tree: ast.AST) -> set[str]:
+    """Names defined with an @pytest.fixture decorator, bare or called."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if getattr(target, "attr", getattr(target, "id", None)) == "fixture":
+                names.add(node.name)
+    return names
+
+
+def _fixture_imports(tree: ast.AST, known: set[str]) -> list[str]:
+    """`from tests... import <a fixture name>` — the pattern that duplicates."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not (node.module or "").startswith("tests"):
+            continue
+        found.extend(f"{node.module}.{a.name}" for a in node.names if a.name in known)
+    return found
+
+
+def _parsed_test_modules() -> dict[Path, ast.AST]:
+    return {
+        path: ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for path in sorted(TESTS_ROOT.rglob("*.py"))
+    }
+
+
+class TestFixturesAreSharedViaConftest:
+    def test_the_scan_sees_the_test_tree(self):
+        """Anti-vacuity: an empty scan would pass having checked nothing."""
+        modules = _parsed_test_modules()
+        assert len(modules) >= 50, f"only {len(modules)} test modules found under {TESTS_ROOT}"
+
+        known: set[str] = set()
+        for tree in modules.values():
+            known |= _fixture_names(tree)
+        assert len(known) >= 20, (
+            f"only {len(known)} fixtures detected — the decorator scan is probably "
+            "not matching, which would make the check below vacuously green"
+        )
+
+    def test_no_test_module_imports_a_fixture_from_another_test_module(self):
+        modules = _parsed_test_modules()
+        known: set[str] = set()
+        for tree in modules.values():
+            known |= _fixture_names(tree)
+
+        offenders = {
+            str(path.relative_to(TESTS_ROOT)): imports
+            for path, tree in modules.items()
+            if (imports := _fixture_imports(tree, known))
+        }
+        assert not offenders, (
+            f"Fixtures imported across test modules: {offenders}.\n"
+            "pytest registers an imported fixture as a second FixtureDef, so a "
+            "session- or module-scoped fixture runs its body once per importing "
+            "module. Move it to a conftest.py in the nearest shared directory; "
+            "plain helper functions are fine to import."
+        )
+
+
+class TestTheGuardDiscriminates:
+    """A scan that cannot fail is decoration — prove it flags the real shape."""
+
+    def test_an_imported_fixture_is_flagged(self):
+        provider = ast.parse(
+            "import pytest\n@pytest.fixture(scope='session')\ndef shared_db():\n    yield 1\n"
+        )
+        consumer = ast.parse("from tests.test_migrations.test_roundtrip import shared_db\n")
+
+        known = _fixture_names(provider)
+        assert known == {"shared_db"}
+        assert _fixture_imports(consumer, known) == [
+            "tests.test_migrations.test_roundtrip.shared_db"
+        ]
+
+    def test_importing_a_plain_helper_is_not_flagged(self):
+        provider = ast.parse("def _run_alembic(cmd, url):\n    return None\n")
+        consumer = ast.parse("from tests.test_migrations.conftest import _run_alembic\n")
+
+        assert _fixture_names(provider) == set()
+        assert _fixture_imports(consumer, _fixture_names(provider)) == []

--- a/tests/test_migrations/conftest.py
+++ b/tests/test_migrations/conftest.py
@@ -1,0 +1,137 @@
+"""Shared Postgres harness for the migration tests.
+
+**Why this is a conftest and not an import.** ``test_roundtrip.py`` owned
+``roundtrip_db_url``, and ``test_expand_contract.py`` reached for it with
+``from ...test_roundtrip import roundtrip_db_url``. That looks like sharing and
+isn't: pytest registers an imported fixture as a **separate FixtureDef in the
+importing module**, so ``scope="session"`` caches once per module rather than
+once per session. ``pytest --setup-plan`` showed it plainly::
+
+    SETUP    S roundtrip_db_url      <- for test_expand_contract.py
+    SETUP    S roundtrip_db_url      <- for test_roundtrip.py
+    TEARDOWN S roundtrip_db_url
+    TEARDOWN S roundtrip_db_url
+
+Two setups meant **two Postgres containers per run**, each with its own ryuk and
+its own teardown — and on Windows the second teardown timed out against the
+Docker named pipe, failing an otherwise green suite in ``TEARDOWN`` (session
+``exitstatus=OK, testsfailed=0``) and leaving containers running.
+
+A fixture defined here is discovered by every module in this directory as **one**
+FixtureDef: one container, one teardown. Helpers live here too, so neither test
+module has to import from the other.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+def _docker_available() -> bool:
+    """Fast check for a reachable Docker daemon."""
+    if not shutil.which("docker"):
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "info"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _no_postgres(reason: str) -> None:
+    """Skip locally when Postgres is unavailable — but FAIL in CI.
+
+    The ``migration-roundtrip`` job exists to run these files, so if they skip,
+    the job exits 0 and reports green having verified nothing — while the thing
+    it guards (a downgrade that only matters at 2 AM during a prod rollback)
+    goes unchecked. CI always has both Docker and ``DATABASE_URL_SYNC_TEST``, so
+    reaching here in CI means the workflow broke, and that must be loud.
+
+    Locally, skipping stays correct: devs without Docker shouldn't be blocked.
+    Same reasoning as the connector smoke suite's strict mode (core#407).
+    """
+    if os.environ.get("CI"):
+        pytest.fail(
+            f"{reason}\n\n"
+            "This is a hard failure because CI is expected to provide Postgres "
+            "(DATABASE_URL_SYNC_TEST, or Docker for testcontainers). Skipping here "
+            "would let the migration-roundtrip job pass without testing a single "
+            "migration. Check the job's env block and service container."
+        )
+    pytest.skip(reason)
+
+
+def _run_alembic(cmd: list[str], db_url: str) -> subprocess.CompletedProcess:
+    """Run an alembic command against the test DB.
+
+    Uses `uv run` so the subprocess inherits the project's venv, and
+    passes ``DATABASE_URL_SYNC`` in the environment — alembic's env.py
+    reads `settings.database_url_sync` which is sourced from that env var.
+    """
+    env = {**os.environ, "DATABASE_URL_SYNC": db_url, "DATABASE_URL": db_url}
+    return subprocess.run(
+        ["uv", "run", "alembic", *cmd],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def roundtrip_db_url():
+    """Postgres URL for the migration tests.
+
+    Priority:
+    1. ``DATABASE_URL_SYNC_TEST`` env var (CI, or manual override)
+    2. testcontainers[postgres] auto-provisioned container (local with Docker)
+    3. skip the test locally — but **fail** in CI (see ``_no_postgres``)
+
+    Must be a generator (yield-based) on every path — pytest treats a
+    function with any `yield` as a generator, and hitting `return` on
+    one path while `yield`-ing on another raises
+    ``ValueError: fixture did not yield a value``.
+    """
+    env_url = os.environ.get("DATABASE_URL_SYNC_TEST")
+    if env_url:
+        yield env_url
+        return
+
+    if not _docker_available():
+        _no_postgres(
+            "Round-trip test requires Postgres. Set DATABASE_URL_SYNC_TEST or run "
+            "with Docker Desktop running."
+        )
+
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        _no_postgres(
+            "testcontainers not installed. Install with: "
+            "`uv pip install 'testcontainers[postgres]'` or run CI instead."
+        )
+
+    # One container per pytest session, shared by every module in this
+    # directory. Torn down when the fixture generator exits.
+    container = PostgresContainer("postgres:16-alpine")
+    container.start()
+    try:
+        yield container.get_connection_url().replace("postgresql+psycopg2", "postgresql")
+    finally:
+        container.stop()

--- a/tests/test_migrations/test_expand_contract.py
+++ b/tests/test_migrations/test_expand_contract.py
@@ -48,11 +48,11 @@ import sys
 import pytest
 import sqlalchemy
 
-from tests.test_migrations.test_roundtrip import (  # reuse: one Postgres harness
-    _no_postgres,
-    _run_alembic,
-    roundtrip_db_url,  # noqa: F401 — fixture re-export
-)
+from tests.test_migrations.conftest import _no_postgres, _run_alembic
+
+# `roundtrip_db_url` is deliberately NOT imported. It is a session-scoped
+# fixture in conftest.py and pytest discovers it; importing it here would
+# register a *second* FixtureDef and boot a second Postgres container.
 
 #: What production is running. The `t1` risk is defined against the deployed
 #: release, so this is the ref to compare with — not the merge base.
@@ -162,7 +162,7 @@ def _live_schema(engine) -> dict[str, dict[str, bool]]:
 
 
 @pytest.fixture(scope="module")
-def migrated_schema(roundtrip_db_url):  # noqa: F811 — pytest fixture injection
+def migrated_schema(roundtrip_db_url):
     """Postgres migrated to this branch's head, as `information_schema` sees it."""
     result = _run_alembic(["upgrade", "head"], roundtrip_db_url)
     assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/test_migrations/test_expand_contract.py
+++ b/tests/test_migrations/test_expand_contract.py
@@ -174,16 +174,27 @@ def migrated_schema(roundtrip_db_url):  # noqa: F811 — pytest fixture injectio
         engine.dispose()
 
 
+def _require_deployed_ref() -> None:
+    """Skip locally without the ref; fail loudly in CI, which must have it.
+
+    A shallow ``actions/checkout`` has no ``origin/master``, so every check in
+    this file would compare an empty dict and pass. Locally that is a missing
+    fetch and shouldn't block anyone; in CI it means the workflow lost its
+    fetch step and the guard is silently inert.
+    """
+    if not _deployed_model_files():
+        _no_postgres(
+            f"Cannot read models at {_DEPLOYED_REF!r} — run `git fetch origin master` "
+            "(CI does this explicitly; actions/checkout is shallow). Without it "
+            "this file compares nothing."
+        )
+
+
 class TestDeployedCodeSurvivesTheNewSchema:
     def test_the_deployed_ref_is_readable(self):
         """Guard the guard: no ref, no comparison, and silence would look green."""
-        files = _deployed_model_files()
-        if not files:
-            _no_postgres(
-                f"Cannot read models at {_DEPLOYED_REF!r} — `git fetch origin master` "
-                "first. Without it this file compares nothing."
-            )
-        assert files, f"no model files at {_DEPLOYED_REF}"
+        _require_deployed_ref()
+        assert _deployed_model_files(), f"no model files at {_DEPLOYED_REF}"
 
     def test_the_deployed_models_actually_parsed(self):
         """The hole this whole file exists to avoid, one level up.

--- a/tests/test_migrations/test_expand_contract.py
+++ b/tests/test_migrations/test_expand_contract.py
@@ -1,0 +1,285 @@
+"""The `t1` window: deployed code must survive the new schema (core#449).
+
+Blue/green starts the new container **while the old one still serves**, and
+`alembic upgrade head` runs in its startup command:
+
+    t0  old code + old schema     <- serving
+    t1  old code + NEW schema     <- serving, new container already migrated  *** here ***
+    t2  new code + new schema
+
+At `t1` the previously-deployed version runs against the migrated schema, so a
+drop, rename or `SET NOT NULL` breaks production at that instant — not at the
+swap, and **not in CI, which only ever runs one version against one schema**
+(`plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md`).
+
+Until now the only control was a checklist item — *a human answering a
+question* — which is the same control that let promotion-ref enumeration leak
+until it was automated.
+
+**Why this doesn't literally "run the previous release's test suite".** The
+spec proposes exactly that, and it would prove very little here: almost every
+test builds its schema with `Base.metadata.create_all` on SQLite and never
+touches a migrated Postgres. That job would pass while exercising nothing —
+the failure mode this repo has spent a week removing.
+
+So it asserts the property the checklist actually asks about — *"would the
+currently deployed version still run against this schema?"* — by comparing the
+**deployed release's models** against the **new schema**:
+
+1. migrate a real Postgres to the branch's `head`;
+2. read the deployed release's models straight out of git (AST, never
+   imported — importing two versions of the same package in one process is
+   its own bug);
+3. assert every table and column those models reference still exists, and that
+   nothing tightened to `NOT NULL` under them.
+
+Covered: `DROP COLUMN` · rename · `DROP TABLE` · `SET NOT NULL`.
+Not covered, and left explicit rather than implied: type narrowing, and a new
+`UNIQUE` on an existing column. Both are on the spec's forbidden list; neither
+is reliably derivable from the old models by AST, so the checklist remains the
+control for those two.
+"""
+
+import ast
+import os
+import subprocess
+import sys
+
+import pytest
+import sqlalchemy
+
+from tests.test_migrations.test_roundtrip import (  # reuse: one Postgres harness
+    _no_postgres,
+    _run_alembic,
+    roundtrip_db_url,  # noqa: F401 — fixture re-export
+)
+
+#: What production is running. The `t1` risk is defined against the deployed
+#: release, so this is the ref to compare with — not the merge base.
+_DEPLOYED_REF = os.environ.get("DEPLOYED_REF", "origin/master")
+
+_MODELS_DIR = "datanika/models"
+
+
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], capture_output=True, text=True, timeout=60, check=False)
+
+
+def _deployed_model_files() -> list[str]:
+    result = _git("ls-tree", "--name-only", _DEPLOYED_REF, f"{_MODELS_DIR}/")
+    if result.returncode != 0:
+        return []
+    return [p for p in result.stdout.split() if p.endswith(".py")]
+
+
+def _deployed_schema() -> dict[str, dict[str, bool]]:
+    """{table: {column: nullable}} as the **deployed** models declare it.
+
+    Parsed with `ast` rather than imported: importing the old and new versions
+    of `datanika.models` into one interpreter would collide on module names and
+    on SQLAlchemy's declarative registry.
+    """
+    schema: dict[str, dict[str, bool]] = {}
+
+    for path in _deployed_model_files():
+        blob = _git("show", f"{_DEPLOYED_REF}:{path}")
+        if blob.returncode != 0:
+            continue
+        try:
+            tree = ast.parse(blob.stdout, filename=path)
+        except SyntaxError:  # pragma: no cover - old revision should parse
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            table = _tablename(node)
+            if not table:
+                continue
+            columns = schema.setdefault(table, {})
+            columns.update(_columns(node))
+            # TenantMixin contributes org_id to every tenant table; it is
+            # declared on the mixin, not on each model.
+            if any(getattr(b, "id", getattr(b, "attr", None)) == "TenantMixin" for b in node.bases):
+                columns.setdefault("org_id", False)
+
+    return schema
+
+
+def _tablename(node: ast.ClassDef) -> str | None:
+    for stmt in node.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and any(getattr(t, "id", None) == "__tablename__" for t in stmt.targets)
+            and isinstance(stmt.value, ast.Constant)
+        ):
+            return str(stmt.value.value)
+    return None
+
+
+def _columns(node: ast.ClassDef) -> dict[str, bool]:
+    """Column name -> nullable, for `x: Mapped[...] = mapped_column(...)`."""
+    out: dict[str, bool] = {}
+    for stmt in node.body:
+        if not isinstance(stmt, ast.AnnAssign) or not isinstance(stmt.target, ast.Name):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        if getattr(call.func, "id", getattr(call.func, "attr", None)) != "mapped_column":
+            continue
+
+        name = stmt.target.id
+        # An explicit string first arg overrides the attribute name.
+        if (
+            call.args
+            and isinstance(call.args[0], ast.Constant)
+            and isinstance(call.args[0].value, str)
+        ):
+            name = call.args[0].value
+
+        nullable = False
+        for kw in call.keywords:
+            if kw.arg == "nullable" and isinstance(kw.value, ast.Constant):
+                nullable = bool(kw.value.value)
+            elif kw.arg == "primary_key" and isinstance(kw.value, ast.Constant):
+                nullable = False
+        out[name] = nullable
+    return out
+
+
+def _live_schema(engine) -> dict[str, dict[str, bool]]:
+    """{table: {column: nullable}} as the migrated database actually is."""
+    query = sqlalchemy.text(
+        "SELECT table_name, column_name, is_nullable "
+        "FROM information_schema.columns WHERE table_schema = 'public'"
+    )
+    live: dict[str, dict[str, bool]] = {}
+    with engine.connect() as conn:
+        for table, column, is_nullable in conn.execute(query):
+            live.setdefault(table, {})[column] = is_nullable == "YES"
+    return live
+
+
+@pytest.fixture(scope="module")
+def migrated_schema(roundtrip_db_url):  # noqa: F811 — pytest fixture injection
+    """Postgres migrated to this branch's head, as `information_schema` sees it."""
+    result = _run_alembic(["upgrade", "head"], roundtrip_db_url)
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = sqlalchemy.create_engine(roundtrip_db_url)
+    try:
+        yield _live_schema(engine)
+    finally:
+        engine.dispose()
+
+
+class TestDeployedCodeSurvivesTheNewSchema:
+    def test_the_deployed_ref_is_readable(self):
+        """Guard the guard: no ref, no comparison, and silence would look green."""
+        files = _deployed_model_files()
+        if not files:
+            _no_postgres(
+                f"Cannot read models at {_DEPLOYED_REF!r} — `git fetch origin master` "
+                "first. Without it this file compares nothing."
+            )
+        assert files, f"no model files at {_DEPLOYED_REF}"
+
+    def test_the_deployed_models_actually_parsed(self):
+        """The hole this whole file exists to avoid, one level up.
+
+        Every comparison below is `for table in deployed` — so if the AST walk
+        silently yielded nothing (a refactor to the model style, a moved
+        directory), all three tests pass having compared zero columns. Anchor
+        on tables that must exist in any deployed release.
+        """
+        deployed = _deployed_schema()
+        assert len(deployed) >= 10, (
+            f"only {len(deployed)} tables parsed from {_DEPLOYED_REF} — the AST walk "
+            "is probably not matching the current model style, which would make "
+            "every check below vacuously green"
+        )
+        for table, column in (("users", "email"), ("api_keys", "key_hash")):
+            assert column in deployed.get(table, {}), (
+                f"expected {table}.{column} in the parsed deployed schema; "
+                f"got {sorted(deployed.get(table, {}))}"
+            )
+
+    def test_no_table_the_deployed_release_reads_was_dropped(self, migrated_schema):
+        deployed = _deployed_schema()
+        missing = sorted(t for t in deployed if t not in migrated_schema)
+        assert not missing, (
+            f"Tables dropped that {_DEPLOYED_REF} still reads: {missing}.\n"
+            "At t1 the deployed version runs against this schema and will fail. "
+            "Drop belongs in the CONTRACT phase, a release later "
+            "(plans/infra/SPEC_EXPAND_CONTRACT_MIGRATIONS.md)."
+        )
+
+    def test_no_column_the_deployed_release_reads_was_dropped_or_renamed(self, migrated_schema):
+        """A rename is a drop plus an add — it fails here as the drop."""
+        deployed = _deployed_schema()
+        missing = [
+            f"{table}.{column}"
+            for table, columns in deployed.items()
+            if table in migrated_schema
+            for column in columns
+            if column not in migrated_schema[table]
+        ]
+        assert not missing, (
+            f"Columns removed that {_DEPLOYED_REF} still selects: {sorted(missing)}.\n"
+            "SELECT names every mapped column, so the deployed version breaks on "
+            "every query to that table at t1 — not only where the column is used. "
+            "Expand now, contract next release."
+        )
+
+    def test_nothing_tightened_to_not_null_under_the_deployed_release(self, migrated_schema):
+        """The subtler half: the column exists, but old INSERTs now fail."""
+        deployed = _deployed_schema()
+        tightened = [
+            f"{table}.{column}"
+            for table, columns in deployed.items()
+            if table in migrated_schema
+            for column, was_nullable in columns.items()
+            if was_nullable
+            and column in migrated_schema[table]
+            and not migrated_schema[table][column]
+        ]
+        assert not tightened, (
+            f"Columns now NOT NULL that {_DEPLOYED_REF} treats as nullable: "
+            f"{sorted(tightened)}.\n"
+            "The deployed version omits them on INSERT and will fail at t1. "
+            "Backfill and add the constraint in a later release."
+        )
+
+
+class TestTheGuardDiscriminates:
+    """A guard that cannot fail is decoration — prove it fails on a real breach."""
+
+    def test_a_dropped_column_is_detected(self, migrated_schema):
+        pretend_deployed = {"api_keys": {"key_hash": False, "column_we_removed": False}}
+        missing = [
+            f"{t}.{c}"
+            for t, cols in pretend_deployed.items()
+            if t in migrated_schema
+            for c in cols
+            if c not in migrated_schema[t]
+        ]
+        assert missing == ["api_keys.column_we_removed"]
+
+    def test_a_tightened_column_is_detected(self, migrated_schema):
+        assert "api_keys" in migrated_schema, "fixture did not migrate"
+        pretend_deployed = {"api_keys": {"expires_at": True, "key_hash": True}}
+        tightened = [
+            f"{t}.{c}"
+            for t, cols in pretend_deployed.items()
+            for c, was_nullable in cols.items()
+            if was_nullable and c in migrated_schema[t] and not migrated_schema[t][c]
+        ]
+        # key_hash is NOT NULL in the live schema; expires_at is nullable.
+        assert tightened == ["api_keys.key_hash"], (
+            f"expected the NOT NULL column to be flagged, got {tightened}"
+        )
+
+
+if sys.version_info < (3, 12):  # pragma: no cover - repo requires 3.12
+    pytest.skip("requires Python 3.12 AST", allow_module_level=True)

--- a/tests/test_migrations/test_roundtrip.py
+++ b/tests/test_migrations/test_roundtrip.py
@@ -28,119 +28,13 @@ skip them.
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-from pathlib import Path
-
-import pytest
 from sqlalchemy import create_engine, inspect, text
 
-PROJECT_ROOT = Path(__file__).parent.parent.parent
+from tests.test_migrations.conftest import _run_alembic
 
-
-def _docker_available() -> bool:
-    """Fast check for a reachable Docker daemon."""
-    if not shutil.which("docker"):
-        return False
-    try:
-        return (
-            subprocess.run(
-                ["docker", "info"],
-                capture_output=True,
-                timeout=5,
-                check=False,
-            ).returncode
-            == 0
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return False
-
-
-def _no_postgres(reason: str) -> None:
-    """Skip locally when Postgres is unavailable — but FAIL in CI.
-
-    The ``migration-roundtrip`` job runs *only* this file, so if these tests
-    skip, the job exits 0 and reports green having verified nothing — while
-    the thing it guards (a downgrade that only matters at 2 AM during a prod
-    rollback) goes unchecked. CI always has both Docker and
-    ``DATABASE_URL_SYNC_TEST``, so reaching here in CI means the workflow
-    broke, and that must be loud.
-
-    Locally, skipping stays correct: devs without Docker shouldn't be blocked.
-    Same reasoning as the connector smoke suite's strict mode (core#407).
-    """
-    if os.environ.get("CI"):
-        pytest.fail(
-            f"{reason}\n\n"
-            "This is a hard failure because CI is expected to provide Postgres "
-            "(DATABASE_URL_SYNC_TEST, or Docker for testcontainers). Skipping here "
-            "would let the migration-roundtrip job pass without testing a single "
-            "migration. Check the job's env block and service container."
-        )
-    pytest.skip(reason)
-
-
-@pytest.fixture(scope="session")
-def roundtrip_db_url():
-    """Postgres URL for round-trip tests.
-
-    Priority:
-    1. ``DATABASE_URL_SYNC_TEST`` env var (CI, or manual override)
-    2. testcontainers[postgres] auto-provisioned container (local with Docker)
-    3. skip the test locally — but **fail** in CI (see ``_no_postgres``)
-
-    Must be a generator (yield-based) on every path — pytest treats a
-    function with any `yield` as a generator, and hitting `return` on
-    one path while `yield`-ing on another raises
-    ``ValueError: fixture did not yield a value``.
-    """
-    env_url = os.environ.get("DATABASE_URL_SYNC_TEST")
-    if env_url:
-        yield env_url
-        return
-
-    if not _docker_available():
-        _no_postgres(
-            "Round-trip test requires Postgres. Set DATABASE_URL_SYNC_TEST or run "
-            "with Docker Desktop running."
-        )
-
-    try:
-        from testcontainers.postgres import PostgresContainer
-    except ImportError:
-        _no_postgres(
-            "testcontainers not installed. Install with: "
-            "`uv pip install 'testcontainers[postgres]'` or run CI instead."
-        )
-
-    # Session-scoped container — one per pytest session. Torn down when
-    # the fixture generator exits.
-    container = PostgresContainer("postgres:16-alpine")
-    container.start()
-    try:
-        yield container.get_connection_url().replace("postgresql+psycopg2", "postgresql")
-    finally:
-        container.stop()
-
-
-def _run_alembic(cmd: list[str], db_url: str) -> subprocess.CompletedProcess:
-    """Run an alembic command against the test DB.
-
-    Uses `uv run` so the subprocess inherits the project's venv, and
-    passes ``DATABASE_URL_SYNC`` in the environment — alembic's env.py
-    reads `settings.database_url_sync` which is sourced from that env var.
-    """
-    env = {**os.environ, "DATABASE_URL_SYNC": db_url, "DATABASE_URL": db_url}
-    return subprocess.run(
-        ["uv", "run", "alembic", *cmd],
-        cwd=PROJECT_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=False,
-    )
+# `roundtrip_db_url` is deliberately NOT imported here. It lives in
+# conftest.py and pytest discovers it automatically; importing a fixture
+# registers a *second* FixtureDef and starts a second Postgres container.
 
 
 def _snapshot_schema(db_url: str) -> dict[str, list[str]]:

--- a/tests/test_services/test_catalog_duckdb.py
+++ b/tests/test_services/test_catalog_duckdb.py
@@ -1,0 +1,140 @@
+"""DuckDB loads must reach the Data Catalog (core#494).
+
+After a successful upload into a DuckDB destination, Models / Catalog stayed
+empty: *"No models found. Run an upload or transformation to populate the
+catalog."* The load itself worked — dlt writes to DuckDB through its own driver
+— but the catalog sync goes through **SQLAlchemy**, and the dialect was missing:
+
+    sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
+
+`duckdb` was installed; `duckdb_engine`, the SQLAlchemy dialect, was not.
+
+**Installing the dialect was necessary and not sufficient**, which these tests
+found and the issue's diagnosis did not. With `duckdb_engine` present,
+`create_engine` and `get_table_names` both work — but `get_columns` still
+raises, because the dialect derives from PostgreSQL's and queries
+`pg_collation`, which DuckDB does not have::
+
+    ProgrammingError: Catalog Error: Table with name pg_collation does not exist!
+
+`introspect_tables` wrapped that in a bare `except Exception: continue`, so
+every table was dropped silently and the catalog came back **empty even after
+the dependency fix**. A test asserting only `import duckdb_engine` would have
+gone green over a still-broken feature.
+
+DuckDB is the destination in the zero-credentials onboarding template, and both
+`/docs/connectors/duckdb` and `/docs/connectors/csv` tell the user to verify
+their first run by browsing Catalog. **For every DuckDB user that instruction
+had never once worked.** Data Preview (#260) was unreachable for the same
+reason — it needs a catalog entry.
+
+Both failures were swallowed — the per-table one here, and the whole sync in
+`upload_tasks` — so nothing outside the worker log knew. Both are covered.
+"""
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from datanika.services.catalog_service import CatalogService
+
+pytest.importorskip("duckdb", reason="core#494 is specifically about the DuckDB path")
+
+
+class TestTheDuckDBDialectIsInstalled:
+    def test_sqlalchemy_can_build_a_duckdb_engine(self):
+        """The exact failure from the production traceback.
+
+        `create_engine` is where it raised — before any query, so no amount of
+        retrying or different SQL would have helped.
+        """
+        engine = create_engine("duckdb:///:memory:")
+        engine.dispose()
+
+    def test_duckdb_engine_is_importable(self):
+        """Names the missing package, so a failure here reads as its own fix."""
+        import duckdb_engine  # noqa: F401
+
+
+class TestCatalogIntrospectionWorksOnDuckDB:
+    def test_introspect_tables_finds_a_real_table(self, tmp_path):
+        """Drive the real consumer, not just the import.
+
+        `import duckdb_engine` passing proves the package exists; it does not
+        prove `CatalogService` can read a DuckDB file. This is the call that
+        raised in production.
+        """
+        db_path = tmp_path / "warehouse.duckdb"
+        engine = create_engine(f"duckdb:///{db_path}")
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE SCHEMA customersdailyload"))
+                conn.execute(
+                    text(
+                        "CREATE TABLE customersdailyload.customers "
+                        "(customer_id BIGINT, full_name VARCHAR)"
+                    )
+                )
+                conn.execute(
+                    text("INSERT INTO customersdailyload.customers VALUES (1001, 'Ada Lovelace')")
+                )
+        finally:
+            engine.dispose()
+
+        tables = CatalogService.introspect_tables(
+            f"duckdb:///{db_path}", schema_name="customersdailyload"
+        )
+
+        assert [t["table_name"] for t in tables] == ["customers"]
+        assert {c["name"] for c in tables[0]["columns"]} == {"customer_id", "full_name"}
+
+    def test_a_dialect_that_cannot_answer_falls_back_instead_of_vanishing(self, tmp_path):
+        """The defect that installing the dependency did *not* fix.
+
+        `duckdb_engine` derives from the PostgreSQL dialect, so `get_columns`
+        queries `pg_collation` — which DuckDB does not have. The old bare
+        `except Exception: continue` turned that into an **empty catalog**, so
+        the dependency fix alone still left Models/Catalog blank.
+
+        Forced here rather than relying on the live dialect: whether upstream
+        fixes `get_columns` should not decide whether we notice a regression.
+        """
+        from unittest.mock import patch
+
+        db_path = tmp_path / "warehouse.duckdb"
+        engine = create_engine(f"duckdb:///{db_path}")
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE SCHEMA probe"))
+                conn.execute(text("CREATE TABLE probe.customers (customer_id BIGINT)"))
+        finally:
+            engine.dispose()
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("Catalog Error: Table with name pg_collation does not exist!")
+
+        with patch("sqlalchemy.engine.reflection.Inspector.get_columns", _boom):
+            tables = CatalogService.introspect_tables(f"duckdb:///{db_path}", schema_name="probe")
+
+        assert [t["table_name"] for t in tables] == ["customers"]
+        assert [c["name"] for c in tables[0]["columns"]] == ["customer_id"]
+
+    def test_dlt_bookkeeping_tables_are_filtered_out(self, tmp_path):
+        """The catalog should show the user's tables, not dlt's.
+
+        Production had *only* `_dlt_loads` / `_dlt_pipeline_state` /
+        `_dlt_version` in the destination, so this is also the shape a
+        zero-row run leaves behind (core#493).
+        """
+        db_path = tmp_path / "warehouse.duckdb"
+        engine = create_engine(f"duckdb:///{db_path}")
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE SCHEMA probe"))
+                conn.execute(text("CREATE TABLE probe._dlt_loads (load_id VARCHAR)"))
+                conn.execute(text("CREATE TABLE probe.customers (customer_id BIGINT)"))
+        finally:
+            engine.dispose()
+
+        tables = CatalogService.introspect_tables(f"duckdb:///{db_path}", schema_name="probe")
+
+        assert [t["table_name"] for t in tables] == ["customers"]

--- a/tests/test_services/test_connection_service.py
+++ b/tests/test_services/test_connection_service.py
@@ -399,15 +399,22 @@ class TestTestConnection:
         assert ok is False
         assert "Driver not installed" in msg
 
-    def test_non_db_type_skipped_s3(self, svc):
-        ok, msg = svc.test_connection({"bucket_url": "s3://my-bucket"}, ConnectionType.S3)
-        assert ok is True
-        assert "not applicable" in msg.lower()
+    def test_file_types_are_no_longer_skipped_s3(self, svc):
+        """Contract change (core#493): file sources are testable, so they get tested.
 
-    def test_non_db_type_skipped_csv(self, svc):
+        These two used to assert `(True, "not applicable")` — which is exactly
+        how a wrong path came to test identically to a right one, and why a
+        typo'd `bucket_url` was first noticed as a green run with zero rows.
+        An unreachable bucket must not report success.
+        """
+        ok, msg = svc.test_connection({"bucket_url": "s3://no-such-bucket"}, ConnectionType.S3)
+        assert ok is False
+        assert "not applicable" not in msg.lower()
+
+    def test_file_types_are_no_longer_skipped_csv(self, svc):
         ok, msg = svc.test_connection({"bucket_url": "/data"}, ConnectionType.CSV)
-        assert ok is True
-        assert "not applicable" in msg.lower()
+        assert ok is False
+        assert "not applicable" not in msg.lower()
 
     def test_non_db_type_skipped_rest_api(self, svc):
         config = {"base_url": "https://api.example.com"}

--- a/tests/test_services/test_dlt_file_sources.py
+++ b/tests/test_services/test_dlt_file_sources.py
@@ -1,0 +1,255 @@
+"""File sources must load file **contents** (core#492).
+
+`dlt`'s `filesystem()` is a *lister*: it yields one record per matched file
+(name, size, mtime, mime type). Reading contents requires piping it through a
+format transformer. Without one, prod loaded a **table of filenames**, reported
+`success`, and showed `Rows: 1` — that 1 being the file, not the data. On the
+zero-credentials onboarding path we advertise hardest.
+
+**Why 2,500 green tests said nothing about it.** Every existing test in
+`TestBuildFileSource` patches `datanika.services.dlt_runner.filesystem` and
+asserts the kwargs we passed, with the mock returning the string `"csv_src"`.
+What dlt *yields* was unobservable to all of them, so the entire defect lived
+in the gap between "we called it correctly" and "it returns rows".
+
+So this file mocks nothing. It writes real files, runs a real dlt pipeline into
+a real DuckDB, and asserts the rows and columns that actually land. Every test
+here fails on the pre-fix code — that is the point of it existing.
+"""
+
+import json
+
+import pytest
+
+from datanika.services.dlt_runner import DltRunnerError, DltRunnerService
+
+duckdb = pytest.importorskip("duckdb", reason="file-source loads assert against a real DuckDB")
+
+CUSTOMERS = [
+    {"customer_id": 1001, "full_name": "Ada Lovelace", "lifetime_value_usd": 1840.00},
+    {"customer_id": 1002, "full_name": "Grace Hopper", "lifetime_value_usd": 7325.50},
+]
+
+#: The columns `filesystem()` yields when nobody pipes it through a reader.
+#: Their presence in a destination table *is* the bug.
+FILE_LISTING_COLUMNS = {"file_name", "relative_path", "file_url", "mime_type", "size_in_bytes"}
+
+
+def _write_csv(directory, name="customers.csv", delimiter=","):
+    header = delimiter.join(["customer_id", "full_name", "lifetime_value_usd"])
+    lines = [
+        delimiter.join([str(r["customer_id"]), r["full_name"], str(r["lifetime_value_usd"])])
+        for r in CUSTOMERS
+    ]
+    path = directory / name
+    path.write_text("\n".join([header, *lines]) + "\n", encoding="utf-8")
+    return path
+
+
+def _load(source, tmp_path, label="probe"):
+    """Run a real dlt pipeline into DuckDB; return {table: (columns, rows)}."""
+    import dlt
+
+    db_path = tmp_path / f"{label}.duckdb"
+    pipeline = dlt.pipeline(
+        pipeline_name=f"t492_{label}",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="probe",
+        pipelines_dir=str(tmp_path / f"state_{label}"),
+    )
+    pipeline.run(source)
+
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        tables = con.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'probe' AND table_name NOT LIKE '\\_dlt%' ESCAPE '\\'"
+        ).fetchall()
+        out = {}
+        for (table,) in tables:
+            columns = [
+                c[0]
+                for c in con.execute(f'DESCRIBE probe."{table}"').fetchall()
+                if not c[0].startswith("_dlt")
+            ]
+            rows = con.execute(f'SELECT count(*) FROM probe."{table}"').fetchone()[0]
+            out[table] = (columns, rows)
+        return out
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def svc():
+    return DltRunnerService(pipelines_dir="/tmp/t492")
+
+
+class TestFileContentsActuallyLand:
+    def test_csv_loads_rows_not_a_file_listing(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "csv")
+
+        assert len(tables) == 1, f"expected one table, got {sorted(tables)}"
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS), f"expected {len(CUSTOMERS)} data rows, got {rows}"
+        assert "customer_id" in columns and "full_name" in columns
+        assert not FILE_LISTING_COLUMNS & set(columns), (
+            f"the file *listing* landed instead of the data: {columns}"
+        )
+
+    def test_csv_values_survive_the_round_trip(self, svc, tmp_path):
+        """Row count alone would pass on a table of two filenames."""
+        _write_csv(tmp_path)
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "table_name": "customers"}
+        )
+        _load(source, tmp_path, "csvvals")
+
+        con = duckdb.connect(str(tmp_path / "csvvals.duckdb"), read_only=True)
+        try:
+            names = {r[0] for r in con.execute("SELECT full_name FROM probe.customers").fetchall()}
+        finally:
+            con.close()
+        assert names == {"Ada Lovelace", "Grace Hopper"}
+
+    def test_json_array_loads_flat_not_as_a_nested_child_table(self, svc, tmp_path):
+        """The shape dlt's own `read_jsonl` gets wrong.
+
+        Fed an array, `read_jsonl` parses the whole file as one value: dlt then
+        writes a parent row with no business columns plus a `__value` child
+        table. Green run, data in the wrong shape — the same class of failure as
+        the file listing.
+        """
+        (tmp_path / "customers.json").write_text(json.dumps(CUSTOMERS), encoding="utf-8")
+        source = svc.build_source("json", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "jsonarray")
+
+        assert len(tables) == 1, f"expected one flat table, got {sorted(tables)}"
+        table, (columns, rows) = next(iter(tables.items()))
+        assert not table.endswith("__value"), f"data landed in a child table: {table}"
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns
+
+    def test_json_lines_load(self, svc, tmp_path):
+        (tmp_path / "customers.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in CUSTOMERS), encoding="utf-8"
+        )
+        source = svc.build_source("json", {}, {"bucket_url": str(tmp_path), "file_glob": "*.jsonl"})
+
+        tables = _load(source, tmp_path, "jsonl")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns
+
+    def test_a_single_pretty_printed_object_loads_as_one_row(self, svc, tmp_path):
+        """Not line-delimited and not an array — the third real shape."""
+        (tmp_path / "customer.json").write_text(json.dumps(CUSTOMERS[0], indent=2), "utf-8")
+        source = svc.build_source("json", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "jsonobj")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == 1
+        assert "customer_id" in columns
+
+    def test_parquet_loads_rows(self, svc, tmp_path):
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        pd.DataFrame(CUSTOMERS).to_parquet(tmp_path / "customers.parquet", index=False)
+
+        source = svc.build_source("parquet", {}, {"bucket_url": str(tmp_path)})
+        tables = _load(source, tmp_path, "parquet")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS)
+        assert not FILE_LISTING_COLUMNS & set(columns)
+
+    def test_custom_delimiter_is_honoured(self, svc, tmp_path):
+        """A semicolon export read as comma-delimited yields one fused column."""
+        _write_csv(tmp_path, delimiter=";")
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path), "delimiter": ";"})
+
+        tables = _load(source, tmp_path, "semicolon")
+
+        (columns, rows) = next(iter(tables.values()))
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns and "full_name" in columns
+
+
+class TestTableNaming:
+    def test_the_table_is_not_named_after_the_transformer(self, svc, tmp_path):
+        """Unrenamed, a piped transformer lands in `_read_csv`.
+
+        That reads as a dlt internal table, and `_dlt`-prefixed names are how
+        dlt marks its own bookkeeping — so the naive fix trades a wrong payload
+        for a table users would reasonably ignore.
+        """
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+
+        tables = _load(source, tmp_path, "naming")
+
+        for table in tables:
+            assert not table.startswith("_"), f"table {table!r} looks like a dlt internal"
+
+    def test_explicit_table_name_wins(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "table_name": "customers_daily"}
+        )
+        assert "customers_daily" in _load(source, tmp_path, "explicitname")
+
+    def test_a_single_named_file_names_the_table(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "file_glob": "customers.csv"}
+        )
+        assert "customers" in _load(source, tmp_path, "stemname")
+
+    def test_a_wildcard_glob_falls_back_to_the_connection_type(self, svc, tmp_path):
+        """Documents the fallback rather than leaving it to be discovered.
+
+        A wildcard matches many files, so no filename can name the table. The
+        connection type is at least stable and predictable. The *advertised*
+        upload path doesn't rely on this — `upload_tasks` sets `table_name`
+        from the uploaded file's original name, which is the only layer that
+        knows it (the runner sees a hash-named extract dir).
+        """
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+        assert "csv" in _load(source, tmp_path, "wildcardname")
+
+
+class TestUnreadableFormatsRefuseInsteadOfGuessing:
+    def test_bare_s3_glob_raises_rather_than_loading_a_listing(self, svc):
+        """`s3` + `*` carries no format. Guessing reproduces core#492."""
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("s3", {"bucket_url": "s3://bucket"}, {})
+
+        message = str(exc.value)
+        assert "file_format" in message, f"error should name the fix, got: {message}"
+
+    def test_s3_infers_the_format_from_the_pattern(self, svc, tmp_path):
+        _write_csv(tmp_path)
+        source = svc.build_source("s3", {}, {"bucket_url": str(tmp_path), "file_glob": "*.csv"})
+        (columns, rows) = next(iter(_load(source, tmp_path, "s3csv").values()))
+        assert rows == len(CUSTOMERS)
+
+    def test_explicit_file_format_overrides_an_ambiguous_pattern(self, svc, tmp_path):
+        _write_csv(tmp_path, name="customers.data")
+        source = svc.build_source(
+            "s3",
+            {},
+            {"bucket_url": str(tmp_path), "file_glob": "*.data", "file_format": "csv"},
+        )
+        (columns, rows) = next(iter(_load(source, tmp_path, "explicitfmt").values()))
+        assert rows == len(CUSTOMERS)
+        assert "customer_id" in columns
+
+    def test_an_unknown_file_format_is_rejected(self, svc):
+        with pytest.raises(DltRunnerError, match="Unsupported file_format"):
+            svc.build_source("s3", {}, {"bucket_url": "s3://b", "file_format": "avro"})

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -314,7 +314,10 @@ def _fake_lister():
     """
     import dlt
 
-    return dlt.resource(lambda: iter([]), name="filesystem")
+    # Must yield at least one item: `_build_file_source` now peeks the lister
+    # and refuses to build a source that matches nothing (core#493), so an
+    # empty stand-in would fail every test here for the wrong reason.
+    return dlt.resource(lambda: iter([{"file_name": "customers.csv"}]), name="filesystem")
 
 
 class TestBuildFileSource:
@@ -392,7 +395,9 @@ class TestBuildFileSource:
         mock_pipeline.run.return_value = load_info
         mock_dlt.pipeline.return_value = mock_pipeline
         mock_dlt.destinations.postgres.return_value = "pg_dest"
-        mock_fs.return_value = MagicMock()
+        # A MagicMock iterates empty, which now reads as "matched no files"
+        # and refuses to build the source (core#493).
+        mock_fs.return_value = _fake_lister()
 
         result = svc.execute(
             pipeline_id=1,

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -302,49 +302,66 @@ class TestBuildSource:
 # ---------------------------------------------------------------------------
 # build_source — file types (Step 25)
 # ---------------------------------------------------------------------------
+def _fake_lister():
+    """A real (empty) dlt resource standing in for `filesystem()`.
+
+    These tests assert *the kwargs we hand dlt*, which is still worth pinning —
+    but the mock can no longer return a bare string, because `build_source` now
+    pipes the lister into a format reader (core#492). A string isn't pipeable,
+    and `result == "csv_src"` was never evidence of anything anyway: it asserted
+    the mock's own return value. Contents are covered for real, against real
+    files and a real DuckDB, in `test_dlt_file_sources.py`.
+    """
+    import dlt
+
+    return dlt.resource(lambda: iter([]), name="filesystem")
+
+
 class TestBuildFileSource:
     @patch("datanika.services.dlt_runner.filesystem")
     def test_csv_source_uses_filesystem(self, mock_fs, svc):
-        mock_fs.return_value = "csv_src"
-        result = svc.build_source("csv", {}, {"bucket_url": "/data"})
+        mock_fs.return_value = _fake_lister()
+        svc.build_source("csv", {}, {"bucket_url": "/data"})
         mock_fs.assert_called_once()
-        assert result == "csv_src"
         kwargs = mock_fs.call_args[1]
         assert kwargs["bucket_url"] == "/data"
         assert kwargs["file_glob"] == "*.csv"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_json_source_default_glob(self, mock_fs, svc):
-        mock_fs.return_value = "json_src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("json", {}, {"bucket_url": "/data"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["file_glob"] == "*.json"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_parquet_source_default_glob(self, mock_fs, svc):
-        mock_fs.return_value = "pq_src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("parquet", {}, {"bucket_url": "/data"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["file_glob"] == "*.parquet"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_s3_source_passes_credentials(self, mock_fs, svc):
-        mock_fs.return_value = "s3_src"
+        mock_fs.return_value = _fake_lister()
         config = {
             "aws_access_key_id": "AKID",
             "aws_secret_access_key": "secret",
             "region_name": "us-east-1",
             "bucket_url": "s3://my-bucket",
         }
-        svc.build_source("s3", config, {})
+        # A format is required now: `s3` + the default `*` glob names no format,
+        # and guessing one is how core#492 happened. See
+        # TestUnreadableFormatsRefuseInsteadOfGuessing.
+        svc.build_source("s3", config, {"file_glob": "*.csv"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["bucket_url"] == "s3://my-bucket"
-        assert kwargs["file_glob"] == "*"
+        assert kwargs["file_glob"] == "*.csv"
         assert kwargs["credentials"]["aws_access_key_id"] == "AKID"
 
     @patch("datanika.services.dlt_runner.filesystem")
     def test_custom_file_glob_overrides_default(self, mock_fs, svc):
-        mock_fs.return_value = "src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("csv", {}, {"bucket_url": "/data", "file_glob": "reports_*.csv"})
         kwargs = mock_fs.call_args[1]
         assert kwargs["file_glob"] == "reports_*.csv"
@@ -361,7 +378,7 @@ class TestBuildFileSource:
     @patch("datanika.services.dlt_runner.filesystem")
     def test_bucket_url_from_config(self, mock_fs, svc):
         """bucket_url can come from connection config instead of dlt_config."""
-        mock_fs.return_value = "src"
+        mock_fs.return_value = _fake_lister()
         svc.build_source("csv", {"bucket_url": "/from/config"}, {})
         kwargs = mock_fs.call_args[1]
         assert kwargs["bucket_url"] == "/from/config"

--- a/tests/test_services/test_file_source_zero_match.py
+++ b/tests/test_services/test_file_source_zero_match.py
@@ -1,0 +1,173 @@
+"""A file source that matches nothing must not report success (core#493).
+
+Found on production alongside core#492: connection `customerscsv` had
+`bucket_url` set to a **full file path**, and the glob is applied *under* that
+value, so `*.csv` matched nothing. The run completed **`success`** in 3.7s with
+`Rows: 0`, created only dlt's bookkeeping tables, and left no signal anywhere
+that distinguished "loaded everything" from "found nothing".
+
+That is the same family as core#456 (run rows that lie) and the alert rules that
+could not tell healthy from dead: **a state that should be loud is byte-identical
+to the healthy one.** A typo'd path, a moved file, an export that didn't run and
+an emptied S3 prefix all landed here.
+
+`Test Connection` could not catch it either — every file type fell into
+`_NON_DB_TYPES` and returned `(True, "Test not applicable for this type")`
+unconditionally, so a wrong path tested exactly like a right one. Both halves
+are covered here, because fixing only the run would leave the user with no way
+to find out *before* running.
+"""
+
+import pytest
+
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import ConnectionService
+from datanika.services.dlt_runner import DltRunnerError, DltRunnerService
+
+
+@pytest.fixture
+def svc():
+    return DltRunnerService(pipelines_dir="/tmp/t493")
+
+
+def _write_csv(directory, name="customers.csv"):
+    path = directory / name
+    path.write_text("customer_id,full_name\n1001,Ada Lovelace\n", encoding="utf-8")
+    return path
+
+
+class TestTheRunRefusesToLoadNothing:
+    def test_a_glob_matching_nothing_raises(self, svc, tmp_path):
+        (tmp_path / "customers.txt").write_text("not a csv", encoding="utf-8")
+
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+
+        assert "*.csv" in str(exc.value)
+        assert "zero rows" in str(exc.value)
+
+    def test_bucket_url_pointing_at_a_file_says_so(self, svc, tmp_path):
+        """The production repro, and the message that would have solved it.
+
+        `bucket_url` was a full file path. "No files matched" alone sends the
+        user to re-check a glob that was never the problem, so the message has
+        to name the file-vs-directory mistake and the fix.
+        """
+        csv_path = _write_csv(tmp_path)
+
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("csv", {}, {"bucket_url": str(csv_path)})
+
+        message = str(exc.value)
+        assert "is a file" in message
+        assert str(tmp_path) in message, "the message should name the directory to use instead"
+
+    def test_a_missing_path_says_it_does_not_exist(self, svc, tmp_path):
+        with pytest.raises(DltRunnerError, match="does not exist"):
+            svc.build_source("csv", {}, {"bucket_url": str(tmp_path / "nope")})
+
+    def test_an_empty_directory_is_distinguished_from_a_bad_path(self, svc, tmp_path):
+        """Three causes, three messages — otherwise the error is a shrug."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source("csv", {}, {"bucket_url": str(empty)})
+
+        assert "exists but holds nothing" in str(exc.value)
+
+    def test_a_matching_source_still_builds(self, svc, tmp_path):
+        """The guard must not refuse healthy sources.
+
+        Peeking consumes an item from the lister; if that broke re-iteration,
+        every real load would silently lose its first file.
+        """
+        _write_csv(tmp_path)
+        source = svc.build_source("csv", {}, {"bucket_url": str(tmp_path)})
+        assert source is not None
+
+    def test_peeking_does_not_consume_the_first_file(self, svc, tmp_path):
+        """The specific way this guard could corrupt a working pipeline."""
+        duckdb = pytest.importorskip("duckdb")
+        import dlt
+
+        _write_csv(tmp_path)
+        _write_csv(tmp_path, name="customers_2.csv")
+
+        source = svc.build_source(
+            "csv", {}, {"bucket_url": str(tmp_path), "table_name": "customers"}
+        )
+        pipeline = dlt.pipeline(
+            pipeline_name="t493_peek",
+            destination=dlt.destinations.duckdb(str(tmp_path / "peek.duckdb")),
+            dataset_name="probe",
+            pipelines_dir=str(tmp_path / "state"),
+        )
+        pipeline.run(source)
+
+        con = duckdb.connect(str(tmp_path / "peek.duckdb"), read_only=True)
+        try:
+            rows = con.execute("SELECT count(*) FROM probe.customers").fetchone()[0]
+        finally:
+            con.close()
+        assert rows == 2, "a row per file — the peeked file must still be loaded"
+
+
+class TestConnectionTestActuallyTests:
+    def test_a_good_path_passes(self, tmp_path):
+        _write_csv(tmp_path)
+        ok, message = ConnectionService.test_connection(
+            {"bucket_url": str(tmp_path)}, ConnectionType.CSV
+        )
+        assert ok, message
+
+    def test_a_wrong_path_no_longer_looks_like_a_right_one(self, tmp_path):
+        """The whole point: this returned `(True, "not applicable")` before."""
+        ok, message = ConnectionService.test_connection(
+            {"bucket_url": str(tmp_path / "nope")}, ConnectionType.CSV
+        )
+        assert not ok
+        assert "does not exist" in message
+
+    def test_a_file_path_is_diagnosed_at_test_time(self, tmp_path):
+        """Catch the production mistake before the user ever runs."""
+        csv_path = _write_csv(tmp_path)
+        ok, message = ConnectionService.test_connection(
+            {"bucket_url": str(csv_path)}, ConnectionType.CSV
+        )
+        assert not ok
+        assert "is a file" in message
+
+    def test_the_legacy_path_key_is_accepted(self, tmp_path):
+        """`CONFIG_SCHEMAS` declares `path`; live connections carry `bucket_url`."""
+        _write_csv(tmp_path)
+        ok, message = ConnectionService.test_connection({"path": str(tmp_path)}, ConnectionType.CSV)
+        assert ok, message
+
+    def test_an_empty_config_is_rejected_before_listing(self):
+        ok, message = ConnectionService.test_connection({}, ConnectionType.CSV)
+        assert not ok
+
+    def test_a_config_without_a_location_is_rejected(self):
+        ok, message = ConnectionService.test_connection(
+            {"aws_access_key_id": "AKID"}, ConnectionType.S3
+        )
+        assert not ok
+        assert "bucket URL or path" in message
+
+    @pytest.mark.parametrize(
+        "connection_type",
+        [ConnectionType.CSV, ConnectionType.JSON, ConnectionType.PARQUET, ConnectionType.S3],
+    )
+    def test_no_file_type_still_answers_not_applicable(self, connection_type, tmp_path):
+        """All four, not just the one the bug was reported on."""
+        _, message = ConnectionService.test_connection(
+            {"bucket_url": str(tmp_path / "nope")}, connection_type
+        )
+        assert "not applicable" not in message
+
+    def test_non_file_types_are_untouched(self):
+        ok, message = ConnectionService.test_connection(
+            {"base_url": "https://api.example.com"}, ConnectionType.REST_API
+        )
+        assert ok and "not applicable" in message

--- a/tests/test_services/test_run_failure_notifications.py
+++ b/tests/test_services/test_run_failure_notifications.py
@@ -1,0 +1,175 @@
+"""A failed run must notify (core#465).
+
+Both run-completion handlers already branch on `status == "failed"` — building
+`Run #N failed` / `NotificationType.RUN_FAILED` and choosing the `run_failure`
+notification event. **Nothing ever sent that status.** All three announce sites
+were on success paths and the `fail_run` paths announced nothing at all, so the
+branch was unreachable and a failed run had never produced a notification:
+Slack, email or in-app.
+
+Two decisions worth keeping visible, because neither is what the issue proposed:
+
+**Announced from `ExecutionService.fail_run`, not from each task.** The issue
+scoped this as "three `except` paths"; there are **five** `fail_run` call sites,
+and two are not `except` blocks — a dbt command failing
+(`pipeline_tasks`) and upstream dependencies never being satisfied
+(`dependency_helpers`). Announcing from the one place they all pass through
+covers those, leaves the error-handling paths untouched (which is what the
+issue's own warning asked for), and cannot be forgotten by a sixth caller.
+
+**A new `run.failed` event, not `run.*_completed` with `status="failed"`.**
+datanika-cloud subscribes four metering handlers to those three events —
+`handle_model_runs`, `handle_upload_runs`, `handle_transformation_run`,
+`handle_bytes_processed` — and every one calls `record_usage` **unconditionally**;
+not one checks `status`. Reusing those events would have billed users for failed
+runs, turning a missing notification into a billing defect. That is asserted
+below, because it is a cross-repo invariant no core test would otherwise hold.
+"""
+
+import pytest
+
+from datanika import hooks
+from datanika.models.dependency import NodeType
+from datanika.models.notification import NotificationType
+from datanika.models.run import Run, RunStatus
+from datanika.models.user import Organization
+from datanika.services.execution_service import ExecutionService
+from datanika.services.in_app_notification_service import InAppNotificationService
+
+
+@pytest.fixture
+def org(db_session):
+    org = Organization(name="Acme", slug="acme-run-failed")
+    db_session.add(org)
+    db_session.flush()
+    return org
+
+
+@pytest.fixture
+def run(db_session, org):
+    run = Run(
+        org_id=org.id,
+        target_type=NodeType.UPLOAD,
+        target_id=7,
+        status=RunStatus.RUNNING,
+    )
+    db_session.add(run)
+    db_session.flush()
+    return run
+
+
+@pytest.fixture
+def clean_hooks():
+    """Isolate the global bus — it is process-wide state."""
+    saved = {event: list(handlers) for event, handlers in hooks._handlers.items()}
+    hooks._handlers.clear()
+    yield hooks
+    hooks._handlers.clear()
+    hooks._handlers.update(saved)
+
+
+class TestFailedRunsAnnounce:
+    def test_fail_run_announces_run_failed(self, db_session, run, clean_hooks):
+        seen = []
+        clean_hooks.on("run.failed", lambda **kw: seen.append(kw))
+
+        ExecutionService().fail_run(db_session, run.id, error_message="boom", logs="trace")
+
+        assert len(seen) == 1, "a failed run announced nothing"
+        payload = seen[0]
+        assert payload["status"] == "failed"
+        assert payload["error_message"] == "boom"
+        assert payload["run_id"] == run.id
+        assert payload["org_id"] == run.org_id
+
+    def test_the_payload_identifies_which_run_failed(self, db_session, run, clean_hooks):
+        """`Run #N failed` is the notification title — without these it says nothing."""
+        seen = []
+        clean_hooks.on("run.failed", lambda **kw: seen.append(kw))
+
+        ExecutionService().fail_run(db_session, run.id, error_message="boom", logs="t")
+
+        payload = seen[0]
+        assert payload["target_type"] == NodeType.UPLOAD.value
+        assert payload["target_id"] == 7
+        assert isinstance(payload["target_type"], str), "enum would not serialise for Celery"
+
+    def test_a_missing_run_announces_nothing(self, db_session, clean_hooks):
+        seen = []
+        clean_hooks.on("run.failed", lambda **kw: seen.append(kw))
+
+        assert ExecutionService().fail_run(db_session, 999999, error_message="x", logs="y") is None
+        assert seen == []
+
+    def test_a_broken_notifier_cannot_mask_the_failure(self, db_session, run, clean_hooks):
+        """`announce`, not `emit` — the run already failed (core#456)."""
+
+        def explode(**_kw):
+            raise RuntimeError("notifier down")
+
+        clean_hooks.on("run.failed", explode)
+
+        result = ExecutionService().fail_run(db_session, run.id, error_message="boom", logs="t")
+
+        assert result is not None
+        assert result.status == RunStatus.FAILED
+        assert result.error_message == "boom"
+
+
+class TestTheNotificationActuallyArrives:
+    def test_a_failed_run_creates_an_in_app_notification(self, db_session, run, clean_hooks):
+        """The assertion that would have caught this.
+
+        Everything above proves the event fires; this proves a user sees
+        something, through the real handler and the real service.
+        """
+        from datanika.services.in_app_notification_hooks import register_in_app_notification_hooks
+
+        register_in_app_notification_hooks()
+
+        ExecutionService().fail_run(
+            db_session, run.id, error_message="dbt command failed", logs="t"
+        )
+
+        # The hook creates an org-wide notification (no user_id), which
+        # `list_for_user` returns to every member of the org.
+        notifications = InAppNotificationService.list_for_user(db_session, run.org_id, user_id=1)
+        assert len(notifications) == 1, "a failed run produced no notification"
+        assert notifications[0].type == NotificationType.RUN_FAILED
+        assert f"Run #{run.id}" in notifications[0].title
+        assert notifications[0].message == "dbt command failed"
+
+
+class TestFailuresAreNotMetered:
+    def test_run_failed_is_not_one_of_the_metered_events(self):
+        """Cross-repo invariant, asserted here because nothing else holds it.
+
+        datanika-cloud subscribes `handle_model_runs`, `handle_upload_runs`,
+        `handle_transformation_run` and `handle_bytes_processed` to the three
+        `run.*_completed` events, and every one records usage **without
+        checking status**. If a future change routes failures onto those
+        events, users get billed for failed runs.
+        """
+        metered = {
+            "run.upload_completed",
+            "run.models_completed",
+            "run.transformation_completed",
+        }
+        assert "run.failed" not in metered
+
+    def test_fail_run_does_not_announce_a_metered_event(self, db_session, run, clean_hooks):
+        """The behavioural half — a rename could quietly undo the one above."""
+        metered_hits = []
+        for event in (
+            "run.upload_completed",
+            "run.models_completed",
+            "run.transformation_completed",
+        ):
+            clean_hooks.on(event, lambda _event=event, **kw: metered_hits.append(_event))
+
+        ExecutionService().fail_run(db_session, run.id, error_message="boom", logs="t")
+
+        assert metered_hits == [], (
+            f"a failed run fired metered events {metered_hits} — cloud's handlers "
+            "record usage unconditionally, so this bills users for failures"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -942,6 +942,7 @@ dependencies = [
     { name = "dbt-sqlserver" },
     { name = "dlt", extra = ["bigquery", "clickhouse", "databricks", "duckdb", "mssql", "postgres", "snowflake", "synapse"] },
     { name = "duckdb" },
+    { name = "duckdb-engine" },
     { name = "google-auth" },
     { name = "gspread" },
     { name = "oracledb" },
@@ -992,6 +993,7 @@ requires-dist = [
     { name = "dbt-sqlserver", specifier = ">=1.7,<1.8" },
     { name = "dlt", extras = ["postgres", "snowflake", "bigquery", "mssql", "clickhouse", "duckdb", "databricks", "synapse"], specifier = ">=1.21,<2" },
     { name = "duckdb", specifier = ">=1.0,<2" },
+    { name = "duckdb-engine", specifier = ">=0.17,<0.18" },
     { name = "google-auth", specifier = ">=2.0,<3" },
     { name = "gspread", specifier = ">=6.0,<7" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28,<0.29" },
@@ -1376,6 +1378,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/4c/47e838393aa90d3d78549c8c04cb09452efeb14aaae0ee24dc0bd61c3a41/duckdb-1.5.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8843bd9594e1387f1e601439e19ad73abdf57356104fd1e53a708255bb95a13d", size = 21387569, upload-time = "2026-03-23T12:12:05.693Z" },
     { url = "https://files.pythonhosted.org/packages/f4/9b/ce65743e0e85f5c984d2f7e8a81bc908d0bac345d6d8b6316436b29430e7/duckdb-1.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:d68c5a01a283cb13b79eafe016fe5869aa11bff8c46e7141c70aa0aac808010f", size = 13603876, upload-time = "2026-03-23T12:12:09.344Z" },
     { url = "https://files.pythonhosted.org/packages/e6/ac/f9e4e731635192571f86f52d86234f537c7f8ca4f6917c56b29051c077ef/duckdb-1.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:a3be2072315982e232bfe49c9d3db0a59ba67b2240a537ef42656cc772a887c7", size = 14370790, upload-time = "2026-03-23T12:12:12.497Z" },
+]
+
+[[package]]
+name = "duckdb-engine"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "duckdb" },
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d5/c0d8d0a4ca3ffea92266f33d92a375e2794820ad89f9be97cf0c9a9697d0/duckdb_engine-0.17.0.tar.gz", hash = "sha256:396b23869754e536aa80881a92622b8b488015cf711c5a40032d05d2cf08f3cf", size = 48054, upload-time = "2025-03-29T09:49:17.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a2/e90242f53f7ae41554419b1695b4820b364df87c8350aa420b60b20cab92/duckdb_engine-0.17.0-py3-none-any.whl", hash = "sha256:3aa72085e536b43faab635f487baf77ddc5750069c16a2f8d9c6c3cb6083e979", size = 49676, upload-time = "2025-03-29T09:49:15.564Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**#504 — the alert rules never evaluated their conditions.** A threshold applied to an unreduced time series errored on every evaluation, so every probe/scrape rule paged via `execErrState` rather than by matching a condition, and a single 15s blip paged for the whole query window. Fixed with an explicit reduce step, five corrected evaluators (one compared `gt [0]` against a value that is always 0, so it could never be satisfied), and 60s windows on the boolean-filter rules. **CD now fails the deploy if any Grafana rule reports an evaluation error** — the previous check compared expression text and never asked whether Grafana could evaluate it.

**#514** — per-SHA CI concurrency so dev's head always gets a verdict, now that five departments merge independently and pushes were cancelling each other.

Plus #487/#507 pre-push guards, #477 uv cache, #449 expand/contract at the t1 window, #492/#494 Engineering, and QA's golden-path + e2e-staging work.

No migrations in this batch — no `t1` schema window.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #449 — Migrations must be expand/contract once blue-green ships (policy — binds Engineering) _(already closed)_ · via #483, commit d81b751
- #465 — [Engineering] Run failures never notify — nothing announces status=failed _(already closed)_ · via #518, commit 5285196
- #477 — [Infra] CI is ~3 min/job slower since #475 — enable the uv cache _(already closed)_ · via #490, commit 8137392, commit e0238a8
- #482 — [QA] golden-path.spec.ts does not test the golden path — steps 2-5 (connection, upload, run, assert rows) are a comment _(already closed)_ · via #485, commit d1e051d
- #484 — [QA] No CI job sets DATANIKA_E2E_SLOW — every @slow spec (golden path, tenant boundary, RBAC, SSO) is filtered out of every run _(already closed)_ · via #491, commit 4035206
- #487 — pre-push hook does not set UV_NO_SYNC, the workaround WORKFLOW_RULES calls mandatory _(already closed)_ · via #488, commit ba9d244
- #492 — P0: csv/json/parquet/s3 sources load a file *listing*, not the file contents _(already closed)_ · via #500, commit ab15b86
- #493 — A file-source glob that matches zero files completes as `success` with 0 rows _(already closed)_ · via #510, commit 9ddf020
- #494 — DuckDB loads never reach the Data Catalog — duckdb_engine missing from the image _(already closed)_ · via #516, commit d3f8509
- #496 — [QA] The @slow specs cannot pass in e2e-staging as configured — seed omits API keys, SSO specs point at localhost _(already closed)_ · via #497, commit b50bc36
- #501 — [QA] golden-path failed as an unqualified 6-minute timeout — unbounded actions + a cancelled job that uploads no traces _(already closed)_ · via #502, commit 22a7556
- #504 — Alert rules never evaluate their condition — they page via execErrState _(already closed)_ · via #505, commit cea89de
- #507 — pre-push branch/commit guard false-positives on every rebase _(already closed)_ · via #509, commit a78869f
- #508 — [QA] golden-path cannot find the connection-type picker — its trigger shows the current value (postgres), not the placeholder _(already closed)_ · via #511, commit 56f01d1
- #514 — CI cancel-in-progress can leave dev's head with no verdict, which blocks promotion _(already closed)_ · via #524, commit fa38146
- #515 — [QA] golden-path step 4 queries the /uploads pickers while still on /connections _(already closed)_ · via #517, commit eb9cc4a
- #520 — Quarantine golden-path.spec.ts from the promotion gate until it passes once _(already closed)_ · via #523, commit 1151482

<!-- promotion-refs:end -->