### PR TITLE
[Infra] Promote dev → master: vhost sync from the transferred tree

### DIFF
--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -89,38 +89,40 @@ jobs:
         # Production routing used to exist only on the box and in an untracked plans/ folder.
         # When the previous host was terminated (2026-07-14) the server, data and backups went
         # together; the vhost survived only because someone happened to have a local copy.
-        # It is version-controlled now, and deployed the same way everything else is.
         #
-        # Never touches webdav.conf -- that vhost belongs to a co-tenant on this shared box.
+        # No scp: "Transfer source" has already put the whole repo at /opt/datanika/datanika,
+        # so the vhosts are on the box before this runs. That removes the runner-side path as a
+        # failure mode (the first version used deploy/apache/... while the checkout lands in
+        # datanika/, so scp found nothing) and guarantees the vhost matches the tree the image
+        # is built from.
+        #
+        # Never touches webdav.conf -- that vhost belongs to a co-tenant on this shared box --
+        # and never restarts Apache, only graceful.
         run: |
-          for f in app.datanika.io staging-app.datanika.io; do
-            case "$f" in
-              app.datanika.io)         dest=zapp-datanika-io.conf ;;
-              staging-app.datanika.io) dest=zstaging-app-datanika-io.conf ;;
-            esac
-            scp -i ~/.ssh/deploy -o StrictHostKeyChecking=no \
-              "deploy/apache/$f.conf" "root@${{ secrets.POINTER_HOST }}:/tmp/$dest.new"
-          done
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" 'bash -s' <<'VHOST'
           set -e
+          SRC=/opt/datanika/datanika/deploy/apache
           changed=0
-          for dest in zapp-datanika-io.conf zstaging-app-datanika-io.conf; do
-            live=/etc/apache2/sites-enabled/$dest
-            if ! cmp -s "/tmp/$dest.new" "$live"; then
-              cp -a "$live" "/tmp/$dest.bak"
-              cp "/tmp/$dest.new" "$live"
+          sync_one() {
+            src="$SRC/$1"; live="/etc/apache2/sites-enabled/$2"
+            [ -f "$src" ] || { echo "missing in repo: $src"; exit 1; }
+            if ! cmp -s "$src" "$live"; then
+              cp -a "$live" "/tmp/$2.bak"
+              cp "$src" "$live"
               changed=1
-              echo "vhost changed: $dest"
+              echo "vhost changed: $2"
             fi
-          done
+          }
+          sync_one app.datanika.io.conf         zapp-datanika-io.conf
+          sync_one staging-app.datanika.io.conf zstaging-app-datanika-io.conf
           if [ "$changed" = "0" ]; then echo "vhosts already current"; exit 0; fi
           if apachectl configtest 2>&1 | tee /tmp/ct.log | grep -qi 'Syntax OK'; then
             apachectl graceful
-            echo "vhosts applied and Apache gracefully reloaded"
+            echo "vhosts applied, Apache gracefully reloaded"
           else
-            echo "CONFIGTEST FAILED — restoring previous vhosts:"; cat /tmp/ct.log
-            for dest in zapp-datanika-io.conf zstaging-app-datanika-io.conf; do
-              [ -f "/tmp/$dest.bak" ] && cp "/tmp/$dest.bak" "/etc/apache2/sites-enabled/$dest"
+            echo "CONFIGTEST FAILED - restoring previous vhosts:"; cat /tmp/ct.log
+            for d in zapp-datanika-io.conf zstaging-app-datanika-io.conf; do
+              [ -f "/tmp/$d.bak" ] && cp "/tmp/$d.bak" "/etc/apache2/sites-enabled/$d"
             done
             apachectl configtest
             exit 1

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -351,6 +351,38 @@ def describe_empty_file_match(bucket_url: str, file_glob: str) -> str:
     return f"{general} The directory exists but holds nothing matching that pattern."
 
 
