### PR TITLE
[Engineering] Facebook Ads loads; GA and Google Ads fail honestly (refs #543)

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -75,6 +75,12 @@ SUPPORTED_SAAS_TYPES = {
 # Kafka is a streaming source with its own builder
 SUPPORTED_KAFKA_TYPES = {"kafka"}
 
+#: Graph API version for the Facebook Ads fallback. Facebook retires versions on
+#: a rolling ~2-year schedule, so this is a config-overridable default
+#: (`dlt_config["api_version"]`) rather than a constant baked into the path — a
+#: retired version should be a setting to change, not a release to cut.
+DEFAULT_FACEBOOK_API_VERSION = "v21.0"
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -786,11 +792,24 @@ class DltRunnerService:
         )
 
     def _build_saas_source(self, connection_type: str, config: dict, dlt_config: dict):
-        """Build a dlt verified source for SaaS connectors.
+        """Build a source for a SaaS connector.
 
-        Uses official dlt verified sources (bundled via ``dlt init`` at Docker
-        build time).  Falls back to a generic REST API source when the verified
-        source module is not installed.
+        **The REST fallback is the real implementation, not the fallback.** This
+        docstring used to say the verified sources were "bundled via ``dlt init``
+        at Docker build time"; nothing bundles them, and the Dockerfile says so
+        deliberately — *"dlt verified sources … use REST API fallback when not
+        installed via `dlt init`. This avoids dependency conflicts in Docker."*
+        So in every deployment, dev and prod alike, each ``from <source> import``
+        below raises ``ImportError`` and the fallback runs (core#543).
+
+        That mattered twice: the picker offered resource names taken from the
+        verified sources while the fallback built different ones (core#532), and
+        the three connectors with **no** fallback were not degraded but dead —
+        their ``except ImportError`` re-raised, so a run could only ever fail.
+
+        The verified-source branches are kept because a self-hoster may run
+        ``dlt init``, and the imports are what make that work with no code
+        change. They are simply not the path anyone here exercises.
         """
         if connection_type == "stripe":
             api_key = config.get("api_key") or config.get("stripe_secret_key", "")
@@ -1051,8 +1070,20 @@ class DltRunnerService:
                     kwargs_ga["credentials"] = credentials_json
                 return google_analytics(**kwargs_ga)
             except ImportError:
+                # Was "run dlt init google_analytics" — an instruction for a
+                # server the user does not operate, and the only outcome this
+                # connector has ever produced (core#543, same class as #499).
+                #
+                # No REST fallback yet, and unlike Facebook it is not a matter
+                # of writing one: the Data API needs an OAuth token minted from
+                # the service-account JSON, and `runReport` takes a POST body
+                # naming dimensions and metrics — a report shape is a product
+                # decision, not a default. Tracked separately.
                 raise DltRunnerError(
-                    "Google Analytics verified source not installed (run dlt init google_analytics)"
+                    "Google Analytics is not available on this deployment yet. It needs a "
+                    "reporting query (dimensions and metrics) that Datanika does not collect, "
+                    "so there is nothing to configure on your side — see core#543. "
+                    "Google Sheets or a REST API connection can cover GA exports meanwhile."
                 ) from None
 
         if connection_type == "google_ads":
@@ -1065,8 +1096,17 @@ class DltRunnerService:
 
                 return google_ads(customer_id=customer_id)
             except ImportError:
+                # Also not writable as a REST fallback, and for a harder reason
+                # than Google Analytics: every Google Ads API request carries a
+                # `developer-token` header, and the connection form collects no
+                # such field — so no transport can authenticate with what we
+                # store. Obtaining one is an application to Google, not a
+                # setting. Needs a schema change first (core#543).
                 raise DltRunnerError(
-                    "Google Ads verified source not installed (run dlt init google_ads)"
+                    "Google Ads is not available on this deployment. The Google Ads API "
+                    "requires a developer token, which Datanika does not currently collect, "
+                    "so this connection cannot authenticate — see core#543. Nothing you can "
+                    "change in the connection settings will fix this."
                 ) from None
 
         if connection_type == "facebook_ads":
@@ -1079,9 +1119,29 @@ class DltRunnerService:
 
                 return facebook_ads_source(account_id=account_id, access_token=access_token)
             except ImportError:
-                raise DltRunnerError(
-                    "Facebook Ads verified source not installed (run dlt init facebook_ads)"
-                ) from None
+                # Falls back to the Graph API like every other SaaS connector
+                # (core#543). Before this, the ImportError re-raised "run
+                # dlt init facebook_ads" — advice for a server the user does
+                # not operate, and the only possible outcome, every time.
+                #
+                # `act_` is part of the ad-account identifier; users paste it
+                # inconsistently, so it is normalised rather than demanded.
+                account = account_id if str(account_id).startswith("act_") else f"act_{account_id}"
+                version = dlt_config.get("api_version") or DEFAULT_FACEBOOK_API_VERSION
+                return self._rest_api_fallback(
+                    f"https://graph.facebook.com/{version}/",
+                    {"type": "bearer", "token": access_token},
+                    dlt_config.get("resources")
+                    or [
+                        {"name": "campaigns", "endpoint": {"path": f"{account}/campaigns"}},
+                        # Resource names are the picker's; paths are Facebook's.
+                        # `ad_sets`/`creatives` read better than `adsets`/
+                        # `adcreatives` and the two are independent here.
+                        {"name": "ad_sets", "endpoint": {"path": f"{account}/adsets"}},
+                        {"name": "ads", "endpoint": {"path": f"{account}/ads"}},
+                        {"name": "creatives", "endpoint": {"path": f"{account}/adcreatives"}},
+                    ],
+                )
 
         if connection_type == "zendesk":
             subdomain = config.get("subdomain", "") or config.get("domain", "")

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -92,12 +92,16 @@ SAAS_DEFAULT_ENDPOINTS: dict[str, list[str]] = {
     "shopify": ["orders", "products", "customers"],
     "jira": ["issues", "projects"],
     "slack": ["channels", "users"],
-    # The three below cannot build a source at all (core#543): no verified
-    # source, no REST fallback. Their lists are left as the verified sources
-    # describe them and are excluded from the contract test until that is fixed.
+    # google_analytics and google_ads still cannot build a source at all
+    # (core#543) and stay out of the contract test. Their lists are what the
+    # verified sources describe, not what any code here can produce.
     "google_analytics": ["report"],
     "google_ads": ["customers", "campaigns", "ad_groups", "ads"],
-    "facebook_ads": ["campaigns", "ad_sets", "ads", "leads", "creatives"],
+    # facebook_ads now builds via the Graph API fallback. `leads` is gone on
+    # purpose: it is not an ad-account edge (lead records hang off a lead-gen
+    # form, not the account), so offering it would tick a box for a resource
+    # the loader cannot fetch — the core#532 mistake in miniature.
+    "facebook_ads": ["ad_sets", "ads", "campaigns", "creatives"],
     "zendesk": ["organizations", "tickets", "users"],
     "airtable": ["tables"],
     "notion": ["databases", "pages"],

--- a/tests/test_services/test_facebook_ads_fallback.py
+++ b/tests/test_services/test_facebook_ads_fallback.py
@@ -1,0 +1,142 @@
+"""Facebook Ads loads via the Graph API fallback (core#543).
+
+Three connectors could only ever fail: `google_analytics`, `google_ads` and
+`facebook_ads` had no REST fallback, so their `except ImportError` re-raised
+*"run `dlt init <source>`"* — an instruction for a server the user does not
+operate, and the sole outcome of every run. All three are advertised on the
+marketing site with setup guides walking through credential creation for a load
+that cannot succeed.
+
+They are not equivalent, which is why only one is fixed here:
+
+* **facebook_ads** — the Graph API takes exactly the two fields the connection
+  form already collects (`access_token`, `account_id`). A fallback is
+  constructible today, and it is what this file covers.
+* **google_analytics** — `runReport` takes a POST body naming dimensions and
+  metrics. A report shape is a product decision, not a default.
+* **google_ads** — every request carries a `developer-token` header and the form
+  collects no such field, so nothing we store can authenticate. Needs a schema
+  change and an application to Google before any transport can work.
+
+**Verified against the documented Marketing API edges, not a live account** —
+there are no Facebook credentials here or in CI. This replaces a guaranteed
+failure with a plausible one; the first real run is the actual test. The parts
+asserted below are the parts that do not depend on Facebook: which resources
+exist, what paths they address, and that the account id is normalised.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from datanika.services.dlt_runner import DEFAULT_FACEBOOK_API_VERSION, DltRunnerService
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _built_config(svc, config, dlt_config=None):
+    """The config handed to `rest_api_source` — base URL, auth and paths.
+
+    A built `DltResource` does not expose its request path: `_hints` is only
+    ``{'columns': {}, 'write_disposition': 'append'}``. An earlier version of
+    this file asserted `"act_act_" not in repr(resource._hints)`, which passed
+    over a string that never contained a path at all — a check that could not
+    fail. Intercepting the call observes the thing we actually construct.
+    """
+    with patch("datanika.services.dlt_runner.rest_api_source") as mock_source:
+        svc.build_source("facebook_ads", config, dlt_config or {})
+    assert mock_source.call_count == 1, "expected exactly one rest_api_source call"
+    return mock_source.call_args[0][0]
+
+
+def _paths(built) -> dict[str, str]:
+    return {r["name"]: r["endpoint"]["path"] for r in built["resources"]}
+
+
+class TestItBuildsAtAll:
+    def test_a_source_is_returned_instead_of_raising(self, svc):
+        """The whole of core#543 for this connector: it used to be unreachable."""
+        source = svc.build_source("facebook_ads", {"access_token": "t", "account_id": "123"}, {})
+        assert source is not None
+
+    def test_it_builds_the_documented_ad_account_edges(self, svc):
+        source = svc.build_source("facebook_ads", {"access_token": "t", "account_id": "123"}, {})
+        assert set(source.resources.keys()) == {"campaigns", "ad_sets", "ads", "creatives"}
+
+    def test_leads_is_not_offered(self, svc):
+        """`leads` was in the picker and is not an ad-account edge.
+
+        Lead records hang off a lead-gen form, not the account, so offering it
+        would tick a box for something the loader cannot fetch — core#532 in
+        miniature, and the reason that entry was dropped rather than mapped to
+        a guessed path.
+        """
+        source = svc.build_source("facebook_ads", {"access_token": "t", "account_id": "123"}, {})
+        assert "leads" not in source.resources
+
+
+class TestAccountIdNormalisation:
+    """`act_` is part of the identifier and users paste it both ways."""
+
+    @pytest.mark.parametrize("account_id", ["123456789", "act_123456789"])
+    def test_either_form_is_accepted(self, svc, account_id):
+        source = svc.build_source(
+            "facebook_ads", {"access_token": "t", "account_id": account_id}, {}
+        )
+        assert set(source.resources.keys()) == {"campaigns", "ad_sets", "ads", "creatives"}
+
+    def test_the_prefix_is_not_doubled(self, svc):
+        """`act_act_123` would 404 on every request — a connection that looks
+        fine and returns nothing."""
+        built = _built_config(svc, {"access_token": "t", "account_id": "act_123"})
+        paths = _paths(built)
+
+        assert paths["campaigns"] == "act_123/campaigns"
+        assert not any("act_act_" in p for p in paths.values()), paths
+
+    def test_a_bare_id_gets_the_prefix(self, svc):
+        built = _built_config(svc, {"access_token": "t", "account_id": "123"})
+        assert _paths(built)["campaigns"] == "act_123/campaigns"
+
+    def test_every_resource_addresses_the_account(self, svc):
+        built = _built_config(svc, {"access_token": "t", "account_id": "123"})
+        for name, path in _paths(built).items():
+            assert path.startswith("act_123/"), f"{name} addresses {path!r}, not the ad account"
+
+
+class TestApiVersionIsConfigurable:
+    def test_it_defaults_to_the_pinned_version(self, svc):
+        built = _built_config(svc, {"access_token": "t", "account_id": "123"})
+        assert built["client"]["base_url"] == (
+            f"https://graph.facebook.com/{DEFAULT_FACEBOOK_API_VERSION}/"
+        )
+
+    def test_the_version_can_be_overridden_without_a_release(self, svc):
+        """Facebook retires versions on a rolling schedule.
+
+        When the default expires, that must be a setting to change rather than
+        a release to cut — otherwise every Facebook user stays broken until a
+        deploy lands.
+        """
+        built = _built_config(
+            svc, {"access_token": "t", "account_id": "123"}, {"api_version": "v99.0"}
+        )
+        assert built["client"]["base_url"] == "https://graph.facebook.com/v99.0/"
+
+    def test_the_token_is_sent_as_a_bearer(self, svc):
+        built = _built_config(svc, {"access_token": "secret-token", "account_id": "123"})
+        assert built["client"]["auth"] == {"type": "bearer", "token": "secret-token"}
+
+
+class TestSelectionApplies:
+    def test_the_endpoint_picker_narrows_the_load(self, svc):
+        """core#532's selection must work here too, not just for the older ten."""
+        source = svc.build_source(
+            "facebook_ads",
+            {"access_token": "t", "account_id": "123"},
+            {"endpoints": ["campaigns"]},
+        )
+        assert set(source.selected_resources.keys()) == {"campaigns"}

--- a/tests/test_services/test_saas_endpoint_selection.py
+++ b/tests/test_services/test_saas_endpoint_selection.py
@@ -38,17 +38,28 @@ SAAS_PROBE_CONFIG = {
     "pipedrive": {"api_key": "t"},
     "freshdesk": {"api_key": "t", "domain": "d"},
     "asana": {"api_key": "t"},
+    # Bare id on purpose: the builder normalises it to `act_…`, and users paste
+    # it both ways.
+    "facebook_ads": {"access_token": "t", "account_id": "123456789"},
 }
 
-# These three raise instead of building: no verified source is installed and they
-# have no REST fallback (core#543). Their picker entries cannot be validated
-# until that is resolved, and their accuracy is moot while the connector cannot
-# run at all. Config here is *valid* — the point is that the raise happens after
-# the required-field checks, not because of them.
+# These two still raise instead of building (core#543). `facebook_ads` moved out
+# when it gained a Graph API fallback — it is now validated like every other
+# connector by the tests below.
+#
+# The remaining two are not "a fallback nobody has written yet"; each is blocked
+# on something a fallback cannot supply:
+#   google_analytics — `runReport` takes a POST body naming dimensions and
+#                      metrics. A report shape is a product decision.
+#   google_ads       — every request needs a `developer-token` header, and the
+#                      connection form collects no such field, so nothing we
+#                      store can authenticate. Needs a schema change first.
+#
+# Config here is *valid* — the point is that the raise happens after the
+# required-field checks, not because of them.
 CANNOT_BUILD = {
     "google_analytics": {"property_id": "1", "service_account_json": "{}"},
     "google_ads": {"customer_id": "1", "service_account_json": "{}"},
-    "facebook_ads": {"access_token": "t", "account_id": "act_1"},
 }
 
 
@@ -86,11 +97,27 @@ class TestOfferedEndpointsExist:
     def test_the_unbuildable_ones_still_fail_loudly(self, svc, conn_type):
         """Documents core#543 rather than hiding it — move these up when it's fixed.
 
-        Asserted with *valid* config so the failure is the missing verified
-        source, not a missing field: these three raise for every user, always.
+        Asserted with *valid* config so the failure is the missing capability,
+        not a missing field: these two raise for every user, always.
         """
-        with pytest.raises(DltRunnerError, match="verified source not installed"):
+        with pytest.raises(DltRunnerError, match="not available on this deployment"):
             svc.build_source(conn_type, CANNOT_BUILD[conn_type], {})
+
+    @pytest.mark.parametrize("conn_type", sorted(CANNOT_BUILD))
+    def test_the_failure_names_something_the_reader_can_act_on(self, svc, conn_type):
+        """The error used to say "run `dlt init …`" — on a server they don't operate.
+
+        Same class as the s3 message in core#499: advice the reader cannot
+        follow. Here it was also the *only* outcome, every time. The replacement
+        has to name the real blocker and not send anyone to a terminal they
+        have no access to.
+        """
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source(conn_type, CANNOT_BUILD[conn_type], {})
+
+        message = str(exc.value)
+        assert "dlt init" not in message, f"still tells the user to run dlt init: {message}"
+        assert "core#543" in message, "the message should point at the tracking issue"
 
 
 class TestSelectionNarrowsTheLoad:


### PR DESCRIPTION
Refs #543 — **not** closes: two of the three remain blocked, for reasons that are not "nobody wrote the fallback yet".

Three connectors could only ever fail. `google_analytics`, `google_ads` and `facebook_ads` had no REST fallback, so their `except ImportError` re-raised *"run `dlt init <source>`"* — an instruction for a server the user does not operate, and the sole outcome of every run. All three are advertised with setup guides walking through credential creation for a load that cannot succeed.

## Direction changed from the issue

#543 recommends option (1), bundling the verified sources, as *"the smallest change with the largest effect"*. The Dockerfile argues the opposite, deliberately:

```
# Note: dlt verified sources (Stripe, GitHub, HubSpot, etc.) use REST API
# fallback when not installed via `dlt init`. This avoids dependency conflicts
# in Docker.
```

So REST-fallback-everywhere is the *intended* architecture. What was actually wrong is `_build_saas_source`'s docstring claiming the sources are "bundled via `dlt init` at Docker build time" — **nothing bundles them, in dev or prod**. Option (2) is the consistent fix, and #532's endpoint selection now depends on it. The docstring is corrected to say which path actually runs, and why the verified-source branches are kept anyway (a self-hoster may run `dlt init`).

## The three are not equivalent

The issue's option list assumed they were. Only one is fixable by writing a fallback:

| connector | blocker | status |
|---|---|---|
| **facebook_ads** | none — the Graph API takes exactly the two fields the form already collects | **fixed here** |
| **google_analytics** | `runReport` takes a POST body naming dimensions and metrics; a report shape is a product decision, not a default | still blocked |
| **google_ads** | every request carries a `developer-token` header and the form collects **no such field** — nothing we store can authenticate, so no transport helps | still blocked, needs a schema change + an application to Google |

## What ships

- **Facebook Ads Graph API fallback** — four documented ad-account edges (`campaigns`, `adsets`, `ads`, `adcreatives`), `act_` normalised in both directions, and the API version overridable via `dlt_config`. Facebook retires versions on a rolling schedule; a retired default should be a setting to change, not a release to cut.
- **`leads` dropped from the picker.** It isn't an ad-account edge — lead records hang off a lead-gen form — so offering it would tick a box for a resource the loader cannot fetch. That's #532 in miniature.
- **GA and Google Ads now fail honestly**, naming the real blocker instead of sending the reader to a terminal they have no access to (the #499 class). Tested: the message must not contain `dlt init` and must name the tracking issue.
- **`facebook_ads` moved out of the contract test's `CANNOT_BUILD`**, so its picker entries are now validated against what the loader builds, like every other connector. That immediately forced adding it to the probe config — the test doing its job.

## A test-honesty note

The first version of `test_the_prefix_is_not_doubled` asserted `"act_act_" not in repr(resource._hints)`. `_hints` is only `{'columns': {}, 'write_disposition': 'append'}` — the path never appears in it, so **the check could not fail**. It now intercepts `rest_api_source` and asserts on the config we actually construct (`act_123/campaigns`). Worth flagging given how much of this week has been about exactly that failure mode.

## Scope of verification — stated, not implied

Built against the **documented** Marketing API edges, **not a live account**: there are no Facebook credentials here or in CI. This replaces a guaranteed failure with a plausible one, and **the first real run is the actual test**. The default `v21.0` may need bumping, which is why it's configurable rather than baked into the path.

Precheck: **2713 passed, 20 skipped.**
