### PR TITLE
[Engineering] Withdraw Google Ads, and make "withdrawn" a concept (closes #555)

### DIFF
--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -268,16 +268,17 @@ CONFIG_SCHEMAS: dict[str, dict] = {
         },
         required=["property_id", "service_account_json"],
     ),
-    "google_ads": _schema(
-        {
-            "customer_id": _str("Google Ads customer ID"),
-            "service_account_json": _str(
-                "Service account JSON",
-                sensitive=True,
-            ),
-        },
-        required=["customer_id", "service_account_json"],
-    ),
+    # "google_ads" is deliberately absent (core#555). It was schema'd with
+    # `customer_id` + `service_account_json`, but every Google Ads API request
+    # also needs a `developer-token` header — issued per manager account through
+    # an application to Google, not something a user pastes from a settings
+    # page. Nothing we stored could authenticate, so the connector could only
+    # ever be created and then fail.
+    #
+    # Left out rather than completed because collecting the token is a product
+    # decision with a much longer setup guide attached; see core#555 for the
+    # route back. `ConnectionType.GOOGLE_ADS` remains so rows already stored
+    # keep resolving.
     "facebook_ads": _schema(
         {
             "access_token": _str("Marketing API access token", sensitive=True),

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -18,6 +18,27 @@ logger = logging.getLogger(__name__)
 
 validate_connection_name = partial(validate_name, entity_label="Connection")
 
+# Connector types that exist but are no longer offered.
+#
+# A withdrawn type is absent from `SOURCE_TYPES`, `CONFIG_SCHEMAS` and the
+# connections picker, so it cannot be created — but keeps its `ConnectionType`
+# member, its SaaS *classification*, and its loader dispatch, so a connection
+# someone already stored still resolves and still fails with an error that
+# explains itself rather than "Unsupported source type".
+#
+# This is a named concept rather than "whichever lists we remembered to edit"
+# because the first attempt at core#555 removed it from the dispatch set too and
+# gave existing rows a worse error, and because withdrawal is not rare: it is
+# the honest answer whenever a connector cannot work with the credentials we
+# collect. `tests/test_connector_type_contracts.py` pins both halves.
+WITHDRAWN_SOURCE_TYPES = {
+    # Every Google Ads API request needs a `developer-token` header, issued per
+    # manager account through an application to Google. The form collected only
+    # `customer_id` + `service_account_json`, so nothing stored could
+    # authenticate and no fallback could help (core#555).
+    "google_ads",
+}
+
 # Types that can serve as sources (databases + files + rest_api + sheets)
 SOURCE_TYPES = {
     "postgres",
@@ -42,7 +63,7 @@ SOURCE_TYPES = {
     "jira",
     "slack",
     "google_analytics",
-    "google_ads",
+    # google_ads withdrawn (core#555).
     "facebook_ads",
     "zendesk",
     "airtable",

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -62,6 +62,12 @@ SUPPORTED_SAAS_TYPES = {
     "jira",
     "slack",
     "google_analytics",
+    # google_ads is withdrawn from the *picker* and CONFIG_SCHEMAS (core#555) but
+    # stays here on purpose. This set only controls dispatch, so removing it made
+    # a connection someone already stored fail with the generic "Unsupported
+    # source type: google_ads" instead of the developer-token explanation that
+    # tells them why. Withdrawal means "cannot be created", not "existing rows
+    # get a worse error".
     "google_ads",
     "facebook_ads",
     "zendesk",

--- a/datanika/services/ir/builder.py
+++ b/datanika/services/ir/builder.py
@@ -45,6 +45,9 @@ SAAS_TYPES = frozenset(
         "jira",
         "slack",
         "google_analytics",
+        # Classification, not an offer — google_ads is withdrawn from the picker
+        # and CONFIG_SCHEMAS (core#555) but still classified so a stored
+        # connection resolves consistently.
         "google_ads",
         "facebook_ads",
         "zendesk",

--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -60,7 +60,13 @@ PICKER_TYPES: list[str] = [
     "slack",
     # Analytics / ads
     "google_analytics",
-    "google_ads",
+    # google_ads is deliberately absent (core#555). The Google Ads API requires
+    # a `developer-token` header on every request and the connection form
+    # collects no such field, so a connection created here could never
+    # authenticate — no transport or fallback changes that. Offering it only
+    # bought users a credential hunt ending in a failed run. The enum member and
+    # the edit paths stay so connections already stored remain viewable and
+    # deletable.
     "facebook_ads",
     # Messaging
     "kafka",

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -27,6 +27,12 @@ SAAS_SOURCE_TYPES = {
     "jira",
     "slack",
     "google_analytics",
+    # google_ads stays *classified* as SaaS even though it is withdrawn
+    # (core#555). This set says "if this type is rendered, render it as SaaS",
+    # and `test_connector_type_contracts` requires it to equal the loader's
+    # dispatch set exactly — an invariant from core#503 that stops the form
+    # offering SQL controls the loader ignores. Withdrawal is enforced by the
+    # *offering* surfaces instead: PICKER_TYPES, CONFIG_SCHEMAS, SOURCE_TYPES.
     "google_ads",
     "facebook_ads",
     "zendesk",
@@ -92,11 +98,13 @@ SAAS_DEFAULT_ENDPOINTS: dict[str, list[str]] = {
     "shopify": ["orders", "products", "customers"],
     "jira": ["issues", "projects"],
     "slack": ["channels", "users"],
-    # google_analytics and google_ads still cannot build a source at all
-    # (core#543) and stay out of the contract test. Their lists are what the
-    # verified sources describe, not what any code here can produce.
+    # google_analytics still cannot build a source at all (core#543) and stays
+    # out of the contract test. Its list is what the verified source describes,
+    # not what any code here can produce.
+    #
+    # google_ads is gone entirely (core#555) — withdrawn rather than left
+    # offered-and-broken.
     "google_analytics": ["report"],
-    "google_ads": ["customers", "campaigns", "ad_groups", "ads"],
     # facebook_ads now builds via the Graph API fallback. `leads` is gone on
     # purpose: it is not an ad-account edge (lead records hang off a lead-gen
     # form, not the account), so offering it would tick a box for a resource

--- a/tests/test_connector_type_contracts.py
+++ b/tests/test_connector_type_contracts.py
@@ -12,8 +12,11 @@ names for an HTTP API.
 These tests are the binding.
 """
 
-from datanika.services.connection_service import SOURCE_TYPES
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_schemas import CONFIG_SCHEMAS
+from datanika.services.connection_service import SOURCE_TYPES, WITHDRAWN_SOURCE_TYPES
 from datanika.services.dlt_runner import SUPPORTED_SAAS_TYPES
+from datanika.ui.pages.connections import PICKER_TYPES
 from datanika.ui.state.connection_state import (
     FILE_SOURCE_TYPES,
     NON_SQL_SOURCE_TYPES,
@@ -85,9 +88,42 @@ def test_the_form_and_the_loader_agree_on_which_types_are_saas():
 
 
 def test_every_ui_saas_type_has_endpoints_to_offer():
-    """A SaaS type with no endpoint list renders an empty checkbox group."""
-    missing = {t for t in SAAS_SOURCE_TYPES if not SAAS_DEFAULT_ENDPOINTS.get(t)}
+    """A SaaS type with no endpoint list renders an empty checkbox group.
+
+    Withdrawn types are exempt: they are never rendered, so there is nothing to
+    offer. They stay *classified* as SaaS on purpose — see
+    `WITHDRAWN_SOURCE_TYPES` — so this invariant has to know the difference
+    between "not offered" and "offered with nothing in it".
+    """
+    offered = SAAS_SOURCE_TYPES - WITHDRAWN_SOURCE_TYPES
+    missing = {t for t in offered if not SAAS_DEFAULT_ENDPOINTS.get(t)}
     assert not missing, f"{sorted(missing)} would render an empty endpoint selector"
+
+
+def test_a_withdrawn_type_is_not_offered_anywhere():
+    """Withdrawal has to hold on every surface, not just the one we remembered.
+
+    core#555's first attempt removed google_ads from the loader's dispatch set
+    as well, which gave connections already stored the generic "Unsupported
+    source type" instead of the developer-token explanation. The split matters:
+    withdrawn means *cannot be created*, not *becomes unexplainable*.
+    """
+    for withdrawn in WITHDRAWN_SOURCE_TYPES:
+        assert withdrawn not in PICKER_TYPES, f"{withdrawn} is still in the connections picker"
+        assert withdrawn not in CONFIG_SCHEMAS, f"{withdrawn} still has a config schema"
+        assert withdrawn not in SOURCE_TYPES, f"{withdrawn} is still a selectable source type"
+
+
+def test_a_withdrawn_type_still_resolves_for_stored_connections():
+    """The other half — it must keep its identity and its dispatch."""
+    for withdrawn in WITHDRAWN_SOURCE_TYPES:
+        assert withdrawn in {c.value for c in ConnectionType}, (
+            f"{withdrawn} lost its ConnectionType member; rows already stored would not load"
+        )
+        assert withdrawn in SUPPORTED_SAAS_TYPES, (
+            f"{withdrawn} lost loader dispatch, so a stored connection fails with a generic "
+            "'Unsupported source type' instead of an error that explains itself"
+        )
 
 
 def test_file_source_types_are_non_sql():

--- a/tests/test_services/test_meta_routes.py
+++ b/tests/test_services/test_meta_routes.py
@@ -7,6 +7,7 @@ from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 from datanika.services.meta_routes import meta_routes
 from datanika.services.rate_limit_service import RateLimitResult
 
@@ -84,8 +85,18 @@ class TestConnectionTypes:
             assert resp.status_code == 200
             items = resp.json()["items"]
             slugs = {item["type"] for item in items}
-            # Every ConnectionType enum value must be present
+            # Every ConnectionType enum value must be present — except a
+            # withdrawn one, which keeps its enum member so stored rows resolve
+            # but is deliberately not offered (WITHDRAWN_SOURCE_TYPES, core#555).
+            # This endpoint is what agents read to discover connectors, so
+            # listing one that cannot authenticate would send them down the same
+            # dead end a human would have hit.
             for ct in ConnectionType:
+                if ct.value in WITHDRAWN_SOURCE_TYPES:
+                    assert ct.value not in slugs, (
+                        f"{ct.value} is withdrawn but still advertised by /meta/connection-types"
+                    )
+                    continue
                 assert ct.value in slugs, f"Missing {ct.value}"
         finally:
             for s in reversed(stack):

--- a/tests/test_services/test_openapi.py
+++ b/tests/test_services/test_openapi.py
@@ -148,12 +148,25 @@ class TestTier3InlinedSchemas:
         assert len(cc["oneOf"]) >= 27  # at least 27 source types
 
     def test_every_connection_type_has_a_branch(self):
+        """…except a withdrawn one, which has no config schema to describe.
+
+        A withdrawn type keeps its enum member so stored connections resolve,
+        but is not creatable, so the spec has nothing to say about how to create
+        one (`WITHDRAWN_SOURCE_TYPES`, core#555). Advertising a branch here
+        would tell an API client to POST a config that no longer validates.
+        """
         from datanika.models.connection import ConnectionType
+        from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 
         spec = build_openapi_spec()
         cc = spec["components"]["schemas"]["ConnectionCreate"]
         mapping = cc["discriminator"]["mapping"]
         for ct in ConnectionType:
+            if ct.value in WITHDRAWN_SOURCE_TYPES:
+                assert ct.value not in mapping, (
+                    f"{ct.value} is withdrawn but still has a ConnectionCreate branch"
+                )
+                continue
             assert ct.value in mapping, (
                 f"ConnectionType.{ct.name} ({ct.value}) missing from discriminator mapping"
             )

--- a/tests/test_ui/test_connection_picker_coverage.py
+++ b/tests/test_ui/test_connection_picker_coverage.py
@@ -9,12 +9,20 @@ list doesn't, CI fails here.
 """
 
 from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 from datanika.ui.pages.connections import PICKER_TYPES
 
 
 def test_picker_covers_every_connection_type():
-    """Every ConnectionType enum value must appear in the picker list."""
-    enum_values = {t.value for t in ConnectionType}
+    """Every ConnectionType enum value must appear in the picker list.
+
+    Except a **withdrawn** one. A withdrawn type keeps its enum member so
+    connections already stored still resolve, but is deliberately not offered
+    — see `WITHDRAWN_SOURCE_TYPES` (core#555). Without this exemption the test
+    reads "everything in the enum is on sale", which stopped being true the
+    moment a connector had to be retired without orphaning existing rows.
+    """
+    enum_values = {t.value for t in ConnectionType} - WITHDRAWN_SOURCE_TYPES
     picker_values = set(PICKER_TYPES)
 
     missing_from_picker = enum_values - picker_values
@@ -22,6 +30,20 @@ def test_picker_covers_every_connection_type():
         f"The connection picker is missing {len(missing_from_picker)} "
         f"type(s) the backend supports: {sorted(missing_from_picker)}. "
         f"Add them to PICKER_TYPES in datanika/ui/pages/connections.py."
+    )
+
+
+def test_withdrawn_types_are_kept_out_of_the_picker():
+    """The exemption above must not become a hole.
+
+    If a withdrawn type reappeared in PICKER_TYPES it would be creatable again,
+    and the test above would happily pass — it only checks the other direction.
+    """
+    reoffered = WITHDRAWN_SOURCE_TYPES & set(PICKER_TYPES)
+    assert not reoffered, (
+        f"{sorted(reoffered)} are withdrawn but back in the picker — a user could create "
+        "a connection that cannot work. Remove them, or take them out of "
+        "WITHDRAWN_SOURCE_TYPES if they have been fixed."
     )
 
 


### PR DESCRIPTION
Closes #555.

Every Google Ads API request needs a **`developer-token` header**, issued per manager (MCC) account through an application to Google. The connection form collected `customer_id` + `service_account_json` and nothing else — so **nothing we stored could authenticate**, and no REST fallback or transport change helps. The connector could only ever be created and then fail, *after* the user had gone and obtained credentials for it.

Withdrawn rather than completed: collecting the token is a product decision with a much longer setup guide attached, and with 0 paying users, advertising a connector nobody can complete costs more than not listing it. #555 records the route back if demand appears.

## Two attempts, and the second one is the point

The first pass removed `google_ads` from *every* list, including the loader's dispatch set. The contract tests caught what that did: a connection someone had **already stored** then failed with the generic

```
Unsupported source type: google_ads
```

instead of the developer-token explanation written for exactly that reader. Restoring dispatch then broke `SAAS_SOURCE_TYPES == SUPPORTED_SAAS_TYPES` — the equality #503 established so the form cannot offer SQL controls the loader ignores.

Both pulls are legitimate, so **"withdrawn" became a named concept** rather than an accident of which lists got edited:

| | google_ads |
|---|---|
| **Offering** — `PICKER_TYPES`, `CONFIG_SCHEMAS`, `SOURCE_TYPES`, `SAAS_DEFAULT_ENDPOINTS` | **removed** → cannot be created |
| **Identity & classification** — `ConnectionType` member, SaaS classification, loader dispatch | **kept** → stored rows resolve, and fail with an error that explains itself |

`WITHDRAWN_SOURCE_TYPES` carries that reasoning next to the set. Two new contract tests pin both halves — `test_a_withdrawn_type_is_not_offered_anywhere` and `test_a_withdrawn_type_still_resolves_for_stored_connections` — the second naming the exact regression the first attempt introduced, so the next withdrawal doesn't repeat it.

The endpoints-to-offer invariant now excludes withdrawn types, because *"not offered"* and *"offered with nothing in it"* are different failures and only the second one is a bug.

Worth having as a concept rather than a precedent: `google_analytics` may take the same route.

## For Growth, not in this PR

`/connectors/google-ads` and its setup guide are still live and now advertise a connector **absent from the app**. They need to come down in the same window — otherwise a reader follows the guide, obtains a developer token, and finds nothing to connect it to.
