### PR TITLE
[Engineering] Route the SaaS REST fallback through the guarded client builder

### DIFF
--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -1815,21 +1815,33 @@ class DltRunnerService:
 
         return _kafka_source()
 
-    @staticmethod
+    @classmethod
     def _rest_api_fallback(
+        cls,
         base_url: str,
         auth: dict | None,
         resources: list,
         headers: dict | None = None,
     ):
-        """Generic REST API source used when a verified source module is not installed."""
-        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
-        client: dict = {"base_url": base_url}
-        if auth:
-            client["auth"] = auth
-        if headers:
-            client["headers"] = headers
-        return rest_api_source({"client": client, "resources": resources})
+        """Generic REST API source used when a verified source module is not installed.
+
+        Despite the name this is **the** production path for all ten SaaS
+        connectors — none of the verified dlt source modules are installed in
+        the image (the Dockerfile is deliberate about it, to avoid dependency
+        conflicts), so the ``except ImportError`` branch is what runs.
+
+        It is deliberately a thin alias over :meth:`_rest_api_from_parts` rather
+        than a second client builder. The two used to differ in one line — this
+        one omitted the pinning session — and the divergence was invisible at
+        every call site, so a connector could pick the unguarded path by
+        accident. ``salesforce`` did, and its ``instance_url`` is free-form user
+        input, which made core#405's DNS-rebinding TOCTOU reachable on the very
+        path core#405 was written to close. One builder means the wrong choice
+        is no longer available; ``tests/test_security/
+        test_egress_saas_fallback_pinning.py`` fails any new call site that
+        reaches for ``rest_api_source`` directly.
+        """
+        return cls._rest_api_from_parts(base_url, resources, auth=auth, headers=headers)
 
     def build_pipeline(
         self,

--- a/tests/test_security/test_egress_saas_fallback_pinning.py
+++ b/tests/test_security/test_egress_saas_fallback_pinning.py
@@ -1,0 +1,252 @@
+"""The SaaS REST fallback must use the pinning session, not merely call the guard.
+
+Write-up: ``plans/qa/notes/SECURITY-saas-fallback-egress-2026-07-22.md``. Held off
+public GitHub until the fix ships, per the SAML precedent.
+
+``dlt_runner`` had two REST client builders and only one of them got core#405's
+pinning session. ``_rest_api_fallback`` — **the production path for all ten SaaS
+connectors**, since none of the verified dlt source modules are installed in the
+image — validated ``base_url`` once and then handed dlt the *hostname*, which
+resolves a second time. That is the exact TOCTOU ``egress_guard``'s own docstring
+claims core#405 closed, and ``salesforce``'s ``instance_url`` is a free-form URL
+from the connection form, so it is reachable rather than theoretical.
+
+**Why 2,500 green tests said nothing.** ``TestEgressGuardWiring`` asserts
+``validate_egress_host`` *is called* on both paths. That is true, and it is the
+pre-flight check — but it never asserts the session is pinned. *The guard was
+tested for presence, not for effect.* So the tests here are the inverse: they
+assert the pinned session is the one **dlt actually uses**.
+
+The discriminator is a hostname that cannot resolve. ``rebind.invalid`` is a
+reserved TLD (RFC 2606); the pinned address is supplied only by
+``resolve_public_ip``. So a row can arrive **only** if dlt connected to the
+address we validated instead of resolving the name itself — which is precisely
+what the missing session changed. ``TestTheProbeDiscriminates`` proves the
+unguarded shape fails the same probe, so this is not a green that measures
+nothing.
+"""
+
+import ast
+import http.server
+import importlib.util
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from dlt.sources.rest_api import rest_api_source
+
+import datanika
+import datanika.services.dlt_runner as dlt_runner
+
+# Never resolvable (RFC 2606), so reaching the server proves the socket went to
+# the pinned address rather than to a second DNS answer.
+PINNED_HOST = "rebind.invalid"
+PINNED_IP = "127.0.0.1"
+
+
+class _ItemsHandler(http.server.BaseHTTPRequestHandler):
+    """Serves one row and records the headers it was reached with."""
+
+    seen: list[dict] = []
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        type(self).seen.append(dict(self.headers))
+        body = json.dumps([{"id": 1, "name": "reached-the-pinned-address"}]).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def pinned_api(monkeypatch):
+    """A real server on the loopback address, reachable only via the pin.
+
+    ``validate_egress_host`` is the pre-flight and has its own tests; it is
+    no-opped so loopback is testable at all. ``resolve_public_ip`` is the
+    single authoritative resolve-validate-pin since core#441 — patching only
+    the former no longer reaches a loopback test server.
+    """
+    _ItemsHandler.seen = []
+    server = http.server.HTTPServer((PINNED_IP, 0), _ItemsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+    monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    monkeypatch.setattr(
+        "datanika.services.egress_guard.resolve_public_ip", lambda hostname: PINNED_IP
+    )
+
+    try:
+        yield f"http://{PINNED_HOST}:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _resources():
+    return [{"name": "accounts", "endpoint": {"path": "items"}}]
+
+
+class TestFallbackUsesThePinnedSession:
+    def test_salesforce_reaches_only_the_pinned_address(self, pinned_api):
+        """The reachable connector, driven through its production entry point.
+
+        ``salesforce`` is the one fallback connector whose host is free-form
+        user input, so this drives ``_build_saas_source`` rather than the
+        builder underneath it — the unguarded client was picked *by a call
+        site*, and a test that skips the call site cannot see that choice.
+        """
+        assert importlib.util.find_spec("salesforce") is None, (
+            "the verified `salesforce` source is installed here, so this test "
+            "would take the non-fallback branch and prove nothing about the "
+            "path that runs in the image"
+        )
+
+        source = dlt_runner.DltRunnerService()._build_saas_source(
+            "salesforce",
+            {"access_token": "sekrit", "instance_url": pinned_api},
+            {"resources": _resources()},
+        )
+        rows = list(source.resources["accounts"])
+
+        assert [r["name"] for r in rows] == ["reached-the-pinned-address"], (
+            f"dlt did not connect to the pinned address; got {rows}"
+        )
+
+    def test_auth_survives_alongside_the_pinned_session(self, pinned_api):
+        """Passing a session must not cost the connector its credentials.
+
+        The open question on the fix was whether dlt overrides the session when
+        ``auth`` is also configured. Measured here rather than read: the bearer
+        token arrives on a request that could only have been made through the
+        pinned session.
+        """
+        source = dlt_runner.DltRunnerService()._build_saas_source(
+            "salesforce",
+            {"access_token": "sekrit", "instance_url": pinned_api},
+            {"resources": _resources()},
+        )
+        list(source.resources["accounts"])
+
+        assert _ItemsHandler.seen, "server was never reached"
+        assert _ItemsHandler.seen[0].get("Authorization") == "Bearer sekrit"
+
+    def test_host_header_stays_the_hostname(self, pinned_api):
+        """Pinning must not break virtual-hosted APIs.
+
+        The socket goes to the IP; the ``Host`` header — and, over TLS, the SNI
+        and certificate identity — stay the hostname. Half the SaaS fallbacks
+        are virtual-hosted (``*.myshopify.com``, ``*.zendesk.com``), so a fix
+        that sent the IP as ``Host`` would route them to the wrong tenant.
+        """
+        source = dlt_runner.DltRunnerService()._build_saas_source(
+            "salesforce",
+            {"access_token": "sekrit", "instance_url": pinned_api},
+            {"resources": _resources()},
+        )
+        list(source.resources["accounts"])
+
+        host = _ItemsHandler.seen[0].get("Host", "")
+        assert host.startswith(PINNED_HOST), f"Host header leaked the pinned IP: {host!r}"
+
+    def test_fallback_hands_dlt_a_guarded_session(self, pinned_api):
+        """Fast structural companion to the behavioural tests above.
+
+        Presence alone proved nothing here once — but paired with the
+        behavioural tests it localises a regression to the wiring instead of
+        leaving a failure that only says "no rows".
+        """
+        captured = {}
+        original = dlt_runner.rest_api_source
+
+        def _capture(config, *args, **kwargs):
+            captured.update(config["client"])
+            return original(config, *args, **kwargs)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(dlt_runner, "rest_api_source", _capture)
+            dlt_runner.DltRunnerService()._build_saas_source(
+                "salesforce",
+                {"access_token": "sekrit", "instance_url": pinned_api},
+                {"resources": _resources()},
+            )
+
+        session = captured.get("session")
+        assert session is not None, "no session passed — dlt would build its own and re-resolve"
+        assert getattr(session, "_datanika_egress_guarded", False) is True
+
+
+class TestTheProbeDiscriminates:
+    def test_the_unguarded_shape_cannot_reach_the_server(self, pinned_api):
+        """The control. Without it the tests above are unfalsifiable.
+
+        This is the exact client the fallback used to build — ``base_url`` and
+        ``auth``, no session. dlt then resolves the hostname itself, and the
+        hostname does not resolve, so no row can arrive. If this ever passes,
+        the probe above has stopped measuring pinning and is green for some
+        other reason.
+        """
+        source = rest_api_source(
+            {
+                "client": {"base_url": pinned_api, "auth": {"type": "bearer", "token": "sekrit"}},
+                "resources": _resources(),
+            }
+        )
+
+        with pytest.raises(Exception):  # noqa: B017 - any failure to connect proves the point
+            list(source.resources["accounts"])
+
+        assert not _ItemsHandler.seen, "the unguarded client reached the server — probe is broken"
+
+
+class TestOnlyOneClientBuilderExists:
+    """The defect was that a wrong choice was *available*, not just taken.
+
+    Two builders differing in one line, with the divergence invisible at every
+    call site, is how a connector picks the unguarded one by accident. Deriving
+    the check from the source rather than restating a rule is the only version
+    that cannot drift: a new connector calling ``rest_api_source`` directly
+    fails here at PR time.
+    """
+
+    @staticmethod
+    def _call_sites():
+        root = Path(datanika.__file__).parent
+        sites = []
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            enclosing = {}
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                    for child in ast.walk(node):
+                        enclosing.setdefault(child, node.name)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name == "rest_api_source":
+                    sites.append(
+                        (path.relative_to(root).as_posix(), enclosing.get(node), node.lineno)
+                    )
+        return sites
+
+    def test_every_rest_api_source_call_goes_through_the_guarded_builder(self):
+        sites = self._call_sites()
+
+        # Anti-vacuity: a scan that finds nothing reports three green assertions
+        # having checked nothing (the core#483 lesson).
+        assert sites, "found no rest_api_source call sites — the scan is broken, not the code"
+
+        stray = [s for s in sites if s[1] != "_rest_api_from_parts"]
+        assert not stray, (
+            "rest_api_source is called outside _rest_api_from_parts, so this call site "
+            f"gets no pinning session: {stray}"
+        )


### PR DESCRIPTION
## The gap

`dlt_runner` had two builders that assemble a `rest_api_source` client, and only one of them got core#405's pinning session:

```
rest_api  client keys : ['base_url', 'session']   ← guarded, pinning session
saas fb   client keys : ['auth', 'base_url']      ← none
```

`_rest_api_fallback` validated `base_url` and then handed dlt the **hostname**, which resolves a second time — the DNS-rebinding TOCTOU that `egress_guard.py`'s own module docstring says core#405 closed.

It is not a rarely-taken branch. None of the ten verified dlt source modules are installed in the image (the Dockerfile is deliberate about it, to avoid dependency conflicts), so the `except ImportError` branch is **the production path for every SaaS connector**. Nine of the ten have a fixed host suffix and are hardened by accident; `salesforce` takes a free-form `instance_url` straight from the connection form.

## The fix

`_rest_api_fallback` is now a thin alias over `_rest_api_from_parts`.

The missing session was the symptom. The defect was that a *second, unguarded builder existed at all*, with the divergence invisible at all seventeen call sites — so a connector could pick the wrong one without anyone choosing. One builder means the wrong choice is no longer available.

## The tests assert effect, not presence

This is the part worth reviewing. The existing `TestEgressGuardWiring` asserts `validate_egress_host` **is called** on both paths. That is true, and it is the pre-flight check — but it never asserts the session is pinned. **The guard was tested for presence, not for effect**, which is why a green suite sat over this.

The new tests invert that. They drive `_build_saas_source("salesforce", …)` — the production entry point, not the builder underneath it — against a real HTTP server, using a base URL whose hostname **cannot resolve** (`rebind.invalid`, RFC 2606). The pinned address is supplied only by `resolve_public_ip`. So a row can arrive **only if dlt connected to the address we validated instead of resolving the name itself**, which is exactly what the missing session changed.

- `test_salesforce_reaches_only_the_pinned_address` — the load-bearing one.
- `test_auth_survives_alongside_the_pinned_session` — measured rather than read: the open question on this fix was whether dlt drops the session when `auth` is configured. It does not; the bearer token arrives on a request that could only have been made through the pinned session.
- `test_host_header_stays_the_hostname` — half the fallback connectors are virtual-hosted (`*.myshopify.com`, `*.zendesk.com`), so a fix that sent the IP as `Host` would route them to the wrong tenant.
- `TestTheProbeDiscriminates` — the control. Builds the exact unguarded client the fallback used to build and asserts it **cannot** reach the server. Without this the tests above are unfalsifiable.
- `TestOnlyOneClientBuilderExists` — AST scan: every `rest_api_source` call site must sit inside `_rest_api_from_parts`, with an anti-vacuity assert so a broken scan fails loudly instead of reporting green over nothing. This is what stops a future connector reintroducing the class.

## Evidence

**Proven red before the fix**: all five new assertions failed, the two behavioural ones with `getaddrinfo failed` on the hostname — dlt resolving it itself, which is the gap.

**Production path intact**: `TestSaasRestFallbackMovesRows` (the real-row probe over a real socket into DuckDB) still lands records.

Full precheck green: **2801 passed, 21 skipped**.

## Note

No linked issue, deliberately — see the standing practice for security findings on a public repo. Disclosure route is a separate decision after this ships.
