### PR TITLE
[Infra] Promote dev → master: alert rules stop overstating transients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,24 @@ jobs:
             --data-urlencode "text=${TEXT}" \
             --data-urlencode "parse_mode=Markdown"
 
+  # Two tiers (core#521). GATING specs have a track record and their red holds
+  # the promotion. INFORMATIONAL specs are newly written: they run, report and
+  # upload artifacts, but do not hold it. A spec graduates informational →
+  # gating after 3 consecutive greens on `dev`; demotion is deliberate and needs
+  # an issue, or "informational" becomes where tests quietly go to die.
+  #
+  # Why the tier exists: taking this job from 5 of 62 tests to 62 (#484/#496)
+  # also coupled production promotion to the stability of tests written that
+  # morning — golden-path, authored 2026-07-22, held back a P0 the same
+  # afternoon (#520). Without a tier, every future coverage expansion repeats
+  # that, and the cheapest way to unblock a promotion becomes loosening the
+  # assertion. Product already caught exactly that on #485: relaxing step 4 to
+  # `rows >= 1` would have gone green against an OPEN P0, because you get one
+  # row and it is the file listing. A gate that punishes honest new tests
+  # produces dishonest ones.
+  #
+  # Env is job-level so both tiers share one definition — two copies is how
+  # they drift apart, which is the failure mode this whole job has been fixing.
   e2e-staging:
     needs: [deploy-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
@@ -333,6 +351,32 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      CI: "true"
+      DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
+      DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
+      DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
+      # Include @slow specs (core#484). Until 2026-07-22 NO job set this, so
+      # `playwright.config.ts`'s grepInvert silently dropped every @slow spec
+      # from every run: this job reported success having executed 5 of 62 tests,
+      # both files about `?template=` handling. golden-path, tenant-jwt-boundary,
+      # tenant-isolation, rbac and viewer-role-ui had never gated a merge.
+      DATANIKA_E2E_SLOW: "1"
+      # sso-edge-cases hits the backend directly via fixtures/sso.ts, which
+      # defaults to http://localhost:8000 — on a CI runner that is nothing, and
+      # 5 specs died with `connect ECONNREFUSED ::1:8000` (core#496). The
+      # e2e-sso job has always set this; this job never did.
+      DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
+      # E2E_SEED_INCLUDE_API_KEYS=1 is required by rbac / tenant-isolation /
+      # tenant-jwt-boundary: without it the payload carries no keys and the
+      # fixtures throw at setup (`DATANIKA_E2E_API_KEY_READONLY not set`), which
+      # reads in the log as ~35 tenant-isolation FAILURES rather than as a
+      # missing flag (core#496). global-setup.ts already maps all three keys and
+      # every org-B field; only the flag was missing. Org B is seeded
+      # unconditionally — there is no second-tenant gate.
+      DATANIKA_E2E_SEED_CMD: >-
+        ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
+        'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 -e E2E_SEED_INCLUDE_API_KEYS=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
     steps:
       - uses: actions/checkout@v6
 
@@ -363,48 +407,39 @@ jobs:
           printf 'Host *\n  ServerAliveInterval 30\n  ServerAliveCountMax 120\n  TCPKeepAlive yes\n' > ~/.ssh/config
           chmod 600 ~/.ssh/config
 
-      - name: Run E2E tests against staging
+      # ── TIER 1: GATING ──────────────────────────────────────────────────────
+      # Proven specs. Red here holds the promotion, which is the whole point of
+      # the job. Note this job is not a required check on `dev` (those are lint
+      # + test), so a red is loud without blocking a merge — it blocks the
+      # promotion, which is the decision that should be blocked.
+      - name: Run gating E2E specs against staging
         working-directory: e2e
-        env:
-          CI: "true"
-          DATANIKA_E2E_BASE_URL: https://staging-app.datanika.io
-          DATANIKA_STAGING_CF_ACCESS_CLIENT_ID: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_ID }}
-          DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET: ${{ secrets.DATANIKA_STAGING_CF_ACCESS_CLIENT_SECRET }}
-          # Include @slow specs (core#484). Until 2026-07-22 NO job set this, so
-          # `playwright.config.ts`'s grepInvert silently dropped every @slow spec
-          # from every run: this job reported success having executed 5 of 62
-          # tests, both files about `?template=` handling. golden-path,
-          # tenant-jwt-boundary, tenant-isolation, rbac and viewer-role-ui had
-          # never gated a merge.
-          #
-          # Safe to switch on wholesale because the expensive-and-unavailable
-          # specs gate themselves independently, and therefore skip rather than
-          # fail: sso-* need DATANIKA_E2E_SSO_AUTHENTIK (its own job is
-          # `if: false` — the IdP was not rebuilt after the 2026-07-17 outage)
-          # and overage-charge-cycle needs DATANIKA_E2E_OVERAGE_CHARGE plus the
-          # Paddle sandbox secrets, which the nightly soak owns. Neither is set
-          # here, so this flag adds 5 real specs, not 57.
-          #
-          # This job is NOT a required check on `dev` (those are lint + test),
-          # so a red here is loud without blocking anyone's merge — which is the
-          # point: the signal was missing, not the tests.
-          DATANIKA_E2E_SLOW: "1"
-          # sso-edge-cases hits the backend directly via fixtures/sso.ts, which
-          # defaults to http://localhost:8000 — on a CI runner that is nothing,
-          # and 5 specs died with `connect ECONNREFUSED ::1:8000` (core#496).
-          # The e2e-sso job has always set this; this job never did.
-          DATANIKA_E2E_BACKEND_URL: https://staging-app.datanika.io
-          # E2E_SEED_INCLUDE_API_KEYS=1 is required by rbac / tenant-isolation /
-          # tenant-jwt-boundary: without it the payload carries no keys and the
-          # fixtures throw at setup (`DATANIKA_E2E_API_KEY_READONLY not set`),
-          # which reads in the log as ~35 tenant-isolation FAILURES rather than
-          # as a missing flag (core#496). global-setup.ts already maps all three
-          # keys and every org-B field; only the flag was missing. Org B itself
-          # is seeded unconditionally — there is no second-tenant gate.
-          DATANIKA_E2E_SEED_CMD: >-
-            ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new root@${{ secrets.POINTER_HOST }}
-            'docker exec -e E2E_SEED_ALLOW_ANY_HOST=1 -e E2E_SEED_INCLUDE_API_KEYS=1 $(/opt/datanika-staging/active-app.sh) uv run python -m datanika.scripts.e2e_seed'
-        run: npx playwright test
+        run: npx playwright test --grep-invert "@informational"
+
+      # ── TIER 2: INFORMATIONAL ───────────────────────────────────────────────
+      # New specs earning a track record. `continue-on-error` quarantines the
+      # VERDICT, never the execution: they still run against staging and still
+      # upload artifacts, because a quarantined test that stops producing
+      # evidence is just a disabled one — and you would never learn it had
+      # started passing.
+      - name: Run informational E2E specs (not gating)
+        id: informational
+        working-directory: e2e
+        continue-on-error: true
+        run: npx playwright test --grep "@informational"
+
+      # `continue-on-error` masks the step's conclusion, so the graduation
+      # evidence has to be emitted explicitly rather than read off the tick.
+      - name: Report informational tier result
+        if: always()
+        run: |
+          OUTCOME='${{ steps.informational.outcome }}'
+          echo "INFORMATIONAL_RESULT=$OUTCOME"
+          if [ "$OUTCOME" = "success" ]; then
+            echo "::warning::Informational E2E specs PASSED. That is 1 green toward graduation — see PLAN_QA.md §E2E tiers. Three consecutive greens on dev and they move into the gating tier."
+          else
+            echo "::notice::Informational E2E specs failed (not gating). Graduation counter resets to 0."
+          fi
 
       # A green tick above is not evidence that anything ran — that is exactly
       # how core#484 hid for months. Print the collected count so the run log
