### PR TITLE
[Infra] Promote dev → master: serialise staging deploys (#572)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,17 @@ jobs:
   # removed 2026-07-17 — the Hetzner box is gone and GHCR is inaccessible from the box.
 
   deploy-staging:
+    # Serialise staging deploys (#572). Merges into dev now arrive faster than a staging
+    # deploy takes to finish, so two runs manipulated the same container names at once: one
+    # removed a container while the other recreated it, the removal failed, docker renamed the
+    # loser to <id>_<name>, and every later run hit "container name is already in use".
+    #
+    # cancel-in-progress is FALSE on purpose. Cancelling a deploy mid-flight is what created the
+    # wedged state; queueing is safe because GitHub holds only one pending job, so the newest
+    # queued run wins and nothing is killed while it is manipulating containers.
+    concurrency:
+      group: staging-deploy
+      cancel-in-progress: false
     needs: [lint, test, helm-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
@@ -272,8 +283,13 @@ jobs:
           if docker compose -p datanika-staging up -d postgres redis app celery; then
             echo "staging stack up"
           else
-            echo "compose up failed - clearing stale state for app/celery, retrying once"
-            docker compose -p datanika-staging rm -sf app celery || true
+            echo "compose up failed - clearing the whole project's containers, retrying once"
+            # By PROJECT LABEL, not service name: a container docker renamed to <id>_<name>
+            # after a failed removal is no longer recognised by compose as that service, so
+            # `rm -sf app celery` walks straight past the very container blocking the name.
+            # Named volumes are untouched by `docker rm`, so staging data survives.
+            docker ps -aq --filter 'label=com.docker.compose.project=datanika-staging' \
+              | xargs -r docker rm -f || true
             docker compose -p datanika-staging up -d --force-recreate postgres redis app celery
             echo "staging stack up after recovery"
           fi

--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -303,6 +303,14 @@ CONFIG_SCHEMAS: dict[str, dict] = {
             "user": _str("Username"),
             "password": _str("Password", sensitive=True),
             "database": _str("Database name"),
+            # Exposed, not just defaulted (core#550). Defaulting to `admin`
+            # fixes the standard deployment, but anyone whose user lives inside
+            # the target database needs a way to say so — and a setting with no
+            # surface is the core#499 mistake.
+            "auth_source": _str(
+                "Authentication database (default: admin — where MongoDB users "
+                "are normally created; set to the database name if yours is not)"
+            ),
         },
         required=["host", "database"],
     ),

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -115,6 +115,14 @@ GA4_PAGE_SIZE = 10_000
 
 GA4_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
 
+#: Where MongoDB looks for the user when none is specified.
+#:
+#: The database in a Mongo URI path doubles as the auth database, so omitting
+#: `authSource` means "the user lives inside the database you are reading" —
+#: which is not where anyone puts it. `MONGO_INITDB_ROOT_USERNAME`, Atlas and
+#: every managed provider create users in `admin` (core#550).
+DEFAULT_MONGO_AUTH_SOURCE = "admin"
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -989,8 +997,27 @@ class DltRunnerService:
         )
 
     def _build_mongodb_source(self, config: dict, dlt_config: dict, batch_size: int):
-        """Build a dlt source for MongoDB using pymongo."""
-        from urllib.parse import quote_plus
+        """Build a dlt source for MongoDB using pymongo.
+
+        **The database in a MongoDB URI path is also the authentication
+        database.** This used to build `mongodb://u:p@host:port/<target-db>`
+        with no `authSource`, so the driver looked for the user *inside the
+        database being read* — and MongoDB users are conventionally created in
+        `admin`, which is what `MONGO_INITDB_ROOT_USERNAME` does in the official
+        image and what Atlas and every managed provider do. So the connector
+        could not authenticate against any standard deployment (core#550).
+
+        It went unnoticed because an unauthenticated mongod is unaffected, and
+        that is what a local dev instance looks like.
+
+        `auth_source` defaults to `admin` rather than to the target database:
+        that is the configuration almost everyone has, and leaving the old
+        behaviour as the default would mean the connector stays broken unless
+        the user knows to set a field nobody told them about. Anyone who really
+        does keep the user inside the target database sets `auth_source` to that
+        database name and is back to the previous behaviour — explicitly.
+        """
+        from urllib.parse import quote_plus, urlencode
 
         from datanika.services.mongodb_source import mongodb_source
 
