### PR TITLE
[QA] Row probe for the SQL path — sql_database + sql_table PROVEN, last unproven builder closed (refs #545)

### DIFF
--- a/tests/test_services/test_source_builders_move_rows.py
+++ b/tests/test_services/test_source_builders_move_rows.py
@@ -237,6 +237,87 @@ requires_docker = pytest.mark.skipif(
 
 
 @requires_docker
+class TestSqlDatabaseSourceMovesRows:
+    """The SQL path — the last builder core#545 listed as unproven.
+
+    Its only prior evidence was **one manual prod run** (landing#280, 19 rows
+    verified in the destination). Everything automated was mocked: ``sql_database``
+    is patched 24 times in ``test_dlt_runner.py``, more than ``filesystem``'s 7.
+
+    #545 argues this is the **lowest-risk** builder, and that argument is sound:
+    ``sql_database()`` yields rows by construction, so there is no
+    missing-transformer shape for #492's mechanism to recur in. Worth being precise
+    about what that means though — it says the *specific* defect cannot recur, not
+    that the path works. Credentials assembly, drivername mapping and the
+    user→username rename are all real transformations with no live coverage, and
+    #550 is exactly what an unexercised credentials path looks like one connector
+    over.
+
+    Both modes are covered because they call different dlt functions:
+      full_database → sql_database()
+      single_table  → sql_table()
+    """
+
+    @staticmethod
+    def _seed(postgres) -> dict:
+        """Create the fixture table and return the connection config the app stores."""
+        import sqlalchemy
+
+        engine = sqlalchemy.create_engine(postgres.get_connection_url())
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text("CREATE TABLE widgets (id int, name text, price int)"))
+            conn.execute(
+                sqlalchemy.text(
+                    "INSERT INTO widgets VALUES (1,'alpha',100),(2,'beta',200),(3,'gamma',300)"
+                )
+            )
+        engine.dispose()
+        # The shape ConnectionState saves: note `user`, which _to_dlt_credentials
+        # renames to `username`. That rename is only exercised for real here.
+        return {
+            "host": postgres.get_container_host_ip(),
+            "port": int(postgres.get_exposed_port(5432)),
+            "user": postgres.username,
+            "password": postgres.password,
+            "database": postgres.dbname,
+        }
+
+    def test_full_database_mode_moves_rows(self, tmp_path):
+        from testcontainers.postgres import PostgresContainer
+
+        with PostgresContainer("postgres:16-alpine") as postgres:
+            config = self._seed(postgres)
+            db_path = _extract_load(
+                tmp_path,
+                "postgres",
+                config,
+                {"mode": "full_database", "table_names": ["widgets"]},
+            )
+            rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)], (
+            "sql_database() did not deliver row contents into DuckDB."
+        )
+
+    def test_single_table_mode_moves_rows(self, tmp_path):
+        from testcontainers.postgres import PostgresContainer
+
+        with PostgresContainer("postgres:16-alpine") as postgres:
+            config = self._seed(postgres)
+            db_path = _extract_load(
+                tmp_path,
+                "postgres",
+                config,
+                {"mode": "single_table", "table": "widgets"},
+            )
+            rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)], (
+            "sql_table() did not deliver row contents into DuckDB."
+        )
+
+
+@requires_docker
 class TestMongoDbSourceMovesRows:
     """``_build_mongodb_source`` — and it cannot authenticate today (core#550).
 


### PR DESCRIPTION
Refs #545 — the next slice. **Closes the last builder QA flagged as unproven.**

No credentials, no staging, no overlap with Engineering'\''s `_build_saas_source` rewrite. Test-only, so collision is impossible.

## Result: the SQL path moves rows, in both modes

| Mode | dlt function | Result |
|---|---|---|
| `full_database` | `sql_database()` | ✅ **PROVEN** |
| `single_table` | `sql_table()` | ✅ **PROVEN** |

Real `postgres:16-alpine` via testcontainers, seeded through SQLAlchemy, loaded by the real `DltRunnerService.execute()` into DuckDB, and the assertion made by **reading the destination back** — not from `result["rows_loaded"]`.

Both modes rather than one because they call **different dlt functions**. Proving `sql_database()` says nothing about `sql_table()`, and `single_table` is the mode the UI'\''s load-mode selector actually offers.

## On "lowest risk" — the reasoning is right, and narrower than it reads

#545 argues `sql_database()` yields rows **by construction**, so #492'\''s missing-transformer mechanism cannot recur here. That is correct and I am not disputing it.

But it says the *specific* defect cannot recur — not that the path works. What had no live coverage was everything **around** the yield: credentials assembly, the drivername map (`postgres` → `postgresql`), and the `user` → `username` rename in `_to_dlt_credentials`. The probe deliberately passes the config shape the app actually stores (`user`, not `username`) so that rename is exercised for real.

**#550 is exactly what an unexercised credentials path looks like, one connector over** — MongoDB'\''s URI was fine as a string and wrong as a credential. That is the risk this closes, and it is not the risk the "yields rows by construction" argument addresses.

## The probes can fail

Verified, not assumed: seeded the table with **no rows** and both probes went red; restored and both went green. Without that check they are two more greens of unknown value.

```
with rows     -> 2 passed
table empty   -> 2 failed
restored      -> 2 passed
```

## Cost

~48s for the pair (two containers). Runs in PR CI alongside the existing probes; full file is now **4 passed / 2 xfailed** (the xfails are #550 and #551).