### PR TITLE
[Infra] Promote dev → master: guarded SaaS REST fallback, uploads shared across tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Datanika combines [dlt](https://dlthub.com) (extract + load) with [dbt-core](htt
 
 ## Features
 
-🔌 **36 Connectors** — PostgreSQL, MySQL, Oracle, MongoDB, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
+🔌 **35 Connectors** — PostgreSQL, MySQL, Oracle, MongoDB, BigQuery, Snowflake, Stripe, HubSpot, Salesforce, Kafka, S3, and more
 🔄 **dbt Transformations** — SQL models, tests, snapshots, packages, and source freshness built in
 📊 **Visual Pipeline Builder** — DAG editor with dependency management
 ⏰ **Scheduling** — Cron-based with APScheduler, persistent across restarts
@@ -83,7 +83,7 @@ tag tells you immediately whether you're affected.
 
 | | Datanika | Airbyte | Fivetran | dbt Cloud |
 |---|---|---|---|---|
-| Extract + Load | ✅ 36 connectors | ✅ 400+ | ✅ 500+ | ❌ |
+| Extract + Load | ✅ 35 connectors | ✅ 400+ | ✅ 500+ | ❌ |
 | Transformations | ✅ dbt built-in | ❌ | ❌ (add-on) | ✅ |
 | Scheduling | ✅ Cron + DAG | ✅ Basic | ✅ Basic | ✅ |
 | Pipeline DAG | ✅ Visual | ❌ | ❌ | ❌ |
@@ -110,7 +110,7 @@ tag tells you immediately whether you're affected.
 
 ## Roadmap
 
-- [x] 36 connectors (databases, SaaS APIs, files, streaming)
+- [x] 35 connectors (databases, SaaS APIs, files, streaming)
 - [x] dbt transformations, tests, snapshots, packages
 - [x] REST API v1 with OpenAPI/Swagger and typed per-connector inline schemas
 - [x] AI-agent compatibility (`/llms.txt`, agent-guide, 5-tier API, golden-path loop, `?wait=true`, `Idempotency-Key`, run cancel, MCP server)

--- a/datanika/services/dlt_runner.py
+++ b/datanika/services/dlt_runner.py
@@ -1815,21 +1815,33 @@ class DltRunnerService:
 
         return _kafka_source()
 
-    @staticmethod
+    @classmethod
     def _rest_api_fallback(
+        cls,
         base_url: str,
         auth: dict | None,
         resources: list,
         headers: dict | None = None,
     ):
-        """Generic REST API source used when a verified source module is not installed."""
-        validate_egress_host(base_url)  # SSRF pre-flight guard (core#338)
-        client: dict = {"base_url": base_url}
-        if auth:
-            client["auth"] = auth
-        if headers:
-            client["headers"] = headers
-        return rest_api_source({"client": client, "resources": resources})
+        """Generic REST API source used when a verified source module is not installed.
+
+        Despite the name this is **the** production path for all ten SaaS
+        connectors — none of the verified dlt source modules are installed in
+        the image (the Dockerfile is deliberate about it, to avoid dependency
+        conflicts), so the ``except ImportError`` branch is what runs.
+
+        It is deliberately a thin alias over :meth:`_rest_api_from_parts` rather
+        than a second client builder. The two used to differ in one line — this
+        one omitted the pinning session — and the divergence was invisible at
+        every call site, so a connector could pick the unguarded path by
+        accident. ``salesforce`` did, and its ``instance_url`` is free-form user
+        input, which made core#405's DNS-rebinding TOCTOU reachable on the very
+        path core#405 was written to close. One builder means the wrong choice
+        is no longer available; ``tests/test_security/
+        test_egress_saas_fallback_pinning.py`` fails any new call site that
+        reaches for ``rest_api_source`` directly.
+        """
+        return cls._rest_api_from_parts(base_url, resources, auth=auth, headers=headers)
 
     def build_pipeline(
         self,

--- a/datanika/services/file_upload_service.py
+++ b/datanika/services/file_upload_service.py
@@ -82,8 +82,26 @@ class FileUploadService:
         extract_path = os.path.join(self._extracted_dir(), uploaded_file.file_hash)
         os.makedirs(extract_path, exist_ok=True)
 
-        with tarfile.open(uploaded_file.archive_path, "r:gz") as tar:
-            tar.extractall(extract_path, filter="data")
+        try:
+            with tarfile.open(uploaded_file.archive_path, "r:gz") as tar:
+                tar.extractall(extract_path, filter="data")
+        except FileNotFoundError as exc:
+            # This runs in the Celery worker; the archive was written by the web
+            # tier. If the two do not share this directory the run dies here,
+            # before any data moves, and the bare OSError names a path while
+            # saying nothing about the cause — which is how core#529 cost three
+            # CI rounds. Deployment is the overwhelmingly likely explanation, so
+            # say so; the alternative (a genuinely deleted archive) is still
+            # identifiable from the path.
+            raise FileNotFoundError(
+                f"Uploaded file archive not found: {uploaded_file.archive_path}\n"
+                "The web tier stored this file and this worker cannot see it, which "
+                "normally means the two do not share the uploads directory. Mount one "
+                "volume read-write on both the app and the Celery worker, and set "
+                f"FILE_UPLOADS_DIR (currently {self._uploads_dir}) to the same absolute "
+                "path in both — the default is relative to the working directory, so "
+                "sharing the volume alone is not enough."
+            ) from exc
 
         return extract_path
 

--- a/deploy/helm/datanika/README.md
+++ b/deploy/helm/datanika/README.md
@@ -14,11 +14,12 @@ docker-compose deployment on Hetzner, minus the bundled monitoring stack.
 | Component | Kind | Notes |
 |-----------|------|-------|
 | `app` | Deployment (1 replica) | Reflex frontend (`:3000`) + backend (`:8000`). Runs `alembic upgrade head` on startup. |
-| `celery` | Deployment (1 replica) | Background worker. Shares the `dbt_projects` PVC with `app`. |
+| `celery` | Deployment (1 replica) | Background worker. Shares the `dbt_projects` **and `uploaded_files`** PVCs with `app`. |
 | `postgres` | StatefulSet (1 replica) | Postgres 16-alpine with `pg_stat_statements`. Disable via `postgres.enabled=false` to bring your own. |
 | `redis` | Deployment (1 replica) | Redis 7-alpine. Broker + cache. Disable via `redis.enabled=false` to bring your own. |
 | `ingress` | Ingress (optional) | `/` → app frontend, `/api` → app backend. Mirrors the production Nginx reverse proxy. |
 | `dbt-projects` PVC | PVC (RWX) | Shared between `app` and `celery` pods. **Requires a ReadWriteMany storage class.** |
+| `uploaded-files` PVC | PVC (RWX) | Uploaded-file archives. `app` writes them, `celery` reads them back when the run executes — so this is **not optional**: without it a CSV upload succeeds and its run fails immediately with 0 rows (core#529). Also RWX. |
 | Secret | `Opaque` | `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, and all `POSTGRES_*`/`REDIS_*` values, rendered from `.Values.env` + `.Values.secrets`. |
 
 Monitoring (Prometheus, Grafana, node-exporter, cAdvisor) is **not** in scope
@@ -74,11 +75,14 @@ See `values.yaml` for the full list. Common overrides:
 | `ingress.enabled` | `false` | Turn on once you have a TLS-terminating ingress class |
 | `app.replicaCount` | `1` | Keep at `1` until the migration job is extracted (see caveats) |
 | `app.dbtProjectsSize` | `5Gi` | Size of the shared dbt projects PVC |
+| `app.uploadedFilesSize` | `5Gi` | Size of the shared uploaded-files PVC |
+| `env.FILE_UPLOADS_DIR` | `/app/uploaded_files` | Must match the mount path and be identical for both tiers — the app default is relative to the working directory, so a shared volume alone is not enough |
 
 ## Known caveats
 
 - **RWX storage required.** The `app` and `celery` Deployments both mount
-  the `dbt_projects` PVC, so the chart requests `ReadWriteMany`. On managed
+  the `dbt_projects` and `uploaded_files` PVCs, so the chart requests
+  `ReadWriteMany` for both. On managed
   Kubernetes that usually means NFS, EFS, Azure Files, or Filestore. On
   bare-metal clusters, Longhorn and Rook/CephFS both work. If your cluster
   only has `ReadWriteOnce`, you can pin both Deployments to the same node
@@ -103,7 +107,7 @@ See `values.yaml` for the full list. Common overrides:
 | Feature | Hetzner docker-compose | This chart |
 |---------|------------------------|------------|
 | App + Celery + Postgres + Redis | yes | yes |
-| Persistent volumes | Docker volumes | PVCs (PVC for Postgres, PVC for `dbt_projects`) |
+| Persistent volumes | Docker volumes | PVCs (Postgres, `dbt_projects`, `uploaded_files`) |
 | Nginx reverse proxy + TLS | host-level Nginx | ingress resource (optional) |
 | Grafana + Prometheus + cAdvisor | yes | no (run separately) |
 | Auto-deploy on push to master | yes | no (managed by user) |

--- a/deploy/helm/datanika/templates/app-deployment.yaml
+++ b/deploy/helm/datanika/templates/app-deployment.yaml
@@ -49,12 +49,19 @@ spec:
           volumeMounts:
             - name: dbt-projects
               mountPath: /app/dbt_projects
+            # Must match the celery deployment exactly. This tier writes the
+            # upload archive; the worker reads it back (core#529).
+            - name: uploaded-files
+              mountPath: /app/uploaded_files
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
       volumes:
         - name: dbt-projects
           persistentVolumeClaim:
             claimName: {{ include "datanika.fullname" . }}-dbt-projects
+        - name: uploaded-files
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-uploaded-files
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/datanika/templates/celery-deployment.yaml
+++ b/deploy/helm/datanika/templates/celery-deployment.yaml
@@ -40,12 +40,20 @@ spec:
           volumeMounts:
             - name: dbt-projects
               mountPath: /app/dbt_projects
+            # Must match the app deployment exactly — the LOAD runs here, so a
+            # worker resolving a different directory fails at run time, not at
+            # upload time (core#529, and #471's comment on docker-compose.yml).
+            - name: uploaded-files
+              mountPath: /app/uploaded_files
           resources:
             {{- toYaml .Values.celery.resources | nindent 12 }}
       volumes:
         - name: dbt-projects
           persistentVolumeClaim:
             claimName: {{ include "datanika.fullname" . }}-dbt-projects
+        - name: uploaded-files
+          persistentVolumeClaim:
+            claimName: {{ include "datanika.fullname" . }}-uploaded-files
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/datanika/templates/secret.yaml
+++ b/deploy/helm/datanika/templates/secret.yaml
@@ -18,6 +18,8 @@ stringData:
   DATABASE_URL: "postgresql+asyncpg://{{ .Values.env.POSTGRES_USER }}:{{ .Values.secrets.POSTGRES_PASSWORD }}@{{ include "datanika.postgresHost" . }}:{{ .Values.postgres.port | default 5432 }}/{{ .Values.env.POSTGRES_DB }}"
   SECRET_KEY: {{ .Values.secrets.SECRET_KEY | quote }}
   DATANIKA_EDITION: {{ .Values.env.DATANIKA_EDITION | quote }}
+  {{- /* Reaches app and celery identically via envFrom — see uploads-pvc.yaml (core#529). */}}
+  FILE_UPLOADS_DIR: {{ .Values.env.FILE_UPLOADS_DIR | quote }}
   {{- range $key, $val := .Values.env.extra }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}

--- a/deploy/helm/datanika/templates/uploads-pvc.yaml
+++ b/deploy/helm/datanika/templates/uploads-pvc.yaml
@@ -1,0 +1,26 @@
+{{/*
+Uploaded-file archives. Shared, not per-pod, and that is load-bearing (core#529).
+
+The web tier writes `<hash>.tar.gz` here when a user uploads a file; the Celery
+worker opens that same path when the run executes. They are separate Deployments,
+so without a shared claim the worker raises FileNotFoundError before any data
+moves — the run ends `failed` in under 100ms with 0 rows, on the CSV → DuckDB
+path that is the advertised first-run experience.
+
+ReadWriteMany for the same reason as the dbt claim: two Deployments mount it, and
+app.replicaCount > 1 adds more. A cluster whose default StorageClass cannot do
+RWX must supply one that can, or point FILE_UPLOADS_DIR at shared storage.
+*/}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "datanika.fullname" . }}-uploaded-files
+  labels:
+    {{- include "datanika.labels" . | nindent 4 }}
+    app.kubernetes.io/component: uploads
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.app.uploadedFilesSize }}

--- a/deploy/helm/datanika/values.yaml
+++ b/deploy/helm/datanika/values.yaml
@@ -29,6 +29,11 @@ env:
   POSTGRES_USER: datanika
   POSTGRES_DB: datanika
   DATANIKA_EDITION: "oss"
+  ## Pinned absolute, and it must be identical for the app and the worker.
+  ## config.py defaults this to `./uploaded_files`, which resolves against the
+  ## working directory — so a shared volume alone is not enough if the two tiers
+  ## ever start from different directories (core#529).
+  FILE_UPLOADS_DIR: /app/uploaded_files
   ## Optional extras — anything else the app reads from .env.docker. Keys listed
   ## here become literal Secret entries. Values left empty will be emitted as
   ## empty strings; users should populate them before running in a real env.
@@ -74,6 +79,9 @@ app:
       periodSeconds: 30
       failureThreshold: 3
   dbtProjectsSize: 5Gi
+  ## Uploaded-file archives, shared with the celery worker. Sized for the 20 MB
+  ## per-file cap in FileUploadService plus retention.
+  uploadedFilesSize: 5Gi
 
 ## Celery worker.
 celery:

--- a/tests/test_deploy/test_deployment_manifest_parity.py
+++ b/tests/test_deploy/test_deployment_manifest_parity.py
@@ -1,0 +1,174 @@
+"""Every shipped deployment manifest must share what the tiers share (core#529).
+
+The web tier stores an uploaded file and the Celery worker reads it back. If the
+two do not share that directory, the upload succeeds, the run is queued, and the
+worker dies on `tarfile.open` before any data moves — a run that ends `failed` in
+under 100ms with 0 rows.
+
+`docker-compose.yml` gets this right, and #471's comment on it says why:
+
+    # Must match app/app_b exactly — the LOAD runs here, so if the worker
+    # resolves a different directory the failure surfaces at run time, not at
+    # upload time (#471).
+
+**That knowledge lived in a comment in one manifest, and the other two shipped
+without it.** Staging (a box-only compose file) and the Helm chart both mount
+`dbt_projects` alone, so core#529 reproduced on staging for three CI rounds and
+the same defect is latent for every Helm self-hoster on the CSV → DuckDB
+onboarding path the landing page calls "the first pipeline you ever run".
+
+So the requirement is **derived** here rather than restated. A restated list
+drifts — that is how this happened. Compose is the reference deployment: any
+directory it mounts on *both* `app` and `celery` is by construction a cross-tier
+directory, and any env var it sets identically on both is by construction a
+cross-tier agreement. Both must hold in the chart too, and a future one added to
+compose fails this test until the chart catches up.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = ROOT / "docker-compose.yml"
+CHART = ROOT / "deploy" / "helm" / "datanika"
+APP_TEMPLATE = CHART / "templates" / "app-deployment.yaml"
+CELERY_TEMPLATE = CHART / "templates" / "celery-deployment.yaml"
+
+# The tiers that run application code. `app_b` is the blue/green sibling of
+# `app` and is covered by the same reasoning, but it is a compose-only concept.
+WEB, WORKER = "app", "celery"
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+
+
+def _named_volume_mounts(service: dict) -> dict[str, str]:
+    """Container paths backed by a **named volume**, keyed by path.
+
+    Bind mounts are deliberately excluded: those carry host config (Prometheus
+    rules, certificates) and say nothing about what the tiers exchange.
+    """
+    mounts = {}
+    for entry in service.get("volumes") or []:
+        if not isinstance(entry, str) or ":" not in entry:
+            continue
+        source, _, dest = entry.partition(":")
+        if source.startswith((".", "/")):
+            continue
+        mounts[dest.split(":")[0]] = source
+    return mounts
+
+
+def _environment(service: dict) -> dict[str, str]:
+    """Compose accepts `environment` as a mapping or a `KEY=value` list."""
+    env = service.get("environment") or {}
+    if isinstance(env, list):
+        pairs = (entry.split("=", 1) for entry in env if "=" in entry)
+        return {k: v for k, v in pairs}
+    return {str(k): str(v) for k, v in env.items()}
+
+
+class TestSharedDirectories:
+    def test_compose_declares_at_least_the_two_known_shared_directories(self, compose):
+        """Anti-vacuity. A parse that silently yields nothing would make every
+        assertion below pass having checked no manifest at all."""
+        shared = self._shared_paths(compose)
+        assert len(shared) >= 2, (
+            f"expected compose to share dbt_projects and uploaded_files between "
+            f"{WEB} and {WORKER}; found {shared}. The scan is broken, not the chart."
+        )
+
+    @staticmethod
+    def _shared_paths(compose: dict) -> set[str]:
+        services = compose["services"]
+        web = _named_volume_mounts(services[WEB])
+        worker = _named_volume_mounts(services[WORKER])
+        return set(web) & set(worker)
+
+    def test_helm_shares_every_directory_compose_shares(self, compose):
+        """The bug core#529 is: `/app/uploaded_files` was shared in compose and
+        in neither other manifest."""
+        app_text = APP_TEMPLATE.read_text(encoding="utf-8")
+        celery_text = CELERY_TEMPLATE.read_text(encoding="utf-8")
+
+        missing = []
+        for path in sorted(self._shared_paths(compose)):
+            for tier, text in ((WEB, app_text), (WORKER, celery_text)):
+                if f"mountPath: {path}" not in text:
+                    missing.append(f"{tier} deployment does not mount {path}")
+
+        assert not missing, (
+            "the Helm chart does not share a directory the tiers exchange data through, "
+            "so the web tier will write a file the worker cannot read:\n  " + "\n  ".join(missing)
+        )
+
+
+class TestSharedEnvironment:
+    """A shared directory is only half of it — both tiers must also *resolve*
+    the same path.
+
+    `config.py` defaults `file_uploads_dir` to `./uploaded_files`, which is
+    relative to the working directory. Two tiers with the same mount and
+    different working directories still diverge, which is exactly why compose
+    pins the absolute value on both rather than relying on the default.
+    """
+
+    @staticmethod
+    def _shared_env(compose: dict) -> dict[str, str]:
+        services = compose["services"]
+        web = _environment(services[WEB])
+        worker = _environment(services[WORKER])
+        return {k: web[k] for k in set(web) & set(worker) if web[k] == worker[k]}
+
+    def test_compose_pins_at_least_one_cross_tier_variable(self, compose):
+        """Anti-vacuity, same reasoning as above."""
+        assert self._shared_env(compose), (
+            "compose sets no environment variable identically on both tiers — "
+            "either the scan is broken or #471's pinning was removed"
+        )
+
+    def test_helm_pins_the_same_cross_tier_variables(self, compose):
+        values = yaml.safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
+        chart_env = {str(k): str(v) for k, v in (values.get("env") or {}).items()}
+
+        shared = self._shared_env(compose)
+        wrong = {
+            key: (expected, chart_env.get(key))
+            for key, expected in shared.items()
+            if chart_env.get(key) != expected
+        }
+        assert not wrong, (
+            "the Helm chart does not pin a value compose pins on both tiers, so the "
+            f"two tiers can resolve different directories: {wrong}"
+        )
+
+    def test_the_pinned_variables_actually_reach_the_containers(self, compose):
+        """`values.yaml` is not the consumer — `secret.yaml` is.
+
+        The Secret enumerates its keys explicitly and only then falls through to
+        ``env.extra``, so a key added to ``values.env`` and nowhere else is
+        inert: it never lands in the Secret, and the deployments consume the
+        Secret via ``envFrom``. The first version of the test above asserted
+        ``values.yaml`` alone and passed over a chart that still shipped the
+        bug — the same mistake as reading a config schema instead of what the
+        form writes (core#565). Assert the plumbing, not the declaration.
+        """
+        secret = (CHART / "templates" / "secret.yaml").read_text(encoding="utf-8")
+        values = yaml.safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
+        # Two ways in: named explicitly in the Secret, or supplied through the
+        # `env.extra` range. Being in `values.env` is neither.
+        extra = (values.get("env") or {}).get("extra") or {}
+
+        unplumbed = [
+            key
+            for key in sorted(self._shared_env(compose))
+            if key not in secret and key not in extra
+        ]
+        assert not unplumbed, (
+            "these variables are declared in values.yaml but never rendered into the env "
+            f"Secret, so no container ever sees them: {unplumbed}"
+        )

--- a/tests/test_docs/test_readme_claims.py
+++ b/tests/test_docs/test_readme_claims.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from datanika.models.connection import ConnectionType
+from datanika.services.connection_service import WITHDRAWN_SOURCE_TYPES
 
 README = Path(__file__).resolve().parents[2] / "README.md"
 
@@ -24,6 +25,10 @@ README = Path(__file__).resolve().parents[2] / "README.md"
 # marketed connector count. Keep this list short and justified — every entry is
 # a claim that users cannot actually use something we shipped an enum member
 # for. If you add one, say why.
+#
+# This list covers only types held back *before* launch. Types that were offered
+# and then withdrawn are not listed here — they come from
+# ``WITHDRAWN_SOURCE_TYPES`` below, which is the service's own set.
 UNMARKETED_TYPES = {
     # core#310 — OpenAPI source generation is behind a deferred feature and has
     # no connector page, setup guide, or docs entry. Counting it would inflate
@@ -31,7 +36,20 @@ UNMARKETED_TYPES = {
     "openapi",
 }
 
-EXPECTED_CONNECTOR_COUNT = len(ConnectionType) - len(UNMARKETED_TYPES)
+# Withdrawn types are imported, never re-listed. `connection_service` already
+# owns the set that removes a type from `SOURCE_TYPES`, `CONFIG_SCHEMAS` and the
+# picker, so importing it makes the README count fall out of the *same* fact
+# that makes the connector unreachable in the app.
+#
+# The alternative — adding "google_ads" to UNMARKETED_TYPES by hand — would make
+# the two numbers agree by coincidence, and would silently stop agreeing the next
+# time a connector is withdrawn (core#555/#567 is unlikely to be the last: a
+# withdrawal is the honest answer whenever a connector cannot work with the
+# credentials we collect). With the import, the next withdrawal fails this test
+# until the README is updated in the same PR, which is the entire point.
+EXCLUDED_FROM_COUNT = UNMARKETED_TYPES | set(WITHDRAWN_SOURCE_TYPES)
+
+EXPECTED_CONNECTOR_COUNT = len(ConnectionType) - len(EXCLUDED_FROM_COUNT)
 
 
 @pytest.fixture(scope="module")
@@ -39,16 +57,32 @@ def readme() -> str:
     return README.read_text(encoding="utf-8")
 
 
-def test_unmarketed_types_actually_exist() -> None:
-    """A typo in UNMARKETED_TYPES would silently inflate the expected count."""
+def test_excluded_types_actually_exist() -> None:
+    """A typo in either exclusion set would silently inflate the expected count.
+
+    Covers the imported withdrawn set too: a withdrawal that misspells a type
+    would remove nothing from the app while still shrinking this count, so the
+    README would be "corrected" to a number matching neither.
+    """
     members = {t.value for t in ConnectionType}
-    unknown = UNMARKETED_TYPES - members
-    assert not unknown, f"UNMARKETED_TYPES names types that aren't in ConnectionType: {unknown}"
+    unknown = EXCLUDED_FROM_COUNT - members
+    assert not unknown, f"excluded types that aren't in ConnectionType: {sorted(unknown)}"
 
 
-def test_expected_count_is_sane() -> None:
-    """Tripwire against the exclusion list quietly swallowing real connectors."""
-    assert len(ConnectionType) - 1 == EXPECTED_CONNECTOR_COUNT
+def test_exclusions_stay_small_and_deliberate() -> None:
+    """Tripwire against the exclusion sets quietly swallowing real connectors.
+
+    Deliberately not ``len(ConnectionType) - 1``: that hardcoded the one
+    exclusion that existed when this guard was written, so the first withdrawal
+    (core#567) broke it for the wrong reason. The invariant worth pinning is
+    that exclusions stay few and the marketed count stays plausible, not that
+    there is exactly one.
+    """
+    assert len(EXCLUDED_FROM_COUNT) <= 3, (
+        f"too many connectors excluded from the marketed count: "
+        f"{sorted(EXCLUDED_FROM_COUNT)}. Each one is something we shipped an "
+        f"enum member for and do not sell — if this is growing, say why."
+    )
     assert EXPECTED_CONNECTOR_COUNT > 30, "connector count collapsed — check ConnectionType"
 
 

--- a/tests/test_security/test_egress_saas_fallback_pinning.py
+++ b/tests/test_security/test_egress_saas_fallback_pinning.py
@@ -1,0 +1,252 @@
+"""The SaaS REST fallback must use the pinning session, not merely call the guard.
+
+Write-up: ``plans/qa/notes/SECURITY-saas-fallback-egress-2026-07-22.md``. Held off
+public GitHub until the fix ships, per the SAML precedent.
+
+``dlt_runner`` had two REST client builders and only one of them got core#405's
+pinning session. ``_rest_api_fallback`` — **the production path for all ten SaaS
+connectors**, since none of the verified dlt source modules are installed in the
+image — validated ``base_url`` once and then handed dlt the *hostname*, which
+resolves a second time. That is the exact TOCTOU ``egress_guard``'s own docstring
+claims core#405 closed, and ``salesforce``'s ``instance_url`` is a free-form URL
+from the connection form, so it is reachable rather than theoretical.
+
+**Why 2,500 green tests said nothing.** ``TestEgressGuardWiring`` asserts
+``validate_egress_host`` *is called* on both paths. That is true, and it is the
+pre-flight check — but it never asserts the session is pinned. *The guard was
+tested for presence, not for effect.* So the tests here are the inverse: they
+assert the pinned session is the one **dlt actually uses**.
+
+The discriminator is a hostname that cannot resolve. ``rebind.invalid`` is a
+reserved TLD (RFC 2606); the pinned address is supplied only by
+``resolve_public_ip``. So a row can arrive **only** if dlt connected to the
+address we validated instead of resolving the name itself — which is precisely
+what the missing session changed. ``TestTheProbeDiscriminates`` proves the
+unguarded shape fails the same probe, so this is not a green that measures
+nothing.
+"""
+
+import ast
+import http.server
+import importlib.util
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from dlt.sources.rest_api import rest_api_source
+
+import datanika
+import datanika.services.dlt_runner as dlt_runner
+
+# Never resolvable (RFC 2606), so reaching the server proves the socket went to
+# the pinned address rather than to a second DNS answer.
+PINNED_HOST = "rebind.invalid"
+PINNED_IP = "127.0.0.1"
+
+
+class _ItemsHandler(http.server.BaseHTTPRequestHandler):
+    """Serves one row and records the headers it was reached with."""
+
+    seen: list[dict] = []
+
+    def do_GET(self):  # noqa: N802 - stdlib callback name
+        type(self).seen.append(dict(self.headers))
+        body = json.dumps([{"id": 1, "name": "reached-the-pinned-address"}]).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def pinned_api(monkeypatch):
+    """A real server on the loopback address, reachable only via the pin.
+
+    ``validate_egress_host`` is the pre-flight and has its own tests; it is
+    no-opped so loopback is testable at all. ``resolve_public_ip`` is the
+    single authoritative resolve-validate-pin since core#441 — patching only
+    the former no longer reaches a loopback test server.
+    """
+    _ItemsHandler.seen = []
+    server = http.server.HTTPServer((PINNED_IP, 0), _ItemsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    monkeypatch.setattr(dlt_runner, "validate_egress_host", lambda url: None)
+    monkeypatch.setattr("datanika.services.egress_guard.validate_egress_host", lambda url: None)
+    monkeypatch.setattr(
+        "datanika.services.egress_guard.resolve_public_ip", lambda hostname: PINNED_IP
+    )
+
+    try:
+        yield f"http://{PINNED_HOST}:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _resources():
+    return [{"name": "accounts", "endpoint": {"path": "items"}}]
+
+
+class TestFallbackUsesThePinnedSession:
+    def test_salesforce_reaches_only_the_pinned_address(self, pinned_api):
+        """The reachable connector, driven through its production entry point.
+
+        ``salesforce`` is the one fallback connector whose host is free-form
+        user input, so this drives ``_build_saas_source`` rather than the
+        builder underneath it — the unguarded client was picked *by a call
+        site*, and a test that skips the call site cannot see that choice.
+        """
+        assert importlib.util.find_spec("salesforce") is None, (
+            "the verified `salesforce` source is installed here, so this test "
+            "would take the non-fallback branch and prove nothing about the "
+            "path that runs in the image"
+        )
+
+        source = dlt_runner.DltRunnerService()._build_saas_source(
+            "salesforce",
+            {"access_token": "sekrit", "instance_url": pinned_api},
+            {"resources": _resources()},
+        )
+        rows = list(source.resources["accounts"])
+
+        assert [r["name"] for r in rows] == ["reached-the-pinned-address"], (
+            f"dlt did not connect to the pinned address; got {rows}"
+        )
+
+    def test_auth_survives_alongside_the_pinned_session(self, pinned_api):
+        """Passing a session must not cost the connector its credentials.
+
+        The open question on the fix was whether dlt overrides the session when
+        ``auth`` is also configured. Measured here rather than read: the bearer
+        token arrives on a request that could only have been made through the
+        pinned session.
+        """
+        source = dlt_runner.DltRunnerService()._build_saas_source(
+            "salesforce",
+            {"access_token": "sekrit", "instance_url": pinned_api},
+            {"resources": _resources()},
+        )
+        list(source.resources["accounts"])
+
+        assert _ItemsHandler.seen, "server was never reached"
+        assert _ItemsHandler.seen[0].get("Authorization") == "Bearer sekrit"
+
+    def test_host_header_stays_the_hostname(self, pinned_api):
+        """Pinning must not break virtual-hosted APIs.
+
+        The socket goes to the IP; the ``Host`` header — and, over TLS, the SNI
+        and certificate identity — stay the hostname. Half the SaaS fallbacks
+        are virtual-hosted (``*.myshopify.com``, ``*.zendesk.com``), so a fix
+        that sent the IP as ``Host`` would route them to the wrong tenant.
+        """
+        source = dlt_runner.DltRunnerService()._build_saas_source(
+            "salesforce",
+            {"access_token": "sekrit", "instance_url": pinned_api},
+            {"resources": _resources()},
+        )
+        list(source.resources["accounts"])
+
+        host = _ItemsHandler.seen[0].get("Host", "")
+        assert host.startswith(PINNED_HOST), f"Host header leaked the pinned IP: {host!r}"
+
+    def test_fallback_hands_dlt_a_guarded_session(self, pinned_api):
+        """Fast structural companion to the behavioural tests above.
+
+        Presence alone proved nothing here once — but paired with the
+        behavioural tests it localises a regression to the wiring instead of
+        leaving a failure that only says "no rows".
+        """
+        captured = {}
+        original = dlt_runner.rest_api_source
+
+        def _capture(config, *args, **kwargs):
+            captured.update(config["client"])
+            return original(config, *args, **kwargs)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(dlt_runner, "rest_api_source", _capture)
+            dlt_runner.DltRunnerService()._build_saas_source(
+                "salesforce",
+                {"access_token": "sekrit", "instance_url": pinned_api},
+                {"resources": _resources()},
+            )
+
+        session = captured.get("session")
+        assert session is not None, "no session passed — dlt would build its own and re-resolve"
+        assert getattr(session, "_datanika_egress_guarded", False) is True
+
+
+class TestTheProbeDiscriminates:
+    def test_the_unguarded_shape_cannot_reach_the_server(self, pinned_api):
+        """The control. Without it the tests above are unfalsifiable.
+
+        This is the exact client the fallback used to build — ``base_url`` and
+        ``auth``, no session. dlt then resolves the hostname itself, and the
+        hostname does not resolve, so no row can arrive. If this ever passes,
+        the probe above has stopped measuring pinning and is green for some
+        other reason.
+        """
+        source = rest_api_source(
+            {
+                "client": {"base_url": pinned_api, "auth": {"type": "bearer", "token": "sekrit"}},
+                "resources": _resources(),
+            }
+        )
+
+        with pytest.raises(Exception):  # noqa: B017 - any failure to connect proves the point
+            list(source.resources["accounts"])
+
+        assert not _ItemsHandler.seen, "the unguarded client reached the server — probe is broken"
+
+
+class TestOnlyOneClientBuilderExists:
+    """The defect was that a wrong choice was *available*, not just taken.
+
+    Two builders differing in one line, with the divergence invisible at every
+    call site, is how a connector picks the unguarded one by accident. Deriving
+    the check from the source rather than restating a rule is the only version
+    that cannot drift: a new connector calling ``rest_api_source`` directly
+    fails here at PR time.
+    """
+
+    @staticmethod
+    def _call_sites():
+        root = Path(datanika.__file__).parent
+        sites = []
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            enclosing = {}
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                    for child in ast.walk(node):
+                        enclosing.setdefault(child, node.name)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name == "rest_api_source":
+                    sites.append(
+                        (path.relative_to(root).as_posix(), enclosing.get(node), node.lineno)
+                    )
+        return sites
+
+    def test_every_rest_api_source_call_goes_through_the_guarded_builder(self):
+        sites = self._call_sites()
+
+        # Anti-vacuity: a scan that finds nothing reports three green assertions
+        # having checked nothing (the core#483 lesson).
+        assert sites, "found no rest_api_source call sites — the scan is broken, not the code"
+
+        stray = [s for s in sites if s[1] != "_rest_api_from_parts"]
+        assert not stray, (
+            "rest_api_source is called outside _rest_api_from_parts, so this call site "
+            f"gets no pinning session: {stray}"
+        )

--- a/tests/test_services/test_file_upload_service.py
+++ b/tests/test_services/test_file_upload_service.py
@@ -107,6 +107,37 @@ class TestExtractForDlt:
         with open(os.path.join(extracted_dir, "data.csv"), "rb") as f:
             assert f.read() == sample_csv
 
+    def test_missing_archive_names_the_cause_not_just_the_path(self, svc, db_session, sample_csv):
+        """A worker that cannot see the archive must say why (core#529).
+
+        This is the single most expensive error message in the product. When
+        the web tier and the Celery worker do not share the uploads directory,
+        the run dies here in under 100ms with 0 rows, and the bare
+        ``[Errno 2] No such file or directory: './uploaded_files/archives/…'``
+        names a path while saying nothing about the cause. It cost three CI
+        rounds and two departments to work out that the two tiers had separate
+        filesystems — and it is the first thing a Helm self-hoster hits on the
+        advertised CSV → DuckDB onboarding path.
+
+        So the assertion is on the diagnosis, not on the exception type.
+        """
+        from datanika.models.user import Organization
+
+        org = Organization(name="Acme", slug="acme-missing-archive")
+        db_session.add(org)
+        db_session.flush()
+
+        record = svc.save_file(db_session, org.id, "data.csv", sample_csv)
+        os.remove(record.archive_path)
+
+        with pytest.raises(FileNotFoundError) as exc:
+            svc.extract_for_dlt(record)
+
+        message = str(exc.value)
+        assert record.archive_path in message, "the path is still needed for support"
+        assert "share" in message.lower(), "must say the tiers need a shared directory"
+        assert "FILE_UPLOADS_DIR" in message, "must name the setting the operator changes"
+
 
 class TestCleanupExtracted:
     def test_removes_dir(self, svc, db_session, sample_csv):


### PR DESCRIPTION
**47716d0 — security**: route the SaaS REST fallback through the guarded client.

**e6e382a**: share the uploads directory across tiers in every manifest — the repo-side half of #529's mechanism. ⚠️ Staging's compose lives on the box (`/opt/datanika-staging/docker-compose.yml`, not a git checkout), so it does **not** pick this up from the manifest change; it is being edited separately.

Plus c3b2880 (Growth) connector count derived from the withdrawn set.