@@ -1004,7 +1031,14 @@ class DltRunnerService:
         password = config.get("password", "")
 
         if user:
-            uri = f"mongodb://{quote_plus(user)}:{quote_plus(password)}@{host}:{port}/{database}"
+            # Only authenticated connections carry authSource — an unauthenticated
+            # mongod rejects nothing, and sending one would be noise.
+            auth_source = config.get("auth_source") or DEFAULT_MONGO_AUTH_SOURCE
+            query = urlencode({"authSource": auth_source})
+            uri = (
+                f"mongodb://{quote_plus(user)}:{quote_plus(password)}"
+                f"@{host}:{port}/{database}?{query}"
+            )
         else:
             uri = f"mongodb://{host}:{port}/{database}"
 

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -94,6 +94,27 @@ DEFAULT_FACEBOOK_API_VERSION = "v21.0"
 #: a busy topic than on an hourly one.
 DEFAULT_KAFKA_IDLE_TIMEOUT_MS = 10_000
 
+#: The report a Google Analytics connection loads when nobody says otherwise.
+#:
+#: GA4's Data API has no "just give me the table" endpoint — `runReport` takes a
+#: POST body naming dimensions and metrics, and a different body is a different
+#: table. That is why this connector shipped unusable (core#543): there was no
+#: obvious default, so nothing was chosen and it raised instead.
+#:
+#: Daily traffic is the report almost everyone starts from, and it is the one a
+#: dashboard can be built on without knowing anything about the property.
+#: Overridable per upload via `dlt_config["dimensions"]` / `["metrics"]`.
+DEFAULT_GA4_DIMENSIONS = ["date"]
+DEFAULT_GA4_METRICS = ["sessions", "totalUsers", "screenPageViews"]
+DEFAULT_GA4_START_DATE = "28daysAgo"
+DEFAULT_GA4_END_DATE = "today"
+
+#: GA4 caps `runReport` at 100k rows per request; page below that so a wide
+#: date range still completes rather than silently truncating.
+GA4_PAGE_SIZE = 10_000
+
+GA4_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -152,6 +173,10 @@ INTERNAL_CONFIG_KEYS = {
     "base_id",
     "database",
     "auth",
+    # Google Analytics report shape (core#543).
+    "dimensions",
+    "metrics",
+    "end_date",
 }
 
 # Client-side row-filter lambdas — applied AFTER source yield.
@@ -397,6 +422,92 @@ def describe_empty_file_match(bucket_url: str, file_glob: str) -> str:
         return f"{general} That path does not exist."
 
     return f"{general} The directory exists but holds nothing matching that pattern."
