### PR TITLE
[Growth] Derive the connector count from the withdrawn set, not a second list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Datanika combines [dlt](https://dlthub.com) (extract + load) with [dbt-core](htt
 
 ## Features
 
-🔌 **36 Connectors** — PostgreSQL, MySQL, Oracle, MongoDB, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
+🔌 **35 Connectors** — PostgreSQL, MySQL, Oracle, MongoDB, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
 🔄 **dbt Transformations** — SQL models, tests, snapshots, packages, and source freshness built in
 📊 **Visual Pipeline Builder** — DAG editor with dependency management
 ⏰ **Scheduling** — Cron-based with APScheduler, persistent across restarts
@@ -83,7 +83,7 @@ tag tells you immediately whether you're affected.
 
 | | Datanika | Airbyte | Fivetran | dbt Cloud |
 |---|---|---|---|---|
-| Extract + Load | ✅ 36 connectors | ✅ 400+ | ✅ 500+ | ❌ |
+| Extract + Load | ✅ 35 connectors | ✅ 400+ | ✅ 500+ | ❌ |
 | Transformations | ✅ dbt built-in | ❌ | ❌ (add-on) | ✅ |
 | Scheduling | ✅ Cron + DAG | ✅ Basic | ✅ Basic | ✅ |
 | Pipeline DAG | ✅ Visual | ❌ | ❌ | ❌ |
@@ -110,7 +110,7 @@ tag tells you immediately whether you're affected.
 
 ## Roadmap
 
-- [x] 36 connectors (databases, SaaS APIs, files, streaming)
+- [x] 35 connectors (databases, SaaS APIs, files, streaming)
 - [x] dbt transformations, tests, snapshots, packages
 - [x] REST API v1 with OpenAPI/Swagger and typed per-connector inline schemas
 - [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel, MCP server)

--- a/tests/test_docs/test_readme_claims.py
+++ b/tests/test_docs/test_readme_claims.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 
 README = Path(__file__).resolve().parents[2] / "README.md"
 
@@ -24,6 +25,10 @@ README = Path(__file__).resolve().parents[2] / "README.md"
 # marketed connector count. Keep this list short and justified — every entry is
 # a claim that users cannot actually use something we shipped an enum member
 # for. If you add one, say why.
+#
+# This list covers only types held back *before* launch. Types that were offered
+# and then withdrawn are not listed here — they come from
+# ``WITHDRAWN_SOURCE_TYPES`` below, which is the service's own set.
 UNMARKETED_TYPES = {
     # core#310 — OpenAPI source generation is behind a deferred feature and has
     # no connector page, setup guide, or docs entry. Counting it would inflate
@@ -31,7 +36,20 @@ UNMARKETED_TYPES = {
     "openapi",
 }
 
-EXPECTED_CONNECTOR_COUNT = len(ConnectionType) - len(UNMARKETED_TYPES)
+# Withdrawn types are imported, never re-listed. `connection_service` already
+# owns the set that removes a type from `SOURCE_TYPES`, `CONFIG_SCHEMAS` and the
+# picker, so importing it makes the README count fall out of the *same* fact
+# that makes the connector unreachable in the app.
+#
+# The alternative — adding "google_ads" to UNMARKETED_TYPES by hand — would make
+# the two numbers agree by coincidence, and would silently stop agreeing the next
+# time a connector is withdrawn (core#555/#567 is unlikely to be the last: a
+# withdrawal is the honest answer whenever a connector cannot work with the
+# credentials we collect). With the import, the next withdrawal fails this test
+# until the README is updated in the same PR, which is the entire point.
+EXCLUDED_FROM_COUNT = UNMARKETED_TYPES | set(WITHDRAWN_SOURCE_TYPES)
+
+EXPECTED_CONNECTOR_COUNT = len(ConnectionType) - len(EXCLUDED_FROM_COUNT)
 
 
 @pytest.fixture(scope="module")
@@ -39,16 +57,32 @@ def readme() -> str:
     return README.read_text(encoding="utf-8")
 
 
-def test_unmarketed_types_actually_exist() -> None:
-    """A typo in UNMARKETED_TYPES would silently inflate the expected count."""
+def test_excluded_types_actually_exist() -> None:
+    """A typo in either exclusion set would silently inflate the expected count.
+
+    Covers the imported withdrawn set too: a withdrawal that misspells a type
+    would remove nothing from the app while still shrinking this count, so the
+    README would be "corrected" to a number matching neither.
+    """
     members = {t.value for t in ConnectionType}
-    unknown = UNMARKETED_TYPES - members
-    assert not unknown, f"UNMARKETED_TYPES names types that aren't in ConnectionType: {unknown}"
+    unknown = EXCLUDED_FROM_COUNT - members
+    assert not unknown, f"excluded types that aren't in ConnectionType: {sorted(unknown)}"
 
 
-def test_expected_count_is_sane() -> None:
-    """Tripwire against the exclusion list quietly swallowing real connectors."""
-    assert len(ConnectionType) - 1 == EXPECTED_CONNECTOR_COUNT
+def test_exclusions_stay_small_and_deliberate() -> None:
+    """Tripwire against the exclusion sets quietly swallowing real connectors.
+
+    Deliberately not ``len(ConnectionType) - 1``: that hardcoded the one
+    exclusion that existed when this guard was written, so the first withdrawal
+    (core#567) broke it for the wrong reason. The invariant worth pinning is
+    that exclusions stay few and the marketed count stays plausible, not that
+    there is exactly one.
+    """
+    assert len(EXCLUDED_FROM_COUNT) <= 3, (
+        f"too many connectors excluded from the marketed count: "
+        f"{sorted(EXCLUDED_FROM_COUNT)}. Each one is something we shipped an "
+        f"enum member for and do not sell — if this is growing, say why."
+    )
     assert EXPECTED_CONNECTOR_COUNT > 30, "connector count collapsed — check ConnectionType"
 
 


### PR DESCRIPTION
Core half of [datanika-io/datanika-landing#291](https://github.com/datanika-io/datanika-landing/issues/291). Google Ads was withdrawn in #567, so the marketed connector count moves **36 → 35**.

## The design decision

The guard now subtracts **`WITHDRAWN_SOURCE_TYPES`**, imported from `connection_service` — the same set that removes a type from `SOURCE_TYPES`, `CONFIG_SCHEMAS` and the picker.

The alternative was adding `"google_ads"` to `UNMARKETED_TYPES` by hand. That would make the README and the app agree **by coincidence**, and stop agreeing at the next withdrawal. With the import, the README count falls out of the *same fact* that makes the connector unreachable, so the next withdrawal fails this test until the README is updated in the same PR — which is the entire point of the guard.

Withdrawal is not a one-off: #567's own comment calls it *"the honest answer whenever a connector cannot work with the credentials we collect."*

## A guard of mine that was wrong

`test_expected_count_is_sane` asserted `len(ConnectionType) - 1`, hardcoding the single exclusion that existed when I wrote it in #443. The first withdrawal broke it **for the wrong reason** — it would have failed even with a correct README. Replaced with the invariant worth pinning: exclusions stay few (≤3) and deliberate, and the count stays plausible.

`test_unmarketed_types_actually_exist` → `test_excluded_types_actually_exist`, now validating the imported set too: a withdrawal that misspells a type would remove nothing from the app while still shrinking the count, so the README would be "corrected" to a number matching neither.

## README

36 → 35 in all three places, including the Airbyte/Fivetran comparison row the guard exists to protect.

## Verification

Red first (guard derived 35, README said 36 → 2 failures), then green. Full suite: **2795 passed, 21 skipped**, ruff clean.

> Six unrelated failures appeared first — `duckdb_engine` / `kafka-python` missing. Not a code defect: this worktree's venv predated #494 adding `duckdb-engine`. Fixed with `uv sync --extra dev`, no `--no-verify`.

## ⚠️ Must land with the landing half

[datanika-io/datanika-landing#291](https://github.com/datanika-io/datanika-landing/issues/291) removes the pages and moves the site to 35 from its own data file.
