### PR TITLE
[Infra] Promote dev → master: pre-push honours the refspec, flags a stale venv

### DIFF
--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -268,16 +268,17 @@ CONFIG_SCHEMAS: dict[str, dict] = {
         },
         required=["property_id", "service_account_json"],
     ),
-    "google_ads": _schema(
-        {
-            "customer_id": _str("Google Ads customer ID"),
-            "service_account_json": _str(
-                "Service account JSON",
-                sensitive=True,
-            ),
-        },
-        required=["customer_id", "service_account_json"],
-    ),
+    # "google_ads" is deliberately absent (core#555). It was schema'd with
+    # `customer_id` + `service_account_json`, but every Google Ads API request
+    # also needs a `developer-token` header — issued per manager account through
+    # an application to Google, not something a user pastes from a settings
+    # page. Nothing we stored could authenticate, so the connector could only
+    # ever be created and then fail.
+    #
+    # Left out rather than completed because collecting the token is a product
+    # decision with a much longer setup guide attached; see core#555 for the
+    # route back. `ConnectionType.GOOGLE_ADS` remains so rows already stored
+    # keep resolving.
     "facebook_ads": _schema(
         {
             "access_token": _str("Marketing API access token", sensitive=True),

--- a/datanika/services/connection_service.py
+++ b/datanika/services/connection_service.py
@@ -18,6 +18,27 @@ logger = logging.getLogger(__name__)
 
 validate_connection_name = partial(validate_name, entity_label="Connection")
 
+# Connector types that exist but are no longer offered.
+#
+# A withdrawn type is absent from `SOURCE_TYPES`, `CONFIG_SCHEMAS` and the
+# connections picker, so it cannot be created — but keeps its `ConnectionType`
+# member, its SaaS *classification*, and its loader dispatch, so a connection
+# someone already stored still resolves and still fails with an error that
+# explains itself rather than "Unsupported source type".
+#
+# This is a named concept rather than "whichever lists we remembered to edit"
+# because the first attempt at core#555 removed it from the dispatch set too and
+# gave existing rows a worse error, and because withdrawal is not rare: it is
+# the honest answer whenever a connector cannot work with the credentials we
+# collect. `tests/test_connector_type_contracts.py` pins both halves.
+WITHDRAWN_SOURCE_TYPES = {
+    # Every Google Ads API request needs a `developer-token` header, issued per
+    # manager account through an application to Google. The form collected only
+    # `customer_id` + `service_account_json`, so nothing stored could
+    # authenticate and no fallback could help (core#555).
+    "google_ads",
+}
+
 # Types that can serve as sources (databases + files + rest_api + sheets)
 SOURCE_TYPES = {
     "postgres",
@@ -42,7 +63,7 @@ SOURCE_TYPES = {
     "jira",
     "slack",
     "google_analytics",
-    "google_ads",
+    # google_ads withdrawn (core#555).
     "facebook_ads",
     "zendesk",
     "airtable",

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -62,6 +62,12 @@ SUPPORTED_SAAS_TYPES = {
     "jira",
     "slack",
     "google_analytics",
+    # google_ads is withdrawn from the *picker* and CONFIG_SCHEMAS (core#555) but
+    # stays here on purpose. This set only controls dispatch, so removing it made
+    # a connection someone already stored fail with the generic "Unsupported
+    # source type: google_ads" instead of the developer-token explanation that
+    # tells them why. Withdrawal means "cannot be created", not "existing rows
+    # get a worse error".
     "google_ads",
     "facebook_ads",
     "zendesk",

--- a/datanika/services/ir/builder.py
+++ b/datanika/services/ir/builder.py
@@ -45,6 +45,9 @@ SAAS_TYPES = frozenset(
         "jira",
         "slack",
         "google_analytics",
+        # Classification, not an offer — google_ads is withdrawn from the picker
+        # and CONFIG_SCHEMAS (core#555) but still classified so a stored
+        # connection resolves consistently.
         "google_ads",
         "facebook_ads",
         "zendesk",

--- a/datanika/ui/pages/connections.py
+++ b/datanika/ui/pages/connections.py
@@ -60,7 +60,13 @@ PICKER_TYPES: list[str] = [
     "slack",
     # Analytics / ads
     "google_analytics",
-    "google_ads",
+    # google_ads is deliberately absent (core#555). The Google Ads API requires
+    # a `developer-token` header on every request and the connection form
+    # collects no such field, so a connection created here could never
+    # authenticate — no transport or fallback changes that. Offering it only
+    # bought users a credential hunt ending in a failed run. The enum member and
+    # the edit paths stay so connections already stored remain viewable and
+    # deletable.
     "facebook_ads",
     # Messaging
     "kafka",

--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -27,6 +27,12 @@ SAAS_SOURCE_TYPES = {
     "jira",
     "slack",
     "google_analytics",
+    # google_ads stays *classified* as SaaS even though it is withdrawn
+    # (core#555). This set says "if this type is rendered, render it as SaaS",
+    # and `test_connector_type_contracts` requires it to equal the loader's
+    # dispatch set exactly — an invariant from core#503 that stops the form
+    # offering SQL controls the loader ignores. Withdrawal is enforced by the
+    # *offering* surfaces instead: PICKER_TYPES, CONFIG_SCHEMAS, SOURCE_TYPES.
     "google_ads",
     "facebook_ads",
     "zendesk",
@@ -92,11 +98,13 @@ SAAS_DEFAULT_ENDPOINTS: dict[str, list[str]] = {
     "shopify": ["orders", "products", "customers"],
     "jira": ["issues", "projects"],
     "slack": ["channels", "users"],
-    # google_analytics and google_ads still cannot build a source at all
-    # (core#543) and stay out of the contract test. Their lists are what the
-    # verified sources describe, not what any code here can produce.
+    # google_analytics still cannot build a source at all (core#543) and stays
+    # out of the contract test. Its list is what the verified source describes,
+    # not what any code here can produce.
+    #
+    # google_ads is gone entirely (core#555) — withdrawn rather than left
+    # offered-and-broken.
     "google_analytics": ["report"],
-    "google_ads": ["customers", "campaigns", "ad_groups", "ads"],
     # facebook_ads now builds via the Graph API fallback. `leads` is gone on
     # purpose: it is not an ad-account edge (lead records hang off a lead-gen
     # form, not the account), so offering it would tick a box for a resource

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -7,6 +7,28 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# --- what is actually being pushed? (#556) ---------------------------------------------
+# Git feeds the hook one line per ref on STDIN:  <local ref> <local sha> <remote ref> <remote sha>
+# This hook used to consult only `git rev-parse HEAD`, so a refspec push -- notably the
+# post-promotion resync `git push origin origin/master:refs/heads/dev` -- made it rebase an
+# unrelated feature branch and abort. The resync then silently did not happen.
+#
+# Consume stdin FIRST: anything below that reads stdin would otherwise eat these lines.
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+PUSHING_HEAD=0
+SAW_ANY=0
+while read -r _lref lsha _rref _rsha; do
+  SAW_ANY=1
+  [ "$lsha" = "$HEAD_SHA" ] && PUSHING_HEAD=1
+done
+# No lines at all means git told us nothing (or the hook was invoked by hand) -- assume a
+# normal push and check, rather than skipping silently.
+if [ "$SAW_ANY" = "1" ] && [ "$PUSHING_HEAD" = "0" ]; then
+  echo "pre-push: pushing a ref that is not HEAD (refspec push) — skipping rebase and tests."
+  echo "          Your working tree is irrelevant to what is being pushed."
+  exit 0
+fi
+
 # Auto-rebase onto origin/dev (feature branches only)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH" != "dev" && "$BRANCH" != "master" && "$BRANCH" != "main" ]]; then
@@ -73,6 +95,26 @@ echo "pre-push: ruff check"
 "$PY" -m ruff check datanika tests
 echo "pre-push: ruff format --check"
 "$PY" -m ruff format --check datanika tests
+# --- is this venv stale against uv.lock? (#557) ----------------------------------------
+# A venv that predates a dependency added on dev fails in a way that points at the wrong
+# thing entirely: adding duckdb-engine (#494) produced
+#   sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
+# which reads as a DuckDB problem and cost two failed pushes before anyone looked at the venv.
+# Say it plainly instead. The stamp is refreshed after a green run: if the suite passes, this
+# venv is adequate for the current lockfile by definition.
+LOCK_STAMP=".venv/.uv-lock-sha"
+if [ -f uv.lock ]; then
+  LOCK_SHA=$(sha256sum uv.lock 2>/dev/null | cut -d" " -f1)
+  if [ -n "$LOCK_SHA" ] && [ "$LOCK_SHA" != "$(cat "$LOCK_STAMP" 2>/dev/null || echo)" ]; then
+    echo ""
+    echo "  pre-push NOTE: uv.lock has changed since this venv last passed."
+    echo "      If the suite now fails with an unrelated-looking ImportError or a missing"
+    echo "      driver/dialect, the venv is stale — not your change. Fix with:"
+    echo "        uv pip install -e \".[dev]\" --python $PY"
+    echo ""
+  fi
+fi
+
 echo "pre-push: pytest"
 # UV_NO_SYNC=1 is NOT optional on Windows. test_head_downgrade_upgrade_roundtrip shells
 # out to `uv run alembic`, which tries to replace native extensions (sqlalchemy's
@@ -97,6 +139,11 @@ if command -v helm >/dev/null 2>&1 && [ -d "$REPO_ROOT/deploy/helm" ]; then
   else
     echo "pre-push: helm lint skipped (no chart changes)"
   fi
+fi
+
+# Record that this venv satisfied the current lockfile (#557).
+if [ -f uv.lock ] && [ -d .venv ]; then
+  sha256sum uv.lock 2>/dev/null | cut -d" " -f1 > "$LOCK_STAMP" || true
 fi
 
 echo "pre-push: all checks passed"

--- a/tests/test_connector_type_contracts.py
+++ b/tests/test_connector_type_contracts.py
@@ -12,8 +12,11 @@ names for an HTTP API.
 These tests are the binding.
 """
 
-from datanika.services.connection_service import SOURCE_TYPES
+from datanika.models.connection import ConnectionType
+from datanika.services.connection_schemas import CONFIG_SCHEMAS
+from datanika.services.connection_service import SOURCE_TYPES, WITHDRAWN_SOURCE_TYPES
 from datanika.services.dlt_runner import SUPPORTED_SAAS_TYPES
+from datanika.ui.pages.connections import PICKER_TYPES
 from datanika.ui.state.connection_state import (
     FILE_SOURCE_TYPES,
     NON_SQL_SOURCE_TYPES,
@@ -85,9 +88,42 @@ def test_the_form_and_the_loader_agree_on_which_types_are_saas():
 
 
 def test_every_ui_saas_type_has_endpoints_to_offer():
-    """A SaaS type with no endpoint list renders an empty checkbox group."""
-    missing = {t for t in SAAS_SOURCE_TYPES if not SAAS_DEFAULT_ENDPOINTS.get(t)}
+    """A SaaS type with no endpoint list renders an empty checkbox group.
+
+    Withdrawn types are exempt: they are never rendered, so there is nothing to
+    offer. They stay *classified* as SaaS on purpose — see
+    `WITHDRAWN_SOURCE_TYPES` — so this invariant has to know the difference
+    between "not offered" and "offered with nothing in it".
+    """
+    offered = SAAS_SOURCE_TYPES - WITHDRAWN_SOURCE_TYPES
+    missing = {t for t in offered if not SAAS_DEFAULT_ENDPOINTS.get(t)}
     assert not missing, f"{sorted(missing)} would render an empty endpoint selector"
+
+
+def test_a_withdrawn_type_is_not_offered_anywhere():
+    """Withdrawal has to hold on every surface, not just the one we remembered.
+
+    core#555's first attempt removed google_ads from the loader's dispatch set
+    as well, which gave connections already stored the generic "Unsupported
+    source type" instead of the developer-token explanation. The split matters:
+    withdrawn means *cannot be created*, not *becomes unexplainable*.
+    """
+    for withdrawn in WITHDRAWN_SOURCE_TYPES:
+        assert withdrawn not in PICKER_TYPES, f"{withdrawn} is still in the connections picker"
+        assert withdrawn not in CONFIG_SCHEMAS, f"{withdrawn} still has a config schema"
+        assert withdrawn not in SOURCE_TYPES, f"{withdrawn} is still a selectable source type"
+
+
+def test_a_withdrawn_type_still_resolves_for_stored_connections():
+    """The other half — it must keep its identity and its dispatch."""
+    for withdrawn in WITHDRAWN_SOURCE_TYPES:
+        assert withdrawn in {c.value for c in ConnectionType}, (
+            f"{withdrawn} lost its ConnectionType member; rows already stored would not load"
+        )
+        assert withdrawn in SUPPORTED_SAAS_TYPES, (
+            f"{withdrawn} lost loader dispatch, so a stored connection fails with a generic "
+            "'Unsupported source type' instead of an error that explains itself"
+        )
 
 
 def test_file_source_types_are_non_sql():

--- a/tests/test_services/test_meta_routes.py
+++ b/tests/test_services/test_meta_routes.py
@@ -7,6 +7,7 @@ from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 from datanika.services.meta_routes import meta_routes
 from datanika.services.rate_limit_service import RateLimitResult
 
@@ -84,8 +85,18 @@ class TestConnectionTypes:
             assert resp.status_code == 200
             items = resp.json()["items"]
             slugs = {item["type"] for item in items}
-            # Every ConnectionType enum value must be present
+            # Every ConnectionType enum value must be present — except a
+            # withdrawn one, which keeps its enum member so stored rows resolve
+            # but is deliberately not offered (WITHDRAWN_SOURCE_TYPES, core#555).
+            # This endpoint is what agents read to discover connectors, so
+            # listing one that cannot authenticate would send them down the same
+            # dead end a human would have hit.
             for ct in ConnectionType:
+                if ct.value in WITHDRAWN_SOURCE_TYPES:
+                    assert ct.value not in slugs, (
+                        f"{ct.value} is withdrawn but still advertised by /meta/connection-types"
+                    )
+                    continue
                 assert ct.value in slugs, f"Missing {ct.value}"
         finally:
             for s in reversed(stack):

--- a/tests/test_services/test_openapi.py
+++ b/tests/test_services/test_openapi.py
@@ -148,12 +148,25 @@ class TestTier3InlinedSchemas:
         assert len(cc["oneOf"]) >= 27  # at least 27 source types
 
     def test_every_connection_type_has_a_branch(self):
+        """…except a withdrawn one, which has no config schema to describe.
+
+        A withdrawn type keeps its enum member so stored connections resolve,
+        but is not creatable, so the spec has nothing to say about how to create
+        one (`WITHDRAWN_SOURCE_TYPES`, core#555). Advertising a branch here
+        would tell an API client to POST a config that no longer validates.
+        """
         from datanika.models.connection import ConnectionType
+        from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 
         spec = build_openapi_spec()
         cc = spec["components"]["schemas"]["ConnectionCreate"]
         mapping = cc["discriminator"]["mapping"]
         for ct in ConnectionType:
+            if ct.value in WITHDRAWN_SOURCE_TYPES:
+                assert ct.value not in mapping, (
+                    f"{ct.value} is withdrawn but still has a ConnectionCreate branch"
+                )
+                continue
             assert ct.value in mapping, (
                 f"ConnectionType.{ct.name} ({ct.value}) missing from discriminator mapping"
             )

--- a/tests/test_services/test_source_builders_move_rows.py
+++ b/tests/test_services/test_source_builders_move_rows.py
@@ -32,9 +32,12 @@ existed**. This is the thin layer that was missing, not a replacement.
 
 - One resource / one collection per builder. These prove *rows arrive*, not that
   pagination, incremental cursors, auth flows or schema contracts are correct.
-- ``google_sheets`` and ``saas`` are absent: both need accounts. ``saas`` is also
-  being actively rewritten (#532, #543) — auditing a moving target re-discovers
-  findings that already have issue numbers.
+- ``google_sheets`` is absent: it needs an account.
+- ``saas`` is covered only at the **shared fallback spine** (see
+  ``TestSaasRestFallbackMovesRows``), not per connector. Each connector's own auth
+  assembly and default resource list still need credentials. ``google_analytics``,
+  ``google_ads`` and ``facebook_ads`` are excluded outright — #543 says they cannot
+  run at all.
 - A pass here says the builder can move a row **today, on this shape of data**. It
   is a floor, not a guarantee.
 """
@@ -234,6 +237,60 @@ requires_docker = pytest.mark.skipif(
     not _docker_available() and not os.environ.get("CI"),
     reason="Docker unavailable locally; in CI this is a hard failure, not a skip",
 )
+
+
+class TestSaasRestFallbackMovesRows:
+    """The SaaS REST fallback — shared machinery for ten connectors (core#545).
+
+    ## Why this one test covers ten connectors
+
+    `stripe`, `github`, `hubspot`, `salesforce`, `shopify`, `jira`, `slack`, `zendesk`,
+    `airtable` and `notion` all reach `_rest_api_fallback()` inside an
+    `except ImportError`. **That branch is the production path**, not an edge case:
+    none of the verified sources ship — checked all ten, every one absent — and the
+    Dockerfile says so deliberately ("fallback when not installed via `dlt init` …
+    avoids dependency conflicts in Docker").
+
+    So what runs in production for those ten is: per-connector base URL + auth +
+    default resource list → `_rest_api_fallback` → `rest_api_source`. This exercises
+    that spine end to end.
+
+    ## Why salesforce is the representative
+
+    It is the only one of the ten whose **host** comes from config
+    (`instance_url`); the rest hardcode it (`api.stripe.com`) or fix the suffix
+    (`{store}.myshopify.com`). So it is the only one that can be pointed at a local
+    server without patching the source — the others would need their URL rewritten,
+    which would test the rewrite rather than the connector.
+
+    ## What this does NOT cover, per connector
+
+    Each connector's own auth assembly and default resource list are still unproven
+    — those differ per connector and mostly need credentials. This proves the shared
+    fallback spine yields rows, not that any specific vendor integration works.
+    `pipedrive` / `freshdesk` / `asana` already have live row evidence from the
+    nightly Wave-1 suite (core#311), so the fallback has been exercised against real
+    vendors too — just not anywhere PR CI can see.
+    """
+
+    def test_the_fallback_spine_delivers_rows(self, tmp_path, json_api, allow_loopback):
+        db_path = _extract_load(
+            tmp_path,
+            "salesforce",
+            {"instance_url": json_api, "access_token": "probe-token"},
+            # Override the default Account/Contact/Opportunity list with the one
+            # resource the local server serves. The override path itself is what
+            # #532 fixed, so exercising it is deliberate.
+            {"resources": [{"name": "widgets", "endpoint": {"path": "widgets"}}]},
+        )
+
+        rows = _rows(db_path, "widgets")
+
+        assert rows == [("alpha", 100), ("beta", 200), ("gamma", 300)], (
+            "the SaaS REST fallback did not deliver record contents into DuckDB — "
+            "this is the path ten connectors run in production, since no verified "
+            "source ships."
+        )
 
 
 @requires_docker

--- a/tests/test_ui/test_connection_picker_coverage.py
+++ b/tests/test_ui/test_connection_picker_coverage.py
@@ -9,12 +9,20 @@ list doesn't, CI fails here.
 """
 
 from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 from datanika.ui.pages.connections import PICKER_TYPES
 
 
 def test_picker_covers_every_connection_type():
-    """Every ConnectionType enum value must appear in the picker list."""
-    enum_values = {t.value for t in ConnectionType}
+    """Every ConnectionType enum value must appear in the picker list.
+
+    Except a **withdrawn** one. A withdrawn type keeps its enum member so
+    connections already stored still resolve, but is deliberately not offered
+    — see `WITHDRAWN_SOURCE_TYPES` (core#555). Without this exemption the test
+    reads "everything in the enum is on sale", which stopped being true the
+    moment a connector had to be retired without orphaning existing rows.
+    """
+    enum_values = {t.value for t in ConnectionType} - WITHDRAWN_SOURCE_TYPES
     picker_values = set(PICKER_TYPES)
 
     missing_from_picker = enum_values - picker_values
@@ -22,6 +30,20 @@ def test_picker_covers_every_connection_type():
         f"The connection picker is missing {len(missing_from_picker)} "
         f"type(s) the backend supports: {sorted(missing_from_picker)}. "
         f"Add them to PICKER_TYPES in datanika/ui/pages/connections.py."
+    )
+
+
+def test_withdrawn_types_are_kept_out_of_the_picker():
+    """The exemption above must not become a hole.
+
+    If a withdrawn type reappeared in PICKER_TYPES it would be creatable again,
+    and the test above would happily pass — it only checks the other direction.
+    """
+    reoffered = WITHDRAWN_SOURCE_TYPES & set(PICKER_TYPES)
+    assert not reoffered, (
+        f"{sorted(reoffered)} are withdrawn but back in the picker — a user could create "
+        "a connection that cannot work. Remove them, or take them out of "
+        "WITHDRAWN_SOURCE_TYPES if they have been fixed."
     )
 
 


### PR DESCRIPTION
#556 — the hook rebased HEAD regardless of what was being pushed, which silently broke the post-promotion resync. It now reads the refs git supplies on stdin.

#557 — a venv stale against `uv.lock` failed as an unrelated missing dialect/module. Now compared against a stamp and reported plainly. It caught its own blocking failure on first contact (`No module named 'kafka'`).

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #555 — Google Ads cannot authenticate — we collect no developer token, so no fallback can help _(already closed)_ · via #567, commit a343140
- #556 — pre-push hook ignores the refspec being pushed and rebases HEAD _(already closed)_ · via #568, commit 1b38d6e
- #557 — pre-push should detect a venv stale against uv.lock _(already closed)_ · via #568, commit 1b38d6e

<!-- promotion-refs:end -->