@@ -426,6 +461,15 @@ jobs:
             echo "::error::Only ${COUNT:-0} tests collected (expected 60+). The @slow specs are being filtered out again — see core#484."
             exit 1
           fi
+          # A skip is neither tier and counts toward nothing (core#521). Say so
+          # out loud: 16 specs skip today (SSO needs an Authentik that has been
+          # down since the 2026-07-17 outage; overage belongs to the nightly
+          # soak), and "46 passed" reads like full coverage until you notice.
+          GATING=$(npx playwright test --list --grep-invert "@informational" | tail -1)
+          INFO=$(npx playwright test --list --grep "@informational" | tail -1)
+          echo "gating tier:        $GATING"
+          echo "informational tier: $INFO"
+          echo "::notice::Tier split — gating: ${GATING}; informational: ${INFO}. Skipped specs belong to NEITHER tier; a skip is not a green."
 
       - name: Upload Playwright report
         if: always()
@@ -478,14 +522,40 @@ jobs:
         run: |
           SHORT_SHA=${GITHUB_SHA:0:7}
           FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
-          gh issue create \
+          # Dedup: comment on the open e2e-failure issue if one exists, else
+          # open one. Without this, a red streak files one issue PER SHA — on
+          # 2026-07-22 that produced SIX issues for TWO causes inside two hours
+          # (#495, #498 harness; #506, #512, #513, #519 golden-path), which
+          # buries the real signal in bookkeeping and makes a two-cause outage
+          # look like six problems. The overage nightly already dedups this way;
+          # only this copy was missed.
+          existing=$(gh issue list \
             --repo ${{ github.repository }} \
-            --title "[QA] e2e-staging failure on $SHORT_SHA" \
-            --body "**Run:** $RUN_URL
-          **Commit:** \`$SHORT_SHA\`
-          **Message:** $FIRST_LINE
-          **Report:** playwright-report artifact on the run page" \
-            --label "e2e-failure"
+            --label e2e-failure \
+            --state open \
+            --limit 1 \
+            --json number --jq '.[0].number // empty')
+          # printf with the strings indented INSIDE the block scalar: a body
+          # line at column 0 terminates the YAML block early and a leading `*`
+          # is then read as an alias — the exact break that stopped the Paddle
+          # nightly compiling for three months (cloud#77).
+          body=$(printf '%s\n' \
+            "**Run:** $RUN_URL" \
+            "**Commit:** \`$SHORT_SHA\`" \
+            "**Message:** $FIRST_LINE" \
+            "**Report:** playwright-report artifact on the run page" \
+            "" \
+            "Only the GATING tier can open this — informational specs do not fail the job (core#521).")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo ${{ github.repository }} \
+              --body "Another e2e-staging failure on \`$SHORT_SHA\`: $RUN_URL"
+          else
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "[QA] e2e-staging failure on $SHORT_SHA" \
+              --body "$body" \
+              --label "e2e-failure"
+          fi
 
   # SSO E2E tests — runs 16 Playwright specs (OIDC + SAML + edge cases)
   # against the staging app with a disposable Authentik IdP on Hetzner.

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -34,7 +34,18 @@ SAAS_SOURCE_TYPES = {
 # File-based source types
 FILE_SOURCE_TYPES = {"s3", "csv", "json", "parquet"}
 
-# Source types that need their own config instead of SQL mode
+# Source types that need their own config instead of SQL mode.
+#
+# Membership here is what hides the SQL block (Load Mode / Write Disposition /
+# Source schema / Table names) on the upload form — `uploads.py` renders it
+# under `~UploadState.form_is_non_sql_source`. **Omission is not neutral**: an
+# unclassified type falls through to the SQL branch and is shown four controls
+# its loader never reads. That was core#503 — pipedrive/freshdesk/asana were
+# added to SOURCE_TYPES and to `dlt_runner.SUPPORTED_SAAS_TYPES`, but not here,
+# so an HTTP API asked the user for a source schema and table names.
+#
+# `tests/test_connector_type_contracts.py` fails if a source type is left
+# unclassified. Add new connectors there and here in the same change.
 NON_SQL_SOURCE_TYPES = (
     SAAS_SOURCE_TYPES
     | FILE_SOURCE_TYPES
@@ -43,6 +54,16 @@ NON_SQL_SOURCE_TYPES = (
         "mongodb",
         "rest_api",
         "kafka",
+        # SaaS at run time (dlt_runner dispatches them to the SaaS builder) but
+        # deliberately absent from SAAS_SOURCE_TYPES above: that set drives the
+        # "Select endpoints to load" checkboxes, which are inert for every
+        # connector but Stripe until core#532 wires the selection through.
+        # Listing them here fixes the wrong controls without adding a fake one.
+        "pipedrive",
+        "freshdesk",
+        "asana",
+        # Resources come from the uploaded spec, not from a SQL schema.
+        "openapi",
     }
 )
 

--- a/e2e/tests/golden-path.spec.ts
+++ b/e2e/tests/golden-path.spec.ts
@@ -43,6 +43,22 @@ import {
  * no CI job set, so nothing here ran at all (core#484). If you are reading this
  * because the job is slow, the fix is a smaller fixture — not dropping the tag,
  * and not un-setting the flag.
+ *
+ * ── Tier: @informational (core#521, supersedes the #520 quarantine) ──────────
+ * This spec runs on every push to `dev` and uploads artifacts, but its result
+ * does NOT hold the promotion. It was authored 2026-07-22 and has not yet
+ * passed; a test with no track record was never protecting production, and
+ * letting it gate meant a spec written that morning held back a P0 the same
+ * afternoon (#520).
+ *
+ * The line, and it is load-bearing: a spec that USED TO PASS must stay gating —
+ * demoting one hides a regression. This tier is for specs that have not yet
+ * earned in, never a bolt-hole for ones that broke.
+ *
+ * **Graduation: 3 consecutive greens on `dev` → remove `@informational`.** The
+ * run log prints `INFORMATIONAL_RESULT=` each time, and a green emits a CI
+ * warning, so the evidence is mechanical rather than remembered. Procedure and
+ * owner: `plans/qa/PLAN_QA.md` §E2E tiers.
  */
 
 const CSV_ROWS = 3;
@@ -56,19 +72,25 @@ const CSV_CONTENT = ["id,name,amount", "1,alpha,100", "2,beta,200", "3,gamma,300
  */
 const SHARED_DIR = process.env.DATANIKA_E2E_SHARED_DIR ?? "/app/uploaded_files";
 
-// Artifacts unconditionally while quarantined (core#520). The global config uses
-// `retain-on-failure`, and a `test.fail()` test that fails is classified
-// `expected` rather than `failed` — so the diagnostics every round has depended
-// on could be dropped exactly when the verdict stops being reported. A
-// quarantined test that stops producing evidence is just a disabled one.
+// Artifacts unconditionally while this spec is @informational (core#521).
+//
+// The global config is `retain-on-failure`, which would in fact cover a genuine
+// failure — this is belt and braces, deliberately. An informational spec exists
+// to produce evidence, and its whole value is the trace of the round it is
+// currently losing; every fix so far (#508, #515, #529) came out of one. Losing
+// that to a config nuance would leave a spec that runs and teaches nothing.
+//
+// (It previously read "while quarantined (core#520)" and justified itself by
+// `test.fail()` classifying failures as `expected`. That marker is gone — the
+// tier replaced it — so the reasoning is restated rather than left stale.)
 //
 // Must be file top-level, NOT inside the describe: `use({ trace })` forces a new
 // worker, and Playwright refuses it in a describe group — which fails collection
 // of the WHOLE suite, not just this spec. Caught by running `--list`; it would
-// have taken all 62 tests down, far worse than the thing being quarantined.
+// have taken all 62 tests down.
 test.use({ trace: "on", screenshot: "on", video: "retain-on-failure" });
 
-test.describe("Golden path: signup → connection → pipeline → run @slow", () => {
+test.describe("Golden path: signup → connection → pipeline → run @slow @informational", () => {
   // Signup, two connections, an upload and a Celery round trip. The default
   // 60s covers none of that. Deliberately NOT larger: every interaction is
   // individually bounded in fixtures/data.ts, so this cap should never be what
@@ -76,31 +98,6 @@ test.describe("Golden path: signup → connection → pipeline → run @slow", (
   test.setTimeout(300_000);
 
   test("new user signs up, wires CSV → DuckDB, runs it, and sees rows land", async ({ page }) => {
-    // ── QUARANTINED FROM THE PROMOTION GATE — core#520 ───────────────────────
-    // This spec has NEVER passed. It was written 2026-07-22 (#482/#485) and each
-    // round moves the failure one step later; step 5 has still never executed.
-    // It was therefore not protecting production — it was work in progress that
-    // happened to live in the gating job, holding back #500 (a P0), #505, #510,
-    // #516, #518, Growth's announcement and landing#281.
-    //
-    // The distinction that makes this safe, and the line not to cross:
-    //   • quarantining a test that USED TO PASS hides a regression — never.
-    //   • quarantining a test that has NEVER PASSED removes a non-gate from the
-    //     gate. Same call as the Kafka smoke quarantine (#399), which was
-    //     un-quarantined once it could pass.
-    //
-    // `test.fail()` rather than `test.skip()` is the whole point: the test still
-    // RUNS, still exercises staging, still uploads artifacts — only its verdict
-    // is quarantined. And Playwright reports an *unexpectedly passing*
-    // `test.fail()` as a failure, so the first green turns the job red and
-    // forces this marker out. Re-arming is enforced by the tool, not by someone
-    // remembering. When that happens: delete this line and close core#520.
-    test.fail(
-      true,
-      "core#520: golden-path has never passed; quarantined from the promotion " +
-        "gate. It still runs. Playwright fails the job if it starts passing — " +
-        "when it does, remove this and close core#520.",
-    );
 
     const stamp = `${Date.now()}`;
     // set_form_name strips everything outside [a-zA-Z0-9 ], so keep names in

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -15,7 +15,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -28,7 +28,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -38,7 +38,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -73,7 +73,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -81,7 +81,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -91,7 +91,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 300
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -118,15 +118,15 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: '100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85'
+              expr: '100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85'
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -136,7 +136,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -163,7 +163,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -171,7 +171,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -181,7 +181,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -208,7 +208,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -216,7 +216,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -226,7 +226,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -255,7 +255,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -263,7 +263,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -273,7 +273,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -300,7 +300,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 3600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -308,7 +308,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 3600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -318,7 +318,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 3600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -345,7 +345,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -353,7 +353,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -363,7 +363,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -445,7 +445,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -453,7 +453,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -463,7 +463,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -490,7 +490,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -498,7 +498,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -508,7 +508,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -782,7 +782,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -790,7 +790,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -800,7 +800,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 900
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -936,7 +936,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -960,7 +960,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -973,7 +973,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1005,7 +1005,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1022,7 +1022,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1035,7 +1035,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1067,7 +1067,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1113,7 +1113,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1126,7 +1126,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1174,7 +1174,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1206,7 +1206,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1219,7 +1219,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1255,7 +1255,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: datanika-postgres
             model:
@@ -1288,7 +1288,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1301,7 +1301,7 @@ groups:
                 replaceWithValue: 0
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1405,7 +1405,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1413,7 +1413,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1423,7 +1423,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1448,7 +1448,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1456,7 +1456,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1466,7 +1466,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1491,7 +1491,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1499,7 +1499,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1509,7 +1509,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1534,7 +1534,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1544,7 +1544,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1554,7 +1554,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1579,7 +1579,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1587,7 +1587,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1597,7 +1597,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1628,7 +1628,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1636,7 +1636,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1646,7 +1646,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1672,7 +1672,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1680,7 +1680,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1690,7 +1690,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1715,7 +1715,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
@@ -1723,7 +1723,7 @@ groups:
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:
@@ -1733,7 +1733,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 600
+              from: 60
               to: 0
             datasourceUid: __expr__
             model:

--- a/tests/test_connector_type_contracts.py
+++ b/tests/test_connector_type_contracts.py
@@ -1,0 +1,96 @@
+"""Contracts between the connector-type sets that must agree but aren't linked.
+
+`SOURCE_TYPES` (what may be a source), `NON_SQL_SOURCE_TYPES` (what the upload
+form treats as non-SQL) and `dlt_runner.SUPPORTED_SAAS_TYPES` (what the loader
+dispatches to the SaaS builder) are three separate literals in three modules.
+Nothing binds them, so adding a connector to one and forgetting another is
+silent — which is exactly what happened in core#503: pipedrive, freshdesk and
+asana shipped as SaaS at run time but were never classified in the UI, so the
+upload form rendered Load Mode / Write Disposition / Source schema / Table
+names for an HTTP API.
+
+These tests are the binding.
+"""
+
+from datanika.services.connection_service import SOURCE_TYPES
+from datanika.services.dlt_runner import SUPPORTED_SAAS_TYPES
+from datanika.ui.state.connection_state import (
+    FILE_SOURCE_TYPES,
+    NON_SQL_SOURCE_TYPES,
+    SAAS_DEFAULT_ENDPOINTS,
+    SAAS_SOURCE_TYPES,
+)
+
+# The source types that really are SQL databases — the only ones for which the
+# upload form's Load Mode / Write Disposition / Source schema / Table names
+# block means anything. Listed explicitly rather than derived, so adding a
+# connector forces a deliberate choice instead of inheriting one.
+SQL_SOURCE_TYPES = {
+    "postgres",
+    "mysql",
+    "mssql",
+    "oracle",
+    "sqlite",
+    "clickhouse",
+    "duckdb",
+}
+
+
+def test_every_source_type_is_classified_sql_or_non_sql():
+    """A source type must be one or the other. Unclassified defaults to SQL.
+
+    `form_is_non_sql_source = conn_type in NON_SQL_SOURCE_TYPES`, and the SQL
+    block renders under `~form_is_non_sql_source` — so *forgetting* a connector
+    silently gives it SQL controls. The failure mode is a default, not an error,
+    which is why this needs a test rather than care.
+    """
+    unclassified = SOURCE_TYPES - NON_SQL_SOURCE_TYPES - SQL_SOURCE_TYPES
+    assert not unclassified, (
+        f"Source types {sorted(unclassified)} are in neither NON_SQL_SOURCE_TYPES nor "
+        "SQL_SOURCE_TYPES. The upload form will render Load Mode / Write Disposition / "
+        "Source schema / Table names for them by default. Add them to "
+        "NON_SQL_SOURCE_TYPES (connection_state.py) if they are not SQL databases."
+    )
+
+
+def test_no_type_is_both_sql_and_non_sql():
+    assert not (NON_SQL_SOURCE_TYPES & SQL_SOURCE_TYPES)
+
+
+def test_runner_saas_types_are_all_non_sql():
+    """The loader's view and the form's view must not contradict each other.
+
+    This is the assertion that fails on core#503 as filed: `SUPPORTED_SAAS_TYPES`
+    carries pipedrive/freshdesk/asana, and none of them were in
+    NON_SQL_SOURCE_TYPES.
+    """
+    sql_looking_saas = SUPPORTED_SAAS_TYPES - NON_SQL_SOURCE_TYPES
+    assert not sql_looking_saas, (
+        f"{sorted(sql_looking_saas)} are dispatched to the SaaS builder by dlt_runner "
+        "but are not classified as non-SQL by the upload form, so the form shows them "
+        "SQL controls that the loader ignores."
+    )
+
+
+def test_saas_source_types_are_a_subset_of_the_runners_saas_types():
+    """The form may recognise *fewer* SaaS types than the runner, never more.
+
+    Deliberately a subset rather than equality. Equality would force
+    pipedrive/freshdesk/asana into `SAAS_SOURCE_TYPES`, which renders the
+    "Select endpoints to load" checkboxes — and per core#532 that control is
+    currently inert for every connector except Stripe, because the form writes
+    `dlt_config["endpoints"]` and the builders read `resources`. Adding an
+    inert control is worse than omitting it. Tighten this to equality when
+    core#532 lands.
+    """
+    assert SAAS_SOURCE_TYPES <= SUPPORTED_SAAS_TYPES
+
+
+def test_every_ui_saas_type_has_endpoints_to_offer():
+    """A SaaS type with no endpoint list renders an empty checkbox group."""
+    missing = {t for t in SAAS_SOURCE_TYPES if not SAAS_DEFAULT_ENDPOINTS.get(t)}
+    assert not missing, f"{sorted(missing)} would render an empty endpoint selector"
+
+
+def test_file_source_types_are_non_sql():
+    assert FILE_SOURCE_TYPES <= NON_SQL_SOURCE_TYPES


### PR DESCRIPTION
**#538** — `High CPU Usage` paged as "above 85% for 5 minutes" on a single 30-second sample. `> 85` is a filtering expression, so with `reducer: last` over a 600s lookback one breach stays 'current' for ten minutes; #504 had fixed only the `== 0` rules. Windows normalised to 60s across all 30 rules, and `irate` → `rate` for CPU so the rule measures the 5-minute average its own text promises.

No migrations.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #503 — Pipedrive/Freshdesk/Asana uploads render SQL controls and no endpoint picker — two 'is this SaaS?' lists disagree _(already closed)_ · via #537, commit 5932983
- #521 — New e2e specs should graduate into the promotion gate, not enter it _(already closed)_ · via #533, commit 4c118a7
- #538 — Threshold alert rules still overstate: one 30s spike pages as '5 minutes above 85%' _(already closed)_ · via #539, commit 37a3ae2

<!-- promotion-refs:end -->