+def _select_endpoints(source, endpoints):
+    """Narrow a SaaS source to the endpoints the user ticked (core#532).
+
+    Applied at the one place every SaaS source passes through, rather than in
+    each builder: the sixteen branches construct their resources differently
+    (verified-source module or REST fallback) but all return a `DltSource`, and
+    `with_resources` is dlt's own way to select on one.
+
+    Two sharp edges, both pinned by tests:
+
+    * `with_resources()` with **no arguments selects everything**, so an empty
+      or absent list must short-circuit rather than be forwarded. The form only
+      writes the key when something is ticked, so `[]` means "unset".
+    * dlt raises `ResourcesNotFoundError` for an unknown name. That is the right
+      outcome, but its message does not say where the name came from, and the
+      names come from a hardcoded picker list that has drifted before — so it is
+      re-raised as a `DltRunnerError` naming both sides.
+    """
+    if not endpoints:
+        return source
+
+    available = set(source.resources.keys())
+    unknown = [e for e in endpoints if e not in available]
+    if unknown:
+        raise DltRunnerError(
+            f"Unknown endpoint(s) {sorted(unknown)} for this source. "
+            f"Available: {sorted(available)}."
+        )
+
+    return source.with_resources(*endpoints)
+
+
 def _first_file_or_none(lister):
     """Peek the lister dlt itself will use.
 
@@ -498,7 +530,8 @@ class DltRunnerService:
             return self._build_mongodb_source(config, dlt_config, batch_size)
 
         if connection_type in SUPPORTED_SAAS_TYPES:
-            return self._build_saas_source(connection_type, config, dlt_config)
+            source = self._build_saas_source(connection_type, config, dlt_config)
+            return _select_endpoints(source, dlt_config.get("endpoints"))
 
         if connection_type in SUPPORTED_KAFKA_TYPES:
             return self._build_kafka_source(config, dlt_config)

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -14,7 +14,10 @@ from datanika.services.connection_service import (
 from datanika.services.encryption import EncryptionService
 from datanika.ui.state.base_state import BaseState, get_sync_session
 
-# SaaS source types that use endpoint/resource selection (not SQL mode)
+# SaaS source types that use endpoint/resource selection (not SQL mode).
+#
+# Must equal `dlt_runner.SUPPORTED_SAAS_TYPES` — the loader's view of which
+# connectors are SaaS. `tests/test_connector_type_contracts.py` asserts it.
 SAAS_SOURCE_TYPES = {
     "stripe",
     "github",
@@ -29,6 +32,9 @@ SAAS_SOURCE_TYPES = {
     "zendesk",
     "airtable",
     "notion",
+    "pipedrive",
+    "freshdesk",
+    "asana",
 }
 
 # File-based source types
@@ -54,34 +60,58 @@ NON_SQL_SOURCE_TYPES = (
         "mongodb",
         "rest_api",
         "kafka",
-        # SaaS at run time (dlt_runner dispatches them to the SaaS builder) but
-        # deliberately absent from SAAS_SOURCE_TYPES above: that set drives the
-        # "Select endpoints to load" checkboxes, which are inert for every
-        # connector but Stripe until core#532 wires the selection through.
-        # Listing them here fixes the wrong controls without adding a fake one.
-        "pipedrive",
-        "freshdesk",
-        "asana",
         # Resources come from the uploaded spec, not from a SQL schema.
         "openapi",
     }
+    # pipedrive/freshdesk/asana used to be listed explicitly here, because
+    # core#503 fixed their SQL-control leak while deliberately keeping them out
+    # of SAAS_SOURCE_TYPES — that set renders the endpoint picker, and the
+    # picker did nothing (core#532). Now that the selection is honoured they
+    # belong in SAAS_SOURCE_TYPES, which this union already covers.
 )
 
-# Default available endpoints per SaaS connector
+# Default available endpoints per SaaS connector — the checkbox list, and the
+# names the selection is resolved against.
+#
+# These MUST be the resource names the loader actually builds. They were not:
+# the original list described the dlt *verified sources*, while what runs is the
+# REST fallback (no verified-source package is installed — core#543), so Stripe
+# offered `Product`/`Price` where the fallback defines `products`/`prices`, and
+# HubSpot offered six resources where three exist. While the selection was
+# ignored (core#532) that was merely misleading; once honoured it would fail the
+# run. Corrected below against the built sources.
+#
+# `tests/test_services/test_saas_endpoint_selection.py` builds each source and
+# asserts both directions — nothing offered that isn't built, nothing built that
+# isn't offered. Update that test's expectations by running it, not by hand.
 SAAS_DEFAULT_ENDPOINTS: dict[str, list[str]] = {
-    "stripe": ["Subscription", "Account", "Coupon", "Customer", "Invoice", "Product", "Price"],
+    "stripe": ["charges", "customers", "invoices", "prices", "products", "subscriptions"],
     "github": ["issues", "pulls", "commits", "stargazers"],
-    "hubspot": ["contacts", "companies", "deals", "products", "tickets", "quotes"],
-    "salesforce": ["Account", "Contact", "Opportunity", "Lead", "Campaign", "Case"],
+    "hubspot": ["companies", "contacts", "deals"],
+    "salesforce": ["accounts", "contacts", "opportunities"],
     "shopify": ["orders", "products", "customers"],
-    "jira": ["issues", "users", "workflows", "projects"],
-    "slack": ["channels", "messages", "users", "threads"],
+    "jira": ["issues", "projects"],
+    "slack": ["channels", "users"],
+    # The three below cannot build a source at all (core#543): no verified
+    # source, no REST fallback. Their lists are left as the verified sources
+    # describe them and are excluded from the contract test until that is fixed.
     "google_analytics": ["report"],
     "google_ads": ["customers", "campaigns", "ad_groups", "ads"],
     "facebook_ads": ["campaigns", "ad_sets", "ads", "leads", "creatives"],
-    "zendesk": ["tickets", "users", "organizations", "groups", "brands"],
+    "zendesk": ["organizations", "tickets", "users"],
     "airtable": ["tables"],
     "notion": ["databases", "pages"],
+    "pipedrive": [
+        "activities",
+        "deals",
+        "organizations",
+        "persons",
+        "pipelines",
+        "stages",
+        "users",
+    ],
+    "freshdesk": ["agents", "companies", "contacts", "groups", "tickets"],
+    "asana": ["projects", "tags", "tasks", "users", "workspaces"],
 }
 
 # Default ports for database connection types

--- a/tests/test_connector_type_contracts.py
+++ b/tests/test_connector_type_contracts.py
@@ -72,18 +72,16 @@ def test_runner_saas_types_are_all_non_sql():
     )
 
 
-def test_saas_source_types_are_a_subset_of_the_runners_saas_types():
-    """The form may recognise *fewer* SaaS types than the runner, never more.
+def test_the_form_and_the_loader_agree_on_which_types_are_saas():
+    """Tightened from subset to equality once core#532 landed, as noted here.
 
-    Deliberately a subset rather than equality. Equality would force
-    pipedrive/freshdesk/asana into `SAAS_SOURCE_TYPES`, which renders the
-    "Select endpoints to load" checkboxes — and per core#532 that control is
-    currently inert for every connector except Stripe, because the form writes
-    `dlt_config["endpoints"]` and the builders read `resources`. Adding an
-    inert control is worse than omitting it. Tighten this to equality when
-    core#532 lands.
+    It was a subset while the endpoint picker was inert: forcing
+    pipedrive/freshdesk/asana into `SAAS_SOURCE_TYPES` would have rendered a
+    control that did nothing. The selection is honoured now, so the two sets
+    must match exactly — a type in one and not the other is either a picker
+    with no loader behind it or a loader the picker can't configure.
     """