+
+
+def _ga4_access_token(service_account_json) -> str:
+    """Mint a read-only Data API token from the service-account JSON.
+
+    GA4 takes an OAuth bearer token, not an API key, so there is no way to hand
+    dlt a static credential — the token has to be minted per run. `google-auth`
+    is already a dependency (Google Sheets uses it), so this adds no new
+    surface.
+
+    Called from inside the resource, never at build time: `build_source` must
+    stay offline so a source can be constructed and inspected without valid
+    credentials or a network.
+    """
+    from google.auth.transport.requests import Request
+    from google.oauth2 import service_account
+
+    info = service_account_json
+    if isinstance(info, str):
+        try:
+            info = dlt_json.loads(info)
+        except Exception as exc:
+            raise DltRunnerError(
+                "Google Analytics service account JSON is not valid JSON — paste the whole "
+                "key file, including the surrounding braces."
+            ) from exc
+
+    try:
+        credentials = service_account.Credentials.from_service_account_info(
+            info, scopes=[GA4_SCOPE]
+        )
+    except Exception as exc:
+        raise DltRunnerError(
+            f"Google Analytics service account JSON is missing required fields ({exc}). "
+            "Use the key file downloaded from the Google Cloud console."
+        ) from exc
+
+    credentials.refresh(Request())
+    return credentials.token
+
+
+def _ga4_rows(payload: dict) -> list[dict]:
+    """Flatten one `runReport` response into named columns.
+
+    GA4 answers with parallel arrays — `dimensionHeaders`/`metricHeaders` name
+    the columns, and each row carries `dimensionValues`/`metricValues` in the
+    same order. Loading that shape as-is gives a table of nested lists that no
+    one can query, so the headers are zipped back onto the values here.
+
+    Metrics arrive as **strings** whatever their type. They are coerced using
+    the type GA4 declares, because a `sessions` column of text cannot be summed
+    — which would make the load technically successful and analytically
+    useless, the failure this whole issue has been about.
+    """
+    dimension_names = [h.get("name") for h in payload.get("dimensionHeaders", [])]
+    metric_headers = payload.get("metricHeaders", [])
+    metric_names = [h.get("name") for h in metric_headers]
+    metric_types = [h.get("type", "") for h in metric_headers]
+
+    rows = []
+    for row in payload.get("rows", []):
+        record: dict = {}
+        for name, cell in zip(dimension_names, row.get("dimensionValues", []), strict=False):
+            record[name] = cell.get("value")
+        for name, kind, cell in zip(
+            metric_names, metric_types, row.get("metricValues", []), strict=False
+        ):
+            record[name] = _ga4_metric_value(cell.get("value"), kind)
+        rows.append(record)
+    return rows
+
+
+def _ga4_metric_value(raw, kind: str):
+    """Coerce a GA4 metric string using the type GA4 declares for it."""
+    if raw is None or raw == "":
+        return None
+    try:
+        if kind == "TYPE_INTEGER":
+            return int(raw)
+        if kind in ("TYPE_FLOAT", "TYPE_SECONDS", "TYPE_CURRENCY", "TYPE_MINUTES", "TYPE_HOURS"):
+            return float(raw)
+    except (TypeError, ValueError):
+        # An unparseable number is worth keeping as text rather than dropping:
+        # losing the value silently is worse than a column that needs a cast.
+        return raw
+    return raw
 
 
 def _kafka_topics(raw) -> list[str]:
@@ -1200,21 +1311,22 @@ class DltRunnerService:
                     kwargs_ga["credentials"] = credentials_json
                 return google_analytics(**kwargs_ga)
             except ImportError:
-                # Was "run dlt init google_analytics" — an instruction for a
-                # server the user does not operate, and the only outcome this
-                # connector has ever produced (core#543, same class as #499).
+                # The Data API directly, since no verified source is installed
+                # anywhere (core#543). This used to re-raise "run dlt init
+                # google_analytics" — an instruction for a server the user does
+                # not operate, and the only outcome this connector ever had.
                 #
-                # No REST fallback yet, and unlike Facebook it is not a matter
-                # of writing one: the Data API needs an OAuth token minted from
-                # the service-account JSON, and `runReport` takes a POST body
-                # naming dimensions and metrics — a report shape is a product
-                # decision, not a default. Tracked separately.
-                raise DltRunnerError(
-                    "Google Analytics is not available on this deployment yet. It needs a "
-                    "reporting query (dimensions and metrics) that Datanika does not collect, "
-                    "so there is nothing to configure on your side — see core#543. "
-                    "Google Sheets or a REST API connection can cover GA exports meanwhile."
-                ) from None
+                # What blocked it was not a missing library but a missing
+                # decision: `runReport` takes a POST body naming dimensions and
+                # metrics, and a different body is a different table, so there
+                # was no obvious default and nothing was chosen. Daily traffic
+                # is the report almost everyone starts from; the rest is
+                # overridable per upload.
+                if not credentials_json:
+                    raise DltRunnerError(
+                        "Google Analytics source requires 'service_account_json'"
+                    ) from None
+                return self._build_ga4_source(property_id, credentials_json, dlt_config)
 
         if connection_type == "google_ads":
             credentials_json = config.get("service_account_json", "")
@@ -1401,6 +1513,72 @@ class DltRunnerService:
             )
 
         raise DltRunnerError(f"Unsupported SaaS source type: {connection_type}")
