### PR TITLE
[Engineering] Warehouse destinations get credentials dlt can read (closes #565)

### DIFF
--- a/datanika/services/connection_schemas.py
+++ b/datanika/services/connection_schemas.py
@@ -124,12 +124,18 @@ CONFIG_SCHEMAS: dict[str, dict] = {
         {
             "project": _str("GCP project ID"),
             "dataset": _str("BigQuery dataset name"),
-            "service_account_json": _str(
-                "Service account JSON (paste the full JSON)",
+            # `keyfile_json`, not `service_account_json`: this schema declared
+            # the latter while the connection form has always written the
+            # former, so the schema described a key no stored connection had
+            # (core#565). Corrected to match reality rather than renaming the
+            # form and stranding every BigQuery connection already saved. The
+            # runner accepts both, so neither name breaks.
+            "keyfile_json": _str(
+                "Service account JSON (paste the full key file)",
                 sensitive=True,
             ),
         },
-        required=["project", "dataset", "service_account_json"],
+        required=["project", "dataset", "keyfile_json"],
     ),
     "snowflake": _schema(
         {

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -123,6 +123,28 @@ GA4_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
 #: every managed provider create users in `admin` (core#550).
 DEFAULT_MONGO_AUTH_SOURCE = "admin"
 
+#: Cloud-warehouse fields whose stored name is not the name dlt reads (core#565).
+#:
+#: `_to_dlt_credentials` translated only for SQL types, so these passed through
+#: untouched and dlt saw no credential it recognised — BigQuery and Databricks
+#: could not complete a run, and Snowflake was suspected and then confirmed.
+#: Names taken from dlt's own credential classes in the installed version, not
+#: from documentation.
+_WAREHOUSE_CREDENTIAL_RENAMES = {
+    "databricks": {"host": "server_hostname", "token": "access_token"},
+    # `SnowflakeCredentials` has no `account`; the account identifier is its host.
+    "snowflake": {"account": "host"},
+}
+
+#: Keys stored on a warehouse connection that are *not* credentials. dlt rejects
+#: unknown fields, and `schema`/`dataset` describe where to write rather than
+#: how to authenticate.
+_NON_CREDENTIAL_WAREHOUSE_KEYS = {
+    "bigquery": {"dataset"},
+    "databricks": {"schema"},
+    "snowflake": {"schema"},
+}
+
 INTERNAL_CONFIG_KEYS = {
     "mode",
     "table",
@@ -432,6 +454,60 @@ def describe_empty_file_match(bucket_url: str, file_glob: str) -> str:
     return f"{general} The directory exists but holds nothing matching that pattern."
 
 
+def _bigquery_credentials(creds: dict) -> dict:
+    """Explode a service-account JSON into the fields dlt actually reads.
+
+    dlt's `GcpServiceAccountCredentials` reads `project_id`, `private_key`,
+    `client_email` and friends. It does **not** read a blob — passing the JSON
+    under any key at all is silently ignored, which is why BigQuery failed in
+    prod with *"missing project_id, private_key, client_email"* while the
+    connection form was filled in correctly (core#565).
+
+    **Both key names are accepted on purpose.** The connection form writes
+    `keyfile_json`; `CONFIG_SCHEMAS` declares `service_account_json`. Connections
+    already stored carry the former, so reading only the schema's name would fix
+    nothing for anyone who has a BigQuery connection today. The schema is
+    corrected to match reality in the same change; this keeps working either way.
+    """
+    raw = creds.pop("keyfile_json", None) or creds.pop("service_account_json", None)
+
+    if not raw:
+        # Leave it alone: dlt will fail with its own message, and on a machine
+        # with Application Default Credentials it may legitimately succeed
+        # without one.
+        return creds
+
+    if isinstance(raw, str):
+        try:
+            parsed = dlt_json.loads(raw)
+        except Exception as exc:
+            raise DltRunnerError(
+                "BigQuery service account JSON is not valid JSON — paste the whole key "
+                "file, including the surrounding braces."
+            ) from exc
+    else:
+        parsed = raw
+
+    if not isinstance(parsed, dict):
+        raise DltRunnerError("BigQuery service account JSON must be a JSON object.")
+
+    for field in ("project_id", "private_key", "client_email"):
+        if not parsed.get(field):
+            raise DltRunnerError(
+                f"BigQuery service account JSON is missing {field!r}. Use the key file "
+                "downloaded from the Google Cloud console, not a truncated copy."
+            )
+
+    # The stored `project` is the project to bill/query; the key's `project_id`
+    # is where the service account lives. They are usually the same, and when
+    # they differ the explicit field wins.
+    project_override = creds.pop("project", None)
+    merged = {**parsed}
+    if project_override:
+        merged["project_id"] = project_override
+    return merged
+
+
 def _ga4_access_token(service_account_json) -> str:
     """Mint a read-only Data API token from the service-account JSON.
 
@@ -702,9 +778,36 @@ class DltRunnerService:
     def _to_dlt_credentials(connection_type: str, config: dict) -> dict:
         """Convert stored connection config to dlt-compatible credentials.
 
-        Adds drivername for SQL source types, renames user→username.
+        Adds drivername for SQL source types, renames user→username, and maps
+        the cloud-warehouse fields whose names never lined up (core#565).
+
+        **BigQuery and Databricks could not complete a single run.** This
+        translated only for SQL types, so warehouse configs passed through
+        untouched and dlt never saw a credential it recognised:
+
+            stored                          dlt wants
+            keyfile_json                    project_id, private_key, client_email, …
+            host / token                    server_hostname / access_token
+            account                         host
+
+        Verified against dlt's own resolution rather than a table — and worth
+        knowing why that mattered: on a developer machine with gcloud ADC,
+        BigQuery resolves *whatever you pass*, including nothing at all, because
+        Application Default Credentials fill the gap. The failure only appears
+        where there is no ADC, which is prod.
         """
         creds = dict(config)
+
+        for key in _NON_CREDENTIAL_WAREHOUSE_KEYS.get(connection_type, ()):
+            creds.pop(key, None)
+
+        if connection_type in _WAREHOUSE_CREDENTIAL_RENAMES:
+            for stored, wanted in _WAREHOUSE_CREDENTIAL_RENAMES[connection_type].items():
+                if stored in creds:
+                    creds[wanted] = creds.pop(stored)
+
+        if connection_type == "bigquery":
+            creds = _bigquery_credentials(creds)
 
         # Rename user → username for SQL and Snowflake types
         if connection_type in _RENAME_USER_TYPES and "user" in creds:

--- a/tests/test_services/test_destination_credentials.py
+++ b/tests/test_services/test_destination_credentials.py
@@ -1,0 +1,195 @@
+"""Every destination's stored config must resolve into dlt credentials (core#565).
+
+BigQuery and Databricks could not complete a single run. `_to_dlt_credentials`
+translated only for **SQL** types, so warehouse configs passed through untouched
+and dlt never saw a credential it recognised:
+
+    stored                    dlt reads
+    keyfile_json              project_id, private_key, client_email, …
+    host / token              server_hostname / access_token
+    account                   host
+
+The failure lands at the *last* step, after the user has created a GCP service
+account or a Databricks PAT and filled in every field — and Test Connection
+never exercises the dlt credential path, so nothing hints at it.
+
+**These tests drive the config the connection form actually writes**, not the
+config `CONFIG_SCHEMAS` describes. For BigQuery those disagreed — the form wrote
+`keyfile_json`, the schema declared `service_account_json` — and reading the
+schema is how you write a test that passes while production fails.
+
+## Why ADC has to be neutralised
+
+On a machine with `gcloud` Application Default Credentials, BigQuery resolves
+**whatever you pass, including nothing at all**: dlt falls back to ADC and hands
+back someone's real project. Measured during this fix — passing no credentials
+resolved to a live personal project. A test written without disabling that would
+pass locally, pass for the wrong reason, and say nothing about prod, where there
+is no ADC. `_no_ambient_google_credentials` is therefore load-bearing, not
+hygiene.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from datanika.services.dlt_runner import DltRunnerError, DltRunnerService
+
+SERVICE_ACCOUNT = {
+    "type": "service_account",
+    "project_id": "datanika-test-565",
+    "private_key_id": "kid",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nZmFrZQ==\n-----END PRIVATE KEY-----\n",
+    "client_email": "svc@datanika-test-565.iam.gserviceaccount.com",
+    "client_id": "1",
+    "token_uri": "https://oauth2.googleapis.com/token",
+}
+
+#: Exactly what `connection_state.py` writes for each type — see the `elif t ==`
+#: branches. Deliberately not built from CONFIG_SCHEMAS: for BigQuery the two
+#: disagreed, and the form is what reaches production.
+STORED_CONFIG = {
+    "bigquery": {
+        "project": "datanika-test-565",
+        "dataset": "analytics",
+        "keyfile_json": json.dumps(SERVICE_ACCOUNT),
+    },
+    "databricks": {
+        "host": "adb-1234.azuredatabricks.net",
+        "http_path": "/sql/1.0/warehouses/abc123",
+        "token": "dapi-fake-token",
+        "catalog": "main",
+        "schema": "public",
+    },
+    "snowflake": {
+        "account": "xy12345.us-east-1",
+        "user": "loader",
+        "password": "s3cret",
+        "database": "ANALYTICS",
+        "warehouse": "COMPUTE_WH",
+        "schema": "PUBLIC",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_google_credentials(monkeypatch):
+    """Make Application Default Credentials undiscoverable for these tests.
+
+    Without this, BigQuery resolves from the developer's own gcloud login and
+    every assertion below passes regardless of the code under test.
+    """
+    monkeypatch.setenv("CLOUDSDK_CONFIG", tempfile.mkdtemp(prefix="no-adc-"))
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return DltRunnerService(pipelines_dir=str(tmp_path))
+
+
+def _resolved_credentials(svc, connection_type, config, tmp_path):
+    """Resolve the destination the way `pipeline.run()` does — no network."""
+    import dlt
+
+    destination = svc.build_destination(connection_type, config)
+    pipeline = dlt.pipeline(
+        pipeline_name=f"t565_{connection_type}",
+        destination=destination,
+        dataset_name="probe_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    return pipeline.destination_client().config.credentials
+
+
+class TestTheStoredConfigResolves:
+    """The reported failure was `ConfigFieldMissingException` at resolution."""
+
+    @pytest.mark.parametrize("connection_type", sorted(STORED_CONFIG))
+    def test_credentials_resolve_without_raising(self, svc, connection_type, tmp_path):
+        _resolved_credentials(svc, connection_type, STORED_CONFIG[connection_type], tmp_path)
+
+
+class TestTheCredentialsCarryOurValues:
+    """Resolution succeeding is not the same as our config being used.
+
+    This is the distinction ADC hid: BigQuery resolved fine while ignoring
+    everything passed to it.
+    """
+
+    def test_bigquery_uses_the_service_account_we_stored(self, svc, tmp_path):
+        creds = _resolved_credentials(svc, "bigquery", STORED_CONFIG["bigquery"], tmp_path)
+
+        assert creds.project_id == "datanika-test-565"
+        assert creds.client_email == SERVICE_ACCOUNT["client_email"]
+        assert creds.private_key == SERVICE_ACCOUNT["private_key"]
+
+    def test_databricks_host_and_token_are_renamed(self, svc, tmp_path):
+        creds = _resolved_credentials(svc, "databricks", STORED_CONFIG["databricks"], tmp_path)
+
+        assert creds.server_hostname == "adb-1234.azuredatabricks.net"
+        assert creds.access_token == "dapi-fake-token"
+        assert creds.http_path == "/sql/1.0/warehouses/abc123"
+
+    def test_snowflake_account_becomes_host(self, svc, tmp_path):
+        creds = _resolved_credentials(svc, "snowflake", STORED_CONFIG["snowflake"], tmp_path)
+
+        assert creds.host == "xy12345.us-east-1"
+        assert creds.username == "loader"
+        assert creds.database == "ANALYTICS"
+
+
+class TestBigQueryKeyNames:
+    """The form and the schema disagreed; both names must work."""
+
+    def test_the_schemas_old_name_still_resolves(self, svc, tmp_path):
+        """Connections saved against the old schema must not break."""
+        config = {
+            "project": "datanika-test-565",
+            "dataset": "analytics",
+            "service_account_json": json.dumps(SERVICE_ACCOUNT),
+        }
+        creds = _resolved_credentials(svc, "bigquery", config, tmp_path)
+
+        assert creds.client_email == SERVICE_ACCOUNT["client_email"]
+
+    def test_the_schema_now_matches_what_the_form_writes(self):
+        from datanika.services.connection_schemas import CONFIG_SCHEMAS
+
+        assert "keyfile_json" in CONFIG_SCHEMAS["bigquery"]["properties"]
+
+
+class TestBadInputFailsClearly:
+    def test_malformed_json_says_so(self, svc):
+        with pytest.raises(DltRunnerError, match="not valid JSON"):
+            svc.build_destination(
+                "bigquery",
+                {"project": "p", "dataset": "d", "keyfile_json": "{not json"},
+            )
+
+    @pytest.mark.parametrize("missing", ["project_id", "private_key", "client_email"])
+    def test_a_truncated_key_file_names_the_missing_field(self, svc, missing):
+        """dlt's own error blames `credentials` as a whole; this names the field."""
+        partial = {k: v for k, v in SERVICE_ACCOUNT.items() if k != missing}
+
+        with pytest.raises(DltRunnerError, match=missing):
+            svc.build_destination(
+                "bigquery",
+                {"project": "p", "dataset": "d", "keyfile_json": json.dumps(partial)},
+            )
+
+
+class TestSynapseIsNotCovered:
+    """Stated rather than silently skipped.
+
+    `SynapseCredentials` resolution requires an ODBC driver to be installed, so
+    it cannot be exercised here or in CI. core#565 lists synapse as *suspected*;
+    it stays suspected — this file does not pretend otherwise.
+    """
+
+    def test_synapse_is_documented_as_unverified(self):
+        assert "synapse" not in STORED_CONFIG
+        assert os.name is not None  # keeps the test honest rather than empty

--- a/tests/test_services/test_dlt_runner.py
+++ b/tests/test_services/test_dlt_runner.py
@@ -147,11 +147,26 @@ class TestToDltCredentials:
         assert creds["database"] == "db"
         assert creds["schema"] == "public"
 
-    def test_passthrough_for_unknown_types(self, svc):
-        """bigquery/snowflake credentials pass through unchanged."""
-        config = {"project": "proj", "dataset": "ds"}
-        creds = svc._to_dlt_credentials("bigquery", config)
-        assert creds == config
+    def test_non_credential_keys_are_not_sent_as_credentials(self, svc):
+        """This used to assert *"bigquery credentials pass through unchanged"*.
+
+        That was the bug written down as the contract (core#565): passing the
+        stored config straight through is why dlt never saw a credential it
+        recognised and BigQuery could not complete a run. `dataset` describes
+        where to write, not how to authenticate, and dlt rejects fields it does
+        not know.
+        """
+        creds = svc._to_dlt_credentials("bigquery", {"project": "proj", "dataset": "ds"})
+
+        assert "dataset" not in creds
+        assert creds["project"] == "proj"
+
+    def test_snowflake_account_becomes_the_host(self, svc):
+        """`SnowflakeCredentials` has no `account` — the identifier is its host."""
+        creds = svc._to_dlt_credentials("snowflake", {"account": "xy1.us-east-1"})
+
+        assert creds["host"] == "xy1.us-east-1"
+        assert "account" not in creds
 
     def test_snowflake_renames_user_to_username(self, svc):
         creds = svc._to_dlt_credentials(


### PR DESCRIPTION
Closes #565.

BigQuery and Databricks could not complete a single run. `_to_dlt_credentials` translated only for **SQL** types, so warehouse configs passed through untouched and dlt never saw a credential it recognised. The failure lands at the **last** step — after the user has created a GCP service account or a Databricks PAT and filled in every field — and Test Connection never exercises the dlt credential path, so nothing hints at it.

## Three distinct defects wearing one symptom

| | defect |
|---|---|
| **bigquery** | dlt reads `project_id`/`private_key`/`client_email` and **never a blob**, so the service-account JSON was ignored under *any* key. Compounded by a three-way name split: the form writes `keyfile_json`, `CONFIG_SCHEMAS` declared `service_account_json`, dlt reads neither. |
| **databricks** | `host`→`server_hostname` and `token`→`access_token` never happened. |
| **snowflake** | `account` never became dlt's `host`. The issue listed this as *suspected*; reproduction **confirms** it fails. |

BigQuery now explodes the key file into the real fields. **Both key names are accepted**, so connections already stored keep working, and the **schema is corrected to match the form** rather than renaming the form and stranding every saved BigQuery connection.

## The finding that matters most is not in the issue

**On any machine with `gcloud` Application Default Credentials, BigQuery resolves whatever you pass — including nothing at all.** Measured during this fix:

```
===== no credentials at all =====
  resolved   : GcpServiceAccountCredentials
  project_id : junehomes-analytics      <-- a live personal project
  ** carries MY config: False **
```

Two consequences:

1. **My own first reproduction was a false green** and very nearly read as "the runner is fine, the issue is wrong".
2. **Any test written here without disabling ADC would pass locally, pass for the wrong reason, and say nothing about prod** — where there is no ADC and the connector fails exactly as reported.

So the fixture that neutralises ADC is load-bearing, not hygiene, and the assertions check that the resolved credentials **carry our values**, not merely that resolution succeeded. That distinction is the whole bug.

## Tests drive what the form writes, not what the schema says

For BigQuery those disagreed — and reading the schema is precisely how you write a test that passes while production fails. `STORED_CONFIG` is copied from the `elif t == …` branches in `connection_state.py`.

One existing test asserted **the bug as the contract** — *"bigquery/snowflake credentials pass through unchanged"* — which is exactly what broke both destinations. Rewritten to assert that non-credential keys are stripped, with the history in the docstring so it doesn't get "fixed" back.

**Proven red: 11 of 13** with the mapping removed, including all three destinations failing to resolve at all.

## Synapse stays unverified, and says so

`SynapseCredentials` resolution requires an ODBC driver present neither here nor in CI (`SystemConfigurationException: No supported ODBC driver found`). #565 lists synapse as *suspected* — it remains suspected. There is a test documenting the gap rather than a skip that reads like coverage.
