### PR TITLE
[Infra] Promote dev → master: vhost rollback backs up content, not the symlink

### DIFF
--- a/.github/workflows/deploy-pointer.yml
+++ b/.github/workflows/deploy-pointer.yml
@@ -103,14 +103,21 @@ jobs:
           set -e
           SRC=/opt/datanika/datanika/deploy/apache
           changed=0
+          # sites-enabled holds SYMLINKS into sites-available. Resolve once and work on the
+          # real file: `cp -a` on the link would back up the LINK, leaving a dangling relative
+          # symlink and no content -- a rollback that silently restores nothing, discovered
+          # only when configtest fails and it is too late.
           sync_one() {
-            src="$SRC/$1"; live="/etc/apache2/sites-enabled/$2"
+            src="$SRC/$1"
+            link="/etc/apache2/sites-enabled/$2"
             [ -f "$src" ] || { echo "missing in repo: $src"; exit 1; }
-            if ! cmp -s "$src" "$live"; then
-              cp -a "$live" "/tmp/$2.bak"
-              cp "$src" "$live"
+            target=$(readlink -f "$link")
+            [ -f "$target" ] || { echo "vhost target missing: $link -> $target"; exit 1; }
+            if ! cmp -s "$src" "$target"; then
+              cp "$target" "/tmp/$2.bak"          # content, not the link
+              cp "$src" "$target"
               changed=1
-              echo "vhost changed: $2"
+              echo "vhost changed: $2 ($target)"
             fi
           }
           sync_one app.datanika.io.conf         zapp-datanika-io.conf
@@ -122,7 +129,8 @@ jobs:
           else
             echo "CONFIGTEST FAILED - restoring previous vhosts:"; cat /tmp/ct.log
             for d in zapp-datanika-io.conf zstaging-app-datanika-io.conf; do
-              [ -f "/tmp/$d.bak" ] && cp "/tmp/$d.bak" "/etc/apache2/sites-enabled/$d"
+              t=$(readlink -f "/etc/apache2/sites-enabled/$d")
+              if [ -f "/tmp/$d.bak" ]; then cp "/tmp/$d.bak" "$t"; echo "restored $d"; fi
             done
             apachectl configtest
             exit 1

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -75,6 +75,12 @@ SUPPORTED_SAAS_TYPES = {
 # Kafka is a streaming source with its own builder
 SUPPORTED_KAFKA_TYPES = {"kafka"}
 
+#: Graph API version for the Facebook Ads fallback. Facebook retires versions on
+#: a rolling ~2-year schedule, so this is a config-overridable default
+#: (`dlt_config["api_version"]`) rather than a constant baked into the path — a
+#: retired version should be a setting to change, not a release to cut.
+DEFAULT_FACEBOOK_API_VERSION = "v21.0"
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -786,11 +792,24 @@ class DltRunnerService:
         )
 
     def _build_saas_source(self, connection_type: str, config: dict, dlt_config: dict):
-        """Build a dlt verified source for SaaS connectors.
+        """Build a source for a SaaS connector.
 
