### PR TITLE
[Infra] Promote dev → master: rule-health guard false-red fix, run metering

### DIFF
--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -175,11 +175,23 @@ jobs:
           bad = []
           for g in d.get('data', {}).get('groups', []):
               for r in g.get('rules', []):
+                  # lastError is per-evaluation and authoritative.
+                  #
+                  # Do NOT fall back to alert-instance annotations. Grafana persists alert
+                  # instances across a restart, so an instance sitting in Normal (NoData)
+                  # still carries the Error annotation from BEFORE a fix was deployed.
+                  # Reading that as current state fails a perfectly good deploy -- exactly
+                  # what happened on 2026-07-22, when lastError was empty, health was ok,
+                  # and the rules were evaluating on schedule.
                   err = (r.get('lastError') or '').strip()
-                  for a in (r.get('alerts') or []):
-                      err = err or (a.get('annotations', {}) or {}).get('Error', '')
                   if err:
                       bad.append(r.get('name', '?') + ': ' + err[:110])
+                  elif r.get('health') not in ('ok', 'nodata', '', None):
+                      bad.append(r.get('name', '?') + ': health=' + str(r.get('health')))
+                  elif not (r.get('lastEvaluation') or '').strip():
+                      # A rule that never ran carries no lastError either, so silence on
+                      # its own is not evidence of health.
+                      bad.append(r.get('name', '?') + ': never evaluated')
           if bad:
               print('ALERT RULES CANNOT EVALUATE:')
               for b in bad: print('  -', b)

