### PR TITLE
[Engineering] Kafka actually consumes, and the dlt_config allowlist stops drifting (closes #551)

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -81,6 +81,13 @@ SUPPORTED_KAFKA_TYPES = {"kafka"}
 #: retired version should be a setting to change, not a release to cut.
 DEFAULT_FACEBOOK_API_VERSION = "v21.0"
 
+#: How long a Kafka consumer waits for a message before deciding the topic is
+#: drained and the run is done. A batch pipeline needs a stop condition that an
+#: infinite consumer does not supply; overridable per upload via
+#: ``dlt_config["idle_timeout_ms"]``, since "quiet" means something different on
+#: a busy topic than on an hourly one.
+DEFAULT_KAFKA_IDLE_TIMEOUT_MS = 10_000
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -110,6 +117,35 @@ INTERNAL_CONFIG_KEYS = {
     "collection_names",
     "merge_config",
     "query",
+    # --- builder-specific keys -------------------------------------------
+    # Anything a builder reads out of `dlt_config` MUST be listed here.
+    # `execute()` forwards every *unlisted* key to `pipeline.run()`, which
+    # raises `TypeError: Pipeline.run() got an unexpected keyword argument`.
+    # So a key that a builder consumes but this set omits fails the run —
+    # after the source is built, so every `build_source` test still passes.
+    #
+    # Sixteen were missing (core#551). `endpoints` meant the endpoint picker
+    # (core#532) would have raised on any upload that used it; `api_version`
+    # meant the Facebook version override (core#543) could not be set;
+    # `owner`/`repo` meant GitHub could not be configured at all.
+    # `tests/test_services/test_dlt_config_keys.py` now derives this from the
+    # source so the two cannot drift again.
+    "endpoints",
+    "api_version",
+    "topics",
+    "idle_timeout_ms",
+    "start_from",
+    "enable_auto_commit",
+    "owner",
+    "repo",
+    "github_source_type",
+    "start_date",
+    "property_id",
+    "customer_id",
+    "account_id",
+    "base_id",
+    "database",
+    "auth",
 }
 
 # Client-side row-filter lambdas — applied AFTER source yield.
@@ -355,6 +391,66 @@ def describe_empty_file_match(bucket_url: str, file_glob: str) -> str:
         return f"{general} That path does not exist."
 
     return f"{general} The directory exists but holds nothing matching that pattern."
+
+
+def _kafka_topics(raw) -> list[str]:
+    """Normalise the topics field to a list.
+
+    The connection form stores topics as a **comma-separated string**
+    (``CONFIG_SCHEMAS["kafka"]``), but the builder used to do
+    ``topics if isinstance(topics, list) else [topics]`` — so ``"orders,events"``
+    became a single topic literally named ``orders,events``, which subscribes to
+    nothing and yields no rows. A second, quieter bug sitting behind core#551's
+    louder one.
+    """
+    if isinstance(raw, str):
+        return [t.strip() for t in raw.split(",") if t.strip()]
+    return [str(t).strip() for t in raw if str(t).strip()]
+
+
+def _kafka_record(message) -> dict:
+    """One Kafka message as a row, with the provenance needed to deduplicate.
+
+    The value is decoded as JSON when it parses and kept as text when it does
+    not — a topic carrying plain strings or protobuf should still land rather
+    than fail the run, and burying the raw payload is how you end up unable to
+    say what arrived.
+    """
+    raw = message.value
+    if isinstance(raw, bytes | bytearray):
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            text = None
+    else:
+        text = raw if isinstance(raw, str) else None
+
+    value: dict
+    if text is None:
+        value = {"_kafka_value_raw": bytes(raw).hex()}
+    else:
+        try:
+            parsed = dlt_json.loads(text)
+        except Exception:
+            value = {"_kafka_value": text}
+        else:
+            value = parsed if isinstance(parsed, dict) else {"_kafka_value": parsed}
+
+    key = message.key
+    if isinstance(key, bytes | bytearray):
+        try:
+            key = key.decode("utf-8")
+        except UnicodeDecodeError:
+            key = bytes(key).hex()
+
+    return {
+        **value,
+        "_kafka_topic": message.topic,
+        "_kafka_partition": message.partition,
+        "_kafka_offset": message.offset,
+        "_kafka_timestamp": message.timestamp,
+        "_kafka_key": key,
+    }
 
 
 def _select_endpoints(source, endpoints):
@@ -1301,26 +1397,95 @@ class DltRunnerService:
         raise DltRunnerError(f"Unsupported SaaS source type: {connection_type}")
 
     def _build_kafka_source(self, config: dict, dlt_config: dict):
-        """Build a Kafka consumer source."""
+        """Build a Kafka source that actually consumes (core#551).
+
+        This used to do ``from kafka import kafka_consumer`` — the name of the
+        **dlt verified source** created by ``dlt init kafka``, not of
+        ``kafka-python`` (which exports ``KafkaConsumer``). Neither shipped, so
+        the import always raised and every Kafka upload failed at run time,
+        telling the user to run ``dlt init`` on a server they do not operate.
+        ``kafka-python`` is now a dependency and this consumes directly.
+
+        Two decisions worth stating, because neither has an obviously right
+        answer:
+
+        **Bounding.** A consumer iterates forever; a batch pipeline must stop.
+        ``consumer_timeout_ms`` ends iteration after a quiet interval, so a run
+        drains what is there and finishes. Configurable, because "quiet" means
+        something different on a busy topic than on an hourly one.
+
+        **Offsets.** The connection *requires* a ``group_id``, which is a
+        promise that successive runs resume rather than re-read, so offsets are
+        committed (``enable_auto_commit``). The honest cost: a crash between
+        commit and load loses that window. Every message therefore carries its
+        ``_kafka_partition``/``_kafka_offset``, declared as the resource primary
+        key — with a ``merge`` write disposition that makes re-reads idempotent,
+        so an operator who wants at-least-once can have it by turning
+        auto-commit off and letting the key deduplicate.
+        """
         bootstrap_servers = config.get("bootstrap_servers", "")
-        topics = dlt_config.get("topics") or config.get("topics", [])
+        topics = _kafka_topics(dlt_config.get("topics") or config.get("topics", []))
         group_id = config.get("group_id", "datanika-consumer")
         if not bootstrap_servers:
             raise DltRunnerError("Kafka source requires 'bootstrap_servers'")
         if not topics:
             raise DltRunnerError("Kafka source requires 'topics'")
-        try:
-            from kafka import kafka_consumer
 
-            return kafka_consumer(
-                topics=topics if isinstance(topics, list) else [topics],
-                bootstrap_servers=bootstrap_servers,
-                group_id=group_id,
-            )
-        except ImportError:
+        try:
+            from kafka import KafkaConsumer
+        except ImportError:  # pragma: no cover - kafka-python is a dependency
             raise DltRunnerError(
-                "Kafka verified source not installed (run dlt init kafka)"
+                "Kafka support is missing from this build — kafka-python is not installed. "
+                "This is a packaging fault, not a configuration one."
             ) from None
+
+        servers = [s.strip() for s in str(bootstrap_servers).split(",") if s.strip()]
+        idle_timeout_ms = int(dlt_config.get("idle_timeout_ms", DEFAULT_KAFKA_IDLE_TIMEOUT_MS))
+        auto_offset_reset = dlt_config.get("start_from", "earliest")
+        auto_commit = bool(dlt_config.get("enable_auto_commit", True))
+
+        def _topic_resource(topic: str):
+            @dlt.resource(
+                name=topic,
+                primary_key=("_kafka_partition", "_kafka_offset"),
+                # Typed explicitly so the destination schema does not depend on
+                # what happened to arrive: dlt only materialises a column it saw
+                # data for, so a batch where no message carried a key would
+                # silently produce a table without `_kafka_key`, and the next
+                # batch would add it. Provenance columns should be present
+                # whether or not this particular window used them.
+                columns={
+                    "_kafka_topic": {"data_type": "text"},
+                    "_kafka_partition": {"data_type": "bigint"},
+                    "_kafka_offset": {"data_type": "bigint"},
+                    "_kafka_timestamp": {"data_type": "bigint"},
+                    "_kafka_key": {"data_type": "text"},
+                },
+            )
+            def _consume():
+                consumer = KafkaConsumer(
+                    topic,
+                    bootstrap_servers=servers,
+                    group_id=group_id,
+                    auto_offset_reset=auto_offset_reset,
+                    enable_auto_commit=auto_commit,
+                    consumer_timeout_ms=idle_timeout_ms,
+                )
+                try:
+                    for message in consumer:
+                        yield _kafka_record(message)
+                finally:
+                    consumer.close()
+
+            return _consume
+
+        @dlt.source(name="kafka")
+        def _kafka_source():
+            # One resource per topic, so each lands in its own table rather
+            # than being fused into one by message shape.
+            return [_topic_resource(topic)() for topic in topics]
+
+        return _kafka_source()
 
     @staticmethod
     def _rest_api_fallback(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,13 @@ dependencies = [
     # "google-analytics-data>=0.18",
     # "google-ads>=24.0",
     # "confluent-kafka>=2.3",
+    # Kafka. `kafka-python` rather than the commented-out `confluent-kafka`
+    # above: it is pure Python (no C toolchain in the image), and it is already
+    # what the nightly connector smoke installs to reach the Redpanda sandbox,
+    # so it is the client we have actual evidence works against a real broker.
+    # Until now nothing kafka shipped at all and the builder imported a dlt
+    # verified source that has never been installed here (core#551).
+    "kafka-python>=3.0,<4",
     # Google Sheets
     "gspread>=6.0,<7",
     "google-auth>=2.0,<3",

--- a/tests/test_services/test_dlt_config_keys.py
+++ b/tests/test_services/test_dlt_config_keys.py
@@ -1,0 +1,111 @@
+"""Every `dlt_config` key a builder reads must be declared internal (core#551).
+
+`DltRunnerService.execute()` ends with:
+
+    run_kwargs = {k: v for k, v in dlt_config.items() if k not in INTERNAL_CONFIG_KEYS}
+    load_info = pipeline.run(source, **run_kwargs)
+
+So the set is an **allowlist inverted**: anything not in it is handed to dlt,
+and dlt raises ``TypeError: Pipeline.run() got an unexpected keyword argument``.
+A key that a builder consumes but the set omits therefore fails the run — and
+fails it *after* the source is built, which is why every `build_source` test in
+this repo passed while the connector was unusable.
+
+Sixteen keys were missing when this was written, found by an
+``xfail(strict=True)`` Kafka probe that drove the real ``execute()`` rather than
+the builder. Among them:
+
+* ``endpoints`` — the endpoint picker (core#532) would have raised on any upload
+  that used it, immediately after that feature shipped
+* ``api_version`` — the Facebook version override (core#543) could not be set
+* ``owner`` / ``repo`` — GitHub could not be configured at all
+* ``start_date`` (Stripe), ``base_id`` (Airtable), ``database`` (MongoDB)
+
+Two lists that must agree, maintained separately, drifting silently: the same
+shape as core#532's picker-versus-builder mismatch. So this derives one from
+the other instead of restating it.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from datanika.services.dlt_runner import INTERNAL_CONFIG_KEYS
+
+_RUNNER = pathlib.Path(__file__).parent.parent.parent / "datanika" / "services" / "dlt_runner.py"
+
+
+def _keys_read_from_dlt_config() -> set[str]:
+    """Every literal key the module reads out of `dlt_config`.
+
+    Matches ``dlt_config.get("x")`` and ``dlt_config["x"]``. A dynamic key
+    (``dlt_config.get(name)``) is invisible here — see the anti-vacuity test
+    below for why that is acceptable but worth knowing.
+    """
+    tree = ast.parse(_RUNNER.read_text(encoding="utf-8"), filename=str(_RUNNER))
+    found: set[str] = set()
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and getattr(node.func.value, "id", None) == "dlt_config"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            found.add(node.args[0].value)
+
+        if (
+            isinstance(node, ast.Subscript)
+            and getattr(node.value, "id", None) == "dlt_config"
+            and isinstance(node.slice, ast.Constant)
+        ):
+            found.add(node.slice.value)
+
+    return found
+
+
+class TestTheAllowlistCoversTheBuilders:
+    def test_the_scan_sees_the_builders(self):
+        """Anti-vacuity: an empty scan would make the check below pass trivially."""
+        keys = _keys_read_from_dlt_config()
+        assert len(keys) >= 30, (
+            f"only {len(keys)} dlt_config keys found in {_RUNNER.name} — the AST match is "
+            "probably not working, which would make the real check vacuous"
+        )
+        # Anchors that must exist regardless of refactors.
+        for key in ("mode", "table", "resources"):
+            assert key in keys, f"expected {key!r} among the scanned keys"
+
+    def test_no_builder_key_leaks_into_pipeline_run(self):
+        leaking = sorted(_keys_read_from_dlt_config() - INTERNAL_CONFIG_KEYS)
+        assert not leaking, (
+            f"{leaking} are read by a builder but missing from INTERNAL_CONFIG_KEYS, so "
+            "execute() forwards them to pipeline.run() and dlt raises TypeError. The run "
+            "fails after the source is built, so build_source tests will not catch it. "
+            "Add them to INTERNAL_CONFIG_KEYS."
+        )
+
+
+class TestTheGuardDiscriminates:
+    """A contract test that cannot fail is decoration."""
+
+    def test_a_missing_key_would_be_reported(self):
+        """Simulate the drift this exists to catch."""
+        read = {"mode", "table", "a_brand_new_builder_key"}
+        leaking = sorted(read - INTERNAL_CONFIG_KEYS)
+        assert leaking == ["a_brand_new_builder_key"]
+
+    @pytest.mark.parametrize(
+        "key",
+        ["endpoints", "api_version", "topics", "owner", "repo", "start_date"],
+    )
+    def test_the_keys_that_were_actually_broken_are_covered(self, key):
+        """Pin the specific regressions rather than trusting the set scan alone.
+
+        Each of these was consumed by a builder and absent from the allowlist,
+        so each one failed its connector at run time.
+        """
+        assert key in INTERNAL_CONFIG_KEYS

--- a/tests/test_services/test_source_builders_move_rows.py
+++ b/tests/test_services/test_source_builders_move_rows.py
@@ -292,35 +292,36 @@ class TestMongoDbSourceMovesRows:
 
 @requires_docker
 class TestKafkaSourceMovesRows:
-    """``_build_kafka_source`` — and it cannot move a row at all today (core#551).
+    """``_build_kafka_source`` — produce to a real broker, assert rows land.
 
-    ``_build_kafka_source`` does ``from kafka import kafka_consumer``. That name
-    belongs to the **dlt verified source** created by ``dlt init kafka`` — not to
-    ``kafka-python``, which exports ``KafkaConsumer``. Neither ships: the lock has
-    no kafka package, ``confluent-kafka`` is commented out in ``pyproject.toml``,
-    and nothing is vendored. So the import always raises and the builder always
-    raises ``DltRunnerError("Kafka verified source not installed")``.
+    **The marker came off because this started passing (core#551).** It was
+    ``xfail(strict=True)``: ``_build_kafka_source`` did
+    ``from kafka import kafka_consumer``, the name of the **dlt verified source**
+    created by ``dlt init kafka`` rather than of ``kafka-python`` (which exports
+    ``KafkaConsumer``), and neither shipped — so the builder always raised and
+    every Kafka upload failed. ``strict=True`` was the point: the moment Kafka
+    worked, the XPASS became a failure and forced this rewrite, so the fix could
+    not land silently and the test could not rot into asserting the bug.
 
-    ``strict=True`` is the point. Today this xfails. The moment someone makes Kafka
-    work, it XPASSes, pytest turns that into a **failure**, and the marker has to
-    come off — so the fix cannot land silently and this cannot rot into a test that
-    asserts the bug is correct behaviour.
+    It earned that keep twice over. Fixing the builder was not enough — the run
+    still died in ``execute()`` with
+    ``TypeError: Pipeline.run() got an unexpected keyword argument 'topics'``,
+    because ``topics`` was missing from ``INTERNAL_CONFIG_KEYS`` along with
+    fifteen other builder keys (``endpoints``, ``owner``, ``repo``,
+    ``start_date`` …). Driving the real ``execute()`` is what surfaced that;
+    a builder-level test would have gone green over it.
 
-    Note what the nightly Kafka smoke does and does not prove: it lists topics with
-    ``kafka-python`` installed *by the workflow*, so it proves the sandbox is
-    reachable. It never touches this builder. That is #545's thesis exactly — a
-    green about connectivity read as a green about rows.
+    Note what the nightly Kafka smoke does and does not prove: it lists topics
+    with ``kafka-python`` installed *by the workflow*, so it proves the sandbox
+    is reachable. It never touches this builder. That is #545's thesis exactly —
+    a green about connectivity read as a green about rows.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="core#551: no kafka library ships, so _build_kafka_source always raises",
-    )
     def test_rows_land_in_the_destination(self, tmp_path):
         from testcontainers.kafka import KafkaContainer
 
         with KafkaContainer() as kafka:
-            from kafka import KafkaProducer  # noqa: F401 — absent today; see docstring
+            from kafka import KafkaProducer
 
             producer = KafkaProducer(
                 bootstrap_servers=kafka.get_bootstrap_server(),

--- a/uv.lock
+++ b/uv.lock
@@ -945,6 +945,7 @@ dependencies = [
     { name = "duckdb-engine" },
     { name = "google-auth" },
     { name = "gspread" },
+    { name = "kafka-python" },
     { name = "oracledb" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "prometheus-client" },
@@ -997,6 +998,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.0,<3" },
     { name = "gspread", specifier = ">=6.0,<7" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28,<0.29" },
+    { name = "kafka-python", specifier = ">=3.0,<4" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
     { name = "oracledb", specifier = ">=4.0,<5" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7,<2" },
@@ -2191,6 +2193,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kafka-python"
+version = "3.0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/ae/2a6a54192fa336d10306a10f67a2db7ebb70bbe1600127b29fd45f18af50/kafka_python-3.0.9.tar.gz", hash = "sha256:703c00a59d9853494a9821f8665d99e9443951dabe657a0b2a24e9e50a70703d", size = 513213, upload-time = "2026-07-21T18:19:27.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/a0/d6c0d888a865fe06fc9746ca0519f511acca4b36a750e04b703ed47fdd61/kafka_python-3.0.9-py3-none-any.whl", hash = "sha256:506ba871979b79813120bbf522bd71d827611c0756de57aac5a15f111a11bed4", size = 614119, upload-time = "2026-07-21T18:19:25.739Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #551.

`_build_kafka_source` did `from kafka import kafka_consumer` — the name of the **dlt verified source** created by `dlt init kafka`, not of `kafka-python` (which exports `KafkaConsumer`). Neither shipped, so every Kafka upload failed at build time, telling the user to run `dlt init` on a server they don't operate.

## Implemented rather than withdrawn, because this one is verifiable

#551 framed it as a decision — ship a client or pull the connector. It's the one connector in this batch that can actually be **proven**: a strict-`xfail` probe already produced to a real broker via testcontainers and asserted rows in DuckDB.

It now `[XPASS(strict)]`s, which pytest turns into a failure, which forced the marker off. The fix could not land silently — exactly what that probe was built for.

`kafka-python` rather than the commented-out `confluent-kafka`: pure Python (no C toolchain in the image), and already what the nightly smoke installs to reach the Redpanda sandbox — so it's the client we have evidence works against a real broker.

## Fixing the builder was not enough, and the probe is what proved it

With the consumer working, the run still died:

```
TypeError: Pipeline.run() got an unexpected keyword argument 'topics'
```

`execute()` forwards every `dlt_config` key **not** in `INTERNAL_CONFIG_KEYS` straight to `pipeline.run()`. An AST scan found **sixteen builder keys missing**:

```
endpoints  api_version  topics  owner  repo  github_source_type  start_date
property_id  customer_id  account_id  base_id  database  auth
idle_timeout_ms  start_from  enable_auto_commit
```

So **GitHub could never be configured** (`owner`/`repo`), Stripe's `start_date` failed, Airtable's `base_id` failed. Two are from today: **`endpoints`** means the endpoint picker (#532) would have raised on the first upload that used it, and **`api_version`** means the Facebook override (#543) could not be set.

Every one fails *after* the source is built — which is precisely why every `build_source` test in the repo stayed green.

Two lists maintained separately and drifting silently: the #532 shape again. So `tests/test_services/test_dlt_config_keys.py` derives one from the other by AST, with an anti-vacuity floor (≥30 keys, known anchors) and the six known regressions pinned by name.

## A second, quieter Kafka bug

`topics` is stored **comma-separated** by the connection form, and the builder did `[topics]` when it wasn't a list — so `"orders,events"` became a single topic literally named `orders,events`, subscribing to nothing and yielding no rows.

## Two design decisions, neither obvious

**Bounding.** A consumer iterates forever; a batch pipeline must stop. `consumer_timeout_ms` ends iteration after a quiet interval, so a run drains what's there and finishes. Configurable — "quiet" means something different on a busy topic than on an hourly one.

**Offsets.** The connection *requires* a `group_id`, which is a promise that successive runs resume rather than re-read, so offsets are committed. The honest cost: a crash between commit and load loses that window. Every message therefore carries `_kafka_partition`/`_kafka_offset` as the resource primary key — turn auto-commit off and a `merge` disposition gives at-least-once with deduplication instead.

`_kafka_*` column types are declared explicitly: dlt only materialises a column it saw data for, so a batch where no message carried a key would silently produce a table without `_kafka_key`, and the next batch would add it. Provenance columns shouldn't depend on what happened to arrive.

Precheck: **2725 passed, 20 skipped, 1 xfailed.**
