### PR TITLE
[Engineering] MongoDB authenticates against the right database (closes #550)

### DIFF
--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -303,6 +303,14 @@ CONFIG_SCHEMAS: dict[str, dict] = {
             "user": _str("Username"),
             "password": _str("Password", sensitive=True),
             "database": _str("Database name"),
+            # Exposed, not just defaulted (core#550). Defaulting to `admin`
+            # fixes the standard deployment, but anyone whose user lives inside
+            # the target database needs a way to say so — and a setting with no
+            # surface is the core#499 mistake.
+            "auth_source": _str(
+                "Authentication database (default: admin — where MongoDB users "
+                "are normally created; set to the database name if yours is not)"
+            ),
         },
         required=["host", "database"],
     ),

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -115,6 +115,14 @@ GA4_PAGE_SIZE = 10_000
 
 GA4_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
 
+#: Where MongoDB looks for the user when none is specified.
+#:
+#: The database in a Mongo URI path doubles as the auth database, so omitting
+#: `authSource` means "the user lives inside the database you are reading" —
+#: which is not where anyone puts it. `MONGO_INITDB_ROOT_USERNAME`, Atlas and
+#: every managed provider create users in `admin` (core#550).
+DEFAULT_MONGO_AUTH_SOURCE = "admin"
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -989,8 +997,27 @@ class DltRunnerService:
         )
 
     def _build_mongodb_source(self, config: dict, dlt_config: dict, batch_size: int):
-        """Build a dlt source for MongoDB using pymongo."""
-        from urllib.parse import quote_plus
+        """Build a dlt source for MongoDB using pymongo.
+
+        **The database in a MongoDB URI path is also the authentication
+        database.** This used to build `mongodb://u:p@host:port/<target-db>`
+        with no `authSource`, so the driver looked for the user *inside the
+        database being read* — and MongoDB users are conventionally created in
+        `admin`, which is what `MONGO_INITDB_ROOT_USERNAME` does in the official
+        image and what Atlas and every managed provider do. So the connector
+        could not authenticate against any standard deployment (core#550).
+
+        It went unnoticed because an unauthenticated mongod is unaffected, and
+        that is what a local dev instance looks like.
+
+        `auth_source` defaults to `admin` rather than to the target database:
+        that is the configuration almost everyone has, and leaving the old
+        behaviour as the default would mean the connector stays broken unless
+        the user knows to set a field nobody told them about. Anyone who really
+        does keep the user inside the target database sets `auth_source` to that
+        database name and is back to the previous behaviour — explicitly.
+        """
+        from urllib.parse import quote_plus, urlencode
 
         from datanika.services.mongodb_source import mongodb_source
 
@@ -1004,7 +1031,14 @@ class DltRunnerService:
         password = config.get("password", "")
 
         if user:
-            uri = f"mongodb://{quote_plus(user)}:{quote_plus(password)}@{host}:{port}/{database}"
+            # Only authenticated connections carry authSource — an unauthenticated
+            # mongod rejects nothing, and sending one would be noise.
+            auth_source = config.get("auth_source") or DEFAULT_MONGO_AUTH_SOURCE
+            query = urlencode({"authSource": auth_source})
+            uri = (
+                f"mongodb://{quote_plus(user)}:{quote_plus(password)}"
+                f"@{host}:{port}/{database}?{query}"
+            )
         else:
             uri = f"mongodb://{host}:{port}/{database}"
 