+
+    def _build_ga4_source(self, property_id, service_account_json, dlt_config: dict):
+        """Google Analytics 4 via the Data API's `runReport` (core#543).
+
+        Written by hand rather than through `_rest_api_fallback` for two
+        reasons the generic path cannot cover:
+
+        * **The credential is a minted token, not a static key.** GA4 wants an
+          OAuth bearer refreshed from the service-account JSON, so there is
+          nothing to hand a declarative config up front.
+        * **The response is parallel arrays.** `dimensionHeaders` /
+          `metricHeaders` name the columns and each row carries values in the
+          same order, so a `data_selector` alone would load nested lists nobody
+          can query. `_ga4_rows` zips them back together.
+
+        Paged with `limit`/`offset` because GA4 truncates at its page size and
+        says so only in `rowCount` — a silent short read otherwise, which is the
+        family of bug this whole issue belongs to.
+        """
+        dimensions = list(dlt_config.get("dimensions") or DEFAULT_GA4_DIMENSIONS)
+        metrics = list(dlt_config.get("metrics") or DEFAULT_GA4_METRICS)
+        start_date = dlt_config.get("start_date") or DEFAULT_GA4_START_DATE
+        end_date = dlt_config.get("end_date") or DEFAULT_GA4_END_DATE
+        url = f"https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport"
+
+        @dlt.resource(name="report", primary_key=tuple(dimensions))
+        def _report():
+            # Minted here, not in the builder: `build_source` must stay offline
+            # so a source can be constructed and inspected without credentials.
+            token = _ga4_access_token(service_account_json)
+            session = build_guarded_session()  # SSRF guard, as everywhere else
+            offset = 0
+            while True:
+                response = session.post(
+                    url,
+                    json={
+                        "dateRanges": [{"startDate": start_date, "endDate": end_date}],
+                        "dimensions": [{"name": d} for d in dimensions],
+                        "metrics": [{"name": m} for m in metrics],
+                        "limit": GA4_PAGE_SIZE,
+                        "offset": offset,
+                    },
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=60,
+                )
+                if response.status_code >= 400:
+                    # GA4 explains itself well; surfacing its message beats
+                    # "request failed" when the cause is usually a property the
+                    # service account was never granted access to.
+                    raise DltRunnerError(
+                        f"Google Analytics rejected the report request "
+                        f"({response.status_code}): {response.text[:400]}"
+                    )
+                payload = response.json()
+                rows = _ga4_rows(payload)
+                if rows:
+                    yield rows
+                offset += len(rows)
+                if len(rows) < GA4_PAGE_SIZE or offset >= int(payload.get("rowCount", 0)):
+                    break
+
+        @dlt.source(name="google_analytics")
+        def _ga4_source():
+            return [_report()]
+
+        return _ga4_source()
 
     def _build_kafka_source(self, config: dict, dlt_config: dict):
         """Build a Kafka source that actually consumes (core#551).

--- a/tests/test_services/test_google_analytics_source.py
+++ b/tests/test_services/test_google_analytics_source.py
@@ -1,0 +1,252 @@
+"""Google Analytics loads via the Data API (core#543, last of the three).
+
+`google_analytics` had no verified source and no fallback, so its
+`except ImportError` re-raised *"run `dlt init google_analytics`"* — an
+instruction for a server the user does not operate, and the only outcome it
+ever produced.
+
+What blocked it was **not a missing library but a missing decision**. `runReport`
+takes a POST body naming dimensions and metrics, and a different body is a
+different table, so there was no obvious default and nothing got chosen. This
+picks daily traffic — the report almost anyone starts from — and makes the rest
+overridable per upload.
+
+Two things the generic REST fallback could not have done, both covered here:
+
+* the credential is a **minted OAuth token**, not a static key, so there is
+  nothing to hand a declarative config up front;
+* the response is **parallel arrays** (`dimensionHeaders`/`metricHeaders` name
+  the columns, rows carry values in the same order), which a `data_selector`
+  would load as nested lists nobody can query.
+
+**Verified against the documented API shape, not a live property** — there are
+no GA credentials here or in CI. What is asserted is what does not depend on
+Google: the request we build, the flattening, the paging loop, and that building
+a source touches nothing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datanika.services.dlt_runner import (
+    DEFAULT_GA4_DIMENSIONS,
+    DEFAULT_GA4_METRICS,
+    GA4_PAGE_SIZE,
+    DltRunnerError,
+    DltRunnerService,
+    _ga4_rows,
+)
+
+CONFIG = {"property_id": "123456", "service_account_json": '{"type": "service_account"}'}
+
+
+def _payload(rows: int, row_count: int | None = None) -> dict:
+    """A `runReport` response in GA4's real shape."""
+    return {
+        "dimensionHeaders": [{"name": "date"}],
+        "metricHeaders": [
+            {"name": "sessions", "type": "TYPE_INTEGER"},
+            {"name": "bounceRate", "type": "TYPE_FLOAT"},
+        ],
+        "rows": [
+            {
+                "dimensionValues": [{"value": f"2026072{i % 10}"}],
+                "metricValues": [{"value": str(100 + i)}, {"value": "0.25"}],
+            }
+            for i in range(rows)
+        ],
+        "rowCount": rows if row_count is None else row_count,
+    }
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _drive(svc, dlt_config=None, payloads=None):
+    """Build the source and consume it against a stubbed HTTP session.
+
+    Returns (rows, list_of_request_bodies).
+    """
+    payloads = payloads or [_payload(2)]
+    responses = []
+    for body in payloads:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = body
+        responses.append(response)
+
+    session = MagicMock()
+    session.post.side_effect = responses
+
+    with (
+        patch("datanika.services.dlt_runner._ga4_access_token", return_value="tok"),
+        patch("datanika.services.dlt_runner.build_guarded_session", return_value=session),
+    ):
+        source = svc.build_source("google_analytics", CONFIG, dlt_config or {})
+        rows = list(source)
+
+    bodies = [call.kwargs["json"] for call in session.post.call_args_list]
+    return rows, bodies, session
+
+
+class TestBuildingTouchesNothing:
+    def test_a_source_builds_without_credentials_or_network(self, svc):
+        """The whole connector used to be unreachable; now it must also be inert.
+
+        Token minting lives inside the resource on purpose — `build_source` is
+        called by contract tests and by anything that wants to inspect a
+        connector, so it must not require a valid key or a network.
+        """
+        with patch("datanika.services.dlt_runner._ga4_access_token") as mint:
+            source = svc.build_source(
+                "google_analytics", {"property_id": "1", "service_account_json": "{}"}, {}
+            )
+
+        assert source is not None
+        mint.assert_not_called()
+
+    def test_the_resource_is_named_for_the_picker(self, svc):
+        """`SAAS_DEFAULT_ENDPOINTS["google_analytics"] == ["report"]`."""
+        source = svc.build_source(
+            "google_analytics", {"property_id": "1", "service_account_json": "{}"}, {}
+        )
+        assert list(source.resources.keys()) == ["report"]
+
+    def test_missing_credentials_are_rejected(self, svc):
+        with pytest.raises(DltRunnerError, match="service_account_json"):
+            svc.build_source("google_analytics", {"property_id": "1"}, {})
+
+    def test_missing_property_is_rejected(self, svc):
+        with pytest.raises(DltRunnerError, match="property_id"):
+            svc.build_source("google_analytics", {"service_account_json": "{}"}, {})
+
+
+class TestTheRequestWeBuild:
+    def test_it_defaults_to_daily_traffic(self, svc):
+        _rows, bodies, _ = _drive(svc)
+
+        body = bodies[0]
+        assert [d["name"] for d in body["dimensions"]] == DEFAULT_GA4_DIMENSIONS
+        assert [m["name"] for m in body["metrics"]] == DEFAULT_GA4_METRICS
+
+    def test_the_report_shape_is_overridable(self, svc):
+        """The default is a choice, not a limit — that was the whole blocker."""
+        _rows, bodies, _ = _drive(
+            svc, {"dimensions": ["country", "deviceCategory"], "metrics": ["activeUsers"]}
+        )
+
+        body = bodies[0]
+        assert [d["name"] for d in body["dimensions"]] == ["country", "deviceCategory"]
+        assert [m["name"] for m in body["metrics"]] == ["activeUsers"]
+
+    def test_the_date_range_is_overridable(self, svc):
+        _rows, bodies, _ = _drive(svc, {"start_date": "2026-01-01", "end_date": "2026-06-30"})
+
+        assert bodies[0]["dateRanges"] == [{"startDate": "2026-01-01", "endDate": "2026-06-30"}]
+
+    def test_it_addresses_the_property_and_authenticates(self, svc):
+        _rows, _bodies, session = _drive(svc)
+
+        url = session.post.call_args_list[0].args[0]
+        assert url.endswith("/properties/123456:runReport")
+        assert session.post.call_args_list[0].kwargs["headers"]["Authorization"] == "Bearer tok"
+
+
+class TestFlattening:
+    def test_headers_are_zipped_onto_values(self):
+        rows = _ga4_rows(_payload(1))
+
+        assert rows == [{"date": "20260720", "sessions": 100, "bounceRate": 0.25}]
+
+    def test_metrics_are_typed_not_left_as_text(self):
+        """A `sessions` column of strings cannot be summed.
+
+        GA4 returns every metric as a string; loading it that way would be a
+        technically successful load that no one can query — the exact failure
+        family this issue belongs to.
+        """
+        rows = _ga4_rows(_payload(1))
+
+        assert isinstance(rows[0]["sessions"], int)
+        assert isinstance(rows[0]["bounceRate"], float)
+
+    def test_an_unparseable_metric_is_kept_as_text(self):
+        """Losing a value silently is worse than a column needing a cast."""
+        payload = _payload(1)
+        payload["rows"][0]["metricValues"][0]["value"] = "n/a"
+
+        assert _ga4_rows(payload)[0]["sessions"] == "n/a"
+
+    def test_an_empty_report_is_not_an_error(self):
+        assert _ga4_rows({"dimensionHeaders": [], "metricHeaders": [], "rows": []}) == []
+
+
+class TestPaging:
+    def test_a_full_page_asks_for_the_next(self, svc):
+        """GA4 truncates at its page size and says so only in `rowCount`.
+
+        Stopping after one page would be a silent short read — the same shape as
+        core#492/#493, where the run looks fine and the data is partial.
+        """
+        first = _payload(GA4_PAGE_SIZE, row_count=GA4_PAGE_SIZE + 3)
+        second = _payload(3, row_count=GA4_PAGE_SIZE + 3)
+
+        rows, bodies, _ = _drive(svc, payloads=[first, second])
+
+        assert len(bodies) == 2, "did not request the second page"
+        assert bodies[0]["offset"] == 0
+        assert bodies[1]["offset"] == GA4_PAGE_SIZE
+        assert len(rows) == GA4_PAGE_SIZE + 3
+
+    def test_a_short_page_stops(self, svc):
+        _rows, bodies, _ = _drive(svc, payloads=[_payload(2)])
+
+        assert len(bodies) == 1
+
+
+class TestErrors:
+    def test_googles_own_message_is_surfaced(self, svc):
+        """A GA4 rejection is usually a property the service account cannot see.
+
+        "Request failed" would send the user to re-check credentials that are
+        fine. Asserted on the *message* rather than the exception type: dlt
+        wraps anything raised inside a resource in `ResourceExtractionError`, so
+        the type does not survive extraction — the text does, and the text is
+        what reaches the run log.
+        """
+        response = MagicMock()
+        response.status_code = 403
+        response.text = "User does not have sufficient permissions for this property."
+        session = MagicMock()
+        session.post.return_value = response
+
+        with (
+            patch("datanika.services.dlt_runner._ga4_access_token", return_value="tok"),
+            patch("datanika.services.dlt_runner.build_guarded_session", return_value=session),
+            pytest.raises(Exception) as exc,
+        ):
+            list(svc.build_source("google_analytics", CONFIG, {}))
+
+        assert "sufficient permissions" in str(exc.value), (
+            f"Google's explanation did not reach the caller: {exc.value}"
+        )
+        assert "403" in str(exc.value)
+
+    def test_the_error_type_is_ours_before_dlt_wraps_it(self, svc):
+        """Pin the type at the point we raise it, since extraction hides it."""
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "backend error"
+        session = MagicMock()
+        session.post.return_value = response
+
+        with (
+            patch("datanika.services.dlt_runner._ga4_access_token", return_value="tok"),
+            patch("datanika.services.dlt_runner.build_guarded_session", return_value=session),
+        ):
+            resource = svc.build_source("google_analytics", CONFIG, {}).resources["report"]
+            with pytest.raises(DltRunnerError, match="backend error"):
+                list(resource._pipe.gen())

--- a/tests/test_services/test_mongodb_auth_source.py
+++ b/tests/test_services/test_mongodb_auth_source.py
@@ -1,0 +1,113 @@
+"""MongoDB authenticates against the database the user actually lives in (core#550).
+
+**The database in a Mongo URI path doubles as the authentication database.** The
+builder emitted `mongodb://u:p@host:port/<target-db>` with no `authSource`, so
+the driver looked for the user *inside the database being read* — while MongoDB
+users are conventionally created in `admin` (`MONGO_INITDB_ROOT_USERNAME`, Atlas,
+every managed provider). Every authenticated deployment was rejected.
+
+It went unnoticed because an unauthenticated mongod is unaffected, and that is
+exactly what a local dev instance looks like. Same shape as core#492 one
+connector over: *the string we construct was checked; what happens when
+something consumes it was not.*
+
+The end-to-end proof lives in
+`test_source_builders_move_rows.py::TestMongoDbSourceMovesRows`, which drives a
+real mongod. This file pins the **decision** rather than the plumbing: which
+auth database is used, and whether the escape hatch works — because defaulting
+to `admin` is a behaviour change for anyone whose user really does live in the
+target database, and that trade-off should be visible.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from datanika.services.dlt_runner import DEFAULT_MONGO_AUTH_SOURCE, DltRunnerService
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _uri(svc, config, dlt_config=None):
+    """The connection URI handed to `mongodb_source`."""
+    with patch("datanika.services.mongodb_source.mongodb_source") as source:
+        svc.build_source("mongodb", config, dlt_config or {})
+    assert source.call_count == 1
+    return source.call_args.kwargs["connection_uri"]
+
+
+BASE = {"host": "db.example.com", "port": 27017, "database": "analytics"}
+AUTHED = {**BASE, "user": "reader", "password": "s3cret"}
+
+
+class TestAuthenticatedConnections:
+    def test_auth_source_defaults_to_admin(self, svc):
+        """The configuration almost everyone has.
+
+        Leaving the old behaviour as the default would mean the connector stays
+        broken unless the user knows to set a field nobody told them about.
+        """
+        assert "authSource=admin" in _uri(svc, AUTHED)
+
+    def test_the_target_database_is_still_the_one_read(self, svc):
+        """authSource changes where the *user* is looked up, not what is loaded."""
+        uri = _uri(svc, AUTHED)
+
+        assert "/analytics?" in uri, f"target database changed: {uri}"
+
+    def test_the_auth_database_is_overridable(self, svc):
+        """The escape hatch for anyone whose user lives in the target database.
+
+        That configuration works today and this change would otherwise break it,
+        so it has to remain expressible — explicitly rather than by accident.
+        """
+        uri = _uri(svc, {**AUTHED, "auth_source": "analytics"})
+
+        assert "authSource=analytics" in uri
+        assert "authSource=admin" not in uri
+
+    def test_credentials_are_still_escaped(self, svc):
+        """A password with URI-special characters must not corrupt the string.
+
+        Appending a query is the kind of change that quietly breaks quoting.
+        """
+        uri = _uri(svc, {**AUTHED, "user": "a@b", "password": "p/w?x=1&y"})
+
+        assert "a%40b" in uri
+        assert "p%2Fw%3Fx%3D1%26y" in uri
+        # The only `?` is the one starting the query string.
+        assert uri.count("?") == 1
+
+
+class TestUnauthenticatedConnections:
+    def test_no_auth_source_is_sent_without_a_user(self, svc):
+        """An unauthenticated mongod rejects nothing; sending authSource is noise.
+
+        This is also the configuration that has always worked, so it must not
+        change shape.
+        """
+        uri = _uri(svc, BASE)
+
+        assert "authSource" not in uri
+        assert uri == "mongodb://db.example.com:27017/analytics"
+
+
+class TestTheDefaultIsDeclared:
+    def test_the_constant_is_admin(self):
+        """Named rather than inlined, so the choice is greppable and reviewable."""
+        assert DEFAULT_MONGO_AUTH_SOURCE == "admin"
+
+    def test_it_is_exposed_in_the_connection_schema(self):
+        """A setting with no surface is the core#499 mistake.
+
+        Defaulting fixes the standard deployment, but the non-standard one needs
+        a way to say so — via the API and the discovery endpoint at minimum.
+        """
+        from datanika.services.connection_schemas import CONFIG_SCHEMAS
+
+        properties = CONFIG_SCHEMAS["mongodb"]["properties"]
+        assert "auth_source" in properties
+        assert "admin" in properties["auth_source"]["description"]

--- a/tests/test_services/test_saas_endpoint_selection.py
+++ b/tests/test_services/test_saas_endpoint_selection.py
@@ -41,6 +41,10 @@ SAAS_PROBE_CONFIG = {
     # Bare id on purpose: the builder normalises it to `act_…`, and users paste
     # it both ways.
     "facebook_ads": {"access_token": "t", "account_id": "123456789"},
+    # Deliberately nonsense credentials: building a GA4 source must not mint a
+    # token or touch the network, so an unusable key still has to construct
+    # (core#543). If this starts failing, the builder has gained eager I/O.
+    "google_analytics": {"property_id": "123", "service_account_json": "{}"},
 }
 
 # These two still raise instead of building (core#543). `facebook_ads` moved out
@@ -58,7 +62,6 @@ SAAS_PROBE_CONFIG = {
 # Config here is *valid* — the point is that the raise happens after the
 # required-field checks, not because of them.
 CANNOT_BUILD = {
-    "google_analytics": {"property_id": "1", "service_account_json": "{}"},
     "google_ads": {"customer_id": "1", "service_account_json": "{}"},
 }
 

--- a/tests/test_services/test_source_builders_move_rows.py
+++ b/tests/test_services/test_source_builders_move_rows.py
@@ -376,31 +376,29 @@ class TestSqlDatabaseSourceMovesRows:
 
 @requires_docker
 class TestMongoDbSourceMovesRows:
-    """``_build_mongodb_source`` — and it cannot authenticate today (core#550).
+    """``_build_mongodb_source`` — authenticate against a real mongod, assert rows.
 
-    A real mongod, seeded through pymongo, extracted by our own ``mongodb_source``
-    (not a dlt verified source) into DuckDB. It fails at authentication, and the
-    cause is the builder rather than this harness — measured on one container with
-    one set of credentials, varying only the auth database:
+    **The marker came off because this started passing (core#550).** A real
+    mongod, seeded through pymongo, extracted by our own ``mongodb_source`` (not
+    a dlt verified source) into DuckDB. It used to fail at authentication, and
+    the cause was the builder rather than this harness — measured on one
+    container with one set of credentials, varying only the auth database:
 
         mongodb://u:p@host:port/probedb                   -> Authentication failed
         mongodb://u:p@host:port/probedb?authSource=admin  -> OK
         mongodb://u:p@host:port/admin                     -> OK
 
-    The builder emits the first shape. MongoDB users conventionally live in
-    ``admin`` (``MONGO_INITDB_ROOT_USERNAME``, Atlas, every managed provider), and
-    the database in the URI path doubles as the auth database — so authenticated
-    deployments are rejected. Unauthenticated mongod is unaffected, which is what a
-    local dev instance looks like and presumably why this went unnoticed.
+    The builder emitted the first shape. MongoDB users conventionally live in
+    ``admin`` (``MONGO_INITDB_ROOT_USERNAME``, Atlas, every managed provider),
+    and the database in a Mongo URI path doubles as the **auth** database — so
+    every authenticated deployment was rejected. Unauthenticated mongod is
+    unaffected, which is what a local dev instance looks like and why this went
+    unnoticed.
 
-    ``strict=True``: when the fix lands this XPASSes, pytest turns that into a
-    failure, and the marker must come off. The fix cannot land silently.
+    ``strict=True`` did its job: the fix XPASSed, pytest turned that into a
+    failure, and the marker had to come off. It could not land silently.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="core#550: the MongoDB URI sets no authSource, so users in admin are rejected",
-    )
     def test_rows_land_in_the_destination(self, tmp_path):
         from testcontainers.mongodb import MongoDbContainer
 


### PR DESCRIPTION
#572 — overlapping staging deploys raced on container names, leaving staging wedged with four containers in `Created` and a docker-renamed orphan. Job-level concurrency group serialises them (`cancel-in-progress: false` — cancelling mid-deploy is what caused the wedge), and recovery now clears by compose project label, which is the only way to catch a renamed container.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #543 — Google Analytics, Google Ads and Facebook Ads cannot run at all — no verified source, no fallback _(already closed)_ · via #569, commit f41dfc9
- #550 — [QA] MongoDB source cannot authenticate: the connection URI sets no authSource, so users in admin are rejected _(already closed)_ · via #574, commit 692ed98
- #572 — [QA→Infra] deploy-staging failing again: container NAME conflicts from in-progress removals (overlapping deploys) — Gate 4 night 2 at risk _(already closed)_ · via #573, commit b462d88

<!-- promotion-refs:end -->