### PR TITLE
[Infra] Promote dev → master: staging compose under version control

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ scripts/hooks/* text eol=lf
 # CRLF would make every deploy see a spurious change and reload Apache needlessly.
 deploy/apache/*.conf text eol=lf
 deploy/apache/*.example text eol=lf
+
+# Staging compose is byte-compared on a Linux box by CD; CRLF would fake a change.
+deploy/staging/*.yml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,37 @@ jobs:
           ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" \
             'cd /opt/datanika-staging-src && docker build -t ghcr.io/datanika-io/datanika-core:staging -f datanika/Dockerfile .'
 
+      - name: Sync staging compose from the repo
+        # Staging's docker-compose.yml used to exist only on the box, so manifest changes in the
+        # repo silently did not apply to staging -- that is how #529 (no uploads volume on
+        # staging) persisted after Engineering fixed every in-repo manifest. It is version
+        # controlled now, at deploy/staging/docker-compose.yml, and the transfer step above has
+        # already placed the tree at /opt/datanika-staging-src.
+        #
+        # Backup -> write -> `docker compose config` validate -> restore + fail on invalid. The
+        # recreate step immediately below picks up the new file (it cd's into
+        # /opt/datanika-staging), so this step deliberately does not restart anything.
+        run: |
+          ssh -i ~/.ssh/deploy "root@${{ secrets.POINTER_HOST }}" 'bash -s' <<'SYNC'
+          set -e
+          SRC=/opt/datanika-staging-src/datanika/deploy/staging/docker-compose.yml
+          DST=/opt/datanika-staging/docker-compose.yml
+          [ -f "$SRC" ] || { echo "repo copy missing at $SRC"; exit 1; }
+          if cmp -s "$SRC" "$DST"; then echo "staging compose already current"; exit 0; fi
+          cp -a "$DST" "${DST}.bak.$(date +%s)"
+          cp "$SRC" "$DST"
+          cd /opt/datanika-staging
+          set -a && . ./.env.docker && set +a
+          if docker compose -p datanika-staging config >/dev/null 2>/tmp/cfgerr; then
+            echo "staging compose synced from repo and validated"
+          else
+            echo "INVALID compose from repo -- restoring previous:"; cat /tmp/cfgerr
+            cp "$(ls -t ${DST}.bak.* | head -1)" "$DST"
+            docker compose -p datanika-staging config >/dev/null
+            exit 1
+          fi
+          SYNC
+
       - name: Recreate staging stack on :staging
         # `up -d` can fail with `No such container: <id>` when compose still holds a reference
         # to a container removed out of band (#536). There was no recovery, so the step died.

--- a/deploy/staging/docker-compose.yml
+++ b/deploy/staging/docker-compose.yml
@@ -1,0 +1,133 @@
+# Datanika STAGING stack — pointer.gr, isolated 2nd deployment.
+# Run: cd /opt/datanika-staging && set -a && . ./.env.docker && set +a && \
+#      docker compose -p datanika-staging up -d
+# Reuses the prod-built image (ghcr.io/datanika-io/datanika-core:staging already on
+# the box). Own container names / ports (3100/8100/5433/6380) / volumes — cannot
+# collide with prod (which uses datanika-* names + 3000/8000/5432/6379).
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: datanika-staging-postgres
+    env_file:
+      - .env.docker
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-datanika}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set in .env.docker}
+      POSTGRES_DB: ${POSTGRES_DB:-datanika}
+    ports:
+      - "127.0.0.1:5433:5432"
+    volumes:
+      - staging_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: datanika-staging-redis
+    ports:
+      - "127.0.0.1:6380:6379"
+    command: redis-server --requirepass ${REDIS_PASSWORD:?set in .env.docker}
+    volumes:
+      - staging_redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  app:
+    image: ghcr.io/datanika-io/datanika-core:staging
+    container_name: datanika-staging-app
+    ports:
+      - "127.0.0.1:3100:3000"
+      - "127.0.0.1:8100:8000"
+    env_file:
+      - .env.docker
+    environment:
+      FILE_UPLOADS_DIR: /app/uploaded_files
+      GRANIAN_WORKERS: "2"
+      REFLEX_MOUNT_FRONTEND_COMPILED_APP: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - staging_dbt:/app/dbt_projects
+      - staging_uploads:/app/uploaded_files
+    command: >
+      sh -c "uv run alembic upgrade head &&
+             uv run reflex run --env prod --backend-host 0.0.0.0"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # --- blue/green partner (A3) ---
+  # Same image and env as `app`, different container name and host ports. Behind a
+  # profile so `up -d` never starts it; deploy-bluegreen.sh brings it up for a swap,
+  # waits for its healthcheck, repoints Apache, then stops the other one.
+  app_b:
+    profiles: ["bluegreen"]
+    image: ghcr.io/datanika-io/datanika-core:staging
+    container_name: datanika-staging-app-b
+    ports:
+      - "127.0.0.1:3110:3000"
+      - "127.0.0.1:8110:8000"
+    env_file:
+      - .env.docker
+    environment:
+      FILE_UPLOADS_DIR: /app/uploaded_files
+      GRANIAN_WORKERS: "2"
+      REFLEX_MOUNT_FRONTEND_COMPILED_APP: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - staging_dbt:/app/dbt_projects
+      - staging_uploads:/app/uploaded_files
+    command: >
+      sh -c "uv run alembic upgrade head &&
+             uv run reflex run --env prod --backend-host 0.0.0.0"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  celery:
+    image: ghcr.io/datanika-io/datanika-core:staging
+    container_name: datanika-staging-celery
+    env_file:
+      - .env.docker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      FILE_UPLOADS_DIR: /app/uploaded_files
+    volumes:
+      - staging_dbt:/app/dbt_projects
+      - staging_uploads:/app/uploaded_files
+    command: uv run celery -A datanika.tasks.celery_app:celery_app worker -l info
+    restart: unless-stopped
+
+volumes:
+  staging_pgdata:
+  staging_redisdata:
+  staging_dbt:
+  staging_uploads:


### PR DESCRIPTION
The staging docker-compose was box-local, so repo manifest changes did not reach it — how #529 survived Engineering's e6e382a. Now at deploy/staging/, CD-synced with a config-validate gate. The dev push after this promotion exercises the new sync step against the box.

<!-- promotion-refs:start -->

### Issues closed by this promotion

_Generated from the commits being promoted. Feature PRs merge into `dev`, which is not the default branch, so their own closing keywords never fire — these references are what actually closes the issues on merge._

- #88 — Reflex/lucide deprecation warning: "alert-triangle" should be "triangle-alert" _(already closed)_ · via commit ae02ea8

<!-- promotion-refs:end -->