### PR TITLE
[Infra] Stop Apache reusing connections uvicorn already closed (closes #525)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 *.sh text eol=lf
 scripts/hooks/* text eol=lf
+
+# Apache vhosts are deployed to a Linux box and byte-compared there by CD.
+# CRLF would make every deploy see a spurious change and reload Apache needlessly.
+deploy/apache/*.conf text eol=lf
+deploy/apache/*.example text eol=lf

--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -85,6 +85,48 @@ jobs:
       #
       # ⚠️ Both colours run `alembic upgrade head`, so the previously-deployed code briefly
       # runs against the new schema. Migrations must be expand/contract — #449.
+      - name: Sync Apache vhosts from the repo
+        # Production routing used to exist only on the box and in an untracked plans/ folder.
+        # When the previous host was terminated (2026-07-14) the server, data and backups went
+        # together; the vhost survived only because someone happened to have a local copy.
+        # It is version-controlled now, and deployed the same way everything else is.
+        #
+        # Never touches webdav.conf -- that vhost belongs to a co-tenant on this shared box.
+        run: |
+          for f in app.datanika.io staging-app.datanika.io; do
+            case "$f" in
+              app.datanika.io)         dest=zapp-datanika-io.conf ;;
+              staging-app.datanika.io) dest=zstaging-app-datanika-io.conf ;;
+            esac
+            scp -i ~/.ssh/deploy -o StrictHostKeyChecking=no \
+              "deploy/apache/$f.conf" "root@${{ secrets.POINTER_HOST }}:/tmp/$dest.new"
+          done
+          ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" 'bash -s' <<'VHOST'
+          set -e
+          changed=0
+          for dest in zapp-datanika-io.conf zstaging-app-datanika-io.conf; do
+            live=/etc/apache2/sites-enabled/$dest
+            if ! cmp -s "/tmp/$dest.new" "$live"; then
+              cp -a "$live" "/tmp/$dest.bak"
+              cp "/tmp/$dest.new" "$live"
+              changed=1
+              echo "vhost changed: $dest"
+            fi
+          done
+          if [ "$changed" = "0" ]; then echo "vhosts already current"; exit 0; fi
+          if apachectl configtest 2>&1 | tee /tmp/ct.log | grep -qi 'Syntax OK'; then
+            apachectl graceful
+            echo "vhosts applied and Apache gracefully reloaded"
+          else
+            echo "CONFIGTEST FAILED — restoring previous vhosts:"; cat /tmp/ct.log
+            for dest in zapp-datanika-io.conf zstaging-app-datanika-io.conf; do
+              [ -f "/tmp/$dest.bak" ] && cp "/tmp/$dest.bak" "/etc/apache2/sites-enabled/$dest"
+            done
+            apachectl configtest
+            exit 1
+          fi
+          VHOST
+
       - name: Deploy the app via blue/green swap
         run: |
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \

--- a/deploy/apache/app.datanika.io.conf
+++ b/deploy/apache/app.datanika.io.conf
@@ -1,0 +1,110 @@
+# app.datanika.io — Datanika SaaS app (Reflex: frontend :3000, backend :8000)
+# Restored on pointer.gr 2026-07-17. TLS via Cloudflare *.datanika.io Origin cert.
+# Co-tenant note: leaves the existing :80 webdav vhost + olcrtc VPN untouched.
+
+<VirtualHost *:80>
+    ServerName app.datanika.io
+    RewriteEngine On
+    RewriteRule ^/?(.*)$ https://app.datanika.io/$1 [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName app.datanika.io
+
+    # Do not reuse backend connections. mod_proxy pools keep-alive connections to the
+    # backend, but uvicorn closes an idle connection after ~5s (its default
+    # --timeout-keep-alive). Apache then writes a request onto a socket the backend has
+    # already reaped and gets nothing back, so it returns 502 immediately.
+    #
+    # That single race produced three separate bug reports (core#525): 45 x /healthz probe
+    # failures, 31 x /_event websocket 502s and 12 x / -- all logged as
+    #   AH01102: error reading status line from remote server
+    # The blackbox probe polls /healthz every 15s, so its pooled connection is ALWAYS idle
+    # past uvicorn's 5s window, which is why a health endpoint nobody uses failed more often
+    # than the pages people actually load. Failure rate tracked idle time, not traffic.
+    #
+    # This must be vhost-wide, not `disablereuse=On` on each ProxyPass: the websocket paths
+    # go through `RewriteRule [P]`, which a per-ProxyPass flag never reaches -- fixing only
+    # the ProxyPass entries would leave the /_event 502s in place.
+    #
+    # Cost is one TCP handshake per request over loopback: negligible here, and the
+    # alternative (raising uvicorn's keep-alive above Apache's pool TTL) means reaching into
+    # how Reflex starts uvicorn, which is app-layer and not Infra's to change.
+    SetEnv proxy-nokeepalive 1
+
+    SSLEngine on
+    SSLCertificateFile    /etc/ssl/datanika/datanika.pem
+    SSLCertificateKeyFile /etc/ssl/datanika/datanika.key
+
+    # Security headers
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+
+    ProxyPreserveHost On
+    ProxyRequests Off
+    RequestHeader set X-Forwarded-Proto "https"
+
+    # --- WebSocket /_event (socket.io) -> backend :8000 ---
+    # Apache 2.4.52's `upgrade=websocket` ProxyPass returns 400 on this box, so
+    # route via mod_proxy_wstunnel: WS-upgrade requests over ws://, everything
+    # else (Engine.IO polling / XHR) over http://. `ProxyPass /_event !` keeps
+    # the catch-all from claiming it.
+    RewriteEngine On
+    RewriteCond %{HTTP:Upgrade} =websocket [NC]
+    RewriteRule ^/_event(/.*)?$ ws://127.0.0.1:${DATANIKA_BE}/_event$1 [P,L]
+    RewriteCond %{HTTP:Upgrade} !=websocket [NC]
+    RewriteRule ^/_event(/.*)?$ http://127.0.0.1:${DATANIKA_BE}/_event$1 [P,L]
+    ProxyPass /_event !
+
+    # --- Backend endpoints -> :8000 (most specific first) ---
+    ProxyPass        /_upload http://127.0.0.1:${DATANIKA_BE}/_upload
+    ProxyPassReverse /_upload http://127.0.0.1:${DATANIKA_BE}/_upload
+    ProxyPass        /ping    http://127.0.0.1:${DATANIKA_BE}/ping
+    ProxyPassReverse /ping    http://127.0.0.1:${DATANIKA_BE}/ping
+    ProxyPass        /healthz http://127.0.0.1:${DATANIKA_BE}/healthz
+    ProxyPassReverse /healthz http://127.0.0.1:${DATANIKA_BE}/healthz
+    ProxyPass        /readyz  http://127.0.0.1:${DATANIKA_BE}/readyz
+    ProxyPassReverse /readyz  http://127.0.0.1:${DATANIKA_BE}/readyz
+    ProxyPass        /api/    http://127.0.0.1:${DATANIKA_BE}/api/
+    ProxyPassReverse /api/    http://127.0.0.1:${DATANIKA_BE}/api/
+
+    # --- Remote MCP (/mcp) -> backend :8000 ---
+    # The MCP route is mounted on the BACKEND (datanika/services/mcp_routes.py ->
+    # app._api.routes). Without this it fell through to the :3000 catch-all and the
+    # hosted endpoint served the Reflex SPA HTML instead of MCP.
+    # Transport is Streamable HTTP: POST carries JSON-RPC, GET holds a long-lived
+    # SSE stream -> needs a longer timeout than the global ProxyTimeout 120 (an idle
+    # stream would be cut mid-session), and no gzip (mod_deflate buffers the stream).
+    SetEnvIf Request_URI "^/mcp" no-gzip=1 dont-vary
+    ProxyPass        /mcp http://127.0.0.1:${DATANIKA_BE}/mcp timeout=3600
+    ProxyPassReverse /mcp http://127.0.0.1:${DATANIKA_BE}/mcp
+
+    # --- Remote-MCP OAuth 2.1 authorization server (P2) -> backend :8000 ---
+    # Starlette routes from services/mcp_oauth_routes.py. Without these they fell to
+    # the :3000 catch-all: discovery 404'd and /oauth/token|authorize|register returned
+    # the Reflex SPA (HTML) instead of the AS, so no MCP client could complete the flow.
+    # ⚠️ /oauth/consent is deliberately NOT listed — it is a Reflex FRONTEND page
+    # (app.add_page route="/oauth/consent") and must keep resolving to :3000.
+    # /api/oauth/client-info and /api/oauth/consent are already covered by /api/ above.
+    ProxyPass        /.well-known/oauth-protected-resource   http://127.0.0.1:${DATANIKA_BE}/.well-known/oauth-protected-resource
+    ProxyPassReverse /.well-known/oauth-protected-resource   http://127.0.0.1:${DATANIKA_BE}/.well-known/oauth-protected-resource
+    ProxyPass        /.well-known/oauth-authorization-server http://127.0.0.1:${DATANIKA_BE}/.well-known/oauth-authorization-server
+    ProxyPassReverse /.well-known/oauth-authorization-server http://127.0.0.1:${DATANIKA_BE}/.well-known/oauth-authorization-server
+    ProxyPass        /oauth/authorize http://127.0.0.1:${DATANIKA_BE}/oauth/authorize
+    ProxyPassReverse /oauth/authorize http://127.0.0.1:${DATANIKA_BE}/oauth/authorize
+    ProxyPass        /oauth/token     http://127.0.0.1:${DATANIKA_BE}/oauth/token
+    ProxyPassReverse /oauth/token     http://127.0.0.1:${DATANIKA_BE}/oauth/token
+    ProxyPass        /oauth/register  http://127.0.0.1:${DATANIKA_BE}/oauth/register
+    ProxyPassReverse /oauth/register  http://127.0.0.1:${DATANIKA_BE}/oauth/register
+
+    # --- Everything else -> frontend :3000 (catch-all LAST) ---
+    ProxyPass        / http://127.0.0.1:${DATANIKA_FE}/
+    ProxyPassReverse / http://127.0.0.1:${DATANIKA_FE}/
+
+    ProxyTimeout 120
+
+    ErrorLog  ${APACHE_LOG_DIR}/app.datanika.io-error.log
+    CustomLog ${APACHE_LOG_DIR}/app.datanika.io-access.log combined
+</VirtualHost>

--- a/deploy/apache/datanika-prod-active.conf.example
+++ b/deploy/apache/datanika-prod-active.conf.example
@@ -1,0 +1,4 @@
+# Active prod backend/frontend ports — rewritten by deploy-bluegreen.sh.
+# Parsed before sites-enabled/*, where the vhost consumes ${DATANIKA_BE} / ${DATANIKA_FE}.
+Define DATANIKA_BE 8000
+Define DATANIKA_FE 3000

--- a/deploy/apache/staging-app.datanika.io.conf
+++ b/deploy/apache/staging-app.datanika.io.conf
@@ -1,0 +1,99 @@
+# staging-app.datanika.io — Datanika STAGING (Reflex: frontend :3100, backend :8100)
+# Isolated 2nd stack on pointer.gr. noindex so search engines never index staging.
+
+<VirtualHost *:80>
+    ServerName staging-app.datanika.io
+    RewriteEngine On
+    RewriteRule ^/?(.*)$ https://staging-app.datanika.io/$1 [R=301,L]
+</VirtualHost>
+
+
+<VirtualHost *:443>
+    ServerName staging-app.datanika.io
+
+    # Do not reuse backend connections. mod_proxy pools keep-alive connections to the
+    # backend, but uvicorn closes an idle connection after ~5s (its default
+    # --timeout-keep-alive). Apache then writes a request onto a socket the backend has
+    # already reaped and gets nothing back, so it returns 502 immediately.
+    #
+    # That single race produced three separate bug reports (core#525): 45 x /healthz probe
+    # failures, 31 x /_event websocket 502s and 12 x / -- all logged as
+    #   AH01102: error reading status line from remote server
+    # The blackbox probe polls /healthz every 15s, so its pooled connection is ALWAYS idle
+    # past uvicorn's 5s window, which is why a health endpoint nobody uses failed more often
+    # than the pages people actually load. Failure rate tracked idle time, not traffic.
+    #
+    # This must be vhost-wide, not `disablereuse=On` on each ProxyPass: the websocket paths
+    # go through `RewriteRule [P]`, which a per-ProxyPass flag never reaches -- fixing only
+    # the ProxyPass entries would leave the /_event 502s in place.
+    #
+    # Cost is one TCP handshake per request over loopback: negligible here, and the
+    # alternative (raising uvicorn's keep-alive above Apache's pool TTL) means reaching into
+    # how Reflex starts uvicorn, which is app-layer and not Infra's to change.
+    SetEnv proxy-nokeepalive 1
+
+    SSLEngine on
+    SSLCertificateFile    /etc/ssl/datanika/datanika.pem
+    SSLCertificateKeyFile /etc/ssl/datanika/datanika.key
+
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    # Keep staging out of search indexes
+    Header always set X-Robots-Tag "noindex, nofollow"
+
+    ProxyPreserveHost On
+    ProxyRequests Off
+    RequestHeader set X-Forwarded-Proto "https"
+
+    # WebSocket /_event -> staging backend :8100 (mod_proxy_wstunnel)
+    RewriteEngine On
+    RewriteCond %{HTTP:Upgrade} =websocket [NC]
+    RewriteRule ^/_event(/.*)?$ ws://127.0.0.1:${DATANIKA_STG_BE}/_event$1 [P,L]
+    RewriteCond %{HTTP:Upgrade} !=websocket [NC]
+    RewriteRule ^/_event(/.*)?$ http://127.0.0.1:${DATANIKA_STG_BE}/_event$1 [P,L]
+    ProxyPass /_event !
+
+    ProxyPass        /_upload http://127.0.0.1:${DATANIKA_STG_BE}/_upload
+    ProxyPassReverse /_upload http://127.0.0.1:${DATANIKA_STG_BE}/_upload
+    ProxyPass        /ping    http://127.0.0.1:${DATANIKA_STG_BE}/ping
+    ProxyPassReverse /ping    http://127.0.0.1:${DATANIKA_STG_BE}/ping
+    ProxyPass        /healthz http://127.0.0.1:${DATANIKA_STG_BE}/healthz
+    ProxyPassReverse /healthz http://127.0.0.1:${DATANIKA_STG_BE}/healthz
+    ProxyPass        /readyz  http://127.0.0.1:${DATANIKA_STG_BE}/readyz
+    ProxyPassReverse /readyz  http://127.0.0.1:${DATANIKA_STG_BE}/readyz
+    ProxyPass        /api/    http://127.0.0.1:${DATANIKA_STG_BE}/api/
+    ProxyPassReverse /api/    http://127.0.0.1:${DATANIKA_STG_BE}/api/
+
+    # --- Remote MCP (/mcp) -> staging backend :8100 (mirrors prod) ---
+    # Mounted on the BACKEND (mcp_routes.py -> app._api.routes); without this it
+    # falls through to the :3100 catch-all and serves the Reflex SPA instead of MCP.
+    # Streamable HTTP: POST = JSON-RPC, GET = long-lived SSE stream -> needs a longer
+    # timeout than the global ProxyTimeout 120, and no gzip (mod_deflate buffers it).
+    SetEnvIf Request_URI "^/mcp" no-gzip=1 dont-vary
+    ProxyPass        /mcp http://127.0.0.1:${DATANIKA_STG_BE}/mcp timeout=3600
+    ProxyPassReverse /mcp http://127.0.0.1:${DATANIKA_STG_BE}/mcp
+
+    # --- Remote-MCP OAuth 2.1 authorization server (P2) -> staging backend :8100 ---
+    # Mirrors prod. ⚠️ /oauth/consent is deliberately NOT listed — it's a Reflex
+    # FRONTEND page and must keep resolving to :3100. /api/oauth/* is covered by /api/.
+    ProxyPass        /.well-known/oauth-protected-resource   http://127.0.0.1:${DATANIKA_STG_BE}/.well-known/oauth-protected-resource
+    ProxyPassReverse /.well-known/oauth-protected-resource   http://127.0.0.1:${DATANIKA_STG_BE}/.well-known/oauth-protected-resource
+    ProxyPass        /.well-known/oauth-authorization-server http://127.0.0.1:${DATANIKA_STG_BE}/.well-known/oauth-authorization-server
+    ProxyPassReverse /.well-known/oauth-authorization-server http://127.0.0.1:${DATANIKA_STG_BE}/.well-known/oauth-authorization-server
+    ProxyPass        /oauth/authorize http://127.0.0.1:${DATANIKA_STG_BE}/oauth/authorize
+    ProxyPassReverse /oauth/authorize http://127.0.0.1:${DATANIKA_STG_BE}/oauth/authorize
+    ProxyPass        /oauth/token     http://127.0.0.1:${DATANIKA_STG_BE}/oauth/token
+    ProxyPassReverse /oauth/token     http://127.0.0.1:${DATANIKA_STG_BE}/oauth/token
+    ProxyPass        /oauth/register  http://127.0.0.1:${DATANIKA_STG_BE}/oauth/register
+    ProxyPassReverse /oauth/register  http://127.0.0.1:${DATANIKA_STG_BE}/oauth/register
+
+    ProxyPass        / http://127.0.0.1:${DATANIKA_STG_FE}/
+    ProxyPassReverse / http://127.0.0.1:${DATANIKA_STG_FE}/
+
+    ProxyTimeout 120
+
+    ErrorLog  ${APACHE_LOG_DIR}/staging-app.datanika.io-error.log
+    CustomLog ${APACHE_LOG_DIR}/staging-app.datanika.io-access.log combined
+</VirtualHost>


### PR DESCRIPTION
One race behind three symptom reports — 45 `/healthz` probe failures, 31 `/_event` websocket 502s, 12 `/` — all logged as `AH01102: error reading status line from remote server`. Apache reuses a pooled keep-alive connection that uvicorn closed after its 5s default; the blackbox probe's 15s interval means its connection is *always* stale, which is why a health endpoint nobody uses failed more often than real pages. Failure rate tracked idle time, not load.

`SetEnv` is vhost-wide on purpose: the websocket paths go through `RewriteRule [P]`, which a per-`ProxyPass` `disablereuse=On` never reaches — fixing only the `ProxyPass` entries would leave all 31 `/_event` 502s in place.

Also puts the vhosts under version control with a CD sync: backup → write → `apachectl configtest` → `graceful`, restoring the backup and failing the deploy if configtest fails. Never touches the co-tenant's `webdav.conf`, never restarts Apache. Production routing previously existed only on the box and in an untracked folder — the same exposure that made the 2026-07-14 host loss unrecoverable.

Validated on staging (`Syntax OK`, 200 through Apache, prod and co-tenant unaffected). Efficacy must be measured on prod: staging has no blackbox probe and almost no traffic, and at ~1% a handful of green requests proves nothing.