### PR TITLE
[Product] Connection form: force a deliberate type choice (closes #593)

### DIFF
--- a/datanika/ui/state/connection_state.py
+++ b/datanika/ui/state/connection_state.py
@@ -199,6 +199,13 @@ def _validate_connection_form(
     if not name.strip():
         return "Connection name is required"
 
+    # core#593: the type picker defaults to "" (placeholder), so an untouched
+    # form has no type. Reject before the raw-JSON early return — save() calls
+    # ConnectionType(form_type) regardless of raw mode, so an empty type there
+    # would surface as a generic "Failed to save" instead of this clear message.
+    if not conn_type.strip():
+        return "Connection type is required"
+
     if use_raw_json:
         return ""
 
@@ -256,7 +263,9 @@ class ConnectionItem(BaseModel):
 class ConnectionState(BaseState):
     connections: list[ConnectionItem] = []
     form_name: str = ""
-    form_type: str = "postgres"
+    # "" so the type picker shows its placeholder and forces a deliberate
+    # choice, rather than silently defaulting to postgres (core#593).
+    form_type: str = ""
     form_config: str = "{}"
     form_use_raw_json: bool = False
 
@@ -269,7 +278,8 @@ class ConnectionState(BaseState):
 
     # SQL database fields (postgres, mysql, mssql, redshift)
     form_host: str = ""
-    form_port: str = "5432"
+    # "" until a type is chosen; set_form_type fills the type's default port.
+    form_port: str = ""
     form_user: str = ""
     form_password: str = ""
     form_database: str = ""
@@ -761,11 +771,13 @@ class ConnectionState(BaseState):
         """Clear all typed form fields and exit edit mode."""
         self.editing_conn_id = 0
         self.form_name = ""
-        self.form_type = "postgres"
+        # Back to the placeholder, not postgres — the next connection starts
+        # blank and forces a deliberate type choice (core#593).
+        self.form_type = ""
         self.form_config = "{}"
         self.form_use_raw_json = False
         self.form_host = ""
-        self.form_port = _DEFAULT_PORTS.get("postgres", "")
+        self.form_port = ""
         self.form_user = ""
         self.form_password = ""
         self.form_database = ""

--- a/tests/test_ui/test_state_setters.py
+++ b/tests/test_ui/test_state_setters.py
@@ -40,6 +40,26 @@ class TestConnectionFormValidation:
         err = self._validate(name="   ", conn_type="postgres", use_raw_json=False)
         assert "name is required" in err.lower()
 
+    # -- Connection type must be chosen (core#593) --
+
+    def test_empty_type_rejected(self):
+        # The picker now defaults to "" (placeholder), so an untouched form has
+        # no type. Reject it with a clear message rather than letting save reach
+        # ConnectionType("") and blow up as a generic "Failed to save".
+        err = self._validate(name="X", conn_type="", use_raw_json=False)
+        assert "type is required" in err.lower()
+
+    def test_empty_type_rejected_even_in_raw_json(self):
+        # Raw JSON skips the *field* checks, but save() still calls
+        # ConnectionType(form_type), so the type is required in raw mode too —
+        # the check must precede the raw-JSON early return.
+        err = self._validate(name="X", conn_type="", use_raw_json=True)
+        assert "type is required" in err.lower()
+
+    def test_whitespace_type_rejected(self):
+        err = self._validate(name="X", conn_type="   ", use_raw_json=False)
+        assert "type is required" in err.lower()
+
     # -- Raw JSON skips type-specific checks --
 
     def test_raw_json_skips_field_checks(self):
@@ -435,6 +455,53 @@ class TestSettingsStateSetters:
             method = getattr(SettingsState, name, None)
             assert method is not None, f"SettingsState missing {name}"
             assert callable(method)
+
+
+class TestConnectionFormReset:
+    """The form must return to a blank slate after a save (core#593).
+
+    QA (core#529) asked whether a user creating a *second* connection seeing
+    the previous type + config path pre-filled is a wart. The happy path
+    already resets via _reset_form_fields; these guards pin that the reset
+    lands the type picker on its placeholder ("") rather than a stale/real
+    type, so the next connection starts blank and forces a deliberate choice.
+    """
+
+    def _reset(self):
+        import types
+
+        from datanika.ui.state.connection_state import ConnectionState
+
+        class FakeState:
+            pass
+
+        obj = FakeState()
+        # Pre-dirty every field the reset is supposed to clear.
+        obj.form_type = "duckdb"
+        obj.form_path = "/tmp/prev.duckdb"
+        obj.form_port = "5432"
+        obj.form_host = "leftover-host"
+        obj.editing_conn_id = 7
+        obj._reset_form_fields = types.MethodType(ConnectionState._reset_form_fields, obj)
+        obj._reset_form_fields()
+        return obj
+
+    def test_reset_clears_type_to_placeholder(self):
+        obj = self._reset()
+        # "" makes searchable_select render the connections.ph_type placeholder,
+        # not a silent real default like "postgres".
+        assert obj.form_type == ""
+
+    def test_reset_clears_port(self):
+        obj = self._reset()
+        assert obj.form_port == ""
+
+    def test_reset_clears_previous_config_path(self):
+        # The exact thing QA saw retained across a second create.
+        obj = self._reset()
+        assert obj.form_path == ""
+        assert obj.form_host == ""
+        assert obj.editing_conn_id == 0
 
 
 class TestPipelineStateDualModeFields:


### PR DESCRIPTION
## The Product call QA asked for (core#529 / current_state)

QA flagged, in the golden-path work:

> 👀 **Product call worth having:** a user creating a second connection sees the previous type *and* the previous config path pre-filled. Wart, or accidental-duplicate hazard?

**The call:** the persistent pre-fill QA observed is **not** designed behaviour — `save_connection()` already calls `_reset_form_fields()` on every successful create/update, so the happy path blanks the form. What QA saw is the **#472 websocket-drop** artifact (the reset delta not reaching the browser), which is a reliability bug tracked elsewhere — not form design.

But the question surfaced a genuine, separate **Product wart** worth fixing on its own: **the type picker silently defaulted to `postgres`.** `form_type` defaulted to `"postgres"` (never `""`), so `searchable_select` never rendered its existing `connections.ph_type` placeholder, and a user could create a postgres connection without choosing. This is the root the #529 locator and #511 had to work around.

Closes #593.

## Change

Placeholder-first / forced type choice:

- `form_type` and `form_port` now default to `""` (class default **and** `_reset_form_fields`), so both the first connection and every subsequent one start blank and the picker shows "Connection type".
- `_validate_connection_form` rejects an empty type (**"Connection type is required"**) **before** the raw-JSON early return — `save_connection` calls `ConnectionType(form_type)` regardless of raw mode, so without this an empty type would surface as a generic "Failed to save connection".

## Invariants

- **No new i18n keys.** `connections.ph_type` ("Connection type") already exists, and validation strings are not translated (CLAUDE.md i18n rules skip dynamic error messages).
- **`type_fields()` renders nothing until a type is picked** — each branch is a per-type `rx.cond`, so the form cleanly shows just name + picker, then reveals fields on choice. No crash, no empty-shell fields.
- **Templates unaffected** — `_apply_template_defaults` / `_populate_form_from_config` / `copy_connection` all set `form_type` explicitly.
- **`set_form_type`** still fills the type's default port on selection, so choosing postgres still yields 5432.

## Tests (TDD, red→green)

- `_validate_connection_form`: empty / whitespace type rejected, including in raw-JSON mode. **Verified red first** (returned `""`) → green.
- `TestConnectionFormReset`: after `_reset_form_fields`, `form_type`/`form_port` are `""` and the previous config path (`form_path`/`form_host`) is cleared — the exact retention QA described. Type/port assertions **verified red first** (were `"postgres"`/`"5432"`).
- Full pre-push suite: **2813 passed, 21 skipped** (local, Docker up).

## Out of scope — the "hazard" half

The accidental-duplicate hazard is real but downstream: `create_connection` has no name/config uniqueness guard, so if a create half-succeeds invisibly (the #472 drop hides the new row) a re-submit makes a duplicate. Mitigation = the #472 fix + optionally a soft "you already have a connection named X" guard. Demand-gated; filed separately, not built here.

**Reversible** if usage data later favours a convenience default.