-        Uses official dlt verified sources (bundled via ``dlt init`` at Docker
-        build time).  Falls back to a generic REST API source when the verified
-        source module is not installed.
+        **The REST fallback is the real implementation, not the fallback.** This
+        docstring used to say the verified sources were "bundled via ``dlt init``
+        at Docker build time"; nothing bundles them, and the Dockerfile says so
+        deliberately — *"dlt verified sources … use REST API fallback when not
+        installed via `dlt init`. This avoids dependency conflicts in Docker."*
+        So in every deployment, dev and prod alike, each ``from <source> import``
+        below raises ``ImportError`` and the fallback runs (core#543).
+
+        That mattered twice: the picker offered resource names taken from the
+        verified sources while the fallback built different ones (core#532), and
+        the three connectors with **no** fallback were not degraded but dead —
+        their ``except ImportError`` re-raised, so a run could only ever fail.
+
+        The verified-source branches are kept because a self-hoster may run
+        ``dlt init``, and the imports are what make that work with no code
+        change. They are simply not the path anyone here exercises.
         """
         if connection_type == "stripe":
             api_key = config.get("api_key") or config.get("stripe_secret_key", "")
@@ -1051,8 +1070,20 @@ class DltRunnerService:
                     kwargs_ga["credentials"] = credentials_json
                 return google_analytics(**kwargs_ga)
             except ImportError:
+                # Was "run dlt init google_analytics" — an instruction for a
+                # server the user does not operate, and the only outcome this
+                # connector has ever produced (core#543, same class as #499).
+                #
+                # No REST fallback yet, and unlike Facebook it is not a matter
+                # of writing one: the Data API needs an OAuth token minted from
+                # the service-account JSON, and `runReport` takes a POST body
+                # naming dimensions and metrics — a report shape is a product
+                # decision, not a default. Tracked separately.
                 raise DltRunnerError(
-                    "Google Analytics verified source not installed (run dlt init google_analytics)"
+                    "Google Analytics is not available on this deployment yet. It needs a "
+                    "reporting query (dimensions and metrics) that Datanika does not collect, "
+                    "so there is nothing to configure on your side — see core#543. "
+                    "Google Sheets or a REST API connection can cover GA exports meanwhile."
                 ) from None
 
         if connection_type == "google_ads":
@@ -1065,8 +1096,17 @@ class DltRunnerService:
 
                 return google_ads(customer_id=customer_id)
             except ImportError:
+                # Also not writable as a REST fallback, and for a harder reason
+                # than Google Analytics: every Google Ads API request carries a
+                # `developer-token` header, and the connection form collects no
+                # such field — so no transport can authenticate with what we
+                # store. Obtaining one is an application to Google, not a
+                # setting. Needs a schema change first (core#543).
                 raise DltRunnerError(
-                    "Google Ads verified source not installed (run dlt init google_ads)"
+                    "Google Ads is not available on this deployment. The Google Ads API "
+                    "requires a developer token, which Datanika does not currently collect, "
+                    "so this connection cannot authenticate — see core#543. Nothing you can "
+                    "change in the connection settings will fix this."
                 ) from None
 
         if connection_type == "facebook_ads":
@@ -1079,9 +1119,29 @@ class DltRunnerService:
 
                 return facebook_ads_source(account_id=account_id, access_token=access_token)
             except ImportError:
-                raise DltRunnerError(
-                    "Facebook Ads verified source not installed (run dlt init facebook_ads)"
-                ) from None
+                # Falls back to the Graph API like every other SaaS connector
+                # (core#543). Before this, the ImportError re-raised "run
+                # dlt init facebook_ads" — advice for a server the user does
+                # not operate, and the only possible outcome, every time.
+                #
+                # `act_` is part of the ad-account identifier; users paste it
+                # inconsistently, so it is normalised rather than demanded.
+                account = account_id if str(account_id).startswith("act_") else f"act_{account_id}"
+                version = dlt_config.get("api_version") or DEFAULT_FACEBOOK_API_VERSION
+                return self._rest_api_fallback(
+                    f"https://graph.facebook.com/{version}/",
+                    {"type": "bearer", "token": access_token},
+                    dlt_config.get("resources")
+                    or [
+                        {"name": "campaigns", "endpoint": {"path": f"{account}/campaigns"}},
+                        # Resource names are the picker's; paths are Facebook's.
+                        # `ad_sets`/`creatives` read better than `adsets`/
+                        # `adcreatives` and the two are independent here.
+                        {"name": "ad_sets", "endpoint": {"path": f"{account}/adsets"}},
+                        {"name": "ads", "endpoint": {"path": f"{account}/ads"}},
+                        {"name": "creatives", "endpoint": {"path": f"{account}/adcreatives"}},
+                    ],
+                )
 
         if connection_type == "zendesk":
             subdomain = config.get("subdomain", "") or config.get("domain", "")

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -92,12 +92,16 @@ SAAS_DEFAULT_ENDPOINTS: dict[str, list[str]] = {
     "shopify": ["orders", "products", "customers"],
     "jira": ["issues", "projects"],
     "slack": ["channels", "users"],
-    # The three below cannot build a source at all (core#543): no verified
-    # source, no REST fallback. Their lists are left as the verified sources
-    # describe them and are excluded from the contract test until that is fixed.
+    # google_analytics and google_ads still cannot build a source at all
+    # (core#543) and stay out of the contract test. Their lists are what the
+    # verified sources describe, not what any code here can produce.
     "google_analytics": ["report"],
     "google_ads": ["customers", "campaigns", "ad_groups", "ads"],
-    "facebook_ads": ["campaigns", "ad_sets", "ads", "leads", "creatives"],
+    # facebook_ads now builds via the Graph API fallback. `leads` is gone on
+    # purpose: it is not an ad-account edge (lead records hang off a lead-gen
+    # form, not the account), so offering it would tick a box for a resource
+    # the loader cannot fetch — the core#532 mistake in miniature.
+    "facebook_ads": ["ad_sets", "ads", "campaigns", "creatives"],
     "zendesk": ["organizations", "tickets", "users"],
     "airtable": ["tables"],
     "notion": ["databases", "pages"],

--- a/tests/test_services/test_facebook_ads_fallback.py
+++ b/tests/test_services/test_facebook_ads_fallback.py
@@ -1,0 +1,142 @@
+"""Facebook Ads loads via the Graph API fallback (core#543).
+
+Three connectors could only ever fail: `google_analytics`, `google_ads` and
+`facebook_ads` had no REST fallback, so their `except ImportError` re-raised
+*"run `dlt init <source>`"* — an instruction for a server the user does not
+operate, and the sole outcome of every run. All three are advertised on the
+marketing site with setup guides walking through credential creation for a load
+that cannot succeed.
+
+They are not equivalent, which is why only one is fixed here:
+
+* **facebook_ads** — the Graph API takes exactly the two fields the connection
+  form already collects (`access_token`, `account_id`). A fallback is
+  constructible today, and it is what this file covers.
+* **google_analytics** — `runReport` takes a POST body naming dimensions and
+  metrics. A report shape is a product decision, not a default.
+* **google_ads** — every request carries a `developer-token` header and the form
+  collects no such field, so nothing we store can authenticate. Needs a schema
+  change and an application to Google before any transport can work.
+
+**Verified against the documented Marketing API edges, not a live account** —
+there are no Facebook credentials here or in CI. This replaces a guaranteed
+failure with a plausible one; the first real run is the actual test. The parts
+asserted below are the parts that do not depend on Facebook: which resources
+exist, what paths they address, and that the account id is normalised.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from datanika.services.dlt_runner import DEFAULT_FACEBOOK_API_VERSION, DltRunnerService
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _built_config(svc, config, dlt_config=None):
+    """The config handed to `rest_api_source` — base URL, auth and paths.
+
+    A built `DltResource` does not expose its request path: `_hints` is only
+    ``{'columns': {}, 'write_disposition': 'append'}``. An earlier version of
+    this file asserted `"act_act_" not in repr(resource._hints)`, which passed
+    over a string that never contained a path at all — a check that could not
+    fail. Intercepting the call observes the thing we actually construct.
+    """
+    with patch("datanika.services.dlt_runner.rest_api_source") as mock_source:
+        svc.build_source("facebook_ads", config, dlt_config or {})
+    assert mock_source.call_count == 1, "expected exactly one rest_api_source call"
+    return mock_source.call_args[0][0]
+
+
+def _paths(built) -> dict[str, str]:
+    return {r["name"]: r["endpoint"]["path"] for r in built["resources"]}
+
+
+class TestItBuildsAtAll:
+    def test_a_source_is_returned_instead_of_raising(self, svc):
+        """The whole of core#543 for this connector: it used to be unreachable."""
+        source = svc.build_source("facebook_ads", {"access_token": "t", "account_id": "123"}, {})
+        assert source is not None
+
+    def test_it_builds_the_documented_ad_account_edges(self, svc):
+        source = svc.build_source("facebook_ads", {"access_token": "t", "account_id": "123"}, {})
+        assert set(source.resources.keys()) == {"campaigns", "ad_sets", "ads", "creatives"}
+
+    def test_leads_is_not_offered(self, svc):
+        """`leads` was in the picker and is not an ad-account edge.
+
+        Lead records hang off a lead-gen form, not the account, so offering it
+        would tick a box for something the loader cannot fetch — core#532 in
+        miniature, and the reason that entry was dropped rather than mapped to
+        a guessed path.
+        """
+        source = svc.build_source("facebook_ads", {"access_token": "t", "account_id": "123"}, {})
+        assert "leads" not in source.resources
+
+
+class TestAccountIdNormalisation:
+    """`act_` is part of the identifier and users paste it both ways."""
+
+    @pytest.mark.parametrize("account_id", ["123456789", "act_123456789"])
+    def test_either_form_is_accepted(self, svc, account_id):
+        source = svc.build_source(
+            "facebook_ads", {"access_token": "t", "account_id": account_id}, {}
+        )
+        assert set(source.resources.keys()) == {"campaigns", "ad_sets", "ads", "creatives"}
+
+    def test_the_prefix_is_not_doubled(self, svc):
+        """`act_act_123` would 404 on every request — a connection that looks
+        fine and returns nothing."""
+        built = _built_config(svc, {"access_token": "t", "account_id": "act_123"})
+        paths = _paths(built)
+
+        assert paths["campaigns"] == "act_123/campaigns"
+        assert not any("act_act_" in p for p in paths.values()), paths
+
+    def test_a_bare_id_gets_the_prefix(self, svc):
+        built = _built_config(svc, {"access_token": "t", "account_id": "123"})
+        assert _paths(built)["campaigns"] == "act_123/campaigns"
+
+    def test_every_resource_addresses_the_account(self, svc):
+        built = _built_config(svc, {"access_token": "t", "account_id": "123"})
+        for name, path in _paths(built).items():
+            assert path.startswith("act_123/"), f"{name} addresses {path!r}, not the ad account"
+
+
+class TestApiVersionIsConfigurable:
+    def test_it_defaults_to_the_pinned_version(self, svc):
+        built = _built_config(svc, {"access_token": "t", "account_id": "123"})
+        assert built["client"]["base_url"] == (
+            f"https://graph.facebook.com/{DEFAULT_FACEBOOK_API_VERSION}/"
+        )
+
+    def test_the_version_can_be_overridden_without_a_release(self, svc):
+        """Facebook retires versions on a rolling schedule.
+
+        When the default expires, that must be a setting to change rather than
+        a release to cut — otherwise every Facebook user stays broken until a
+        deploy lands.
+        """
+        built = _built_config(
+            svc, {"access_token": "t", "account_id": "123"}, {"api_version": "v99.0"}
+        )
+        assert built["client"]["base_url"] == "https://graph.facebook.com/v99.0/"
+
+    def test_the_token_is_sent_as_a_bearer(self, svc):
+        built = _built_config(svc, {"access_token": "secret-token", "account_id": "123"})
+        assert built["client"]["auth"] == {"type": "bearer", "token": "secret-token"}
+
+
+class TestSelectionApplies:
+    def test_the_endpoint_picker_narrows_the_load(self, svc):
+        """core#532's selection must work here too, not just for the older ten."""
+        source = svc.build_source(
+            "facebook_ads",
+            {"access_token": "t", "account_id": "123"},
+            {"endpoints": ["campaigns"]},
+        )
+        assert set(source.selected_resources.keys()) == {"campaigns"}

--- a/tests/test_services/test_saas_endpoint_selection.py
+++ b/tests/test_services/test_saas_endpoint_selection.py
@@ -38,17 +38,28 @@ SAAS_PROBE_CONFIG = {
     "pipedrive": {"api_key": "t"},
     "freshdesk": {"api_key": "t", "domain": "d"},
     "asana": {"api_key": "t"},
+    # Bare id on purpose: the builder normalises it to `act_…`, and users paste
+    # it both ways.
+    "facebook_ads": {"access_token": "t", "account_id": "123456789"},
 }
 
-# These three raise instead of building: no verified source is installed and they
-# have no REST fallback (core#543). Their picker entries cannot be validated
-# until that is resolved, and their accuracy is moot while the connector cannot
-# run at all. Config here is *valid* — the point is that the raise happens after
-# the required-field checks, not because of them.
+# These two still raise instead of building (core#543). `facebook_ads` moved out
+# when it gained a Graph API fallback — it is now validated like every other
+# connector by the tests below.
+#
+# The remaining two are not "a fallback nobody has written yet"; each is blocked
+# on something a fallback cannot supply:
+#   google_analytics — `runReport` takes a POST body naming dimensions and
+#                      metrics. A report shape is a product decision.
+#   google_ads       — every request needs a `developer-token` header, and the
+#                      connection form collects no such field, so nothing we
+#                      store can authenticate. Needs a schema change first.
+#
+# Config here is *valid* — the point is that the raise happens after the
+# required-field checks, not because of them.
 CANNOT_BUILD = {
     "google_analytics": {"property_id": "1", "service_account_json": "{}"},
     "google_ads": {"customer_id": "1", "service_account_json": "{}"},
-    "facebook_ads": {"access_token": "t", "account_id": "act_1"},
 }
 
 
@@ -86,11 +97,27 @@ class TestOfferedEndpointsExist:
     def test_the_unbuildable_ones_still_fail_loudly(self, svc, conn_type):
         """Documents core#543 rather than hiding it — move these up when it's fixed.
 
-        Asserted with *valid* config so the failure is the missing verified
-        source, not a missing field: these three raise for every user, always.
+        Asserted with *valid* config so the failure is the missing capability,
+        not a missing field: these two raise for every user, always.
         """
-        with pytest.raises(DltRunnerError, match="verified source not installed"):
+        with pytest.raises(DltRunnerError, match="not available on this deployment"):
             svc.build_source(conn_type, CANNOT_BUILD[conn_type], {})
+
+    @pytest.mark.parametrize("conn_type", sorted(CANNOT_BUILD))
+    def test_the_failure_names_something_the_reader_can_act_on(self, svc, conn_type):
+        """The error used to say "run `dlt init …`" — on a server they don't operate.
+
+        Same class as the s3 message in core#499: advice the reader cannot
+        follow. Here it was also the *only* outcome, every time. The replacement
+        has to name the real blocker and not send anyone to a terminal they
+        have no access to.
+        """
+        with pytest.raises(DltRunnerError) as exc:
+            svc.build_source(conn_type, CANNOT_BUILD[conn_type], {})
+
+        message = str(exc.value)
+        assert "dlt init" not in message, f"still tells the user to run dlt init: {message}"
+        assert "core#543" in message, "the message should point at the tracking issue"
 
 
 class TestSelectionNarrowsTheLoad:

--- a/tests/test_services/test_source_builders_move_rows.py
+++ b/tests/test_services/test_source_builders_move_rows.py
@@ -1,0 +1,342 @@
+"""Real-data row probes for the source builders that need no credentials (core#545).
+
+## Why this file exists
+
+#492 (P0) shipped for months: `csv`/`json`/`parquet`/`s3` loaded a **file listing**
+instead of file contents. 2,500 green tests could not have caught it, because every
+test in ``TestBuildFileSource`` patches ``dlt_runner.filesystem`` and asserts *the
+kwargs we passed in* — what dlt actually **yields** was unobservable to all of them.
+
+``tests/test_services/test_dlt_runner.py`` has 140 tests and 103 ``@patch``
+decorators; ``sql_database`` is patched 24 times, *more* than ``filesystem``'s 7.
+The mocking pattern is not specific to files — it is how that module is tested
+throughout. So the audit question is not "were we sloppy about files" but **"which
+builders have ever been proven to move a row?"**
+
+This suite answers that for the builders provable **without any credential, any
+vendor account, or staging**: a real source, a real dlt pipeline, a real DuckDB
+destination, and the assertion made by **reading the destination back** — never off
+``result["rows_loaded"]``, which is a number the pipeline reports about itself.
+
+Deliberately NOT in ``tests/test_connector_smoke/``: that directory is gated behind
+``DATANIKA_CONNECTOR_SMOKE=1`` for the whole collection, so these would be skipped
+in PR CI — which is exactly where a credential-free probe belongs.
+
+## What this does not do (core#545 "not in scope")
+
+It does not convert the 103 mocked tests to integration tests. Mocks are the right
+tool for "did we pass the right kwargs"; the defect was that **nothing else
+existed**. This is the thin layer that was missing, not a replacement.
+
+## Coverage limits, stated here rather than left implicit
+
+- One resource / one collection per builder. These prove *rows arrive*, not that
+  pagination, incremental cursors, auth flows or schema contracts are correct.
+- ``google_sheets`` and ``saas`` are absent: both need accounts. ``saas`` is also
+  being actively rewritten (#532, #543) — auditing a moving target re-discovers
+  findings that already have issue numbers.
+- A pass here says the builder can move a row **today, on this shape of data**. It
+  is a floor, not a guarantee.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import threading
+
+import duckdb
+import pytest
+
+from datanika.services.dlt_runner import DltRunnerService
+
+# ── The fixture payloads ────────────────────────────────────────────────────────
+# Distinct values per row so a "rows landed" assertion cannot be satisfied by the
+# same record repeated, and a column with a non-trivial value so we can prove the
+# *contents* arrived rather than a listing of them (the #492 failure mode).
+WIDGETS = [
+    {"id": 1, "name": "alpha", "price": 100},
+    {"id": 2, "name": "beta", "price": 200},
+    {"id": 3, "name": "gamma", "price": 300},
+]
+
+
+class _JsonHandler(http.server.BaseHTTPRequestHandler):
+    """Serves the fixture over a real socket — no `requests` mocking anywhere.
+
+    #404 established this pattern: it proved redirect-hop behaviour against a real
+    server rather than by reading `requests` internals. Same reasoning here — the
+    whole point is to observe what dlt *yields*, which a mock cannot show.
+    """
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path.startswith("/widgets"):
+            body = json.dumps(WIDGETS).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+    def log_message(self, *args):  # silence per-request noise in pytest output
+        pass
+
+
+@pytest.fixture
+def json_api():
+    """A real HTTP server on an ephemeral loopback port. Yields its base URL."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _JsonHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def allow_loopback(monkeypatch):
+    """Let the egress guard reach a loopback test server.
+
+    Three patches, not one — this is the shape established in
+    ``tests/test_services/test_openapi_fetch.py`` and it is not optional:
+
+    1. ``dlt_runner.validate_egress_host`` — the pre-flight check in
+       ``_rest_api_from_parts``.
+    2. ``egress_guard.validate_egress_host`` — the guarded session re-validates
+       every request the worker actually makes.
+    3. ``egress_guard.resolve_public_ip`` — since #405 the session resolves **once**
+       and pins the address, so no-oping only the validators leaves the adapter
+       still refusing to connect. Patching the validator alone silently does not
+       reach the server, which is the trap #441 recorded.
+
+    The guard's real behaviour is covered by ``tests/test_security/`` — this fixture
+    exists so a row probe can run offline, not to weaken the guard.
+    """
+    monkeypatch.setattr("datanika.services.dlt_runner.validate_egress_host", lambda url: None)
+    monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    monkeypatch.setattr(
+        "datanika.services.egress_guard.resolve_public_ip", lambda hostname: "127.0.0.1"
+    )
+
+
+def _extract_load(tmp_path, source_type: str, source_config: dict, dlt_config: dict) -> str:
+    """Drive the REAL ``DltRunnerService.execute()`` into a scratch DuckDB.
+
+    Same entrypoint the upload task calls (``upload_tasks.py`` → ``runner.execute``),
+    so this exercises dispatch + build + extract + load, not just the builder.
+    Returns the DuckDB path; the caller reads it back.
+    """
+    db_path = str(tmp_path / "scratch.duckdb")
+    runner = DltRunnerService(pipelines_dir=str(tmp_path / "dlt"))
+    runner.execute(
+        pipeline_id=1,
+        source_type=source_type,
+        source_config=source_config,
+        destination_type="duckdb",
+        destination_config={"path": db_path},
+        dlt_config={"write_disposition": "replace", **dlt_config},
+        dataset_name="probe",
+        run_id=1,
+    )
+    return db_path
+
+
+def _rows(db_path: str, table: str) -> list[tuple]:
+    """Read the destination back. The assertion source of truth.
+
+    Deliberately NOT ``result["rows_loaded"]``: that is the pipeline's own report
+    of its work. #492 is precisely the case where the count looked plausible and
+    the contents were wrong — one row per file, being the file's *name*.
+    """
+    con = duckdb.connect(db_path)
+    try:
+        return con.execute(f'SELECT name, price FROM "probe"."{table}" ORDER BY price').fetchall()
+    finally:
+        con.close()
+
+
+class TestRestApiSourceMovesRows:
+    """``_build_rest_api_source`` — previously mocked-only (core#545)."""
+
+    def test_rows_land_in_the_destination(self, tmp_path, json_api, allow_loopback):
+        db_path = _extract_load(
+            tmp_path,
+            "rest_api",
+            {"base_url": json_api},
+            {"resources": [{"name": "widgets", "endpoint": {"path": "widgets"}}]},
+        )
+
+        rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)], (
+            "rest_api did not deliver the record CONTENTS into DuckDB. Rows landing "
+            "with the wrong shape — e.g. one row per resource naming it — is #492's "
+            "failure mode, which a kwargs assertion cannot see."
+        )
+
+
+class TestOpenApiSourceMovesRows:
+    """``_build_openapi_source`` — previously mocked-only (core#545).
+
+    Distinct from rest_api despite sharing ``_rest_api_from_parts``: it reads the
+    catalog off the *connection* and selects via ``dlt_config["resource_names"]``,
+    stripping the private ``columns`` / ``_source`` keys before handing resources
+    to dlt. That stripping is a real transformation with no other live coverage.
+    """
+
+    def test_rows_land_for_the_selected_resource(self, tmp_path, json_api, allow_loopback):
+        db_path = _extract_load(
+            tmp_path,
+            "openapi",
+            {
+                "base_url": json_api,
+                "resources": [
+                    {
+                        "name": "widgets",
+                        "endpoint": {"path": "widgets"},
+                        # Private keys the builder must strip; dlt rejects unknown keys.
+                        "columns": {"id": {"data_type": "bigint"}},
+                        "_source": "probe-spec",
+                    }
+                ],
+            },
+            {"resource_names": ["widgets"]},
+        )
+
+        rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)], (
+            "openapi did not deliver record contents into DuckDB — check that "
+            "`columns`/`_source` stripping still produces a resource dlt accepts."
+        )
+
+
+def _docker_available() -> bool:
+    try:
+        import docker
+
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+
+
+# In CI this must FAIL rather than skip: a probe that skips when its dependency is
+# missing reports green while testing nothing, which is strictly worse than red
+# (core#407, and the same rule the connector-smoke conftest states). Locally,
+# without Docker, skipping is the honest answer — you have not disproved anything.
+requires_docker = pytest.mark.skipif(
+    not _docker_available() and not os.environ.get("CI"),
+    reason="Docker unavailable locally; in CI this is a hard failure, not a skip",
+)
+
+
+@requires_docker
+class TestMongoDbSourceMovesRows:
+    """``_build_mongodb_source`` — and it cannot authenticate today (core#550).
+
+    A real mongod, seeded through pymongo, extracted by our own ``mongodb_source``
+    (not a dlt verified source) into DuckDB. It fails at authentication, and the
+    cause is the builder rather than this harness — measured on one container with
+    one set of credentials, varying only the auth database:
+
+        mongodb://u:p@host:port/probedb                   -> Authentication failed
+        mongodb://u:p@host:port/probedb?authSource=admin  -> OK
+        mongodb://u:p@host:port/admin                     -> OK
+
+    The builder emits the first shape. MongoDB users conventionally live in
+    ``admin`` (``MONGO_INITDB_ROOT_USERNAME``, Atlas, every managed provider), and
+    the database in the URI path doubles as the auth database — so authenticated
+    deployments are rejected. Unauthenticated mongod is unaffected, which is what a
+    local dev instance looks like and presumably why this went unnoticed.
+
+    ``strict=True``: when the fix lands this XPASSes, pytest turns that into a
+    failure, and the marker must come off. The fix cannot land silently.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="core#550: the MongoDB URI sets no authSource, so users in admin are rejected",
+    )
+    def test_rows_land_in_the_destination(self, tmp_path):
+        from testcontainers.mongodb import MongoDbContainer
+
+        with MongoDbContainer("mongo:7") as mongo:
+            client = mongo.get_connection_client()
+            client["probedb"]["widgets"].insert_many([dict(w) for w in WIDGETS])
+
+            db_path = _extract_load(
+                tmp_path,
+                "mongodb",
+                {
+                    "host": mongo.get_container_host_ip(),
+                    "port": int(mongo.get_exposed_port(27017)),
+                    "user": mongo.username,
+                    "password": mongo.password,
+                    "database": "probedb",
+                },
+                {"collection_names": ["widgets"]},
+            )
+
+            rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)], (
+            "mongodb did not deliver document contents into DuckDB."
+        )
+
+
+@requires_docker
+class TestKafkaSourceMovesRows:
+    """``_build_kafka_source`` — and it cannot move a row at all today (core#551).
+
+    ``_build_kafka_source`` does ``from kafka import kafka_consumer``. That name
+    belongs to the **dlt verified source** created by ``dlt init kafka`` — not to
+    ``kafka-python``, which exports ``KafkaConsumer``. Neither ships: the lock has
+    no kafka package, ``confluent-kafka`` is commented out in ``pyproject.toml``,
+    and nothing is vendored. So the import always raises and the builder always
+    raises ``DltRunnerError("Kafka verified source not installed")``.
+
+    ``strict=True`` is the point. Today this xfails. The moment someone makes Kafka
+    work, it XPASSes, pytest turns that into a **failure**, and the marker has to
+    come off — so the fix cannot land silently and this cannot rot into a test that
+    asserts the bug is correct behaviour.
+
+    Note what the nightly Kafka smoke does and does not prove: it lists topics with
+    ``kafka-python`` installed *by the workflow*, so it proves the sandbox is
+    reachable. It never touches this builder. That is #545's thesis exactly — a
+    green about connectivity read as a green about rows.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="core#551: no kafka library ships, so _build_kafka_source always raises",
+    )
+    def test_rows_land_in_the_destination(self, tmp_path):
+        from testcontainers.kafka import KafkaContainer
+
+        with KafkaContainer() as kafka:
+            from kafka import KafkaProducer  # noqa: F401 — absent today; see docstring
+
+            producer = KafkaProducer(
+                bootstrap_servers=kafka.get_bootstrap_server(),
+                value_serializer=lambda v: json.dumps(v).encode(),
+            )
+            for widget in WIDGETS:
+                producer.send("widgets", widget)
+            producer.flush()
+
+            db_path = _extract_load(
+                tmp_path,
+                "kafka",
+                {"bootstrap_servers": kafka.get_bootstrap_server(), "group_id": "probe"},
+                {"topics": ["widgets"]},
+            )
+
+            rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)]


### PR DESCRIPTION
#550 — `sites-enabled` holds symlinks, so the rollback shipped with #525 backed up the *link* and stored no content; a configtest failure would have restored nothing, precisely when it mattered. Now resolves with `readlink -f` and copies content both ways.

Carries whatever else has landed on dev since the last promotion.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #550 — [QA] MongoDB source cannot authenticate: the connection URI sets no authSource, so users in admin are rejected _(already closed)_ · via #553, commit 9b435a4

<!-- promotion-refs:end -->