-    assert SAAS_SOURCE_TYPES <= SUPPORTED_SAAS_TYPES
+    assert SAAS_SOURCE_TYPES == SUPPORTED_SAAS_TYPES
 
 
 def test_every_ui_saas_type_has_endpoints_to_offer():

--- a/tests/test_services/test_saas_endpoint_selection.py
+++ b/tests/test_services/test_saas_endpoint_selection.py
@@ -1,0 +1,130 @@
+"""The endpoint picker must narrow the load, and offer names that exist (core#532).
+
+Two failures, one cause. The form wrote `dlt_config["endpoints"]` and **no
+builder read it** — only Stripe's verified-source branch did, and that branch
+never runs because `stripe_analytics` is not installed anywhere (see core#543).
+So unticking a resource changed nothing.
+
+Wiring the key through is not enough on its own: the names the picker offers
+came from the *verified sources*, while what actually gets built is the REST
+fallback, and for six connectors the two disagreed — Stripe offered `Product`
+and `Price` where the fallback defines `products` and `prices`, HubSpot offered
+six resources where three exist. Honouring the selection without first aligning
+the names would have turned a dead control into a failing one.
+
+`test_every_offered_endpoint_exists` is the guard for that half, and it is the
+one that matters: it builds each source and compares against the resources dlt
+actually produced, rather than restating a list.
+"""
+
+import pytest
+
+from datanika.services.dlt_runner import DltRunnerError, DltRunnerService
+from datanika.ui.state.connection_state import SAAS_DEFAULT_ENDPOINTS
+
+# Minimal config to get each SaaS branch past its required-field checks. Values
+# are placeholders — no request is made; the source is only constructed.
+SAAS_PROBE_CONFIG = {
+    "stripe": {"api_key": "sk_test_x"},
+    "github": {"access_token": "t", "owner": "o", "repo": "r"},
+    "hubspot": {"api_key": "t"},
+    "salesforce": {"access_token": "t", "instance_url": "https://x.my.salesforce.com"},
+    "shopify": {"api_key": "t", "store": "s"},
+    "jira": {"api_token": "t", "email": "e@x.com", "domain": "d"},
+    "slack": {"api_key": "t"},
+    "zendesk": {"api_token": "t", "email": "e@x.com", "subdomain": "s"},
+    "airtable": {"api_key": "t", "base_id": "b"},
+    "notion": {"api_key": "t"},
+    "pipedrive": {"api_key": "t"},
+    "freshdesk": {"api_key": "t", "domain": "d"},
+    "asana": {"api_key": "t"},
+}
+
+# These three raise instead of building: no verified source is installed and they
+# have no REST fallback (core#543). Their picker entries cannot be validated
+# until that is resolved, and their accuracy is moot while the connector cannot
+# run at all. Config here is *valid* — the point is that the raise happens after
+# the required-field checks, not because of them.
+CANNOT_BUILD = {
+    "google_analytics": {"property_id": "1", "service_account_json": "{}"},
+    "google_ads": {"customer_id": "1", "service_account_json": "{}"},
+    "facebook_ads": {"access_token": "t", "account_id": "act_1"},
+}
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _build(svc, conn_type, dlt_config=None):
+    return svc.build_source(conn_type, SAAS_PROBE_CONFIG[conn_type], dlt_config or {})
+
+
+class TestOfferedEndpointsExist:
+    """Bind the picker's options to the resources that actually get built."""
+
+    @pytest.mark.parametrize("conn_type", sorted(set(SAAS_DEFAULT_ENDPOINTS) - set(CANNOT_BUILD)))
+    def test_every_offered_endpoint_exists(self, svc, conn_type):
+        built = set(_build(svc, conn_type).resources.keys())
+        offered = set(SAAS_DEFAULT_ENDPOINTS[conn_type])
+        missing = offered - built
+        assert not missing, (
+            f"{conn_type}: the picker offers {sorted(missing)}, which the loader does not "
+            f"build. It builds {sorted(built)}. Selecting a name that does not exist makes "
+            "the run fail, so the two lists must agree."
+        )
+
+    @pytest.mark.parametrize("conn_type", sorted(set(SAAS_DEFAULT_ENDPOINTS) - set(CANNOT_BUILD)))
+    def test_no_built_resource_is_hidden_from_the_picker(self, svc, conn_type):
+        """The other direction: a resource you cannot untick is a resource you cannot avoid."""
+        built = set(_build(svc, conn_type).resources.keys())
+        unlisted = built - set(SAAS_DEFAULT_ENDPOINTS[conn_type])
+        assert not unlisted, f"{conn_type}: {sorted(unlisted)} load but are not offered"
+
+    @pytest.mark.parametrize("conn_type", sorted(CANNOT_BUILD))
+    def test_the_unbuildable_ones_still_fail_loudly(self, svc, conn_type):
+        """Documents core#543 rather than hiding it — move these up when it's fixed.
+
+        Asserted with *valid* config so the failure is the missing verified
+        source, not a missing field: these three raise for every user, always.
+        """
+        with pytest.raises(DltRunnerError, match="verified source not installed"):
+            svc.build_source(conn_type, CANNOT_BUILD[conn_type], {})
+
+
+class TestSelectionNarrowsTheLoad:
+    def test_selected_endpoints_are_the_only_ones_loaded(self, svc):
+        source = _build(svc, "github", {"endpoints": ["issues", "commits"]})
+        assert sorted(source.selected_resources.keys()) == ["commits", "issues"]
+
+    def test_all_resources_load_when_nothing_is_selected(self, svc):
+        source = _build(svc, "github")
+        assert sorted(source.selected_resources.keys()) == [
+            "commits",
+            "issues",
+            "pulls",
+            "stargazers",
+        ]
+
+    def test_an_empty_selection_is_treated_as_no_selection(self, svc):
+        """The form only writes the key when something is ticked, so [] means "unset".
+
+        Worth pinning: dlt's own `with_resources()` with no arguments selects
+        *everything*, so an empty list must not be forwarded blindly.
+        """
+        source = _build(svc, "github", {"endpoints": []})
+        assert len(source.selected_resources) == 4
+
+    def test_an_unknown_endpoint_fails_with_a_message_naming_it(self, svc):
+        with pytest.raises(DltRunnerError) as exc:
+            _build(svc, "github", {"endpoints": ["issues", "nonsuch"]})
+        assert "nonsuch" in str(exc.value)
+        assert "issues" in str(exc.value)
+
+    @pytest.mark.parametrize("conn_type", sorted(set(SAAS_DEFAULT_ENDPOINTS) - set(CANNOT_BUILD)))
+    def test_selection_works_for_every_connector_that_offers_it(self, svc, conn_type):
+        """Not just github — the picker is rendered for all of these."""
+        first = sorted(SAAS_DEFAULT_ENDPOINTS[conn_type])[0]
+        source = _build(svc, conn_type, {"endpoints": [first]})
+        assert list(source.selected_resources.keys()) == [first]


### PR DESCRIPTION
Retry of the #525 delivery. The vhost step failed on its first run because it scp'd from a runner path that does not exist (the checkout lands in `datanika/`); it now copies from `/opt/datanika/datanika/deploy/apache`, which `Transfer source` has already placed on the box. The earlier failure was safe — nothing written, configtest clean, prod serving.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #525 — Prod 502s, websocket drops and probe blips are one bug: mod_proxy reuses connections the backend already closed _(already closed)_ · via #547, commit c479214
- #532 — "Select endpoints to load" does nothing for 12 of 13 SaaS connectors — the UI writes `endpoints`, the builders read `resources` _(already closed)_ · via #546, commit b419467

<!-- promotion-refs:end -->