### PR TITLE
[QA] E2E tiers: new specs graduate into the promotion gate, not enter it (closes #521)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,24 @@ jobs:
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
 
+  # Two tiers (core#521). GATING specs have a track record and their red holds
+  # the promotion. INFORMATIONAL specs are newly written: they run, report and
+  # upload artifacts, but do not hold it. A spec graduates informational →
+  # gating after 3 consecutive greens on `dev`; demotion is deliberate and needs
+  # an issue, or "informational" becomes where tests quietly go to die.
+  #
+  # Why the tier exists: taking this job from 5 of 62 tests to 62 (#484/#496)
+  # also coupled production promotion to the stability of tests written that
+  # morning — golden-path, authored 2026-07-22, held back a P0 the same
+  # afternoon (#520). Without a tier, every future coverage expansion repeats
+  # that, and the cheapest way to unblock a promotion becomes loosening the
+  # assertion. Product already caught exactly that on #485: relaxing step 4 to
+  # `rows >= 1` would have gone green against an OPEN P0, because you get one
+  # row and it is the file listing. A gate that punishes honest new tests
+  # produces dishonest ones.
+  #
+  # Env is job-level so both tiers share one definition — two copies is how
+  # they drift apart, which is the failure mode this whole job has been fixing.
   e2e-staging:
     needs: [deploy-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
@@ -333,6 +351,32 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      CI: "true"
+      DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
+      DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
+      DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
+      # Include @slow specs (core#484). Until 2026-07-22 NO job set this, so
+      # `playwright.config.ts`'s grepInvert silently dropped every @slow spec
+      # from every run: this job reported success having executed 5 of 62 tests,
+      # both files about `?template=` handling. golden-path, tenant-jwt-boundary,
+      # tenant-isolation, rbac and viewer-role-ui had never gated a merge.
+      DATANIKA_E2E_SLOW: "1"
+      # sso-edge-cases hits the backend directly via fixtures/sso.ts, which
+      # defaults to http://localhost:8000 — on a CI runner that is nothing, and
+      # 5 specs died with `connect ECONNREFUSED ::1:8000` (core#496). The
+      # e2e-sso job has always set this; this job never did.
+      DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
+      # E2E_SEED_INCLUDE_API_KEYS=1 is required by rbac / tenant-isolation /
+      # tenant-jwt-boundary: without it the payload carries no keys and the
+      # fixtures throw at setup (`DATANIKA_E2E_API_KEY_READONLY not set`), which
+      # reads in the log as ~35 tenant-isolation FAILURES rather than as a
+      # missing flag (core#496). global-setup.ts already maps all three keys and
+      # every org-B field; only the flag was missing. Org B is seeded
+      # unconditionally — there is no second-tenant gate.
+      DATANIKA_E2E_SEED_CMD: >-
+        ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
+        'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 -e E2E_SEED_INCLUDE_API_KEYS=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
     steps:
       - uses: actions/checkout@v6
 
@@ -363,48 +407,39 @@ jobs:
           printf 'Host *\n  ServerAliveInterval 30\n  ServerAliveCountMax 120\n  TCPKeepAlive yes\n' > ~/.ssh/config
           chmod 600 ~/.ssh/config
 
-      - name: Run E2E tests against staging
+      # ── TIER 1: GATING ──────────────────────────────────────────────────────
+      # Proven specs. Red here holds the promotion, which is the whole point of
+      # the job. Note this job is not a required check on `dev` (those are lint
+      # + test), so a red is loud without blocking a merge — it blocks the
+      # promotion, which is the decision that should be blocked.
+      - name: Run gating E2E specs against staging
         working-directory: e2e
-        env:
-          CI: "true"
-          DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
-          DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
-          DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
-          # Include @slow specs (core#484). Until 2026-07-22 NO job set this, so
-          # `playwright.config.ts`'s grepInvert silently dropped every @slow spec
-          # from every run: this job reported success having executed 5 of 62
-          # tests, both files about `?template=` handling. golden-path,
-          # tenant-jwt-boundary, tenant-isolation, rbac and viewer-role-ui had
-          # never gated a merge.
-          #
-          # Safe to switch on wholesale because the expensive-and-unavailable
-          # specs gate themselves independently, and therefore skip rather than
-          # fail: sso-* need DATANIKA_E2E_SSO_AUTHENTIK (its own job is
-          # `if: false` — the IdP was not rebuilt after the 2026-07-17 outage)
-          # and overage-charge-cycle needs DATANIKA_E2E_OVERAGE_CHARGE plus the
-          # Paddle sandbox secrets, which the nightly soak owns. Neither is set
-          # here, so this flag adds 5 real specs, not 57.
-          #
-          # This job is NOT a required check on `dev` (those are lint + test),
-          # so a red here is loud without blocking anyone's merge — which is the
-          # point: the signal was missing, not the tests.
-          DATANIKA_E2E_SLOW: "1"
-          # sso-edge-cases hits the backend directly via fixtures/sso.ts, which
-          # defaults to http://localhost:8000 — on a CI runner that is nothing,
-          # and 5 specs died with `connect ECONNREFUSED ::1:8000` (core#496).
-          # The e2e-sso job has always set this; this job never did.
-          DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
-          # E2E_SEED_INCLUDE_API_KEYS=1 is required by rbac / tenant-isolation /
-          # tenant-jwt-boundary: without it the payload carries no keys and the
-          # fixtures throw at setup (`DATANIKA_E2E_API_KEY_READONLY not set`),
-          # which reads in the log as ~35 tenant-isolation FAILURES rather than
-          # as a missing flag (core#496). global-setup.ts already maps all three
-          # keys and every org-B field; only the flag was missing. Org B itself
-          # is seeded unconditionally — there is no second-tenant gate.
-          DATANIKA_E2E_SEED_CMD: >-
-            ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
-            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 -e E2E_SEED_INCLUDE_API_KEYS=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
-        run: npx playwright test
+        run: npx playwright test --grep-invert "@informational"
+
+      # ── TIER 2: INFORMATIONAL ───────────────────────────────────────────────
+      # New specs earning a track record. `continue-on-error` quarantines the
+      # VERDICT, never the execution: they still run against staging and still
+      # upload artifacts, because a quarantined test that stops producing
+      # evidence is just a disabled one — and you would never learn it had
+      # started passing.
+      - name: Run informational E2E specs (not gating)
+        id: informational
+        working-directory: e2e
+        continue-on-error: true
+        run: npx playwright test --grep "@informational"
+
+      # `continue-on-error` masks the step's conclusion, so the graduation
+      # evidence has to be emitted explicitly rather than read off the tick.
+      - name: Report informational tier result
+        if: always()
+        run: |
+          OUTCOME='${{ steps.informational.outcome }}'
+          echo "INFORMATIONAL_RESULT=$OUTCOME"
+          if [ "$OUTCOME" = "success" ]; then
+            echo "::warning::Informational E2E specs PASSED. That is 1 green toward graduation — see PLAN_QA.md §E2E tiers. Three consecutive greens on dev and they move into the gating tier."
+          else
+            echo "::notice::Informational E2E specs failed (not gating). Graduation counter resets to 0."
+          fi
 
       # A green tick above is not evidence that anything ran — that is exactly
       # how core#484 hid for months. Print the collected count so the run log
@@ -426,6 +461,15 @@ jobs:
             echo "::error::Only ${COUNT:-0} tests collected (expected 60+). The @slow specs are being filtered out again — see core#484."
             exit 1
           fi
+          # A skip is neither tier and counts toward nothing (core#521). Say so
+          # out loud: 16 specs skip today (SSO needs an Authentik that has been
+          # down since the 2026-07-17 outage; overage belongs to the nightly
+          # soak), and "46 passed" reads like full coverage until you notice.
+          GATING=$(npx playwright test --list --grep-invert "@informational" | tail -1)
+          INFO=$(npx playwright test --list --grep "@informational" | tail -1)
+          echo "gating tier:        $GATING"
+          echo "informational tier: $INFO"
+          echo "::notice::Tier split — gating: ${GATING}; informational: ${INFO}. Skipped specs belong to NEITHER tier; a skip is not a green."
 
       - name: Upload Playwright report
         if: always()
@@ -478,14 +522,40 @@ jobs:
         run: |
           SHORT_SHA=${GITHUB_SHA:0:7}
           FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
-          gh issue create \
+          # Dedup: comment on the open e2e-failure issue if one exists, else
+          # open one. Without this, a red streak files one issue PER SHA — on
+          # 2026-07-22 that produced SIX issues for TWO causes inside two hours
+          # (#495, #498 harness; #506, #512, #513, #519 golden-path), which
+          # buries the real signal in bookkeeping and makes a two-cause outage
+          # look like six problems. The overage nightly already dedups this way;
+          # only this copy was missed.
+          existing=$(gh issue list \
             --repo ${{ github.repository }} \
-            --title "[QA] e2e-staging failure on $SHORT_SHA" \
-            --body "**Run:** $RUN_URL
-          **Commit:** \`$SHORT_SHA\`
-          **Message:** $FIRST_LINE
-          **Report:** playwright-report artifact on the run page" \
-            --label "e2e-failure"
+            --label e2e-failure \
+            --state open \
+            --limit 1 \
+            --json number --jq '.[0].number // empty')
+          # printf with the strings indented INSIDE the block scalar: a body
+          # line at column 0 terminates the YAML block early and a leading `*`
+          # is then read as an alias — the exact break that stopped the Paddle
+          # nightly compiling for three months (cloud#77).
+          body=$(printf '%s\n' \
+            "**Run:** $RUN_URL" \
+            "**Commit:** \`$SHORT_SHA\`" \
+            "**Message:** $FIRST_LINE" \
+            "**Report:** playwright-report artifact on the run page" \
+            "" \
+            "Only the GATING tier can open this — informational specs do not fail the job (core#521).")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo ${{ github.repository }} \
+              --body "Another e2e-staging failure on \`$SHORT_SHA\`: $RUN_URL"
+          else
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "[QA] e2e-staging failure on $SHORT_SHA" \
+              --body "$body" \
+              --label "e2e-failure"
+          fi
 
   # SSO E2E tests — runs 16 Playwright specs (OIDC + SAML + edge cases)
   # against the staging app with a disposable Authentik IdP on Hetzner.

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -43,6 +43,22 @@ import {
  * no CI job set, so nothing here ran at all (core#484). If you are reading this
  * because the job is slow, the fix is a smaller fixture — not dropping the tag,
  * and not un-setting the flag.
+ *
+ * ── Tier: @informational (core#521, supersedes the #520 quarantine) ──────────
+ * This spec runs on every push to `dev` and uploads artifacts, but its result
+ * does NOT hold the promotion. It was authored 2026-07-22 and has not yet
+ * passed; a test with no track record was never protecting production, and
+ * letting it gate meant a spec written that morning held back a P0 the same
+ * afternoon (#520).
+ *
+ * The line, and it is load-bearing: a spec that USED TO PASS must stay gating —
+ * demoting one hides a regression. This tier is for specs that have not yet
+ * earned in, never a bolt-hole for ones that broke.
+ *
+ * **Graduation: 3 consecutive greens on `dev` → remove `@informational`.** The
+ * run log prints `INFORMATIONAL_RESULT=` each time, and a green emits a CI
+ * warning, so the evidence is mechanical rather than remembered. Procedure and
+ * owner: `plans/qa/PLAN_QA.md` §E2E tiers.
  */
 
 const CSV_ROWS = 3;
@@ -56,19 +72,25 @@ const CSV_CONTENT = ["id,name,amount", "1,alpha,100", "2,beta,200", "3,gamma,300
  */
 const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
 
-// Artifacts unconditionally while quarantined (core#520). The global config uses
-// `retain-on-failure`, and a `test.fail()` test that fails is classified
-// `expected` rather than `failed` — so the diagnostics every round has depended
-// on could be dropped exactly when the verdict stops being reported. A
-// quarantined test that stops producing evidence is just a disabled one.
+// Artifacts unconditionally while this spec is @informational (core#521).
+//
+// The global config is `retain-on-failure`, which would in fact cover a genuine
+// failure — this is belt and braces, deliberately. An informational spec exists
+// to produce evidence, and its whole value is the trace of the round it is
+// currently losing; every fix so far (#508, #515, #529) came out of one. Losing
+// that to a config nuance would leave a spec that runs and teaches nothing.
+//
+// (It previously read "while quarantined (core#520)" and justified itself by
+// `test.fail()` classifying failures as `expected`. That marker is gone — the
+// tier replaced it — so the reasoning is restated rather than left stale.)
 //
 // Must be file top-level, NOT inside the describe: `use({ trace })` forces a new
 // worker, and Playwright refuses it in a describe group — which fails collection
 // of the WHOLE suite, not just this spec. Caught by running `--list`; it would
-// have taken all 62 tests down, far worse than the thing being quarantined.
+// have taken all 62 tests down.
 test.use({ trace: "on", screenshot: "on", video: "retain-on-failure" });
 
-test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
+test.describe("Golden path: signup → connection → pipeline → run @slow @informational", () => {
   // Signup, two connections, an upload and a Celery round trip. The default
   // 60s covers none of that. Deliberately NOT larger: every interaction is
   // individually bounded in fixtures/data.ts, so this cap should never be what
@@ -76,31 +98,6 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
   test.setTimeout(300_000);
 
   test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
-    // ── QUARANTINED FROM THE PROMOTION GATE — core#520 ───────────────────────
-    // This spec has NEVER passed. It was written 2026-07-22 (#482/#485) and each
-    // round moves the failure one step later; step 5 has still never executed.
-    // It was therefore not protecting production — it was work in progress that
-    // happened to live in the gating job, holding back #500 (a P0), #505, #510,
-    // #516, #518, Growth's announcement and landing#281.
-    //
-    // The distinction that makes this safe, and the line not to cross:
-    //   • quarantining a test that USED TO PASS hides a regression — never.
-    //   • quarantining a test that has NEVER PASSED removes a non-gate from the
-    //     gate. Same call as the Kafka smoke quarantine (#399), which was
-    //     un-quarantined once it could pass.
-    //
-    // `test.fail()` rather than `test.skip()` is the whole point: the test still
-    // RUNS, still exercises staging, still uploads artifacts — only its verdict
-    // is quarantined. And Playwright reports an *unexpectedly passing*
-    // `test.fail()` as a failure, so the first green turns the job red and
-    // forces this marker out. Re-arming is enforced by the tool, not by someone
-    // remembering. When that happens: delete this line and close core#520.
-    test.fail(
-      true,
-      "core#520: golden-path has never passed; quarantined from the promotion " +
-        "gate. It still runs. Playwright fails the job if it starts passing — " +
-        "when it does, remove this and close core#520.",
-    );
 
     const stamp = `${Date.now()}`;
     // set_form_name strips everything outside [a-zA-Z0-9 ], so keep names in


### PR DESCRIPTION
Closes #521.

## Why a tier, not "fix the failing test faster"

Turning the gate on (#484/#496) coupled **production promotion to the stability of tests written that morning**. `golden-path`, authored 2026-07-22, held back a P0 the same afternoon (#520).

And the incentive is the real hazard: under a single-tier gate the cheapest way to unblock a promotion is to **loosen the assertion**. Product already caught precisely that on #485 — relaxing step 4 to `rows >= 1` would have gone green **against an open P0**, because you get exactly one row and it is the file listing. **A gate that punishes honest new tests produces dishonest ones.**

## The tiers

| Tier | Marker | Holds the promotion | Runs | Artifacts |
|---|---|---|---|---|
| Gating | *(default)* | **yes** | yes | yes |
| Informational | `@informational` in the describe title | no | **yes** | **yes** |

`continue-on-error` quarantines the **verdict, never the execution** — an informational spec still exercises staging and still uploads traces. A quarantined test that stops producing evidence is just a disabled one, and you would never learn it had started passing. That is not theoretical here: every golden-path fix so far (#508, #515, #529) came out of exactly those artifacts.

## Graduation, on mechanical evidence

**3 consecutive greens on `dev`** — matching the Gate-4 soak convention — then delete the marker. Because `continue-on-error` masks the step's tick, **the tick is not the evidence**: the run prints `INFORMATIONAL_RESULT=success|failure` and a green raises a CI warning. A cancelled run counts as neither; `dev` is busy enough that this matters.

## 🚫 Demotion is not the inverse — this is the load-bearing half

Moving a spec **out** of gating needs an issue and is only ever legitimate for one that has **never passed**. Demoting a spec that *used to pass* hides a regression. Without that rule, "informational" becomes where tests quietly go to die — worse than the problem it solves. Same line as the Kafka smoke quarantine (#399), un-quarantined once it could pass.

## Verified, not asserted

```
ALL:           Total: 62 tests in 11 files
GATING:        Total: 61 tests in 10 files
INFORMATIONAL: Total:  1 test  in  1 file   (golden-path)
golden-path present in gating tier: 0
```

## Also in here

- **Env moves to job level.** Both tiers now share one definition — two copies is how they drift apart, which is the failure mode this job has spent the day fixing.
- **The collected-count assert prints the tier split** and states that skipped specs are in **neither** tier. "46 passed" reads like full coverage until you notice the 16 skips (SSO's Authentik has been down since the 07-17 outage; overage belongs to the nightly soak). A skip is not a green.
- **Supersedes #520's ad-hoc `test.fail()` quarantine** with the general mechanism. The stale comment that justified artifact-pinning by `test.fail()` semantics is rewritten rather than left to rot.

Policy written up in `plans/qa/PLAN_QA.md` §E2E tiers — who moves a spec, and on what evidence.