### PR TITLE
[Infra] Alerts: stop one transient sample paging as sustained (closes #538)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -15,7 +15,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -28,7 +28,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -38,7 +38,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -73,7 +73,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -81,7 +81,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -91,7 +91,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -118,15 +118,15 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: '100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85'
+              expr: '100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85'
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -136,7 +136,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -163,7 +163,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -171,7 +171,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -181,7 +181,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -208,7 +208,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -216,7 +216,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -226,7 +226,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -255,7 +255,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -263,7 +263,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -273,7 +273,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -300,7 +300,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 3600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -308,7 +308,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 3600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -318,7 +318,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 3600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -345,7 +345,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -353,7 +353,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -363,7 +363,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -445,7 +445,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -453,7 +453,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -463,7 +463,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -490,7 +490,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -498,7 +498,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -508,7 +508,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -782,7 +782,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -790,7 +790,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -800,7 +800,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -936,7 +936,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -960,7 +960,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -973,7 +973,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1005,7 +1005,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1022,7 +1022,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1035,7 +1035,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1067,7 +1067,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1113,7 +1113,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1126,7 +1126,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1174,7 +1174,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1206,7 +1206,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1219,7 +1219,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1255,7 +1255,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1288,7 +1288,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1301,7 +1301,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1405,7 +1405,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1413,7 +1413,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1423,7 +1423,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1448,7 +1448,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1456,7 +1456,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1466,7 +1466,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1491,7 +1491,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1499,7 +1499,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1509,7 +1509,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1534,7 +1534,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1544,7 +1544,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1554,7 +1554,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1579,7 +1579,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1587,7 +1587,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1597,7 +1597,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1628,7 +1628,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1636,7 +1636,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1646,7 +1646,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1672,7 +1672,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1680,7 +1680,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1690,7 +1690,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1715,7 +1715,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1723,7 +1723,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1733,7 +1733,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:


### PR DESCRIPTION
See #538. `High CPU Usage` paged as *"above 85% for 5 minutes"* on a **single 30-second sample** (89.3 at 14:44:34 — one sample in 90 minutes, cause: the prod deploy building its image on the box).

`> 85` filters exactly like `probe_success == 0`, so with `reducer: last` over a 600s window one breach sample stays 'current' for ten minutes. #504 shortened windows only for rules ending in `== 0`. Also swaps `irate` → `rate`: irate computes from the last two samples (~30s) while the message promises a 5-minute average.