--- a/datanika/tasks/pipeline_tasks.py
+++ b/datanika/tasks/pipeline_tasks.py
@@ -155,6 +155,9 @@ def run_pipeline(
     internally.  Tests pass them directly.
     """
     own_session = session is None
+    #: Billable model/test count, set on the success path and announced only
+    #: after the commit lands (core#522). None means "nothing to meter".
+    models_completed = None
     if own_session:
         from datanika.db import get_sync_session
 
@@ -256,20 +259,10 @@ def run_pipeline(
                 and getattr(getattr(r, "node", None), "resource_type", None) is not None
                 and getattr(r.node.resource_type, "value", None) in ("model", "test")
             )
+            # Recorded here, announced after the commit (core#522) — see the
+            # `else` clause below.
             if billable_nodes > 0:
-                from datanika.hooks import announce
-
-                # See upload_tasks: announced, not emitted (core#456).
-                announce(
-                    "run.models_completed",
-                    session=session,
-                    org_id=org_id,
-                    run_id=run_id,
-                    status="success",
-                    target_type="pipeline",
-                    target_id=pipeline.id,
-                    count=billable_nodes,
-                )
+                models_completed = billable_nodes
 
             pipeline.status = PipelineStatus.ACTIVE
             session.flush()
@@ -305,6 +298,32 @@ def run_pipeline(
                 session.flush()
         if own_session:
             session.commit()
+
+    else:
+        # After the commit, not before it (core#522). A commit failure used to
+        # end the run FAILED having already metered its models, and cloud
+        # commits the ledger row on its own session, so the rollback did not
+        # take it back. `else` runs only when the whole `try` succeeded, which
+        # makes the ordering structural rather than a matter of statement
+        # order inside a long block — and still ahead of `finally`, which
+        # closes the session handlers are handed.
+        #
+        # `models_completed` stays None when dbt failed or nothing billable
+        # ran, so neither case announces.
+        if models_completed is not None:
+            from datanika.hooks import announce
+
+            # See upload_tasks: announced, not emitted (core#456).
+            announce(
+                "run.models_completed",
+                session=session,
+                org_id=org_id,
+                run_id=run_id,
+                status="success",
+                target_type="pipeline",
+                target_id=pipeline.id,
+                count=models_completed,
+            )
 
     finally:
         if own_session:

--- a/datanika/tasks/transformation_tasks.py
+++ b/datanika/tasks/transformation_tasks.py
@@ -166,19 +166,6 @@ def run_transformation(
 
         execution_service.complete_run(session, run_id, rows_loaded=rows, logs=logs)
 
-        from datanika.hooks import announce
-
-        # See upload_tasks: announced, not emitted (core#456).
-        announce(
-            "run.transformation_completed",
-            session=session,
-            org_id=org_id,
-            run_id=run_id,
-            status="success",
-            target_type="transformation",
-            target_id=transformation.id,
-        )
-
         try:
             _sync_catalog_after_transformation(
                 session, org_id, transformation, dbt_svc, dst_conn, dst_config
@@ -200,6 +187,25 @@ def run_transformation(
         )
         if own_session:
             session.commit()
+
+    else:
+        # After the commit, not before it (core#522) — a commit failure used to
+        # end the run FAILED having already been metered, and cloud commits the
+        # ledger row on its own session so the rollback did not undo it. `else`
+        # makes the ordering structural and still runs before `finally` closes
+        # the session the handlers receive.
+        from datanika.hooks import announce
+
+        # See upload_tasks: announced, not emitted (core#456).
+        announce(
+            "run.transformation_completed",
+            session=session,
+            org_id=org_id,
+            run_id=run_id,
+            status="success",
+            target_type="transformation",
+            target_id=transformation.id,
+        )
 
     finally:
         if own_session:

--- a/datanika/tasks/upload_tasks.py
+++ b/datanika/tasks/upload_tasks.py
@@ -262,24 +262,6 @@ def run_upload(
                 f"{exc.__class__.__name__}: {exc}",
             )
 
-        from datanika.hooks import announce
-
-        # `announce`, not `emit`: the run is already complete, so no subscriber
-        # may veto it or starve the ones behind it (core#456). session/run_id/
-        # status are what the notification handlers need to say *which* run
-        # succeeded — without them the feature is alive but says nothing.
-        announce(
-            "run.upload_completed",
-            session=session,
-            org_id=org_id,
-            run_id=run_id,
-            status="success",
-            target_type="upload",
-            target_id=upload.id,
-            table_count=table_count,
-            bytes_processed=bytes_processed,
-        )
-
         upload.status = UploadStatus.ACTIVE
         session.flush()
         if own_session:
@@ -304,6 +286,42 @@ def run_upload(
                 session.flush()
         if own_session:
             session.commit()
+
+    else:
+        # Metering lives in `else`, not at the end of `try` (core#522).
+        #
+        # It used to fire before `flush`/`commit`, so a commit failure after a
+        # successful load ended the run FAILED having *already been billed* —
+        # and cloud's handlers meter on their own session and commit
+        # independently, so the rollback did not take the ledger row with it.
+        # `else` runs only when the whole `try` completed, which makes the
+        # ordering structural: no future statement added inside `try` can slip
+        # in front of it, and anything that raises there skips it.
+        #
+        # It stays ahead of `finally`, which closes the session the handlers
+        # are handed.
+        #
+        # Trade-off, taken deliberately: if the worker dies between the commit
+        # and here, the run is under-metered rather than over-metered. That is
+        # the right direction to fail — and the comment below was only ever
+        # strictly true at this point.
+        from datanika.hooks import announce
+
+        # `announce`, not `emit`: the run is already complete, so no subscriber
+        # may veto it or starve the ones behind it (core#456). session/run_id/
+        # status are what the notification handlers need to say *which* run
+        # succeeded — without them the feature is alive but says nothing.
+        announce(
+            "run.upload_completed",
+            session=session,
+            org_id=org_id,
+            run_id=run_id,
+            status="success",
+            target_type="upload",
+            target_id=upload.id,
+            table_count=table_count,
+            bytes_processed=bytes_processed,
+        )
 
     finally:
         # Clean up dlt working directory regardless of success/failure

--- a/tests/test_tasks/test_metering_after_commit.py
+++ b/tests/test_tasks/test_metering_after_commit.py
@@ -1,0 +1,217 @@
+"""A run is metered only after its commit lands (core#522).
+
+The metered announce used to fire **inside the `try`**, before `flush`/`commit`:
+
+    announce("run.upload_completed", ..., status="success", ...)   # cloud meters
+    upload.status = UploadStatus.ACTIVE
+    session.flush()          # <-- can raise
+    session.commit()         # <-- can raise
+    except Exception:
+        session.rollback()
+        execution_service.fail_run(...)   # run ends FAILED
+
+So a commit failure after a successful load ended the run `FAILED` having
+**already been billed**. And the rollback did not undo it: `datanika-cloud`'s
+handlers call `_get_session()` — a new engine — and commit the ledger row
+independently, so it survives the outer rollback.
+
+Found while confirming the core#465 / cloud#84 interaction before the cloud
+promotion. Worth being precise about scope: cloud#84 (handlers skipping
+`status == "failed"`) **cannot** close this, because at announce time the status
+genuinely *is* `"success"` — the failure happens afterwards.
+
+The fix puts the announce in the `try`'s `else` clause, which runs only when the
+whole block completed and still runs before `finally` closes the session the
+handlers are handed. That makes the ordering structural: no statement added
+inside `try` later can slip in front of it, and anything that raises there skips
+it.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+from datanika import hooks
+from datanika.models.connection import ConnectionType
+from datanika.models.dependency import NodeType
+from datanika.models.user import Organization
+from datanika.services.encryption import EncryptionService
+
+#: The events datanika-cloud subscribes its metering handlers to.
+METERED_EVENTS = (
+    "run.upload_completed",
+    "run.models_completed",
+    "run.transformation_completed",
+)
+
+
+@pytest.fixture
+def spy_hooks():
+    """Record every event fired, with the global bus isolated."""
+    saved = {event: list(handlers) for event, handlers in hooks._handlers.items()}
+    hooks._handlers.clear()
+    fired = []
+    for event in (*METERED_EVENTS, "run.failed"):
+        hooks.on(event, lambda _e=event, **kw: fired.append(_e))
+    yield fired
+    hooks._handlers.clear()
+    hooks._handlers.update(saved)
+
+
+@pytest.fixture
+def upload_run(db_session):
+    """Org + connections + upload + pending run, built through the services.
+
+    Deliberately not importing `setup_upload` from `test_upload_tasks`: pytest
+    registers an imported fixture as a second FixtureDef (core#449), and these
+    services set fields — `connections.direction` via `infer_direction` — that
+    hand-built rows miss.
+    """
+    import uuid
+
+    from datanika.services.connection_service import ConnectionService
+    from datanika.services.execution_service import ExecutionService
+    from datanika.services.upload_service import UploadService
+
+    encryption = EncryptionService(Fernet.generate_key().decode())
+    conn_svc = ConnectionService(encryption)
+    upload_svc = UploadService(conn_svc)
+
+    org = Organization(name="Acme", slug=f"acme-522-{uuid.uuid4().hex[:8]}")
+    db_session.add(org)
+    db_session.flush()
+
+    src = conn_svc.create_connection(
+        db_session, org.id, "S", ConnectionType.POSTGRES, {"host": "src", "port": 5432}
+    )
+    dst = conn_svc.create_connection(
+        db_session, org.id, "D", ConnectionType.BIGQUERY, {"project": "p", "dataset": "d"}
+    )
+    upload = upload_svc.create_upload(
+        db_session, org.id, "test", "desc", src.id, dst.id, {"write_disposition": "append"}
+    )
+    run = ExecutionService().create_run(db_session, org.id, NodeType.UPLOAD, upload.id)
+    return org, run, encryption
+
+
+class TestMeteringFollowsTheCommit:
+    def test_a_successful_run_still_meters(self, db_session, upload_run, spy_hooks):
+        """The guard must not stop billing working runs."""
+        org, run, encryption = upload_run
+
+        with (
+            patch("datanika.tasks.upload_tasks.DltRunnerService") as runner,
+            patch("datanika.tasks.upload_tasks._sync_catalog_after_upload", return_value=1),
+        ):
+            runner.return_value.execute.return_value = {
+                "rows_loaded": 12,
+                "load_info": None,
+            }
+            from datanika.tasks.upload_tasks import run_upload
+
+            run_upload(run.id, org.id, session=db_session, encryption=encryption)
+
+        assert "run.upload_completed" in spy_hooks, "a successful run was not metered"
+
+    def test_a_failure_after_the_load_does_not_meter(self, db_session, upload_run, spy_hooks):
+        """The window: load succeeds, the write that follows it fails.
+
+        `flush` is made to raise at the point the task marks the upload ACTIVE
+        — the same position a commit failure occupies. Before core#522 the
+        announce had already fired by then.
+        """
+        from datanika.models.upload import Upload, UploadStatus
+
+        org, run, encryption = upload_run
+
+        real_flush = db_session.flush
+        blown = {"once": False}
+
+        def flaky_flush(*args, **kwargs):
+            # Fail exactly the write that follows the metering point — marking
+            # the upload ACTIVE — rather than counting flushes, which would
+            # silently stop testing this the moment the task gained one.
+            #
+            # One-shot: a transient fault, so the error path that follows can
+            # still record the failure. Raising every time would blow up
+            # `fail_run` too and the task would never reach its own handling.
+            if not blown["once"] and any(
+                isinstance(obj, Upload) and obj.status == UploadStatus.ACTIVE
+                for obj in db_session.dirty
+            ):
+                blown["once"] = True
+                raise RuntimeError("connection reset by peer")
+            return real_flush(*args, **kwargs)
+
+        with (
+            patch("datanika.tasks.upload_tasks.DltRunnerService") as runner,
+            patch("datanika.tasks.upload_tasks._sync_catalog_after_upload", return_value=1),
+            patch.object(db_session, "flush", flaky_flush),
+        ):
+            runner.return_value.execute.return_value = {
+                "rows_loaded": 12,
+                "load_info": None,
+            }
+            from datanika.tasks.upload_tasks import run_upload
+
+            run_upload(run.id, org.id, session=db_session, encryption=encryption)
+
+        metered = [e for e in spy_hooks if e in METERED_EVENTS]
+        assert metered == [], (
+            f"a run that ended FAILED was metered via {metered} — cloud commits "
+            "the ledger row on its own session, so the rollback does not undo it"
+        )
+
+    def test_the_spy_would_have_seen_a_metered_event(self, spy_hooks):
+        """Anti-vacuity: a spy that never fires proves nothing above."""
+        from datanika.hooks import announce
+
+        announce("run.upload_completed", org_id=1, run_id=1, status="success")
+        assert spy_hooks == ["run.upload_completed"]
+
+
+class TestStructuralOrdering:
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "datanika.tasks.upload_tasks",
+            "datanika.tasks.pipeline_tasks",
+            "datanika.tasks.transformation_tasks",
+        ],
+    )
+    def test_the_metered_announce_lives_in_an_else_clause(self, module):
+        """Pin the construct, not just today's behaviour.
+
+        The behavioural test above covers uploads. This covers all three task
+        modules at once and states *why* the code is shaped this way, so a
+        future refactor that moves an announce back inside `try` fails here
+        with the reason attached.
+        """
+        import ast
+        import importlib
+        import pathlib
+
+        path = pathlib.Path(importlib.import_module(module).__file__)
+        source = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+        announced_in_else = set()
+        for node in ast.walk(source):
+            if not isinstance(node, ast.Try) or not node.orelse:
+                continue
+            for inner in ast.walk(ast.Module(body=node.orelse, type_ignores=[])):
+                if (
+                    isinstance(inner, ast.Call)
+                    and getattr(inner.func, "id", None) == "announce"
+                    and inner.args
+                    and isinstance(inner.args[0], ast.Constant)
+                ):
+                    announced_in_else.add(inner.args[0].value)
+
+        metered_here = announced_in_else & set(METERED_EVENTS)
+        assert metered_here, (
+            f"{module} announces no metered event from a try/else. Metering must "
+            "follow the commit (core#522): announcing inside `try` bills runs that "
+            "then fail, and cloud commits the ledger row on its own session so the "
+            "rollback does not undo it."
+        )


### PR DESCRIPTION
**#528** — the rule-health guard added with #504 failed a healthy deploy. It read `Error` from alert-instance annotations, which Grafana persists across a restart, so a `Normal (NoData)` instance still carried the annotation from before the fix shipped. `lastError` was empty, `health` was `ok`, and the rules were evaluating on schedule. It was also wrong the other way: a rule that never evaluated carries no `lastError`, so silence was read as health. Now asserts on `lastError`, `health`, and that the rule evaluated at all.

**#522** (Engineering) — meter a run only after its commit lands.

No migrations — no `t1` window.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #522 — A run metered on success can still end FAILED — the announce fires before the commit _(already closed)_ · via #526, commit 113930f
- #528 — CD rule-health guard fails good deploys on stale alert-instance annotations _(already closed)_ · via #531, commit 16fee78

<!-- promotion-refs:end -->