### PR TITLE
[Infra] Alerts: make a 60-second outage detectable (closes #584)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -4,7 +4,7 @@ groups:
   - orgId: 1
     name: Infrastructure Alerts
     folder: Datanika
-    interval: 1m
+    interval: 30s
     rules:
       # --- Container Health ---
       - uid: container-down
@@ -49,7 +49,7 @@ groups:
                     type: gt
                     params: [0]
               refId: C
-        for: 2m
+        for: 30s
         labels:
           severity: critical
         annotations:
@@ -102,7 +102,7 @@ groups:
                     type: gt
                     params: [0]
               refId: C
-        for: 2m
+        for: 30s
         labels:
           severity: critical
         annotations:
@@ -384,7 +384,7 @@ groups:
   - orgId: 1
     name: Application Alerts
     folder: Datanika
-    interval: 1m
+    interval: 30s
     rules:
       # --- App Health Endpoint ---
       - uid: app-unhealthy
@@ -429,7 +429,7 @@ groups:
                     type: lt
                     params: [1]
               refId: C
-        for: 2m
+        for: 30s
         labels:
           severity: critical
         annotations:
@@ -529,7 +529,7 @@ groups:
   - orgId: 1
     name: External Probes
     folder: Datanika
-    interval: 5m
+    interval: 30s
     rules:
       # --- Sitemap health (SEO-critical) ---
       - uid: sitemap-down
@@ -713,7 +713,7 @@ groups:
                     type: lt
                     params: [1]
               refId: C
-        for: 2m
+        for: 30s
         labels:
           severity: critical
         annotations:
@@ -761,7 +761,7 @@ groups:
                     type: lt
                     params: [1]
               refId: C
-        for: 2m
+        for: 30s
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
Growth's finding — *'no alert fired, and none could have'* — is right, and the cause is worse than high thresholds.

**The detection floor is `group interval + for:`.** `App External Health Down` and `App Frontend Down` were evaluated once every **5 minutes**, so they could not fire on a 60s outage at *any* `for:` value.

```
before  group 5m  + for 2m  = 330s floor
after   group 30s + for 30s =  60s floor   caught ~30-45s in
```

Blip protection unaffected: with a 60s window and `reducer: last`, one failed sample is 'last' only until the next scrape, so a blip spans at most one evaluation and cannot satisfy `for: 30s`.

`for: 2m` was mine, set this morning to stop blips paging while the query window was still 600s. Fixing the window removed the reason; the value outlived it by six hours.