--- a/tests/test_services/test_mongodb_auth_source.py
+++ b/tests/test_services/test_mongodb_auth_source.py
@@ -1,0 +1,113 @@
+"""MongoDB authenticates against the database the user actually lives in (core#550).
+
+**The database in a Mongo URI path doubles as the authentication database.** The
+builder emitted `mongodb://u:p@host:port/<target-db>` with no `authSource`, so
+the driver looked for the user *inside the database being read* — while MongoDB
+users are conventionally created in `admin` (`MONGO_INITDB_ROOT_USERNAME`, Atlas,
+every managed provider). Every authenticated deployment was rejected.
+
+It went unnoticed because an unauthenticated mongod is unaffected, and that is
+exactly what a local dev instance looks like. Same shape as core#492 one
+connector over: *the string we construct was checked; what happens when
+something consumes it was not.*
+
+The end-to-end proof lives in
+`test_source_builders_move_rows.py::TestMongoDbSourceMovesRows`, which drives a
+real mongod. This file pins the **decision** rather than the plumbing: which
+auth database is used, and whether the escape hatch works — because defaulting
+to `admin` is a behaviour change for anyone whose user really does live in the
+target database, and that trade-off should be visible.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from datanika.services.dlt_runner import DEFAULT_MONGO_AUTH_SOURCE, DltRunnerService
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _uri(svc, config, dlt_config=None):
+    """The connection URI handed to `mongodb_source`."""
+    with patch("datanika.services.mongodb_source.mongodb_source") as source:
+        svc.build_source("mongodb", config, dlt_config or {})
+    assert source.call_count == 1
+    return source.call_args.kwargs["connection_uri"]
+
+
+BASE = {"host": "db.example.com", "port": 27017, "database": "analytics"}
+AUTHED = {**BASE, "user": "reader", "password": "s3cret"}
+
+
+class TestAuthenticatedConnections:
+    def test_auth_source_defaults_to_admin(self, svc):
+        """The configuration almost everyone has.
+
+        Leaving the old behaviour as the default would mean the connector stays
+        broken unless the user knows to set a field nobody told them about.
+        """
+        assert "authSource=admin" in _uri(svc, AUTHED)
+
+    def test_the_target_database_is_still_the_one_read(self, svc):
+        """authSource changes where the *user* is looked up, not what is loaded."""
+        uri = _uri(svc, AUTHED)
+
+        assert "/analytics?" in uri, f"target database changed: {uri}"
+
+    def test_the_auth_database_is_overridable(self, svc):
+        """The escape hatch for anyone whose user lives in the target database.
+
+        That configuration works today and this change would otherwise break it,
+        so it has to remain expressible — explicitly rather than by accident.
+        """
+        uri = _uri(svc, {**AUTHED, "auth_source": "analytics"})
+
+        assert "authSource=analytics" in uri
+        assert "authSource=admin" not in uri
+
+    def test_credentials_are_still_escaped(self, svc):
+        """A password with URI-special characters must not corrupt the string.
+
+        Appending a query is the kind of change that quietly breaks quoting.
+        """
+        uri = _uri(svc, {**AUTHED, "user": "a@b", "password": "p/w?x=1&y"})
+
+        assert "a%40b" in uri
+        assert "p%2Fw%3Fx%3D1%26y" in uri
+        # The only `?` is the one starting the query string.
+        assert uri.count("?") == 1
+
+
+class TestUnauthenticatedConnections:
+    def test_no_auth_source_is_sent_without_a_user(self, svc):
+        """An unauthenticated mongod rejects nothing; sending authSource is noise.
+
+        This is also the configuration that has always worked, so it must not
+        change shape.
+        """
+        uri = _uri(svc, BASE)
+
+        assert "authSource" not in uri
+        assert uri == "mongodb://db.example.com:27017/analytics"
+
+
+class TestTheDefaultIsDeclared:
+    def test_the_constant_is_admin(self):
+        """Named rather than inlined, so the choice is greppable and reviewable."""
+        assert DEFAULT_MONGO_AUTH_SOURCE == "admin"
+
+    def test_it_is_exposed_in_the_connection_schema(self):
+        """A setting with no surface is the core#499 mistake.
+
+        Defaulting fixes the standard deployment, but the non-standard one needs
+        a way to say so — via the API and the discovery endpoint at minimum.
+        """
+        from datanika.services.connection_schemas import CONFIG_SCHEMAS
+
+        properties = CONFIG_SCHEMAS["mongodb"]["properties"]
+        assert "auth_source" in properties
+        assert "admin" in properties["auth_source"]["description"]

--- a/tests/test_services/test_source_builders_move_rows.py
+++ b/tests/test_services/test_source_builders_move_rows.py
@@ -376,31 +376,29 @@ class TestSqlDatabaseSourceMovesRows:
 
 @requires_docker
 class TestMongoDbSourceMovesRows:
-    """``_build_mongodb_source`` — and it cannot authenticate today (core#550).
+    """``_build_mongodb_source`` — authenticate against a real mongod, assert rows.
 
-    A real mongod, seeded through pymongo, extracted by our own ``mongodb_source``
-    (not a dlt verified source) into DuckDB. It fails at authentication, and the
-    cause is the builder rather than this harness — measured on one container with
-    one set of credentials, varying only the auth database:
+    **The marker came off because this started passing (core#550).** A real
+    mongod, seeded through pymongo, extracted by our own ``mongodb_source`` (not
+    a dlt verified source) into DuckDB. It used to fail at authentication, and
+    the cause was the builder rather than this harness — measured on one
+    container with one set of credentials, varying only the auth database:
 
         mongodb://u:p@host:port/probedb                   -> Authentication failed
         mongodb://u:p@host:port/probedb?authSource=admin  -> OK
         mongodb://u:p@host:port/admin                     -> OK
 
-    The builder emits the first shape. MongoDB users conventionally live in
-    ``admin`` (``MONGO_INITDB_ROOT_USERNAME``, Atlas, every managed provider), and
-    the database in the URI path doubles as the auth database — so authenticated
-    deployments are rejected. Unauthenticated mongod is unaffected, which is what a
-    local dev instance looks like and presumably why this went unnoticed.
+    The builder emitted the first shape. MongoDB users conventionally live in
+    ``admin`` (``MONGO_INITDB_ROOT_USERNAME``, Atlas, every managed provider),
+    and the database in a Mongo URI path doubles as the **auth** database — so
+    every authenticated deployment was rejected. Unauthenticated mongod is
+    unaffected, which is what a local dev instance looks like and why this went
+    unnoticed.
 
-    ``strict=True``: when the fix lands this XPASSes, pytest turns that into a
-    failure, and the marker must come off. The fix cannot land silently.
+    ``strict=True`` did its job: the fix XPASSed, pytest turned that into a
+    failure, and the marker had to come off. It could not land silently.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="core#550: the MongoDB URI sets no authSource, so users in admin are rejected",
-    )
     def test_rows_land_in_the_destination(self, tmp_path):
         from testcontainers.mongodb import MongoDbContainer
 


### PR DESCRIPTION
Closes #550.

**The database in a MongoDB URI path is also the authentication database.** The builder emitted `mongodb://u:p@host:port/<target-db>` with no `authSource`, so the driver looked for the user *inside the database being read* — while MongoDB users are conventionally created in `admin` (`MONGO_INITDB_ROOT_USERNAME`, Atlas, every managed provider). Every authenticated deployment was rejected.

It went unnoticed because an **unauthenticated** mongod is unaffected, and that is exactly what a local dev instance looks like. Same shape as #492 one connector over: *the string we construct was checked; what happens when something consumes it was not.*

## The judgement call

`auth_source` **defaults to `admin`**, which is a deliberate behaviour change.

Anyone whose user really does live inside the target database works today and would break. But leaving the old behaviour as the default means the connector stays broken unless the user knows to set a field nobody told them about — and the rare case stays expressible by setting `auth_source` to the database name, now **explicitly** rather than by accident.

It is **exposed in the connection schema**, not just defaulted. A setting with no surface is the #499 mistake: defaulting fixes the standard deployment, but the non-standard one needs a way to say so.

`authSource` is sent **only for authenticated connections** — an unauthenticated mongod rejects nothing, and that URI shape has always worked, so it is left byte-identical.

## Proof

`TestMongoDbSourceMovesRows` drives a **real mongod** (testcontainers) into a **real DuckDB** and asserts the rows. It was `xfail(strict=True)`; it now **`[XPASS(strict)]`s**, which pytest turns into a failure, which forced the marker off. The fix could not land silently — that is what the probe was built for.

The unit tests pin the **decision** rather than the plumbing: which auth database is used, that the target database is still what gets *read* (authSource changes lookup, not scope), and that the escape hatch works. **Proven red: 4 of 7 fail** with the query removed; the unauthenticated and declaration tests stay green, correctly.

One of them covers quoting, because appending a query string is exactly the kind of change that quietly breaks URI escaping — credentials containing `@ / ? = &` must still round-trip, and only one `?` may survive.

Full suite: **2763 passed, 20 skipped.**
