### PR TITLE
[Engineering] Share the uploads directory across tiers in every manifest (refs #529)

### DIFF
--- a/datanika/services/file_upload_service.py
+++ b/datanika/services/file_upload_service.py
@@ -82,8 +82,26 @@ class FileUploadService:
         extract_path = os.path.join(self._extracted_dir(), uploaded_file.file_hash)
         os.makedirs(extract_path, exist_ok=True)
 
-        with tarfile.open(uploaded_file.archive_path, "r:gz") as tar:
-            tar.extractall(extract_path, filter="data")
+        try:
+            with tarfile.open(uploaded_file.archive_path, "r:gz") as tar:
+                tar.extractall(extract_path, filter="data")
+        except FileNotFoundError as exc:
+            # This runs in the Celery worker; the archive was written by the web
+            # tier. If the two do not share this directory the run dies here,
+            # before any data moves, and the bare OSError names a path while
+            # saying nothing about the cause — which is how core#529 cost three
+            # CI rounds. Deployment is the overwhelmingly likely explanation, so
+            # say so; the alternative (a genuinely deleted archive) is still
+            # identifiable from the path.
+            raise FileNotFoundError(
+                f"Uploaded file archive not found: {uploaded_file.archive_path}\n"
+                "The web tier stored this file and this worker cannot see it, which "
+                "normally means the two do not share the uploads directory. Mount one "
+                "volume read-write on both the app and the Celery worker, and set "
+                f"FILE_UPLOADS_DIR (currently {self._uploads_dir}) to the same absolute "
+                "path in both — the default is relative to the working directory, so "
+                "sharing the volume alone is not enough."
+            ) from exc
 
         return extract_path
 

--- a/deploy/helm/datanika/README.md
+++ b/deploy/helm/datanika/README.md
@@ -14,11 +14,12 @@ docker-compose deployment on Hetzner, minus the bundled monitoring stack.
 | Component | Kind | Notes |
 |-----------|------|-------|
 | `app` | Deployment (1 replica) | Reflex frontend (`:3000`) + backend (`:8000`). Runs `alembic upgrade head` on startup. |
-| `celery` | Deployment (1 replica) | Background worker. Shares the `dbt_projects` PVC with `app`. |
+| `celery` | Deployment (1 replica) | Background worker. Shares the `dbt_projects` **and `uploaded_files`** PVCs with `app`. |
 | `postgres` | StatefulSet (1 replica) | Postgres 16-alpine with `pg_stat_statements`. Disable via `postgres.enabled=false` to bring your own. |
 | `redis` | Deployment (1 replica) | Redis 7-alpine. Broker + cache. Disable via `redis.enabled=false` to bring your own. |
 | `ingress` | Ingress (optional) | `/` → app frontend, `/api` → app backend. Mirrors the production Nginx reverse proxy. |
 | `dbt-projects` PVC | PVC (RWX) | Shared between `app` and `celery` pods. **Requires a ReadWriteMany storage class.** |
+| `uploaded-files` PVC | PVC (RWX) | Uploaded-file archives. `app` writes them, `celery` reads them back when the run executes — so this is **not optional**: without it a CSV upload succeeds and its run fails immediately with 0 rows (core#529). Also RWX. |
 | Secret | `Opaque` | `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, and all `POSTGRES_*`/`REDIS_*` values, rendered from `.Values.env` + `.Values.secrets`. |
 
 Monitoring (Prometheus, Grafana, node-exporter, cAdvisor) is **not** in scope
@@ -74,11 +75,14 @@ See `values.yaml` for the full list. Common overrides:
 | `ingress.enabled` | `false` | Turn on once you have a TLS-terminating ingress class |
 | `app.replicaCount` | `1` | Keep at `1` until the migration job is extracted (see caveats) |
 | `app.dbtProjectsSize` | `5Gi` | Size of the shared dbt projects PVC |
+| `app.uploadedFilesSize` | `5Gi` | Size of the shared uploaded-files PVC |
+| `env.FILE_UPLOADS_DIR` | `/app/uploaded_files` | Must match the mount path and be identical for both tiers — the app default is relative to the working directory, so a shared volume alone is not enough |
 
 ## Known caveats
 
 - **RWX storage required.** The `app` and `celery` Deployments both mount
-  the `dbt_projects` PVC, so the chart requests `ReadWriteMany`. On managed
+  the `dbt_projects` and `uploaded_files` PVCs, so the chart requests
+  `ReadWriteMany` for both. On managed
   Kubernetes that usually means NFS, EFS, Azure Files, or Filestore. On
   bare-metal clusters, Longhorn and Rook/CephFS both work. If your cluster
   only has `ReadWriteOnce`, you can pin both Deployments to the same node
@@ -103,7 +107,7 @@ See `values.yaml` for the full list. Common overrides:
 | Feature | Hetzner docker-compose | This chart |
 |---------|------------------------|------------|
 | App + Celery + Postgres + Redis | yes | yes |
-| Persistent volumes | Docker volumes | PVCs (PVC for Postgres, PVC for `dbt_projects`) |
+| Persistent volumes | Docker volumes | PVCs (Postgres, `dbt_projects`, `uploaded_files`) |
 | Nginx reverse proxy + TLS | host-level Nginx | ingress resource (optional) |
 | Grafana + Prometheus + cAdvisor | yes | no (run separately) |
 | Auto-deploy on push to master | yes | no (managed by user) |

--- a/deploy/helm/datanika/templates/app-deployment.yaml
+++ b/deploy/helm/datanika/templates/app-deployment.yaml
@@ -49,12 +49,19 @@ spec:
           volumeMounts:
             - name: dbt-projects
               mountPath: /app/dbt_projects
+            # Must match the celery deployment exactly. This tier writes the
+            # upload archive; the worker reads it back (core#529).
+            - name: uploaded-files
+              mountPath: /app/uploaded_files
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
       volumes:
         - name: dbt-projects
           persistentVolumeClaim:
             claimName: {{ include "datanika.fullname" . }}-dbt-projects
+        - name: uploaded-files
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-uploaded-files
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/datanika/templates/celery-deployment.yaml
+++ b/deploy/helm/datanika/templates/celery-deployment.yaml
@@ -40,12 +40,20 @@ spec:
           volumeMounts:
             - name: dbt-projects
               mountPath: /app/dbt_projects
+            # Must match the app deployment exactly — the LOAD runs here, so a
+            # worker resolving a different directory fails at run time, not at
+            # upload time (core#529, and #471's comment on docker-compose.yml).
+            - name: uploaded-files
+              mountPath: /app/uploaded_files
           resources:
             {{- toYaml .Values.celery.resources | nindent 12 }}
       volumes:
         - name: dbt-projects
           persistentVolumeClaim:
             claimName: {{ include "datanika.fullname" . }}-dbt-projects
+        - name: uploaded-files
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-uploaded-files
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/datanika/templates/secret.yaml
+++ b/deploy/helm/datanika/templates/secret.yaml
@@ -18,6 +18,8 @@ stringData:
   DATABASE_URL: "postgresql+asyncpg://{{ .Values.env.POSTGRES_USER }}:{{ .Values.secrets.POSTGRES_PASSWORD }}@{{ include "datanika.postgresHost" . }}:{{ .Values.postgres.port | default 5432 }}/{{ .Values.env.POSTGRES_DB }}"
   SECRET_KEY: {{ .Values.secrets.SECRET_KEY | quote }}
   DATANIKA_EDITION: {{ .Values.env.DATANIKA_EDITION | quote }}
+  {{- /* Reaches app and celery identically via envFrom — see uploads-pvc.yaml (core#529). */}}
+  FILE_UPLOADS_DIR: {{ .Values.env.FILE_UPLOADS_DIR | quote }}
   {{- range $key, $val := .Values.env.extra }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}

--- a/deploy/helm/datanika/templates/uploads-pvc.yaml
+++ b/deploy/helm/datanika/templates/uploads-pvc.yaml
@@ -1,0 +1,26 @@
+{{/*
+Uploaded-file archives. Shared, not per-pod, and that is load-bearing (core#529).
+
+The web tier writes `<hash>.tar.gz` here when a user uploads a file; the Celery
+worker opens that same path when the run executes. They are separate Deployments,
+so without a shared claim the worker raises FileNotFoundError before any data
+moves — the run ends `failed` in under 100ms with 0 rows, on the CSV → DuckDB
+path that is the advertised first-run experience.
+
+ReadWriteMany for the same reason as the dbt claim: two Deployments mount it, and
+app.replicaCount > 1 adds more. A cluster whose default StorageClass cannot do
+RWX must supply one that can, or point FILE_UPLOADS_DIR at shared storage.
+*/}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "datanika.fullname" . }}-uploaded-files
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: uploads
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.app.uploadedFilesSize }}

--- a/deploy/helm/datanika/values.yaml
+++ b/deploy/helm/datanika/values.yaml
@@ -29,6 +29,11 @@ env:
   POSTGRES_USER: datanika
   POSTGRES_DB: datanika
   DATANIKA_EDITION: "oss"
+  ## Pinned absolute, and it must be identical for the app and the worker.
+  ## config.py defaults this to `./uploaded_files`, which resolves against the
+  ## working directory — so a shared volume alone is not enough if the two tiers
+  ## ever start from different directories (core#529).
+  FILE_UPLOADS_DIR: /app/uploaded_files
   ## Optional extras — anything else the app reads from .env.docker. Keys listed
   ## here become literal Secret entries. Values left empty will be emitted as
   ## empty strings; users should populate them before running in a real env.
@@ -74,6 +79,9 @@ app:
       periodSeconds: 30
       failureThreshold: 3
   dbtProjectsSize: 5Gi
+  ## Uploaded-file archives, shared with the celery worker. Sized for the 20 MB
+  ## per-file cap in FileUploadService plus retention.
+  uploadedFilesSize: 5Gi
 
 ## Celery worker.
 celery:

--- a/tests/test_deploy/test_deployment_manifest_parity.py
+++ b/tests/test_deploy/test_deployment_manifest_parity.py
@@ -1,0 +1,174 @@
+"""Every shipped deployment manifest must share what the tiers share (core#529).
+
+The web tier stores an uploaded file and the Celery worker reads it back. If the
+two do not share that directory, the upload succeeds, the run is queued, and the
+worker dies on `tarfile.open` before any data moves — a run that ends `failed` in
+under 100ms with 0 rows.
+
+`docker-compose.yml` gets this right, and #471's comment on it says why:
+
+    # Must match app/app_b exactly — the LOAD runs here, so if the worker
+    # resolves a different directory the failure surfaces at run time, not at
+    # upload time (#471).
+
+**That knowledge lived in a comment in one manifest, and the other two shipped
+without it.** Staging (a box-only compose file) and the Helm chart both mount
+`dbt_projects` alone, so core#529 reproduced on staging for three CI rounds and
+the same defect is latent for every Helm self-hoster on the CSV → DuckDB
+onboarding path the landing page calls "the first pipeline you ever run".
+
+So the requirement is **derived** here rather than restated. A restated list
+drifts — that is how this happened. Compose is the reference deployment: any
+directory it mounts on *both* `app` and `celery` is by construction a cross-tier
+directory, and any env var it sets identically on both is by construction a
+cross-tier agreement. Both must hold in the chart too, and a future one added to
+compose fails this test until the chart catches up.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = ROOT / "docker-compose.yml"
+CHART = ROOT / "deploy" / "helm" / "datanika"
+APP_TEMPLATE = CHART / "templates" / "app-deployment.yaml"
+CELERY_TEMPLATE = CHART / "templates" / "celery-deployment.yaml"
+
+# The tiers that run application code. `app_b` is the blue/green sibling of
+# `app` and is covered by the same reasoning, but it is a compose-only concept.
+WEB, WORKER = "app", "celery"
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+
+
+def _named_volume_mounts(service: dict) -> dict[str, str]:
+    """Container paths backed by a **named volume**, keyed by path.
+
+    Bind mounts are deliberately excluded: those carry host config (Prometheus
+    rules, certificates) and say nothing about what the tiers exchange.
+    """
+    mounts = {}
+    for entry in service.get("volumes") or []:
+        if not isinstance(entry, str) or ":" not in entry:
+            continue
+        source, _, dest = entry.partition(":")
+        if source.startswith((".", "/")):
+            continue
+        mounts[dest.split(":")[0]] = source
+    return mounts
+
+
+def _environment(service: dict) -> dict[str, str]:
+    """Compose accepts `environment` as a mapping or a `KEY=value` list."""
+    env = service.get("environment") or {}
+    if isinstance(env, list):
+        pairs = (entry.split("=", 1) for entry in env if "=" in entry)
+        return {k: v for k, v in pairs}
+    return {str(k): str(v) for k, v in env.items()}
+
+
+class TestSharedDirectories:
+    def test_compose_declares_at_least_the_two_known_shared_directories(self, compose):
+        """Anti-vacuity. A parse that silently yields nothing would make every
+        assertion below pass having checked no manifest at all."""
+        shared = self._shared_paths(compose)
+        assert len(shared) >= 2, (
+            f"expected compose to share dbt_projects and uploaded_files between "
+            f"{WEB} and {WORKER}; found {shared}. The scan is broken, not the chart."
+        )
+
+    @staticmethod
+    def _shared_paths(compose: dict) -> set[str]:
+        services = compose["services"]
+        web = _named_volume_mounts(services[WEB])
+        worker = _named_volume_mounts(services[WORKER])
+        return set(web) & set(worker)
+
+    def test_helm_shares_every_directory_compose_shares(self, compose):
+        """The bug core#529 is: `/app/uploaded_files` was shared in compose and
+        in neither other manifest."""
+        app_text = APP_TEMPLATE.read_text(encoding="utf-8")
+        celery_text = CELERY_TEMPLATE.read_text(encoding="utf-8")
+
+        missing = []
+        for path in sorted(self._shared_paths(compose)):
+            for tier, text in ((WEB, app_text), (WORKER, celery_text)):
+                if f"mountPath: {path}" not in text:
+                    missing.append(f"{tier} deployment does not mount {path}")
+
+        assert not missing, (
+            "the Helm chart does not share a directory the tiers exchange data through, "
+            "so the web tier will write a file the worker cannot read:\n  " + "\n  ".join(missing)
+        )
+
+
+class TestSharedEnvironment:
+    """A shared directory is only half of it — both tiers must also *resolve*
+    the same path.
+
+    `config.py` defaults `file_uploads_dir` to `./uploaded_files`, which is
+    relative to the working directory. Two tiers with the same mount and
+    different working directories still diverge, which is exactly why compose
+    pins the absolute value on both rather than relying on the default.
+    """
+
+    @staticmethod
+    def _shared_env(compose: dict) -> dict[str, str]:
+        services = compose["services"]
+        web = _environment(services[WEB])
+        worker = _environment(services[WORKER])
+        return {k: web[k] for k in set(web) & set(worker) if web[k] == worker[k]}
+
+    def test_compose_pins_at_least_one_cross_tier_variable(self, compose):
+        """Anti-vacuity, same reasoning as above."""
+        assert self._shared_env(compose), (
+            "compose sets no environment variable identically on both tiers — "
+            "either the scan is broken or #471's pinning was removed"
+        )
+
+    def test_helm_pins_the_same_cross_tier_variables(self, compose):
+        values = yaml.safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
+        chart_env = {str(k): str(v) for k, v in (values.get("env") or {}).items()}
+
+        shared = self._shared_env(compose)
+        wrong = {
+            key: (expected, chart_env.get(key))
+            for key, expected in shared.items()
+            if chart_env.get(key) != expected
+        }
+        assert not wrong, (
+            "the Helm chart does not pin a value compose pins on both tiers, so the "
+            f"two tiers can resolve different directories: {wrong}"
+        )
+
+    def test_the_pinned_variables_actually_reach_the_containers(self, compose):
+        """`values.yaml` is not the consumer — `secret.yaml` is.
+
+        The Secret enumerates its keys explicitly and only then falls through to
+        ``env.extra``, so a key added to ``values.env`` and nowhere else is
+        inert: it never lands in the Secret, and the deployments consume the
+        Secret via ``envFrom``. The first version of the test above asserted
+        ``values.yaml`` alone and passed over a chart that still shipped the
+        bug — the same mistake as reading a config schema instead of what the
+        form writes (core#565). Assert the plumbing, not the declaration.
+        """
+        secret = (CHART / "templates" / "secret.yaml").read_text(encoding="utf-8")
+        values = yaml.safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
+        # Two ways in: named explicitly in the Secret, or supplied through the
+        # `env.extra` range. Being in `values.env` is neither.
+        extra = (values.get("env") or {}).get("extra") or {}
+
+        unplumbed = [
+            key
+            for key in sorted(self._shared_env(compose))
+            if key not in secret and key not in extra
+        ]
+        assert not unplumbed, (
+            "these variables are declared in values.yaml but never rendered into the env "
+            f"Secret, so no container ever sees them: {unplumbed}"
+        )

--- a/tests/test_services/test_file_upload_service.py
+++ b/tests/test_services/test_file_upload_service.py
@@ -107,6 +107,37 @@ class TestExtractForDlt:
         with open(os.path.join(extracted_dir, "data.csv"), "rb") as f:
             assert f.read() == sample_csv
 
+    def test_missing_archive_names_the_cause_not_just_the_path(self, svc, db_session, sample_csv):
+        """A worker that cannot see the archive must say why (core#529).
+
+        This is the single most expensive error message in the product. When
+        the web tier and the Celery worker do not share the uploads directory,
+        the run dies here in under 100ms with 0 rows, and the bare
+        ``[Errno 2] No such file or directory: './uploaded_files/archives/…'``
+        names a path while saying nothing about the cause. It cost three CI
+        rounds and two departments to work out that the two tiers had separate
+        filesystems — and it is the first thing a Helm self-hoster hits on the
+        advertised CSV → DuckDB onboarding path.
+
+        So the assertion is on the diagnosis, not on the exception type.
+        """
+        from datanika.models.user import Organization
+
+        org = Organization(name="Acme", slug="acme-missing-archive")
+        db_session.add(org)
+        db_session.flush()
+
+        record = svc.save_file(db_session, org.id, "data.csv", sample_csv)
+        os.remove(record.archive_path)
+
+        with pytest.raises(FileNotFoundError) as exc:
+            svc.extract_for_dlt(record)
+
+        message = str(exc.value)
+        assert record.archive_path in message, "the path is still needed for support"
+        assert "share" in message.lower(), "must say the tiers need a shared directory"
+        assert "FILE_UPLOADS_DIR" in message, "must name the setting the operator changes"
+
 
 class TestCleanupExtracted:
     def test_removes_dir(self, svc, db_session, sample_csv):


### PR DESCRIPTION
Refs #529. **Does not close it** — see "What this does not fix" at the bottom.

## The cause, measured on staging rather than inferred

#529 asserts a run's terminal *status* and never its *reason*, so three CI rounds produced no cause. The reason was in staging's database the whole time:

```
 id | status | rows |   ms   | error
 19 | FAILED |      |  98.3  | [Errno 2] No such file or directory:
 18 | FAILED |      | 113.9  |   './uploaded_files/archives/4c04ae13….tar.gz'
 …  8 consecutive runs, byte-identical
```

```
docker inspect datanika-staging-celery → staging_dbt → /app/dbt_projects   ← the only mount
docker exec    datanika-staging-app    → /app/uploaded_files/archives/4c04ae13….tar.gz  PRESENT
```

**The web tier's write succeeded; the worker's read cannot.** `save_file` inserts the `uploaded_files` row only *after* `tarfile.open(...)` returns, the row exists, and the archive is in the app container. The two containers share no filesystem, and `FILE_UPLOADS_DIR` is unset so `config.py` falls back to the CWD-relative `./uploaded_files`.

`run_upload` → `extract_for_dlt` → `tarfile.open` → `FileNotFoundError` in 48–128 ms, before any data moves. That is the "69 ms, 0 rows" exactly, and it confirms the issue's own reading: refused at the door, not failed partway.

## It is #471's fix never reaching the other manifests

`docker-compose.yml` is correct, and #471's comment on it describes this precise failure:

> `# Must match app/app_b exactly — the LOAD runs here, so if the worker resolves a different directory the failure surfaces at run time, not at upload time (#471).`

That knowledge lived in a comment in **one** manifest. Staging's compose and the Helm chart both shipped with `dbt_projects` alone.

## The part that outlives #529: the shipped chart has the same hole

`app` and `celery` are separate Deployments in the chart too, so **every Helm self-hoster hits this on the CSV → DuckDB path** the landing page calls *"the first pipeline you ever run on Datanika"*. Latent, public, and nothing was pointing at it — found only because #529 was chased to a cause instead of a workaround.

- `uploaded-files` PVC (RWX, mirroring the dbt claim), mounted at `/app/uploaded_files` on **both** Deployments.
- `FILE_UPLOADS_DIR` pinned **in `secret.yaml`**. ⚠️ Worth knowing: `values.yaml` alone is inert — the Secret enumerates its keys and only then falls through to `env.extra`, and the Deployments consume the Secret via `envFrom`. My first version of the parity test asserted `values.yaml` and **passed over a still-broken chart** — the same mistake as reading a config schema instead of what the form writes (#565). The test now asserts the plumbing.
- README updated: the PVC is documented as *not optional*, with the failure it prevents.

## The error now names the cause

`[Errno 2] No such file or directory: './uploaded_files/archives/…'` names a path and says nothing about what to do. It cost three CI rounds and two departments here, and it is also the first thing a self-hoster sees. `extract_for_dlt` now says the two tiers do not share the uploads directory, that one volume must be mounted rw on both, and which setting to point at it.

## The guard is derived, not restated

A restated list is exactly what drifted. `tests/test_deploy/` reads `docker-compose.yml` as the reference deployment and requires:

- every directory compose mounts on **both** `app` and `celery` to be mounted on both Helm Deployments;
- every env var compose sets **identically** on both to be pinned in the chart *and* actually rendered into the env Secret.

Both scans carry anti-vacuity asserts, so a broken parse fails loudly instead of reporting green over nothing. A future shared directory added to compose fails this test until the chart catches up.

## Evidence

- **Proven red first**: the parity tests failed naming `/app/uploaded_files` missing from both Deployments and `FILE_UPLOADS_DIR: (…, None)`; the error-message test failed on the bare `Errno 2`.
- **Proven to discriminate**: deleting `FILE_UPLOADS_DIR` from `secret.yaml` turns the plumbing test red, then restoring it turns it green.
- **Verified against helm itself**, not only pytest — `helm lint` clean, and `helm template` renders the PVC, both `mountPath: /app/uploaded_files`, and `FILE_UPLOADS_DIR: "/app/uploaded_files"` in the Secret.

## What this does not fix

**The golden path stays red.** Staging's compose lives only at `/opt/datanika-staging/docker-compose.yml` on the box — not repo-tracked, CI just `cd`s there — so it is Infra's under WORKFLOW_RULES §9. Exact change is filed in `PLAN_INFRASTRUCTURE.md`, along with the canonical copy at `plans/infra/scripts/staging-docker-compose.yml`, which currently records the broken file faithfully.

**One correction to the record:** earlier triage read this as *"upload → worker handoff, app-layer, Engineering's."* The first half pointed straight at it; the second is wrong, and would have sent the next session reading `upload_tasks.py`. No app-layer change makes two containers share a filesystem.
