### PR TITLE
[Infra] pre-push: honour the refspec being pushed, and flag a stale venv (closes #556, closes #557)

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -7,6 +7,28 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# --- what is actually being pushed? (#556) ---------------------------------------------
+# Git feeds the hook one line per ref on STDIN:  <local ref> <local sha> <remote ref> <remote sha>
+# This hook used to consult only `git rev-parse HEAD`, so a refspec push -- notably the
+# post-promotion resync `git push origin origin/master:refs/heads/dev` -- made it rebase an
+# unrelated feature branch and abort. The resync then silently did not happen.
+#
+# Consume stdin FIRST: anything below that reads stdin would otherwise eat these lines.
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+PUSHING_HEAD=0
+SAW_ANY=0
+while read -r _lref lsha _rref _rsha; do
+  SAW_ANY=1
+  [ "$lsha" = "$HEAD_SHA" ] && PUSHING_HEAD=1
+done
+# No lines at all means git told us nothing (or the hook was invoked by hand) -- assume a
+# normal push and check, rather than skipping silently.
+if [ "$SAW_ANY" = "1" ] && [ "$PUSHING_HEAD" = "0" ]; then
+  echo "pre-push: pushing a ref that is not HEAD (refspec push) — skipping rebase and tests."
+  echo "          Your working tree is irrelevant to what is being pushed."
+  exit 0
+fi
+
 # Auto-rebase onto origin/dev (feature branches only)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH" != "dev" && "$BRANCH" != "master" && "$BRANCH" != "main" ]]; then
@@ -73,6 +95,26 @@ echo "pre-push: ruff check"
 "$PY" -m ruff check datanika tests
 echo "pre-push: ruff format --check"
 "$PY" -m ruff format --check datanika tests
+# --- is this venv stale against uv.lock? (#557) ----------------------------------------
+# A venv that predates a dependency added on dev fails in a way that points at the wrong
+# thing entirely: adding duckdb-engine (#494) produced
+#   sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
+# which reads as a DuckDB problem and cost two failed pushes before anyone looked at the venv.
+# Say it plainly instead. The stamp is refreshed after a green run: if the suite passes, this
+# venv is adequate for the current lockfile by definition.
+LOCK_STAMP=".venv/.uv-lock-sha"
+if [ -f uv.lock ]; then
+  LOCK_SHA=$(sha256sum uv.lock 2>/dev/null | cut -d" " -f1)
+  if [ -n "$LOCK_SHA" ] && [ "$LOCK_SHA" != "$(cat "$LOCK_STAMP" 2>/dev/null || echo)" ]; then
+    echo ""
+    echo "  pre-push NOTE: uv.lock has changed since this venv last passed."
+    echo "      If the suite now fails with an unrelated-looking ImportError or a missing"
+    echo "      driver/dialect, the venv is stale — not your change. Fix with:"
+    echo "        uv pip install -e \".[dev]\" --python $PY"
+    echo ""
+  fi
+fi
+
 echo "pre-push: pytest"
 # UV_NO_SYNC=1 is NOT optional on Windows. test_head_downgrade_upgrade_roundtrip shells
 # out to `uv run alembic`, which tries to replace native extensions (sqlalchemy's
@@ -97,6 +139,11 @@ if command -v helm >/dev/null 2>&1 && [ -d "$REPO_ROOT/deploy/helm" ]; then
   else
     echo "pre-push: helm lint skipped (no chart changes)"
   fi
+fi
+
+# Record that this venv satisfied the current lockfile (#557).
+if [ -f uv.lock ] && [ -d .venv ]; then
+  sha256sum uv.lock 2>/dev/null | cut -d" " -f1 > "$LOCK_STAMP" || true
 fi
 
 echo "pre-push: all checks passed"


### PR DESCRIPTION
**#556** — the hook read only `git rev-parse HEAD`, so `git push origin origin/master:refs/heads/dev` (the post-promotion resync) rebased an unrelated branch and aborted; the resync silently didn't happen. Git supplies the pushed refs on stdin — now read, and consumed first so nothing downstream eats them. Proven against simulated git input: pushing HEAD continues, pushing another ref skips.

**#557** — a venv stale against `uv.lock` fails as `Can't load plugin: sqlalchemy.dialects:duckdb`, pointing at the wrong component. Now compared against a stamp and stated plainly; the stamp refreshes after a green run.

Validated on first contact: this PR was blocked by `ModuleNotFoundError: No module named 'kafka'` (dependency added in be74da66) and the note correctly named the venv rather than the change.